### PR TITLE
fix: use newer policy name in gov & cn regions for xray

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -443,7 +443,14 @@ class SamFunction(SamResourceMacro):
 
         managed_policy_arns = [ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaBasicExecutionRole")]
         if self.Tracing:
-            managed_policy_arns.append(ArnGenerator.generate_aws_managed_policy_arn("AWSXrayWriteOnlyAccess"))
+            # use previous (old) policy name for regular regions
+            # for china and gov regions, use the newer policy name
+            partition_name = ArnGenerator.get_partition_name()
+            if partition_name == "aws":
+                managed_policy_name = "AWSXrayWriteOnlyAccess"
+            else:
+                managed_policy_name = "AWSXRayDaemonWriteAccess"
+            managed_policy_arns.append(ArnGenerator.generate_aws_managed_policy_arn(managed_policy_name))
         if self.VpcConfig:
             managed_policy_arns.append(
                 ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaVPCAccessExecutionRole")

--- a/tests/translator/output/aws-cn/basic_function.json
+++ b/tests/translator/output/aws-cn/basic_function.json
@@ -303,7 +303,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess"
         ],
         "Tags": [
           {
@@ -334,7 +334,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess"
         ],
         "Tags": [
           {

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -5,7 +5,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess",
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ],
         "Tags": [
@@ -107,7 +107,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess",
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ],
         "Tags": [

--- a/tests/translator/output/aws-us-gov/basic_function.json
+++ b/tests/translator/output/aws-us-gov/basic_function.json
@@ -303,7 +303,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess"
         ],
         "Tags": [
           {
@@ -334,7 +334,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess"
         ],
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -5,7 +5,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess",
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/OverridePermissionsBoundary",
@@ -107,7 +107,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess",
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",


### PR DESCRIPTION
*Description of changes:*
Previously used `AWSXrayWriteOnlyAccess` policy name is deprecated and not available in gov & cn regions. With this change we are going to assign newer policy name (`AWSXRayDaemonWriteAccess `) for those regions.

*Description of how you validated changes:*
Updated unit tests and validated different region has different policy names.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
