### PR TITLE
Manage black version using requirement file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# https://github.com/psf/black/blob/master/.pre-commit-config.yaml
+# https://pre-commit.com/#repository-local-hooks
 repos:
 - repo: local
   hooks:
@@ -6,5 +6,4 @@ repos:
       name: black
       entry: black
       language: system
-      require_serial: true
       types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,10 @@
+# https://github.com/psf/black/blob/master/.pre-commit-config.yaml
 repos:
-  - repo: https://github.com/python/black
-    rev: 19.3b0
-    hooks:
-      - id: black
-        language_version: python3.7
-        exclude_types: ['markdown', 'ini', 'toml', 'rst']
+- repo: local
+  hooks:
+    - id: black
+      name: black
+      entry: black
+      language: system
+      require_serial: true
+      types: [python]

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
 
 install:
 # Install the code requirements
-- mkdir $HOME/bin-black
-- wget -O $HOME/bin-black/black https://github.com/python/black/releases/download/19.10b0/black
-- chmod +x $HOME/bin-black/black
-- export PATH=$PATH:$HOME/bin-black
-- black --version
-
 - make init
 
 # Install Docs requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,6 @@ matrix:
 
 install:
 # Install the code requirements
-- >
-  if [ $TOXENV = py27 ]; then
-    mkdir $HOME/bin-black
-    # make sure we are using the same black version as in dev.txt
-    wget -O $HOME/bin-black/black https://github.com/python/black/releases/download/20.8b1/black
-    chmod +x $HOME/bin-black/black
-    export PATH=$PATH:$HOME/bin-black
-    black --version
-  fi
 - make init
 
 # Install Docs requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,15 @@ matrix:
 
 install:
 # Install the code requirements
+- >
+  if [ $TOXENV = py27 ]; then
+    mkdir $HOME/bin-black
+    # make sure we are using the same black version as in dev.txt
+    wget -O $HOME/bin-black/black https://github.com/python/black/releases/download/20.8b1/black
+    chmod +x $HOME/bin-black/black
+    export PATH=$PATH:$HOME/bin-black
+    black --version
+  fi
 - make init
 
 # Install Docs requirements

--- a/DEVELOPMENT_GUIDE.rst
+++ b/DEVELOPMENT_GUIDE.rst
@@ -49,7 +49,7 @@ instruction <https://black.readthedocs.io/en/stable/editor_integration.html>`__,
    (samtranslator37) $ where black
    /Users/<username>/.pyenv/shims/black
 
-However, IDEs such PyCharm (using FileWatcher) will have a hard time
+However, IDEs such as PyCharm (using FileWatcher) will have a hard time
 invoking ``/Users/<username>/.pyenv/shims/black`` and this will happen:
 
 ::

--- a/DEVELOPMENT_GUIDE.rst
+++ b/DEVELOPMENT_GUIDE.rst
@@ -28,16 +28,44 @@ Setup Python locally using `pyenv`_
 
 2. Install Additional Tooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. Black
-~~~~~~~~
+Black
+'''''
 We format our code using `Black`_ and verify the source code is black compliant
-in Appveyor during PRs. You can find installation instructions on `Black's docs`_.
+in Appveyor during PRs. Black will be installed automatically with ``make init``.
 
-After installing, you can check your formatting through our Makefile by running `make black-check`. To automatically update your code to match our formatting, please run `make black`. You can also integrate Black directly in your favorite IDE (instructions
-can be found `here`_)
+After installing, you can run our formatting through our Makefile by
+``make black`` or integrating Black directly in your favorite IDE
+(instructions can be found `here <https://black.readthedocs.io/en/stable/editor_integration.html>`__)
+
+(workaround) Integrating Black directly in your favorite IDE
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Since black is installed in virtualenv, when you follow `this
+instruction <https://black.readthedocs.io/en/stable/editor_integration.html>`__,
+``which black`` might give you this
+
+::
+
+   (samtranslator37) $ where black
+   /Users/<username>/.pyenv/shims/black
+
+However, IDEs such PyChaim (using FileWatcher) will have a hard time
+invoking ``/Users/<username>/.pyenv/shims/black`` and this will happen:
+
+::
+
+   pyenv: black: command not found
+
+   The `black' command exists in these Python versions:
+     3.7.2/envs/samtranslator37
+     samtranslator37
+
+A simple workaround is to use
+``/Users/<username>/.pyenv/versions/samtranslator37/bin/black`` instead of
+``/Users/<username>/.pyenv/shims/black``.
 
 Pre-commit
-~~~~~~~~~~
+''''''''''
 If you don't wish to manually run black on each pr or install black manually, we have integrated black into git hooks through `pre-commit`_.
 After installing pre-commit, run `pre-commit install` in the root of the project. This will install black for you and run the black formatting on
 commit.

