### PR TITLE
updating CodeDeploy lambda managed policy

### DIFF
--- a/tests/translator/model/preferences/test_deployment_preference_collection.py
+++ b/tests/translator/model/preferences/test_deployment_preference_collection.py
@@ -55,7 +55,7 @@ class TestDeploymentPreferenceCollection(TestCase):
             ],
         }
         expected_codedeploy_iam_role.ManagedPolicyArns = [
-            "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+            "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ]
 
         self.assertEqual(

--- a/tests/translator/output/aws-cn/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_custom_codedeploy_deployment_preference.json
@@ -348,7 +348,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-cn/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -65,7 +65,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-cn/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_and_custom_role.json
@@ -181,7 +181,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-cn/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference.json
@@ -118,7 +118,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_all_parameters.json
@@ -177,7 +177,8 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+          "arn:aws-cn:iam::aws:policy/AmazonSNSFullAccess"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_from_parameters.json
@@ -191,7 +191,8 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+          "arn:aws-cn:iam::aws:policy/AmazonSNSFullAccess"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations.json
@@ -314,7 +314,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-cn:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-us-gov/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_custom_codedeploy_deployment_preference.json
@@ -348,7 +348,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-us-gov/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -65,7 +65,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_and_custom_role.json
@@ -181,7 +181,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
@@ -118,7 +118,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_all_parameters.json
@@ -177,7 +177,8 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+          "arn:aws-us-gov:iam::aws:policy/AmazonSNSFullAccess"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_from_parameters.json
@@ -191,7 +191,8 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+          "arn:aws-us-gov:iam::aws:policy/AmazonSNSFullAccess"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations.json
@@ -314,7 +314,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/function_with_custom_codedeploy_deployment_preference.json
@@ -348,7 +348,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -65,7 +65,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/function_with_deployment_and_custom_role.json
@@ -181,7 +181,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/function_with_deployment_preference.json
+++ b/tests/translator/output/function_with_deployment_preference.json
@@ -118,7 +118,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/function_with_deployment_preference_all_parameters.json
@@ -177,7 +177,8 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+          "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/function_with_deployment_preference_from_parameters.json
@@ -191,7 +191,8 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+          "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/function_with_deployment_preference_multiple_combinations.json
@@ -314,7 +314,7 @@
       "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited"
         ], 
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The managed policy `AWSCodeDeployRoleForLambda` used for Lambda deployments has broad permissions, providing publish access to all SNS topics within the user's account.
This change replaces that with a new policy `AWSCodeDeployRoleForLambdaLimited` which removes those permissions.
To handle customers who may have triggers set up for SNS notifications on CodeDeploy, this change also attaches the `AmazonSNSFullAccess` managed policy when the deployment preferences include trigger configurations.

*Description of how you validated changes:*
- `make test` run passes.
- Used the translator to transform a SAM template to a CloudFormation template and then deployed the same (Using instructions in the Development Guide). Then tried a deployment with the newly created resources successfully.
- Also verified that only the `AWSCodeDeployRoleForLambdaLimited` policy is attached when the SAM template does not contain any Trigger Configurations. When it does contain Trigger Configurations, the `AmazonSNSFullAccess` managed policy is also attached.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
