### PR TITLE
Allow SQS pollers to get the queue url.

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -19,7 +19,7 @@
               "sqs:DeleteMessageBatch",
               "sqs:GetQueueAttributes",
               "sqs:ReceiveMessage",
-	      "sqs:GetQueueUrl"
+              "sqs:GetQueueUrl"
             ],
             "Resource": {
               "Fn::Sub": [

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -18,7 +18,8 @@
               "sqs:DeleteMessage",
               "sqs:DeleteMessageBatch",
               "sqs:GetQueueAttributes",
-              "sqs:ReceiveMessage"
+              "sqs:ReceiveMessage",
+	      "sqs:GetQueueUrl"
             ],
             "Resource": {
               "Fn::Sub": [


### PR DESCRIPTION
SQS pollers should be able to obtain the queue url from the queue message queue name in order to delete or change visibility.

Rather than use some kind of variable name or other method of lookup, a poller that can receive a message should be able to get the queue url to perform operations on it. Specifically [SQS.Client.delete_message](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Client.delete_message) which requires the QueueUrl.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