--- a/DEVELOPMENT_GUIDE.rst
+++ b/DEVELOPMENT_GUIDE.rst
@@ -49,7 +49,7 @@ instruction <https://black.readthedocs.io/en/stable/editor_integration.html>`__,
    (samtranslator37) $ where black
    /Users/<username>/.pyenv/shims/black
 
-However, IDEs such PyChaim (using FileWatcher) will have a hard time
+However, IDEs such PyCharm (using FileWatcher) will have a hard time
 invoking ``/Users/<username>/.pyenv/shims/black`` and this will happen:
 
 ::

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ dev: test
 # Verifications to run before sending a pull request
 pr: black-check init dev
 
+# Verifications to run before sending a pull request, skipping black check because black requires Python 3.6+
+pr2.7: init dev
+
 define HELP_MESSAGE
 
 Usage: $ make [TARGETS]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,3 +15,6 @@ requests>=2.20.0
 
 # CLI requirements
 docopt>=0.6.2
+
+# formatter
+black==20.8b1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,4 +17,4 @@ requests>=2.20.0
 docopt>=0.6.2
 
 # formatter
-black==20.8b1
+black==20.8b1; python_version >= '3.6'

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -355,8 +355,7 @@ class ResourceMacro(Resource):
 
 
 class SamResourceMacro(ResourceMacro):
-    """ResourceMacro that specifically refers to SAM (AWS::Serverless::*) resources.
-    """
+    """ResourceMacro that specifically refers to SAM (AWS::Serverless::*) resources."""
 
     # SAM resources can provide a list of properties that they expose. These properties usually resolve to
     # CFN resources that this SAM resource generates. This is provided as a map with the following format:

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -216,7 +216,8 @@ class HttpApiGenerator(object):
             self.domain["EndpointConfiguration"] = "REGIONAL"
         elif endpoint not in ["REGIONAL"]:
             raise InvalidResourceException(
-                self.logical_id, "EndpointConfiguration for Custom Domains must be one of {}.".format(["REGIONAL"]),
+                self.logical_id,
+                "EndpointConfiguration for Custom Domains must be one of {}.".format(["REGIONAL"]),
             )
         domain_config["EndpointType"] = endpoint
         domain_config["CertificateArn"] = self.domain.get("CertificateArn")
@@ -352,7 +353,8 @@ class HttpApiGenerator(object):
             alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")
         else:
             raise InvalidResourceException(
-                self.logical_id, "Only REGIONAL endpoint is supported on HTTP APIs.",
+                self.logical_id,
+                "Only REGIONAL endpoint is supported on HTTP APIs.",
             )
         return alias_target
 

