### PR TITLE
chore: Use Compatible release clause in requirement files

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 pyrsistent~=0.16.0; python_version<"3"
-boto3~=1.5
+boto3~=1.15.16
 enum34~=1.1; python_version<"3.4"
 jsonschema~=3.2
 six~=1.15

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,21 +1,21 @@
-coverage>=5.3
-flake8>=3.8.4
-tox>=3.20.1
-pytest-cov>=2.10.1
+coverage~=5.3
+flake8~=3.8.4
+tox~=3.20.1
+pytest-cov~=2.10.1
 pylint>=1.7.2,<2.0
-pyyaml>=5.3.1
+pyyaml~=5.3.1
 
 # Test requirements
-pytest>=6.1.1; python_version >= '3.6'
+pytest~=6.1.1; python_version >= '3.6'
 pytest~=4.6.11; python_version < '3.6' # pytest dropped python 2 support after 4.6.x
 mock>=3.0.5,<4.0.0  # 4.0.0 drops Python 2 support
-parameterized>=0.7.4
+parameterized~=0.7.4
 
 # Requirements for examples
-requests>=2.24.0
+requests~=2.24.0
 
 # CLI requirements
-docopt>=0.6.2
+docopt~=0.6.2
 
 # formatter
 black==20.8b1; python_version >= '3.6'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`>=` usage was introduced to SAM more than 2 years ago (67826f2a396c725d89d10637cdddeae41f6fee4d) and we have been using it ever since.
`>=` can be breaking if our one of our dependencies has a breaking major/minor release. It is safer to manage upgrade ourselves with exception of patch version releases. Using `~=` ([Compatible release clause](https://www.python.org/dev/peps/pep-0440/#compatible-release)) can maintain compatibility as much as possible without losing access to security patches.

*Description of how you validated changes:*

Checked with `pip freeze` of existing `develop` to ensure they are the versions we are using:
```
(samtranslator37) ~/P/serverless-application-model ❯❯❯ pip freeze
appdirs==1.4.4
astroid==1.6.6
attrs==20.2.0
-e git+git@github.com:aahung/serverless-application-model.git@bd823f1a395ccb3549d151925e92a4dd542666f3#egg=aws_sam_translator
black==20.8b1
boto3==1.15.16
botocore==1.18.16
certifi==2020.6.20
chardet==3.0.4
click==7.1.2
coverage==5.3
distlib==0.3.1
docopt==0.6.2
filelock==3.0.12
flake8==3.8.4
idna==2.10
importlib-metadata==2.0.0
iniconfig==1.1.1
isort==5.6.4
jmespath==0.10.0
jsonschema==3.2.0
lazy-object-proxy==1.4.3
mccabe==0.6.1
mock==3.0.5
mypy-extensions==0.4.3
packaging==20.4
parameterized==0.7.4
pathspec==0.8.0
pluggy==0.13.1
py==1.9.0
pycodestyle==2.6.0
pyflakes==2.2.0
pylint==1.9.4
pyparsing==2.4.7
pyrsistent==0.17.3
pytest==6.1.1
pytest-cov==2.10.1
python-dateutil==2.8.1
PyYAML==5.3.1
regex==2020.10.15
requests==2.24.0
s3transfer==0.3.3
six==1.15.0
toml==0.10.1
tox==3.20.1
typed-ast==1.4.1
typing-extensions==3.7.4.3
urllib3==1.25.10
virtualenv==20.0.35
wrapt==1.12.1
zipp==3.3.0
```

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
