### PR TITLE
fix: do not generate unnecessary 'DependsOn' for api usage plan

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -579,7 +579,7 @@ class ApiGenerator(object):
         # create usage plan for this api only
         elif usage_plan_properties.get("CreateUsagePlan") == "PER_API":
             usage_plan_logical_id = self.logical_id + "UsagePlan"
-            usage_plan = ApiGatewayUsagePlan(logical_id=usage_plan_logical_id, depends_on=[self.logical_id])
+            usage_plan = ApiGatewayUsagePlan(logical_id=usage_plan_logical_id)
             api_stages = list()
             api_stage = dict()
             api_stage["ApiId"] = ref(self.logical_id)
@@ -593,8 +593,6 @@ class ApiGenerator(object):
         # create a usage plan for all the Apis
         elif create_usage_plan == "SHARED":
             usage_plan_logical_id = "ServerlessUsagePlan"
-            if self.logical_id not in ApiGenerator.depends_on_shared:
-                ApiGenerator.depends_on_shared.append(self.logical_id)
             usage_plan = ApiGatewayUsagePlan(
                 logical_id=usage_plan_logical_id, depends_on=ApiGenerator.depends_on_shared
             )
@@ -667,7 +665,7 @@ class ApiGenerator(object):
             # create a mapping between api key and the usage plan
             usage_plan_key_logical_id = self.logical_id + "UsagePlanKey"
 
-        usage_plan_key = ApiGatewayUsagePlanKey(logical_id=usage_plan_key_logical_id, depends_on=[api_key.logical_id])
+        usage_plan_key = ApiGatewayUsagePlanKey(logical_id=usage_plan_key_logical_id)
         usage_plan_key.KeyId = ref(api_key.logical_id)
         usage_plan_key.KeyType = "API_KEY"
         usage_plan_key.UsagePlanId = ref(usage_plan_logical_id)

--- a/tests/translator/output/api_with_usageplans.json
+++ b/tests/translator/output/api_with_usageplans.json
@@ -90,10 +90,7 @@
         "UsagePlanId": {
           "Ref": "MyApiTwoUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiTwoApiKey"
-      ]
+      }
     },
     "MyApiThree": {
       "Type": "AWS::ApiGateway::RestApi",
@@ -383,11 +380,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiThree",
-        "ServerlessRestApi"
-      ]
+      }
     },
     "MyApiTwoUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
@@ -423,10 +416,7 @@
           "BurstLimit": 1000
         },
         "UsagePlanName": "SomeRandomName"
-      },
-      "DependsOn": [
-        "MyApiTwo"
-      ]
+      }
     },
     "MyApiThreeDeployment1d9cff47dc": {
       "Type": "AWS::ApiGateway::Deployment",
@@ -537,10 +527,7 @@
         "UsagePlanId": {
           "Ref": "ServerlessUsagePlan"
         }
-      },
-      "DependsOn": [
-        "ServerlessApiKey"
-      ]
+      }
     },
     "MyApiOne": {
       "Type": "AWS::ApiGateway::RestApi",

--- a/tests/translator/output/api_with_usageplans_intrinsics.json
+++ b/tests/translator/output/api_with_usageplans_intrinsics.json
@@ -38,10 +38,7 @@
         "UsagePlanId": {
           "Ref": "MyApiTwoUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiTwoApiKey"
-      ]
+      }
     },
     "MyApiTwoDeploymenta78b9db9dd": {
       "Type": "AWS::ApiGateway::Deployment",
@@ -65,10 +62,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiOne"
-      ]
+      }
     },
     "MyApiTwoUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
@@ -83,10 +77,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiTwo"
-      ]
+      }
     },
     "MyApiTwoProdStage": {
       "Type": "AWS::ApiGateway::Stage",
@@ -182,10 +173,7 @@
         "UsagePlanId": {
           "Ref": "MyApiOneUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiOneApiKey"
-      ]
+      }
     },
     "MyApiTwoApiKey": {
       "Type": "AWS::ApiGateway::ApiKey",

--- a/tests/translator/output/aws-cn/api_with_usageplans.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans.json
@@ -100,10 +100,7 @@
         "UsagePlanId": {
           "Ref": "MyApiTwoUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiTwoApiKey"
-      ]
+      }
     },
     "MyApiThree": {
       "Type": "AWS::ApiGateway::RestApi",
@@ -399,11 +396,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiThree",
-        "ServerlessRestApi"
-      ]
+      }
     },
     "MyApiTwoUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