--- a/samtranslator/model/iam.py
+++ b/samtranslator/model/iam.py
@@ -23,7 +23,11 @@ class IAMRolePolicies:
         document = {
             "Version": "2012-10-17",
             "Statement": [
-                {"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"Service": [service_principal]},}
+                {
+                    "Action": ["sts:AssumeRole"],
+                    "Effect": "Allow",
+                    "Principal": {"Service": [service_principal]},
+                }
             ],
         }
         return document
@@ -43,7 +47,11 @@ class IAMRolePolicies:
         document = {
             "Version": "2012-10-17",
             "Statement": [
-                {"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"Service": ["states.amazonaws.com"]},}
+                {
+                    "Action": ["sts:AssumeRole"],
+                    "Effect": "Allow",
+                    "Principal": {"Service": ["states.amazonaws.com"]},
+                }
             ],
         }
         return document

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -99,8 +99,7 @@ class LambdaEventInvokeConfig(Resource):
 
 
 class LambdaLayerVersion(Resource):
-    """ Lambda layer version resource
-    """
+    """Lambda layer version resource"""
 
     resource_type = "AWS::Lambda::LayerVersion"
     property_types = {

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -49,8 +49,7 @@ from samtranslator.model.role_utils import construct_role_for_resource
 
 
 class SamFunction(SamResourceMacro):
-    """SAM function macro.
-    """
+    """SAM function macro."""
 
     resource_type = "AWS::Serverless::Function"
     property_types = {
@@ -697,8 +696,7 @@ class SamFunction(SamResourceMacro):
 
 
 class SamApi(SamResourceMacro):
-    """SAM rest API macro.
-    """
+    """SAM rest API macro."""
 
     resource_type = "AWS::Serverless::Api"
     property_types = {
@@ -810,8 +808,7 @@ class SamApi(SamResourceMacro):
 
 
 class SamHttpApi(SamResourceMacro):
-    """SAM rest API macro.
-    """
+    """SAM rest API macro."""
 
     resource_type = "AWS::Serverless::HttpApi"
     property_types = {
@@ -876,7 +873,13 @@ class SamHttpApi(SamResourceMacro):
             disable_execute_api_endpoint=self.DisableExecuteApiEndpoint,
         )
 
-        (http_api, stage, domain, basepath_mapping, route53,) = api_generator.to_cloudformation()
+        (
+            http_api,
+            stage,
+            domain,
+            basepath_mapping,
+            route53,
+        ) = api_generator.to_cloudformation()
 
         resources.append(http_api)
         if domain:
@@ -894,8 +897,7 @@ class SamHttpApi(SamResourceMacro):
 
 
 class SamSimpleTable(SamResourceMacro):
-    """SAM simple table macro.
-    """
+    """SAM simple table macro."""
 
     resource_type = "AWS::Serverless::SimpleTable"
     property_types = {
@@ -954,8 +956,7 @@ class SamSimpleTable(SamResourceMacro):
 
 
 class SamApplication(SamResourceMacro):
-    """SAM application macro.
-    """
+    """SAM application macro."""
 
     APPLICATION_ID_KEY = "ApplicationId"
     SEMANTIC_VERSION_KEY = "SemanticVersion"
@@ -973,14 +974,12 @@ class SamApplication(SamResourceMacro):
     }
 
     def to_cloudformation(self, **kwargs):
-        """Returns the stack with the proper parameters for this application
-        """
+        """Returns the stack with the proper parameters for this application"""
         nested_stack = self._construct_nested_stack()
         return [nested_stack]
 
     def _construct_nested_stack(self):
-        """Constructs a AWS::CloudFormation::Stack resource
-        """
+        """Constructs a AWS::CloudFormation::Stack resource"""
         nested_stack = NestedStack(
             self.logical_id, depends_on=self.depends_on, attributes=self.get_passthrough_resource_attributes()
         )
@@ -994,8 +993,7 @@ class SamApplication(SamResourceMacro):
         return nested_stack
 
     def _get_application_tags(self):
-        """Adds tags to the stack if this resource is using the serverless app repo
-        """
+        """Adds tags to the stack if this resource is using the serverless app repo"""
         application_tags = {}
         if isinstance(self.Location, dict):
             if self.APPLICATION_ID_KEY in self.Location.keys() and self.Location[self.APPLICATION_ID_KEY] is not None:
@@ -1009,8 +1007,7 @@ class SamApplication(SamResourceMacro):
 
 
 class SamLayerVersion(SamResourceMacro):
-    """ SAM Layer macro
-    """
+    """SAM Layer macro"""
 
     resource_type = "AWS::Serverless::LayerVersion"
     property_types = {
@@ -1108,8 +1105,7 @@ class SamLayerVersion(SamResourceMacro):
 
 
 class SamStateMachine(SamResourceMacro):
-    """SAM state machine macro.
-    """
+    """SAM state machine macro."""
 
     resource_type = "AWS::Serverless::StateMachine"
     property_types = {
@@ -1125,7 +1121,9 @@ class SamStateMachine(SamResourceMacro):
         "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),
         "Tracing": PropertyType(False, is_type(dict)),
     }
-    event_resolver = ResourceTypeResolver(samtranslator.model.stepfunctions.events,)
+    event_resolver = ResourceTypeResolver(
+        samtranslator.model.stepfunctions.events,
+    )
 
     def to_cloudformation(self, **kwargs):
         managed_policy_map = kwargs.get("managed_policy_map", {})

--- a/samtranslator/parser/parser.py
+++ b/samtranslator/parser/parser.py
@@ -14,7 +14,7 @@ class Parser:
 
     # private methods
     def _validate(self, sam_template, parameter_values):
-        """ Validates the template and parameter values and raises exceptions if there's an issue
+        """Validates the template and parameter values and raises exceptions if there's an issue
 
         :param dict sam_template: SAM template
         :param dict parameter_values: Dictionary of parameter values provided by the user

--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -294,9 +294,11 @@ class ServerlessAppPlugin(BasePlugin):
 
                 # Check each resource to make sure it's active
                 for application_id, template_id in temp:
-                    get_cfn_template = lambda application_id, template_id: self._sar_client.get_cloud_formation_template(
-                        ApplicationId=self._sanitize_sar_str_param(application_id),
-                        TemplateId=self._sanitize_sar_str_param(template_id),
+                    get_cfn_template = (
+                        lambda application_id, template_id: self._sar_client.get_cloud_formation_template(
+                            ApplicationId=self._sanitize_sar_str_param(application_id),
+                            TemplateId=self._sanitize_sar_str_param(template_id),
+                        )
                     )
                     response = self._sar_service_call(get_cfn_template, application_id, application_id, template_id)
                     self._handle_get_cfn_template_response(response, application_id, template_id)

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -208,7 +208,13 @@ class SwaggerEditor(object):
             path_dict[method] = make_conditional(condition, path_dict[method])
 
     def add_state_machine_integration(
-        self, path, method, integration_uri, credentials, request_templates=None, condition=None,
+        self,
+        path,
+        method,
+        integration_uri,
+        credentials,
+        request_templates=None,
+        condition=None,
     ):
         """
         Adds aws APIGW integration to the given path+method.

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -28,8 +28,7 @@ from samtranslator.sdk.parameter import SamParameterValues
 
 
 class Translator:
-    """Translates SAM templates into CloudFormation templates
-    """
+    """Translates SAM templates into CloudFormation templates"""
 
     def __init__(self, managed_policy_map, sam_parser, plugins=None):
         """

--- a/tests/model/test_api_v2.py
+++ b/tests/model/test_api_v2.py
@@ -47,13 +47,16 @@ class TestApiGatewayV2Authorizer(TestCase):
                 authorization_scopes="invalid_scope",
             )
         self.assertEqual(
-            e.value.message, "Resource with id [logicalId] is invalid. " + "AuthorizationScopes must be a list.",
+            e.value.message,
+            "Resource with id [logicalId] is invalid. " + "AuthorizationScopes must be a list.",
         )
 
     def test_create_authorizer_fails_with_authorization_scopes_non_oauth2(self):
         with pytest.raises(InvalidResourceException) as e:
             ApiGatewayV2Authorizer(
-                api_logical_id="logicalId", name="authName", authorization_scopes=["scope1", "scope2"],
+                api_logical_id="logicalId",
+                name="authName",
+                authorization_scopes=["scope1", "scope2"],
             )
         self.assertEqual(
             e.value.message,
@@ -67,7 +70,9 @@ class TestApiGatewayV2Authorizer(TestCase):
     def test_create_authorizer_fails_with_jtw_configuration_non_oauth2(self):
         with pytest.raises(InvalidResourceException) as e:
             ApiGatewayV2Authorizer(
-                api_logical_id="logicalId", name="authName", jwt_configuration={"config": "value"},
+                api_logical_id="logicalId",
+                name="authName",
+                jwt_configuration={"config": "value"},
             )
         self.assertEqual(
             e.value.message,
@@ -78,7 +83,9 @@ class TestApiGatewayV2Authorizer(TestCase):
     def test_create_authorizer_fails_with_id_source_non_oauth2(self):
         with pytest.raises(InvalidResourceException) as e:
             ApiGatewayV2Authorizer(
-                api_logical_id="logicalId", name="authName", id_source="https://example.com",
+                api_logical_id="logicalId",
+                name="authName",
+                id_source="https://example.com",
             )
         self.assertEqual(
             e.value.message,
@@ -180,7 +187,8 @@ class TestApiGatewayV2Authorizer(TestCase):
     def test_create_lambda_auth_no_function_arn(self):
         with pytest.raises(InvalidResourceException) as e:
             ApiGatewayV2Authorizer(
-                api_logical_id="logicalId", name="lambdaAuth",
+                api_logical_id="logicalId",
+                name="lambdaAuth",
             )
         self.assertEqual(
             e.value.message,
@@ -190,7 +198,9 @@ class TestApiGatewayV2Authorizer(TestCase):
     def test_create_lambda_auth_no_authorizer_payload_format_version(self):
         with pytest.raises(InvalidResourceException) as e:
             ApiGatewayV2Authorizer(
-                api_logical_id="logicalId", name="lambdaAuth", function_arn="lambdaArn",
+                api_logical_id="logicalId",
+                name="lambdaAuth",
+                function_arn="lambdaArn",
             )
         self.assertEqual(
             e.value.message,

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -1168,7 +1168,12 @@ class TestSwaggerEditor_add_resource_policy(TestCase):
                         {"Fn::Sub": ["execute-api:/${__Stage__}/GET/foo", {"__Stage__": "prod"}]},
                     ],
                     "Effect": "Deny",
-                    "Condition": {"StringNotEquals": {"aws:SourceVpc": ["vpc-123"], "aws:SourceVpce": ["vpce-345"],}},
+                    "Condition": {
+                        "StringNotEquals": {
+                            "aws:SourceVpc": ["vpc-123"],
+                            "aws:SourceVpce": ["vpce-345"],
+                        }
+                    },
                     "Principal": "*",
                 },
             ],

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -101,8 +101,7 @@ class TestResourceAttributes(TestCase):
         property_types = {}
 
     def test_to_dict(self):
-        """Tests if resource attributes are correctly set and converted to dictionary
-        """
+        """Tests if resource attributes are correctly set and converted to dictionary"""
 
         empty_resource_dict = {"id": {"Type": "foo", "Properties": {}}}
         dict_with_attributes = {

--- a/tests/translator/test_function_resources.py
+++ b/tests/translator/test_function_resources.py
@@ -550,8 +550,10 @@ class TestVersionsAndAliases(TestCase):
     def test_get_resolved_alias_name_must_error_if_intrinsics_are_not_resolved(self):
 
         property_name = "something"
-        expected_exception_msg = "Resource with id [{}] is invalid. '{}' must be a string or a Ref to a template parameter".format(
-            self.sam_func.logical_id, property_name
+        expected_exception_msg = (
+            "Resource with id [{}] is invalid. '{}' must be a string or a Ref to a template parameter".format(
+                self.sam_func.logical_id, property_name
+            )
         )
 
         alias_value = {"Ref": "param1"}
@@ -567,8 +569,10 @@ class TestVersionsAndAliases(TestCase):
     def test_get_resolved_alias_name_must_error_if_intrinsics_are_not_resolved_with_list(self):
 
         property_name = "something"
-        expected_exception_msg = "Resource with id [{}] is invalid. '{}' must be a string or a Ref to a template parameter".format(
-            self.sam_func.logical_id, property_name
+        expected_exception_msg = (
+            "Resource with id [{}] is invalid. '{}' must be a string or a Ref to a template parameter".format(
+                self.sam_func.logical_id, property_name
+            )
         )
 
         alias_value = ["Ref", "param1"]

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ envlist = py27, py36, py37, py38
 # specifically for Py27 in Tox.
 passenv = AWS*
 setenv = PYTHONHASHSEED = 0
+commands = make pr2.7
+           codecov
 
 [testenv]
 commands = make pr


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

update black version to 20.8b1 and make it managed by requirement dev.txt.

This change is a counterpart of https://github.com/aws/aws-sam-cli/pull/2314 

**Note: Since black does not support Python 2.7, nor the later black releases contains a binary artifact, I turned off black check for Python 2.7.** (https://github.com/psf/black/issues/1669)

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
