### PR TITLE
Additional policy templates

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1797,8 +1797,17 @@
                   "states:DescribeExecution",
                   "states:StopExecution"
               ],
-              "Resource": "*"
-          },
+              "Resource": {
+                "Fn::Sub": [
+                  "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${stateMachineName}:*",
+                  {
+                    "stateMachineName": {
+                      "Ref": "StateMachineName"
+                    }
+                  }
+                ]
+              }
+            },
           {
               "Effect": "Allow",
               "Action": [

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1703,6 +1703,41 @@
         ]
       }
     },
+    "SSMParameterWritePolicy": {
+      "Description": "Gives access to write values to a parameter in this account. If not using default key, KMSEncryptPolicy will also be needed.",
+      "Parameters": {
+        "ParameterName": {
+          "Description":"The name of the secret to be stored in SSM in your account."
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "ssm:DescribeParameters"
+            ],
+            "Resource": "*"
+          },
+          {
+            "Effect": "Allow",
+            "Action": [
+              "ssm:PutParameter",
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${parameterName}",
+                {
+                  "parameterName": {
+                    "Ref": "ParameterName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     "StepFunctionsExecutionPolicy": {
       "Description": "Gives permission to start a Step Functions state machine execution",
       "Parameters": {

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1722,7 +1722,7 @@
           {
             "Effect": "Allow",
             "Action": [
-              "ssm:PutParameter",
+              "ssm:PutParameter"
             ],
             "Resource": {
               "Fn::Sub": [

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1731,6 +1731,53 @@
         ]
       }
     },
+    "StepFunctionsSyncExecutionPolicy": {
+      "Description": "Gives permission to start a synchronous (.sync[:2]) Step Functions state machine execution",
+      "Parameters": {
+        "StateMachineName": {
+          "Description":"The name of the state machine to execute."
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "states:StartExecution"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
+                {
+                  "stateMachineName": {
+                    "Ref": "StateMachineName"
+                  }
+                }
+              ]
+            }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "states:DescribeExecution",
+                  "states:StopExecution"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "events:PutTargets",
+                  "events:PutRule",
+                  "events:DescribeRule"
+              ],
+              "Resource": [
+                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+              ]
+          }
+        ]
+      }
+    },
     "CodeCommitCrudPolicy": {
       "Description": "Gives permissions to create/read/update/delete objects within a specific codecommit repository",
       "Parameters": {


### PR DESCRIPTION
Add a _StepFunctionsSyncExecutionPolicy_ policy template for synchronous execution of Step Functions state machines.
Add a _SSMParameterWritePolicy_ policy template for putting AWS Systems Manager - Parameter Store parameters.

*Issue #, if available:*

#1621 
#1673 

*Description of changes:*

Created a _StepFunctionsSyncExecutionPolicy_ policy template for starting a synchronous ("Run a Job" or .sync[:2]) execution of a state machine.

Created a _SSMParameterWritePolicy_ policy template for creating or updating an SSM parameter.

*Description of how you validated changes:*

Automated tests

*Checklist:*

+ [x] Write/update tests
+ [x] `make pr` passes
+ [x] Update documentation
+ [x] Verify transformed template deploys and application functions as expected
+ [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
