### PR TITLE
fix: adding support for passing target id to EventBridgeRule

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -150,6 +150,7 @@ class CloudWatchEvent(PushEventSource):
         "Pattern": PropertyType(False, is_type(dict)),
         "Input": PropertyType(False, is_str()),
         "InputPath": PropertyType(False, is_str()),
+        "Target": PropertyType(False, is_type(dict)),
     }
 
     def to_cloudformation(self, **kwargs):
@@ -187,7 +188,8 @@ class CloudWatchEvent(PushEventSource):
         :returns: the Target property
         :rtype: dict
         """
-        target = {"Arn": function.get_runtime_attr("arn"), "Id": self.logical_id + "LambdaTarget"}
+        target_id = self.Target["Id"] if self.Target and "Id" in self.Target else self.logical_id + "LambdaTarget"
+        target = {"Arn": function.get_runtime_attr("arn"), "Id": target_id}
         if self.Input is not None:
             target["Input"] = self.Input
 

--- a/tests/model/eventsources/test_cloudwatch_event_source.py
+++ b/tests/model/eventsources/test_cloudwatch_event_source.py
@@ -1,0 +1,24 @@
+from mock import Mock, patch
+from unittest import TestCase
+
+from samtranslator.model.eventsources.push import CloudWatchEvent
+from samtranslator.model.lambda_ import LambdaFunction
+
+
+class CloudWatchEventSourceTests(TestCase):
+    def setUp(self):
+        self.logical_id = "EventLogicalId"
+        self.func = LambdaFunction("func")
+
+    def test_target_id_when_not_provided(self):
+        cloudwatch_event_source = CloudWatchEvent(self.logical_id)
+        cfn = cloudwatch_event_source.to_cloudformation(function=self.func)
+        target_id = cfn[0].Targets[0]["Id"]
+        self.assertEqual(target_id, "{}{}".format(self.logical_id, "LambdaTarget"))
+
+    def test_target_id_when_provided(self):
+        cloudwatch_event_source = CloudWatchEvent(self.logical_id)
+        cloudwatch_event_source.Target = {"Id": "MyTargetId"}
+        cfn = cloudwatch_event_source.to_cloudformation(function=self.func)
+        target_id = cfn[0].Targets[0]["Id"]
+        self.assertEqual(target_id, "MyTargetId")


### PR DESCRIPTION
*Issue #, if available:*
#1742 
*Description of changes:*
Target#Id property in Event::Rule resource is a mandatory property[1]. We have an abstraction in SAM which generates TargetId based on LogicalId and a suffix. Issue is TargetId has a limit of 64 characters. So in case user have a long logical id there is no way for user to provide a shorter Target Id. This changes adds an option Target property which can be used to pass Id. If Target#Id is present then in that case we'll use that Id otherwise generate id as we are generating.

[1] https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_Target.html#eventbridge-Type-Target-Id
*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
