### PR TITLE
Fix: DefaultAuth not a string exception

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -930,6 +930,12 @@ class ApiGenerator(object):
         if not default_authorizer:
             return
 
+        if not isinstance(default_authorizer, string_types):
+            raise InvalidResourceException(
+                self.logical_id,
+                "DefaultAuthorizer is not a string.",
+            )
+
         if not authorizers.get(default_authorizer) and default_authorizer != "AWS_IAM":
             raise InvalidResourceException(
                 self.logical_id,

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -889,6 +889,11 @@ class Cognito(PushEventSource):
     def resources_to_link(self, resources):
         if isinstance(self.UserPool, dict) and "Ref" in self.UserPool:
             userpool_id = self.UserPool["Ref"]
+            if not isinstance(userpool_id, string_types):
+                raise InvalidEventException(
+                    self.logical_id,
+                    "Ref in Userpool is not a string.",
+                )
             if userpool_id in resources:
                 return {"userpool": resources[userpool_id], "userpool_id": userpool_id}
         raise InvalidEventException(

--- a/tests/translator/input/error_cognito_userpool_not_string.yaml
+++ b/tests/translator/input/error_cognito_userpool_not_string.yaml
@@ -1,0 +1,18 @@
+Resources:
+  UserPool:
+    Type: AWS::Cognito::UserPool
+
+  ImplicitApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs12.x
+      Events:
+        OneTrigger:
+          Type: Cognito
+          Properties:
+            UserPool: 
+              Ref:
+                - NotAString
+            Trigger: PreSignUp

--- a/tests/translator/input/error_state_machine_with_invalid_default_authorizer.yaml
+++ b/tests/translator/input/error_state_machine_with_invalid_default_authorizer.yaml
@@ -1,0 +1,48 @@
+Resources:
+  MyApi:
+    Type: "AWS::Serverless::Api"
+    Properties:
+      StageName: Prod
+      Auth:
+        DefaultAuthorizer:
+          - NotAString
+        ApiKeyRequired: true
+        Authorizers:
+          MyLambdaTokenAuth:
+            FunctionPayloadType: TOKEN
+            FunctionArn: arn:aws
+            FunctionInvokeRole: arn:aws:iam::123456789012:role/S3Access
+            Identity:
+              Header: MyCustomAuthHeader
+              ValidationExpression: mycustomauthexpression
+              ReauthorizeEvery: 20
+
+  StateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: MyStateMachine
+      Type: STANDARD
+      Definition:
+        Comment: A Hello World example of the Amazon States Language using Pass states
+        StartAt: Hello
+        States:
+          Hello:
+            Type: Pass
+            Result: Hello
+            Next: World
+          World:
+            Type: Pass
+            Result: World
+            End: true
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Deny
+              Action: "*"
+              Resource: "*"
+      Events:
+        WithNoAuthorizer:
+          Type: Api
+          Properties:
+            Path: /startNoAuth
+            Method: post

--- a/tests/translator/output/error_cognito_userpool_not_string.json
+++ b/tests/translator/output/error_cognito_userpool_not_string.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [ImplicitApiFunction] is invalid. Event with id [ImplicitApiFunctionOneTrigger] is invalid. Ref in Userpool is not a string."
+}

--- a/tests/translator/output/error_state_machine_with_invalid_default_authorizer.json
+++ b/tests/translator/output/error_state_machine_with_invalid_default_authorizer.json
@@ -1,0 +1,3 @@
+{
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApi] is invalid. DefaultAuthorizer is not a string."
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -568,6 +568,7 @@ class TestTranslatorEndToEnd(TestCase):
         "error_state_machine_with_api_auth_none",
         "error_state_machine_with_no_api_authorizers",
         "error_state_machine_with_undefined_api_authorizer",
+        "error_state_machine_with_invalid_default_authorizer",
         "error_cognito_userpool_duplicate_trigger",
         "error_api_duplicate_methods_same_path",
         "error_api_gateway_responses_nonnumeric_status_code",

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -570,6 +570,7 @@ class TestTranslatorEndToEnd(TestCase):
         "error_state_machine_with_undefined_api_authorizer",
         "error_state_machine_with_invalid_default_authorizer",
         "error_cognito_userpool_duplicate_trigger",
+        "error_cognito_userpool_not_string",
         "error_api_duplicate_methods_same_path",
         "error_api_gateway_responses_nonnumeric_status_code",
         "error_api_gateway_responses_unknown_responseparameter",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