@@ -439,10 +432,7 @@
           "BurstLimit": 1000
         },
         "UsagePlanName": "SomeRandomName"
-      },
-      "DependsOn": [
-        "MyApiTwo"
-      ]
+      }
     },
     "MyFunctionTwoImplicitApiEventPermissionProd": {
       "Type": "AWS::Lambda::Permission",
@@ -543,10 +533,7 @@
         "UsagePlanId": {
           "Ref": "ServerlessUsagePlan"
         }
-      },
-      "DependsOn": [
-        "ServerlessApiKey"
-      ]
+      }
     },
     "MyApiOne": {
       "Type": "AWS::ApiGateway::RestApi",

--- a/tests/translator/output/aws-cn/api_with_usageplans_intrinsics.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans_intrinsics.json
@@ -38,10 +38,7 @@
         "UsagePlanId": {
           "Ref": "MyApiTwoUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiTwoApiKey"
-      ]
+      }
     },
     "MyApiOneUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
@@ -56,10 +53,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiOne"
-      ]
+      }
     },
     "MyApiTwoUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
@@ -74,10 +68,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiTwo"
-      ]
+      }
     },
     "MyApiTwoDeploymenta997b9e562": {
       "Type": "AWS::ApiGateway::Deployment",
@@ -98,10 +89,7 @@
         "UsagePlanId": {
           "Ref": "MyApiOneUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiOneApiKey"
-      ]
+      }
     },
     "MyApiTwoProdStage": {
       "Type": "AWS::ApiGateway::Stage",

--- a/tests/translator/output/aws-us-gov/api_with_usageplans.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans.json
@@ -90,10 +90,7 @@
         "UsagePlanId": {
           "Ref": "MyApiTwoUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiTwoApiKey"
-      ]
+      }
     },
     "MyApiThree": {
       "Type": "AWS::ApiGateway::RestApi",
@@ -398,11 +395,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiThree",
-        "ServerlessRestApi"
-      ]
+      }
     },
     "ServerlessApiKey": {
       "Type": "AWS::ApiGateway::ApiKey",
@@ -465,10 +458,7 @@
           "BurstLimit": 1000
         },
         "UsagePlanName": "SomeRandomName"
-      },
-      "DependsOn": [
-        "MyApiTwo"
-      ]
+      }
     },
     "ServerlessRestApiDeploymentd197b03bdf": {
       "Type": "AWS::ApiGateway::Deployment",
@@ -567,10 +557,7 @@
         "UsagePlanId": {
           "Ref": "ServerlessUsagePlan"
         }
-      },
-      "DependsOn": [
-        "ServerlessApiKey"
-      ]
+      }
     },
     "MyApiOne": {
       "Type": "AWS::ApiGateway::RestApi",

--- a/tests/translator/output/aws-us-gov/api_with_usageplans_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans_intrinsics.json
@@ -38,10 +38,7 @@
         "UsagePlanId": {
           "Ref": "MyApiTwoUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiTwoApiKey"
-      ]
+      }
     },
     "MyApiTwoDeployment802c3b471d": {
       "Type": "AWS::ApiGateway::Deployment",
@@ -65,10 +62,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiOne"
-      ]
+      }
     },
     "MyApiOneDeployment8b73115419": {
       "Type": "AWS::ApiGateway::Deployment",
@@ -93,10 +87,7 @@
             }
           }
         ]
-      },
-      "DependsOn": [
-        "MyApiTwo"
-      ]
+      }
     },
     "MyApiTwoProdStage": {
       "Type": "AWS::ApiGateway::Stage",
@@ -182,10 +173,7 @@
         "UsagePlanId": {
           "Ref": "MyApiOneUsagePlan"
         }
-      },
-      "DependsOn": [
-        "MyApiOneApiKey"
-      ]
+      }
     },
     "MyApiTwoApiKey": {
       "Type": "AWS::ApiGateway::ApiKey",


### PR DESCRIPTION
*Issue #, if available:*
awslabs/serverless-application-model#1541

*Description of changes:*
No longer generates unnecessary `DependsOn` for resources which are already referenced (`Ref`). See issue awslabs/serverless-application-model#1541 for more details.

*Description of how you validated changes:*
Transformed templates (`tests/translator/input/{api_with_usageplans,api_with_usageplans_intrinsics}.yaml`; not cn/gov variants due to access ) and stood them up in an aws account to verify.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
