### PR TITLE
feat: Support adding events to existing functions

### DIFF
--- a/docs/cloudformation_compatibility.rst
+++ b/docs/cloudformation_compatibility.rst
@@ -65,8 +65,41 @@ AutoPublishAlias             Ref of a CloudFormation Parameter  Alias resources 
 ReservedConcurrentExecutions       All
 ============================ ================================== ========================
 
+
+AWS::Serverless::FunctionReference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================================== ========================
+     Property Name           Intrinsic(s) Supported            Reasons
+============================ ================================== ========================
+FunctionName                       All
+Events                             All
+============================ ================================== ========================
+
+
+AWS::Serverless::Application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+================================== ======================== ========================
+     Property Name                 Intrinsic(s) Supported          Reasons
+================================== ======================== ========================
+Location                            None                     SAM expects exact values for the Location property
+Parameters                          All
+NotificationARNs                    All
+Tags                                All
+TimeoutInMinutes                    All
+Events                              All
+================================== ======================== ========================
+
+
 Events Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The property Events can appear in three different SAM resources:
+- AWS::Serverless::Function
+- AWS::Serverless::FunctionReference
+- AWS::Serverless::Application
+
 
 Cognito
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -184,20 +217,6 @@ MinimumCompressionSize              All
 Cors                                All
 TracingEnabled                      All
 OpenApiVersion                      None
-================================== ======================== ========================
-
-
-AWS::Serverless::Application
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-================================== ======================== ========================
-     Property Name                 Intrinsic(s) Supported          Reasons
-================================== ======================== ========================
-Location                            None                     SAM expects exact values for the Location property
-Parameters                          All
-NotificationARNs                    All
-Tags                                All
-TimeoutInMinutes                    All
 ================================== ======================== ========================
 
 

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -292,6 +292,119 @@
       ],
       "type": "object"
     },
