### PR TITLE
fix: StateMachine - Resolve parameter references before processing definition

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1119,6 +1119,7 @@ class SamStateMachine(SamResourceMacro):
         "Type": PropertyType(False, is_str()),
         "Tags": PropertyType(False, is_type(dict)),
         "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),
+        "PermissionsBoundary": PropertyType(False, is_str()),
     }
     event_resolver = ResourceTypeResolver(samtranslator.model.stepfunctions.events,)
 
@@ -1137,6 +1138,7 @@ class SamStateMachine(SamResourceMacro):
             logging=self.Logging,
             name=self.Name,
             policies=self.Policies,
+            permissions_boundary=self.PermissionsBoundary,
             definition_substitutions=self.DefinitionSubstitutions,
             role=self.Role,
             state_machine_type=self.Type,

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -42,7 +42,7 @@ class EventSource(ResourceMacro):
             logical_id = generator.gen()
         return logical_id
 
-    def _construct_role(self, resource, prefix=None, suffix=""):
+    def _construct_role(self, resource, permissions_boundary=None, prefix=None, suffix=""):
         """Constructs the IAM Role resource allowing the event service to invoke 
         the StartExecution API of the state machine resource it is associated with.
 
@@ -62,6 +62,9 @@ class EventSource(ResourceMacro):
         event_role.Policies = [
             IAMRolePolicies.step_functions_start_execution_role_policy(state_machine_arn, role_logical_id)
         ]
+
+        if permissions_boundary:
+            event_role.PermissionsBoundary = permissions_boundary
 
         return event_role
 
@@ -88,6 +91,8 @@ class Schedule(EventSource):
         """
         resources = []
 
+        permissions_boundary = kwargs.get("permissions_boundary")
+
         events_rule = EventsRule(self.logical_id)
         resources.append(events_rule)
 
@@ -99,7 +104,7 @@ class Schedule(EventSource):
         if CONDITION in resource.resource_attributes:
             events_rule.set_resource_attribute(CONDITION, resource.resource_attributes[CONDITION])
 
-        role = self._construct_role(resource)
+        role = self._construct_role(resource, permissions_boundary)
         resources.append(role)
         events_rule.Targets = [self._construct_target(resource, role)]
 
