### PR TITLE
Adding PermissionsBoundary property for State Machine resource

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1120,6 +1120,7 @@ class SamStateMachine(SamResourceMacro):
         "Tags": PropertyType(False, is_type(dict)),
         "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),
         "Tracing": PropertyType(False, is_type(dict)),
+        "PermissionsBoundary": PropertyType(False, is_str()),
     }
     event_resolver = ResourceTypeResolver(
         samtranslator.model.stepfunctions.events,
@@ -1140,6 +1141,7 @@ class SamStateMachine(SamResourceMacro):
             logging=self.Logging,
             name=self.Name,
             policies=self.Policies,
+            permissions_boundary=self.PermissionsBoundary,
             definition_substitutions=self.DefinitionSubstitutions,
             role=self.Role,
             state_machine_type=self.Type,

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -42,7 +42,7 @@ class EventSource(ResourceMacro):
             logical_id = generator.gen()
         return logical_id
 
-    def _construct_role(self, resource, prefix=None, suffix=""):
+    def _construct_role(self, resource, permissions_boundary=None, prefix=None, suffix=""):
         """Constructs the IAM Role resource allowing the event service to invoke
         the StartExecution API of the state machine resource it is associated with.
 
@@ -62,6 +62,9 @@ class EventSource(ResourceMacro):
         event_role.Policies = [
             IAMRolePolicies.step_functions_start_execution_role_policy(state_machine_arn, role_logical_id)
         ]
+
+        if permissions_boundary:
+            event_role.PermissionsBoundary = permissions_boundary
 
         return event_role
 
@@ -88,6 +91,8 @@ class Schedule(EventSource):
         """
         resources = []
 
+        permissions_boundary = kwargs.get("permissions_boundary")
+
         events_rule = EventsRule(self.logical_id)
         resources.append(events_rule)
 
@@ -99,7 +104,7 @@ class Schedule(EventSource):
         if CONDITION in resource.resource_attributes:
             events_rule.set_resource_attribute(CONDITION, resource.resource_attributes[CONDITION])
 
-        role = self._construct_role(resource)
+        role = self._construct_role(resource, permissions_boundary)
         resources.append(role)
         events_rule.Targets = [self._construct_target(resource, role)]
 
@@ -144,6 +149,8 @@ class CloudWatchEvent(EventSource):
         """
         resources = []
 
+        permissions_boundary = kwargs.get("permissions_boundary")
+
         events_rule = EventsRule(self.logical_id)
         events_rule.EventBusName = self.EventBusName
         events_rule.EventPattern = self.Pattern
@@ -152,7 +159,7 @@ class CloudWatchEvent(EventSource):
 
         resources.append(events_rule)
 
-        role = self._construct_role(resource)
+        role = self._construct_role(resource, permissions_boundary)
         resources.append(role)
         events_rule.Targets = [self._construct_target(resource, role)]
 
@@ -243,9 +250,9 @@ class Api(EventSource):
         return {"explicit_api": explicit_api, "explicit_api_stage": {"suffix": stage_suffix}}
 
     def to_cloudformation(self, resource, **kwargs):
-        """If the Api event source has a RestApi property, then simply return the IAM role resource 
-        allowing API Gateway to start the state machine execution. If no RestApi is provided, then 
-        additionally inject the path, method, and the x-amazon-apigateway-integration into the 
+        """If the Api event source has a RestApi property, then simply return the IAM role resource
+        allowing API Gateway to start the state machine execution. If no RestApi is provided, then
+        additionally inject the path, method, and the x-amazon-apigateway-integration into the
         Swagger body for a provided implicit API.
 
         :param model.stepfunctions.resources.StepFunctionsStateMachine resource; the state machine \
@@ -259,12 +266,13 @@ class Api(EventSource):
         resources = []
 
         intrinsics_resolver = kwargs.get("intrinsics_resolver")
+        permissions_boundary = kwargs.get("permissions_boundary")
 
         if self.Method is not None:
             # Convert to lower case so that user can specify either GET or get
             self.Method = self.Method.lower()
 
-        role = self._construct_role(resource)
+        role = self._construct_role(resource, permissions_boundary)
         resources.append(role)
 
         explicit_api = kwargs["explicit_api"]

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -47,6 +47,7 @@ class EventSource(ResourceMacro):
         the StartExecution API of the state machine resource it is associated with.
 
         :param model.stepfunctions.StepFunctionsStateMachine resource: The state machine resource associated with the event
+        :param string permissions_boundary: The ARN of the policy used to set the permissions boundary for the role
         :param string prefix: Prefix to use for the logical ID of the IAM role
         :param string suffix: Suffix to add for the logical ID of the IAM role
 

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -61,6 +61,7 @@ class StateMachineGenerator(object):
         :param logging: Logging configuration for the State Machine
         :param name: Name of the State Machine resource
         :param policies: Policies attached to the execution role
+        :param permissions_boundary: The ARN of the policy used to set the permissions boundary for the role
         :param definition_substitutions: Variable-to-value mappings to be replaced in the State Machine definition
         :param role: Role ARN to use for the execution role
         :param state_machine_type: Type of the State Machine

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -37,6 +37,7 @@ class StateMachineGenerator(object):
         logging,
         name,
         policies,
+        permissions_boundary,
         definition_substitutions,
         role,
         state_machine_type,
@@ -82,6 +83,7 @@ class StateMachineGenerator(object):
         self.name = name
         self.logging = logging
         self.policies = policies
+        self.permissions_boundary = permissions_boundary
         self.definition_substitutions = definition_substitutions
         self.role = role
         self.type = state_machine_type
@@ -220,6 +222,7 @@ class StateMachineGenerator(object):
             assume_role_policy_document=IAMRolePolicies.stepfunctions_assume_role_policy(),
             resource_policies=state_machine_policies,
             tags=self._construct_tag_list(),
+            permissions_boundary=self.permissions_boundary,
         )
         return execution_role
 
@@ -242,7 +245,10 @@ class StateMachineGenerator(object):
         resources = []
         if self.events:
             for logical_id, event_dict in self.events.items():
-                kwargs = {"intrinsics_resolver": self.intrinsics_resolver}
+                kwargs = {
+                    "intrinsics_resolver": self.intrinsics_resolver,
+                    "permissions_boundary": self.permissions_boundary,
+                }
                 try:
                     eventsource = self.event_resolver.resolve_resource_type(event_dict).from_dict(
                         self.state_machine.logical_id + logical_id, event_dict, logical_id

--- a/tests/model/stepfunctions/test_state_machine_generator.py
+++ b/tests/model/stepfunctions/test_state_machine_generator.py
@@ -19,6 +19,7 @@ class StepFunctionsStateMachine(TestCase):
             "logging": None,
             "name": None,
             "policies": None,
+            "permissions_boundary": None,
             "definition_substitutions": None,
             "role": None,
             "state_machine_type": None,

--- a/tests/translator/input/state_machine_with_permissions_boundary.yaml
+++ b/tests/translator/input/state_machine_with_permissions_boundary.yaml
@@ -1,0 +1,39 @@
+Resources:
+  MyFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        CodeUri: s3://sam-demo-bucket/hello.zip
+        Handler: hello.handler
+        Runtime: python2.7
+        ReservedConcurrentExecutions: 100
+
+  StateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: MyStateMachine
+      Events:
+        ScheduleEvent:
+          Type: Schedule
+          Properties:
+            Schedule: "rate(1 minute)"
+            Name: TestSchedule
+        CWEvent:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              detail:
+                state:
+                  - terminated
+        MyApiEvent:
+          Type: Api
+          Properties:
+            Path: /startMyExecution
+            Method: post
+      DefinitionUri:
+        Bucket: sam-demo-bucket
+        Key: my-state-machine.asl.json
+        Version: 3
+      PermissionsBoundary: arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref MyFunction

--- a/tests/translator/output/aws-cn/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/aws-cn/state_machine_with_permissions_boundary.json
@@ -1,0 +1,380 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "hello.zip"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ], 
+        "ReservedConcurrentExecutions": 100, 
+        "Handler": "hello.handler", 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "python2.7"
+      }
+    }, 
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine", 
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole", 
+            "Arn"
+          ]
+        }, 
+        "StateMachineName": "MyStateMachine", 
+        "DefinitionS3Location": {
+          "Version": 3, 
+          "Bucket": "sam-demo-bucket", 
+          "Key": "my-state-machine.asl.json"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment05bc9f394c"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment05bc9f394c": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+        "StageName": "Stage"
+      }
+    }, 
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        }, 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      }
+    }, 
+    "MyFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    }, 
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  }, 
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }, 
+                  "httpMethod": "POST", 
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  }, 
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole", 
+                      "Arn"
+                    ]
+                  }, 
+                  "type": "aws"
+                }, 
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }, 
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }, 
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [], 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      {
+                        "functionName": {
+                          "Ref": "MyFunction"
+                        }
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)", 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ], 
+        "Name": "TestSchedule"
+      }
+    }, 
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_permissions_boundary.json
@@ -1,0 +1,380 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "hello.zip"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ], 
+        "ReservedConcurrentExecutions": 100, 
+        "Handler": "hello.handler", 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "python2.7"
+      }
+    }, 
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine", 
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole", 
+            "Arn"
+          ]
+        }, 
+        "StateMachineName": "MyStateMachine", 
+        "DefinitionS3Location": {
+          "Version": 3, 
+          "Bucket": "sam-demo-bucket", 
+          "Key": "my-state-machine.asl.json"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment05bc9f394c"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment05bc9f394c": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+        "StageName": "Stage"
+      }
+    }, 
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        }, 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      }
+    }, 
+    "MyFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    }, 
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  }, 
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }, 
+                  "httpMethod": "POST", 
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  }, 
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole", 
+                      "Arn"
+                    ]
+                  }, 
+                  "type": "aws"
+                }, 
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }, 
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }, 
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [], 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      {
+                        "functionName": {
+                          "Ref": "MyFunction"
+                        }
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)", 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ], 
+        "Name": "TestSchedule"
+      }
+    }, 
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/state_machine_with_permissions_boundary.json
@@ -1,0 +1,372 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "hello.zip"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ], 
+        "ReservedConcurrentExecutions": 100, 
+        "Handler": "hello.handler", 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "python2.7"
+      }
+    }, 
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine", 
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole", 
+            "Arn"
+          ]
+        }, 
+        "StateMachineName": "MyStateMachine", 
+        "DefinitionS3Location": {
+          "Version": 3, 
+          "Bucket": "sam-demo-bucket", 
+          "Key": "my-state-machine.asl.json"
+        }, 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment05bc9f394c"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment05bc9f394c": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+        "StageName": "Stage"
+      }
+    }, 
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        }, 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      }
+    }, 
+    "MyFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    }, 
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  }, 
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }, 
+                  "httpMethod": "POST", 
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  }, 
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole", 
+                      "Arn"
+                    ]
+                  }, 
+                  "type": "aws"
+                }, 
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }, 
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        }
+      }
+    }, 
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }, 
+        "ManagedPolicyArns": [], 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      {
+                        "functionName": {
+                          "Ref": "MyFunction"
+                        }
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    }, 
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule", 
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)", 
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole", 
+                "Arn"
+              ]
+            }, 
+            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ], 
+        "Name": "TestSchedule"
+      }
+    }, 
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution", 
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -300,6 +300,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "state_machine_with_condition_and_events",
                 "state_machine_with_xray",
                 "function_with_file_system_config",
+                "state_machine_with_permissions_boundary",
             ],
             [
                 ("aws", "ap-southeast-1"),


### PR DESCRIPTION
Taking over https://github.com/aws/serverless-application-model/pull/1635 from Vaib. I'm not a maintainer, so I wasn't able to edit the existing PR to address the comments.

---

*Issue #, if available:*

*Description of changes:*

* Adding `PermissionsBoundary` property for State Machine resource similar to that for [SAM Function](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-permissionsboundary)
* `PermissionsBoundary` property only works if the role is generated by SAM (using the `Policies` property)
* `PermissionsBoundary` property also applies to the roles created for the event sources.

*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