+    "AWS::Serverless::FunctionReference": {
+      "additionalProperties": false,
+      "properties": {
+        "Properties": {
+          "additionalProperties": false,
+          "properties": {
+            "Events": {
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9]+$": {
+                  "$ref": "#/definitions/AWS::Serverless::Function.EventSource"
+                }
+              },
+              "type": "object"
+            },            
+            "FunctionName": {
+              "type": "string"
+            }   
+          },
+          "required": [
+            "FunctionName"
+          ],
+          "type": "object"
+        },
+        "Type": {
+          "enum": [
+            "AWS::Serverless::FunctionReference"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "Properties",
+        "Type"
+      ],
+      "type": "object"
+    },
+    "AWS::Serverless::Application": {
+      "additionalProperties": false,
+      "properties": {
+        "Properties": {
+          "additionalProperties": false,
+          "properties": {
+            "Events": {
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9]+$": {
+                  "$ref": "#/definitions/AWS::Serverless::Function.EventSource"
+                }
+              },
+              "type": "object"
+            },
+            "Location": {
+              "anyOf": [
+                {
+                  "type": [
+                    "string"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/AWS::Serverless::Application.Location"
+                }
+              ]
+            },
+            "NotificationARNs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "Parameters": {
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9]+$": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "Tags": {
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9]+$": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "TemplateUrl": {
+              "type": "string"
+            },            
+            "TimeoutInMinutes": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "Location"
+          ],
+          "type": "object"
+        },
+        "Type": {
+          "enum": [
+            "AWS::Serverless::Application"
+          ],
+          "type": "string"
+        }        
+      },
+      "required": [
+        "Properties",
+        "Type"
+      ],
+      "type": "object"
+    },
     "AWS::Serverless::Function.AlexaSkillEvent": {
       "additionalProperties": false,
       "properties": {

--- a/tests/translator/input/application_with_events.yaml
+++ b/tests/translator/input/application_with_events.yaml
@@ -1,0 +1,17 @@
+Resources:
+  BasicApplication:
+    Type: 'AWS::Serverless::Application'
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world
+        SemanticVersion: 1.0.2
+      Events:
+        FunctionInsideApplication:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*          
+
+  Images:
+    Type: AWS::S3::Bucket          

--- a/tests/translator/input/referencefunction_s3.yaml
+++ b/tests/translator/input/referencefunction_s3.yaml
@@ -1,0 +1,19 @@
+Resources:
+  ThumbnailFunction:
+    Type: AWS::Serverless::FunctionReference
+    Properties:
+      FunctionName: 
+        Fn::Join:
+          - ''
+          - - FirstPart
+            - -LastPart      
+      Events:
+        ImageBucket:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*          
+
+  Images:
+    Type: AWS::S3::Bucket

--- a/tests/translator/output/application_with_events.json
+++ b/tests/translator/output/application_with_events.json
@@ -1,0 +1,71 @@
+{
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "BasicApplicationFunctionInsideApplicationPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      {
+                        "Fn::GetAtt": [
+                          "BasicApplication",
+                          "Outputs.FunctionInsideApplication"
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "BasicApplication": {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {
+          "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+          "Tags": [
+            {
+              "Key": "lambda:createdBy",
+              "Value": "SAM"
+            },
+            {
+              "Key": "serverlessrepo:applicationId",
+              "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
+            },
+            {
+              "Key": "serverlessrepo:semanticVersion",
+              "Value": "1.0.2"
+            }
+          ]
+        }
+      },
+      "BasicApplicationFunctionInsideApplicationPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:invokeFunction",
+          "FunctionName": {
+            "Fn::GetAtt": [
+              "BasicApplication",
+              "Outputs.FunctionInsideApplication"
+            ]
+          },
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-cn/application_with_events.json
+++ b/tests/translator/output/aws-cn/application_with_events.json
@@ -1,0 +1,71 @@
+{
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "BasicApplicationFunctionInsideApplicationPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      {
+                        "Fn::GetAtt": [
+                          "BasicApplication",
+                          "Outputs.FunctionInsideApplication"
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "BasicApplication": {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {
+          "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+          "Tags": [
+            {
+              "Key": "lambda:createdBy",
+              "Value": "SAM"
+            },
+            {
+              "Key": "serverlessrepo:applicationId",
+              "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
+            },
+            {
+              "Key": "serverlessrepo:semanticVersion",
+              "Value": "1.0.2"
+            }
+          ]
+        }
+      },
+      "BasicApplicationFunctionInsideApplicationPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:invokeFunction",
+          "FunctionName": {
+            "Fn::GetAtt": [
+              "BasicApplication",
+              "Outputs.FunctionInsideApplication"
+            ]
+          },
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-cn/referencefunction_s3.json
+++ b/tests/translator/output/aws-cn/referencefunction_s3.json
@@ -1,0 +1,57 @@
+{
+  "Resources": {
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": [
+        "ThumbnailFunctionImageBucketPermission"
+      ],      
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "FirstPart",
+                          "-LastPart"
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "Event": "s3:ObjectCreated:*"
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "FunctionName": {
+          "Fn::Join": [
+            "",
+            [
+              "FirstPart",
+              "-LastPart"
+            ]
+          ]
+        },
+        "Principal": "s3.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/application_with_events.json
+++ b/tests/translator/output/aws-us-gov/application_with_events.json
@@ -1,0 +1,71 @@
+{
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "BasicApplicationFunctionInsideApplicationPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      {
+                        "Fn::GetAtt": [
+                          "BasicApplication",
+                          "Outputs.FunctionInsideApplication"
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "BasicApplication": {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {
+          "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+          "Tags": [
+            {
+              "Key": "lambda:createdBy",
+              "Value": "SAM"
+            },
+            {
+              "Key": "serverlessrepo:applicationId",
+              "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
+            },
+            {
+              "Key": "serverlessrepo:semanticVersion",
+              "Value": "1.0.2"
+            }
+          ]
+        }
+      },
+      "BasicApplicationFunctionInsideApplicationPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:invokeFunction",
+          "FunctionName": {
+            "Fn::GetAtt": [
+              "BasicApplication",
+              "Outputs.FunctionInsideApplication"
+            ]
+          },
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/referencefunction_s3.json
+++ b/tests/translator/output/aws-us-gov/referencefunction_s3.json
@@ -1,0 +1,57 @@
+{
+  "Resources": {
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": [
+        "ThumbnailFunctionImageBucketPermission"
+      ],      
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "FirstPart",
+                          "-LastPart"
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "Event": "s3:ObjectCreated:*"
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "FunctionName": {
+          "Fn::Join": [
+            "",
+            [
+              "FirstPart",
+              "-LastPart"
+            ]
+          ]
+        },
+        "Principal": "s3.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/referencefunction_s3.json
+++ b/tests/translator/output/referencefunction_s3.json
@@ -1,0 +1,57 @@
+{
+  "Resources": {
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": [
+        "ThumbnailFunctionImageBucketPermission"
+      ],      
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "FirstPart",
+                          "-LastPart"
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "Event": "s3:ObjectCreated:*"
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "FunctionName": {
+          "Fn::Join": [
+            "",
+            [
+              "FirstPart",
+              "-LastPart"
+            ]
+          ]
+        },
+        "Principal": "s3.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -137,6 +137,7 @@ class TestTranslatorEndToEnd(TestCase):
 
     @parameterized.expand(
       itertools.product([
+        'referencefunction_s3',
         'cognito_userpool_with_event',
         's3_with_condition',
         'function_with_condition',

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -137,6 +137,7 @@ class TestTranslatorEndToEnd(TestCase):
 
     @parameterized.expand(
       itertools.product([
+        'application_with_events',
         'referencefunction_s3',
         'cognito_userpool_with_event',
         's3_with_condition',

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -94,6 +94,7 @@ Globals:
  - [AWS::Serverless::Application](#awsserverlessapplication)
  - [AWS::Serverless::SimpleTable](#awsserverlesssimpletable)
  - [AWS::Serverless::LayerVersion](#awsserverlesslayerversion)
+ - [AWS::Serverless::FunctionReference](#awsserverlessfunctionreference)
 
 #### AWS::Serverless::Function
 
@@ -259,6 +260,7 @@ Embeds a serverless application from the [AWS Serverless Application Repository]
 
 Property Name | Type | Description
 ---|:---:|---
+Events | Map of `string` to [Event source object](#event-source-object) | A map (string to [Event source object](#event-source-object)) that defines the events that trigger functions inside the nested application. The key should be the name of one of the Outputs of the nested application, the value of the Output will be used as the FunctionName. Keys are limited to alphanumeric characters.
 Location | `string` or [Application Location Object](#application-location-object) | **Required** Template URL or location of nested application. If a template URL is given, it must follow the format specified in the [CloudFormation TemplateUrl documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html#cfn-cloudformation-stack-templateurl) and contain a valid CloudFormation or SAM template.
 Parameters | Map of `string` to `string` | Application parameter values.
 NotificationARNs | List of `string` |  A list of existing Amazon SNS topics where notifications about stack events are sent.
@@ -374,6 +376,52 @@ Properties:
     - nodejs8.10
   LicenseInfo: 'Available under the MIT-0 license.'
   RetentionPolicy: Retain
+```
+
+
+#### AWS::Serverless::FunctionReference
+
+Creates a function reference and event source mappings which trigger the referenced function. With a function reference the Events property can be used as if the function were part of the template. Since this is just a reference no actual resource is created in the template.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+FunctionName | `string` | A name of the function to reference. The name is resolved to a Lambda function in the same account, cross account coupling is not supported.(http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname)
+Events | Map of `string` to [Event source object](#event-source-object) | A map (string to [Event source object](#event-source-object)) that defines the events that trigger this referenced function. Keys are limited to alphanumeric characters.
+
+##### Return values
+
+###### Ref
+
+TODO
+
+###### Fn::GetAtt
+
+TODO
+
+###### Referencing Lambda Version & Alias resources
+
+TODO
+
+###### Example: AWS::Serverless::FunctionReference
+
+```yaml
+Resources:
+  ThumbnailFunction:
+    Type: AWS::Serverless::FunctionReference
+    Properties:
+      FunctionName: NameOfMyFunction    
+      Events:
+        ImageBucket:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*          
+
+  Images:
+    Type: AWS::S3::Bucket
 ```
 
 

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -392,13 +392,7 @@ Events | Map of `string` to [Event source object](#event-source-object) | A map 
 
 ##### Return values
 
-###### Ref
-
-TODO
-
-###### Fn::GetAtt
-
-TODO
+Since the FunctionReference does not exist in the transformed template its logical id cannot be reference by Ref or Fn::GetAtt. So the FunctionReference has no return values.
 
 ###### Referencing Lambda Version & Alias resources
 


### PR DESCRIPTION
*Issue #866, if available:*

*Description of changes:*
Add new resources type AWS::Serverless::FunctionReference
Pulled processing of events Events to base class
Made SamFunction SamReferenceFunction and SamApplication subclass from it

*Description of how you validated changes:*
Did two test deploys
- Template with FunctionReference and S3 trigger event
- Template with HelloWorld app in it with events specified that couples function inside app to S3 trigger

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