@@ -144,6 +149,8 @@ class CloudWatchEvent(EventSource):
         """
         resources = []
 
+        permissions_boundary = kwargs.get("permissions_boundary")
+
         events_rule = EventsRule(self.logical_id)
         events_rule.EventBusName = self.EventBusName
         events_rule.EventPattern = self.Pattern
@@ -152,7 +159,7 @@ class CloudWatchEvent(EventSource):
 
         resources.append(events_rule)
 
-        role = self._construct_role(resource)
+        role = self._construct_role(resource, permissions_boundary)
         resources.append(role)
         events_rule.Targets = [self._construct_target(resource, role)]
 
@@ -259,12 +266,13 @@ class Api(EventSource):
         resources = []
 
         intrinsics_resolver = kwargs.get("intrinsics_resolver")
+        permissions_boundary = kwargs.get("permissions_boundary")
 
         if self.Method is not None:
             # Convert to lower case so that user can specify either GET or get
             self.Method = self.Method.lower()
 
-        role = self._construct_role(resource)
+        role = self._construct_role(resource, permissions_boundary)
         resources.append(role)
 
         explicit_api = kwargs["explicit_api"]

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -37,6 +37,7 @@ class StateMachineGenerator(object):
         logging,
         name,
         policies,
+        permissions_boundary,
         definition_substitutions,
         role,
         state_machine_type,
@@ -80,6 +81,7 @@ class StateMachineGenerator(object):
         self.name = name
         self.logging = logging
         self.policies = policies
+        self.permissions_boundary = permissions_boundary
         self.definition_substitutions = definition_substitutions
         self.role = role
         self.type = state_machine_type
@@ -217,6 +219,7 @@ class StateMachineGenerator(object):
             assume_role_policy_document=IAMRolePolicies.stepfunctions_assume_role_policy(),
             resource_policies=state_machine_policies,
             tags=self._construct_tag_list(),
+            permissions_boundary=self.permissions_boundary,
         )
         return execution_role
 
@@ -239,7 +242,10 @@ class StateMachineGenerator(object):
         resources = []
         if self.events:
             for logical_id, event_dict in self.events.items():
-                kwargs = {"intrinsics_resolver": self.intrinsics_resolver}
+                kwargs = {
+                    "intrinsics_resolver": self.intrinsics_resolver,
+                    "permissions_boundary": self.permissions_boundary,
+                }
                 try:
                     eventsource = self.event_resolver.resolve_resource_type(event_dict).from_dict(
                         self.state_machine.logical_id + logical_id, event_dict, logical_id

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -111,6 +111,7 @@ class StateMachineGenerator(object):
             )
         elif self.definition:
             processed_definition = deepcopy(self.definition)
+            processed_definition = self.intrinsics_resolver.resolve_parameter_refs(processed_definition)
             substitutions = self._replace_dynamic_values_with_substitutions(processed_definition)
             if len(substitutions) > 0:
                 if self.state_machine.DefinitionSubstitutions:

--- a/tests/model/stepfunctions/test_state_machine_generator.py
+++ b/tests/model/stepfunctions/test_state_machine_generator.py
@@ -19,6 +19,7 @@ class StepFunctionsStateMachine(TestCase):
             "logging": None,
             "name": None,
             "policies": None,
+            "permissions_boundary": None,
             "definition_substitutions": None,
             "role": None,
             "state_machine_type": None,

--- a/tests/translator/input/state_machine_with_inline_definition_parameters_intrinsics.yaml
+++ b/tests/translator/input/state_machine_with_inline_definition_parameters_intrinsics.yaml
@@ -1,0 +1,38 @@
+Parameters: 
+  MyTimeoutParameter:
+    Type: Number
+    Default: 500
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: hello.handler
+      Runtime: python2.7
+      ReservedConcurrentExecutions: 100
+
+  StateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: MyBasicStateMachine
+      Type: STANDARD
+      Definition:
+        Comment: A Hello World example of the Amazon States Language using Pass states
+        StartAt: Hello
+        States:
+          Hello:
+            Type: Pass
+            Result: Hello
+            Next: World
+          World:
+            Type: Task
+            Resource: !GetAtt MyFunction.Arn
+            TimeoutSeconds: !Ref MyTimeoutParameter
+            End: true
+      Policies:
+        - Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: lambda:InvokeFunction
+            Resource: !GetAtt MyFunction.Arn

--- a/tests/translator/input/state_machine_with_permissions_boundary.yaml
+++ b/tests/translator/input/state_machine_with_permissions_boundary.yaml
@@ -1,0 +1,39 @@
+Resources:
+  MyFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        CodeUri: s3://sam-demo-bucket/hello.zip
+        Handler: hello.handler
+        Runtime: python2.7
+        ReservedConcurrentExecutions: 100
+
+  StateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: MyStateMachine
+      Events:
+        ScheduleEvent:
+          Type: Schedule
+          Properties:
+            Schedule: "rate(1 minute)"
+            Name: TestSchedule
+        CWEvent:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              detail:
+                state:
+                  - terminated
+        MyApiEvent:
+          Type: Api
+          Properties:
+            Path: /startMyExecution
+            Method: post
+      DefinitionUri:
+        Bucket: sam-demo-bucket
+        Key: my-state-machine.asl.json
+        Version: 3
+      PermissionsBoundary: arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref MyFunction

--- a/tests/translator/output/aws-cn/state_machine_with_inline_definition_parameters_intrinsics.json
+++ b/tests/translator/output/aws-cn/state_machine_with_inline_definition_parameters_intrinsics.json
@@ -1,0 +1,163 @@
+{
+    "Resources": {
+      "MyFunction": {
+        "Type": "AWS::Lambda::Function", 
+        "Properties": {
+          "Code": {
+            "S3Bucket": "sam-demo-bucket", 
+            "S3Key": "hello.zip"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ], 
+          "ReservedConcurrentExecutions": 100, 
+          "Handler": "hello.handler", 
+          "Role": {
+            "Fn::GetAtt": [
+              "MyFunctionRole", 
+              "Arn"
+            ]
+          }, 
+          "Runtime": "python2.7"
+        }
+      }, 
+      "StateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Version": "2012-10-17", 
+                "Statement": [
+                  {
+                    "Action": "lambda:InvokeFunction", 
+                    "Resource": {
+                      "Fn::GetAtt": [
+                        "MyFunction", 
+                        "Arn"
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyFunctionRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "lambda.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [
+            "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ]
+        }
+      }, 
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n", 
+              [
+                "{", 
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
+                "    \"StartAt\": \"Hello\",", 
+                "    \"States\": {", 
+                "        \"Hello\": {", 
+                "            \"Next\": \"World\",", 
+                "            \"Result\": \"Hello\",", 
+                "            \"Type\": \"Pass\"", 
+                "        },", 
+                "        \"World\": {", 
+                "            \"End\": true,", 
+                "            \"Resource\": \"${definition_substitution_1}\",", 
+                "            \"TimeoutSeconds\": 500,", 
+                "            \"Type\": \"Task\"", 
+                "        }", 
+                "    }", 
+                "}"
+              ]
+            ]
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ], 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "StateMachineName": "MyBasicStateMachine", 
+          "DefinitionSubstitutions": {
+            "definition_substitution_1": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "StateMachineType": "STANDARD"
+        }
+      }
+    }, 
+    "Parameters": {
+      "MyTimeoutParameter": {
+        "Default": 500, 
+        "Type": "Number"
+      }
+    }
+  }

--- a/tests/translator/output/aws-cn/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/aws-cn/state_machine_with_permissions_boundary.json
@@ -1,0 +1,380 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "hello.zip"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ], 
+        "ReservedConcurrentExecutions": 100, 
+        "Handler": "hello.handler", 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "python2.7"
+      }
+    }, 
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine", 
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole", 
+            "Arn"
+          ]
+        }, 
+        "StateMachineName": "MyStateMachine", 
+        "DefinitionS3Location": {
+          "Version": 3, 
+          "Bucket": "sam-demo-bucket", 
+          "Key": "my-state-machine.asl.json"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment05bc9f394c"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment05bc9f394c": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+        "StageName": "Stage"
+      }
+    }, 
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        }, 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      }
+    }, 
+    "MyFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    }, 
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  }, 
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }, 
+                  "httpMethod": "POST", 
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  }, 
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole", 
+                      "Arn"
+                    ]
+                  }, 
+                  "type": "aws"
+                }, 
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }, 
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }, 
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [], 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      {
+                        "functionName": {
+                          "Ref": "MyFunction"
+                        }
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)", 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ], 
+        "Name": "TestSchedule"
+      }
+    }, 
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/state_machine_with_inline_definition_parameters_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_inline_definition_parameters_intrinsics.json
@@ -1,0 +1,163 @@
+{
+    "Resources": {
+      "MyFunction": {
+        "Type": "AWS::Lambda::Function", 
+        "Properties": {
+          "Code": {
+            "S3Bucket": "sam-demo-bucket", 
+            "S3Key": "hello.zip"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ], 
+          "ReservedConcurrentExecutions": 100, 
+          "Handler": "hello.handler", 
+          "Role": {
+            "Fn::GetAtt": [
+              "MyFunctionRole", 
+              "Arn"
+            ]
+          }, 
+          "Runtime": "python2.7"
+        }
+      }, 
+      "StateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Version": "2012-10-17", 
+                "Statement": [
+                  {
+                    "Action": "lambda:InvokeFunction", 
+                    "Resource": {
+                      "Fn::GetAtt": [
+                        "MyFunction", 
+                        "Arn"
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyFunctionRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "lambda.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [
+            "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ]
+        }
+      }, 
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n", 
+              [
+                "{", 
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
+                "    \"StartAt\": \"Hello\",", 
+                "    \"States\": {", 
+                "        \"Hello\": {", 
+                "            \"Next\": \"World\",", 
+                "            \"Result\": \"Hello\",", 
+                "            \"Type\": \"Pass\"", 
+                "        },", 
+                "        \"World\": {", 
+                "            \"End\": true,", 
+                "            \"Resource\": \"${definition_substitution_1}\",", 
+                "            \"TimeoutSeconds\": 500,", 
+                "            \"Type\": \"Task\"", 
+                "        }", 
+                "    }", 
+                "}"
+              ]
+            ]
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ], 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "StateMachineName": "MyBasicStateMachine", 
+          "DefinitionSubstitutions": {
+            "definition_substitution_1": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "StateMachineType": "STANDARD"
+        }
+      }
+    }, 
+    "Parameters": {
+      "MyTimeoutParameter": {
+        "Default": 500, 
+        "Type": "Number"
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_permissions_boundary.json
@@ -1,0 +1,380 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "hello.zip"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ], 
+        "ReservedConcurrentExecutions": 100, 
+        "Handler": "hello.handler", 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "python2.7"
+      }
+    }, 
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine", 
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole", 
+            "Arn"
+          ]
+        }, 
+        "StateMachineName": "MyStateMachine", 
+        "DefinitionS3Location": {
+          "Version": 3, 
+          "Bucket": "sam-demo-bucket", 
+          "Key": "my-state-machine.asl.json"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment05bc9f394c"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment05bc9f394c": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+        "StageName": "Stage"
+      }
+    }, 
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        }, 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      }
+    }, 
+    "MyFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    }, 
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  }, 
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }, 
+                  "httpMethod": "POST", 
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  }, 
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole", 
+                      "Arn"
+                    ]
+                  }, 
+                  "type": "aws"
+                }, 
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }, 
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }, 
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [], 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      {
+                        "functionName": {
+                          "Ref": "MyFunction"
+                        }
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)", 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ], 
+        "Name": "TestSchedule"
+      }
+    }, 
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/state_machine_with_inline_definition_parameters_intrinsics.json
+++ b/tests/translator/output/state_machine_with_inline_definition_parameters_intrinsics.json
@@ -1,0 +1,163 @@
+{
+    "Resources": {
+      "MyFunction": {
+        "Type": "AWS::Lambda::Function", 
+        "Properties": {
+          "Code": {
+            "S3Bucket": "sam-demo-bucket", 
+            "S3Key": "hello.zip"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ], 
+          "ReservedConcurrentExecutions": 100, 
+          "Handler": "hello.handler", 
+          "Role": {
+            "Fn::GetAtt": [
+              "MyFunctionRole", 
+              "Arn"
+            ]
+          }, 
+          "Runtime": "python2.7"
+        }
+      }, 
+      "StateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Version": "2012-10-17", 
+                "Statement": [
+                  {
+                    "Action": "lambda:InvokeFunction", 
+                    "Resource": {
+                      "Fn::GetAtt": [
+                        "MyFunction", 
+                        "Arn"
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyFunctionRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "lambda.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [
+            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ]
+        }
+      }, 
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n", 
+              [
+                "{", 
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
+                "    \"StartAt\": \"Hello\",", 
+                "    \"States\": {", 
+                "        \"Hello\": {", 
+                "            \"Next\": \"World\",", 
+                "            \"Result\": \"Hello\",", 
+                "            \"Type\": \"Pass\"", 
+                "        },", 
+                "        \"World\": {", 
+                "            \"End\": true,", 
+                "            \"Resource\": \"${definition_substitution_1}\",", 
+                "            \"TimeoutSeconds\": 500,", 
+                "            \"Type\": \"Task\"", 
+                "        }", 
+                "    }", 
+                "}"
+              ]
+            ]
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ], 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "StateMachineName": "MyBasicStateMachine", 
+          "DefinitionSubstitutions": {
+            "definition_substitution_1": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "StateMachineType": "STANDARD"
+        }
+      }
+    }, 
+    "Parameters": {
+      "MyTimeoutParameter": {
+        "Default": 500, 
+        "Type": "Number"
+      }
+    }
+  }

--- a/tests/translator/output/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/state_machine_with_permissions_boundary.json
@@ -1,0 +1,372 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "hello.zip"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ], 
+        "ReservedConcurrentExecutions": 100, 
+        "Handler": "hello.handler", 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "python2.7"
+      }
+    }, 
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine", 
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole", 
+            "Arn"
+          ]
+        }, 
+        "StateMachineName": "MyStateMachine", 
+        "DefinitionS3Location": {
+          "Version": 3, 
+          "Bucket": "sam-demo-bucket", 
+          "Key": "my-state-machine.asl.json"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment05bc9f394c"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment05bc9f394c": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+        "StageName": "Stage"
+      }
+    }, 
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        }, 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      }
+    }, 
+    "MyFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    }, 
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  }, 
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }, 
+                  "httpMethod": "POST", 
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  }, 
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole", 
+                      "Arn"
+                    ]
+                  }, 
+                  "type": "aws"
+                }, 
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }, 
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        }
+      }
+    }, 
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [], 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      {
+                        "functionName": {
+                          "Ref": "MyFunction"
+                        }
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)", 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ], 
+        "Name": "TestSchedule"
+      }
+    }, 
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -276,6 +276,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "api_with_usageplans_intrinsics",
                 "state_machine_with_inline_definition",
                 "state_machine_with_tags",
+                "state_machine_with_inline_definition_parameters_intrinsics",
                 "state_machine_with_inline_definition_intrinsics",
                 "state_machine_with_role",
                 "state_machine_with_inline_policies",

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -298,6 +298,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "state_machine_with_api_resource_policy",
                 "state_machine_with_api_auth_default_scopes",
                 "state_machine_with_condition_and_events",
+                "state_machine_with_permissions_boundary",
             ],
             [
                 ("aws", "ap-southeast-1"),


### PR DESCRIPTION
*Issue #, if available:* #1616 

*Description of changes:* Resolving parameter references provided in the State machine definition before further processing. This allows referencing non-string parameters within the state machine definition without issues.

*Description of how you validated changes:* Added test.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
