### PR TITLE
fix: remove square bracket around referred ip lists

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -948,8 +948,8 @@ class SwaggerEditor(object):
         if not ip_list:
             return
 
-        if not isinstance(ip_list, list):
-            ip_list = [ip_list]
+        # if not isinstance(ip_list, list):
+        #     ip_list = [ip_list]
 
         if conditional not in ["IpAddress", "NotIpAddress"]:
             raise ValueError("Conditional must be one of {}".format(["IpAddress", "NotIpAddress"]))


### PR DESCRIPTION
*Issue #, if available:*
#1696 

*Description of changes:*
Removed the code for adding extra square bracket for reference ip list. Before making this change, customer will get sam deploy error when they try to refer a ip list from SSM in attribute IpRangeWhitelist. The deploy error is caused by we adding extra square bracket around a reference ip list.

*Description of how you validated changes:*
After making the change, I run the sam-translate.py transfer my test sam template to a cloud formation template and then manually deploy the cloud formation template, it works.
*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
