### PR TITLE
feat: Allow Boto3 Session to be configured

### DIFF
--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -25,12 +25,13 @@ from samtranslator.plugins.globals.globals_plugin import GlobalsPlugin
 from samtranslator.plugins.policies.policy_templates_plugin import PolicyTemplatesForResourcePlugin
 from samtranslator.policy_template_processor.processor import PolicyTemplatesProcessor
 from samtranslator.sdk.parameter import SamParameterValues
+from samtranslator.translator.arn_generator import ArnGenerator
 
 
 class Translator:
     """Translates SAM templates into CloudFormation templates"""
 
-    def __init__(self, managed_policy_map, sam_parser, plugins=None):
+    def __init__(self, managed_policy_map, sam_parser, plugins=None, boto_session=None):
         """
         :param dict managed_policy_map: Map of managed policy names to the ARNs
         :param sam_parser: Instance of a SAM Parser
@@ -41,6 +42,9 @@ class Translator:
         self.plugins = plugins
         self.sam_parser = sam_parser
         self.feature_toggle = None
+        self.boto_session = boto_session
+
+        ArnGenerator.class_boto_session = self.boto_session
 
     def _get_function_names(self, resource_dict, intrinsics_resolver):
         """
@@ -92,7 +96,7 @@ class Translator:
         self.redeploy_restapi_parameters = dict()
         sam_parameter_values = SamParameterValues(parameter_values)
         sam_parameter_values.add_default_parameter_values(sam_template)
-        sam_parameter_values.add_pseudo_parameter_values()
+        sam_parameter_values.add_pseudo_parameter_values(self.boto_session)
         parameter_values = sam_parameter_values.parameter_values
         # Create & Install plugins
         sam_plugins = prepare_plugins(self.plugins, parameter_values)

--- a/tests/sdk/test_parameter.py
+++ b/tests/sdk/test_parameter.py
@@ -1,9 +1,10 @@
 from parameterized import parameterized, param
 
-import pytest
 from unittest import TestCase
 from samtranslator.sdk.parameter import SamParameterValues
-from mock import patch
+from mock import patch, Mock
+
+from samtranslator.translator.arn_generator import NoRegionFound
 
 
 class TestSAMParameterValues(TestCase):
@@ -101,3 +102,10 @@ class TestSAMParameterValues(TestCase):
         sam_parameter_values = SamParameterValues(parameter_values)
         sam_parameter_values.add_pseudo_parameter_values()
         self.assertEqual(expected, sam_parameter_values.parameter_values)
+
+    def test_add_pseduo_parameter_values_raises_NoRegionFound(self):
+        boto_session_mock = Mock()
+        boto_session_mock.region_name = None
+        sam_parameter_values = SamParameterValues({})
+        with self.assertRaises(NoRegionFound):
+            sam_parameter_values.add_pseudo_parameter_values(session=boto_session_mock)

--- a/tests/sdk/test_parameter.py
+++ b/tests/sdk/test_parameter.py
@@ -103,7 +103,7 @@ class TestSAMParameterValues(TestCase):
         sam_parameter_values.add_pseudo_parameter_values()
         self.assertEqual(expected, sam_parameter_values.parameter_values)
 
-    def test_add_pseduo_parameter_values_raises_NoRegionFound(self):
+    def test_add_pseudo_parameter_values_raises_NoRegionFound(self):
         boto_session_mock = Mock()
         boto_session_mock.region_name = None
         sam_parameter_values = SamParameterValues({})

--- a/tests/translator/test_arn_generator.py
+++ b/tests/translator/test_arn_generator.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from parameterized import parameterized
-from mock import Mock
+from mock import Mock, patch
 
 from samtranslator.translator.arn_generator import ArnGenerator, NoRegionFound
 
@@ -17,6 +17,7 @@ class TestArnGenerator(TestCase):
 
         self.assertEqual(actual, expected)
 
+    @patch("boto3.session.Session.region_name", None)
     def test_get_partition_name_raise_NoRegionFound(self):
         with self.assertRaises(NoRegionFound):
             ArnGenerator.get_partition_name(None)

--- a/tests/translator/test_arn_generator.py
+++ b/tests/translator/test_arn_generator.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+from parameterized import parameterized
+from mock import Mock
+
+from samtranslator.translator.arn_generator import ArnGenerator, NoRegionFound
+
+
+class TestArnGenerator(TestCase):
+    def setUp(self):
+        ArnGenerator.class_boto_session = None
+
+    @parameterized.expand(
+        [("us-east-1", "aws"), ("cn-east-1", "aws-cn"), ("us-gov-west-1", "aws-us-gov"), ("US-EAST-1", "aws")]
+    )
+    def test_get_partition_name(self, region, expected):
+        actual = ArnGenerator.get_partition_name(region)
+
+        self.assertEqual(actual, expected)
+
+    def test_get_partition_name_raise_NoRegionFound(self):
+        with self.assertRaises(NoRegionFound):
+            ArnGenerator.get_partition_name(None)
+
+    def test_get_partition_name_from_boto_session(self):
+        boto_session_mock = Mock()
+        boto_session_mock.region_name = "us-east-1"
+
+        ArnGenerator.class_boto_session = boto_session_mock
+
+        actual = ArnGenerator.get_partition_name()
+
+        self.assertEqual(actual, "aws")
+
+        ArnGenerator.class_boto_session = None


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-sam-cli/issues/442

*Description of changes:*
This is the first part in solving https://github.com/awslabs/aws-sam-cli/issues/442. Specifically, SAM uses boto to get a region and then pick the associated partition it lives within. This is mainly for two things (that I can tell):
1. Get the partition so it can be added to a generated arn in the generated template
2. Add pseudo values as Parameters so SAM can do some basic resolving. 

For the first, we shouldn't need to explicitly put the partition into the template anywhere but instead use the CloudFormation pseudo value when writing the template. I attempted to do this initially but required changing every single output.json test file we have and the pr started to really grow. So I would like to handle that outside of this PR and get the bug addressed in SAM CLI first, and then come back and see how we can do somethings better.

For the second, we still need to find the partition and since there is no way to do this in the sdk, basing it on the region is the way to go.

This change adds an optional parameter into the transform call (effectively the 'public' api to translate the template). This optional parameter is currently only used to get the region but one could image this would be something SAM might be able to use in the future to be able to create any AWS Clients through Boto.

This will help solve the above issue because currently SAM creates a new session and has no way to know what profile or region was passed into SAM CLI. Because of this, locally customers see command failures with stacktraces from SAM for cases that should work. If approved, I will update SAM CLI to pass in a Boto Session which will end up resolving the issue linked above.

*Description of how you validated changes:*
Added unit tests and since this is an optional parameter, it is backwards compatible.

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
