### PR TITLE
Fix: Impossible to use intrinsic functions in S3 triggering event

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -330,9 +330,7 @@ class S3(PushEventSource):
             base_event_mapping["Filter"] = self.Filter
 
         event_types = self.Events
-        if isinstance(self.event_types, dict) and "Ref" in self.event_types:
-            event_types = self.event_types["Ref"]
-        if isinstance(self.Events, string_types):
+        if isinstance(self.Events, string_types) or isinstance(self.Events, dict) and "Ref" in self.Events:
             event_types = [self.Events]
 
         event_mappings = []

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -330,6 +330,8 @@ class S3(PushEventSource):
             base_event_mapping["Filter"] = self.Filter
 
         event_types = self.Events
+        if isinstance(self.event_types, dict) and "Ref" in self.event_types:
+            event_types = self.event_types["Ref"]
         if isinstance(self.Events, string_types):
             event_types = [self.Events]
 

--- a/tests/translator/input/s3_multiple_events_ref_intrinsic_function.yaml
+++ b/tests/translator/input/s3_multiple_events_ref_intrinsic_function.yaml
@@ -1,0 +1,36 @@
+Parameters:
+  CreateEvents:
+    Type: CommaDelimitedList
+    Default: s3:ObjectCreated:Post,s3:ObjectCreated:Copy
+  DeleteEvents:
+    Type: CommaDelimitedList
+    Default: s3:ObjectRemoved:*
+
+Resources:
+  ThumbnailFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/thumbnails.zip
+      Handler: index.generate_thumbails
+      Runtime: nodejs12.x
+      Events:
+        ImageBucketCreates:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: !Ref CreateEvents
+        ImageBucketDeletes:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: !Ref DeleteEvents
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: suffix
+                    Value: .jpg
+
+  Images:
+    Type: AWS::S3::Bucket

--- a/tests/translator/output/aws-cn/s3_multiple_events_ref_intrinsic_function.json
+++ b/tests/translator/output/aws-cn/s3_multiple_events_ref_intrinsic_function.json
@@ -1,0 +1,120 @@
+{
+  "Parameters": {
+    "CreateEvents": {
+      "Default": "s3:ObjectCreated:Post,s3:ObjectCreated:Copy",
+      "Type": "CommaDelimitedList"
+    },
+    "DeleteEvents": {
+      "Default": "s3:ObjectRemoved:*",
+      "Type": "CommaDelimitedList"
+    }
+  },
+  "Resources": {
+    "ThumbnailFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": ["arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": ["sts:AssumeRole"],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["lambda.amazonaws.com"]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketCreatesPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        },
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        },
+        "Principal": "s3.amazonaws.com"
+      }
+    },
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": ["ThumbnailFunctionImageBucketDeletesPermission", "ThumbnailFunctionImageBucketCreatesPermission"],
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::GetAtt": ["ThumbnailFunction", "Arn"]
+              },
+              "Filter": {
+                "S3Key": {
+                  "Rules": [
+                    {
+                      "Name": "suffix",
+                      "Value": ".jpg"
+                    }
+                  ]
+                }
+              },
+              "Event": {
+                "Ref": "DeleteEvents"
+              }
+            },
+            {
+              "Function": {
+                "Fn::GetAtt": ["ThumbnailFunction", "Arn"]
+              },
+              "Event": {
+                "Ref": "CreateEvents"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketDeletesPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        },
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        },
+        "Principal": "s3.amazonaws.com"
+      }
+    },
+    "ThumbnailFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "thumbnails.zip"
+        },
+        "Handler": "index.generate_thumbails",
+        "Role": {
+          "Fn::GetAtt": ["ThumbnailFunctionRole", "Arn"]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/s3_multiple_events_ref_intrinsic_function.json
+++ b/tests/translator/output/aws-us-gov/s3_multiple_events_ref_intrinsic_function.json
@@ -1,0 +1,120 @@
+{
+  "Parameters": {
+    "CreateEvents": {
+      "Default": "s3:ObjectCreated:Post,s3:ObjectCreated:Copy",
+      "Type": "CommaDelimitedList"
+    },
+    "DeleteEvents": {
+      "Default": "s3:ObjectRemoved:*",
+      "Type": "CommaDelimitedList"
+    }
+  },
+  "Resources": {
+    "ThumbnailFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": ["arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": ["sts:AssumeRole"],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["lambda.amazonaws.com"]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketCreatesPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        },
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        },
+        "Principal": "s3.amazonaws.com"
+      }
+    },
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": ["ThumbnailFunctionImageBucketDeletesPermission", "ThumbnailFunctionImageBucketCreatesPermission"],
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::GetAtt": ["ThumbnailFunction", "Arn"]
+              },
+              "Filter": {
+                "S3Key": {
+                  "Rules": [
+                    {
+                      "Name": "suffix",
+                      "Value": ".jpg"
+                    }
+                  ]
+                }
+              },
+              "Event": {
+                "Ref": "DeleteEvents"
+              }
+            },
+            {
+              "Function": {
+                "Fn::GetAtt": ["ThumbnailFunction", "Arn"]
+              },
+              "Event": {
+                "Ref": "CreateEvents"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketDeletesPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        },
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        },
+        "Principal": "s3.amazonaws.com"
+      }
+    },
+    "ThumbnailFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "thumbnails.zip"
+        },
+        "Handler": "index.generate_thumbails",
+        "Role": {
+          "Fn::GetAtt": ["ThumbnailFunctionRole", "Arn"]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/s3_multiple_events_ref_intrinsic_function.json
+++ b/tests/translator/output/s3_multiple_events_ref_intrinsic_function.json
@@ -1,0 +1,120 @@
+{
+  "Parameters": {
+    "CreateEvents": {
+      "Default": "s3:ObjectCreated:Post,s3:ObjectCreated:Copy",
+      "Type": "CommaDelimitedList"
+    },
+    "DeleteEvents": {
+      "Default": "s3:ObjectRemoved:*",
+      "Type": "CommaDelimitedList"
+    }
+  },
+  "Resources": {
+    "ThumbnailFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": ["sts:AssumeRole"],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["lambda.amazonaws.com"]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketCreatesPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        },
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        },
+        "Principal": "s3.amazonaws.com"
+      }
+    },
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": ["ThumbnailFunctionImageBucketDeletesPermission", "ThumbnailFunctionImageBucketCreatesPermission"],
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::GetAtt": ["ThumbnailFunction", "Arn"]
+              },
+              "Filter": {
+                "S3Key": {
+                  "Rules": [
+                    {
+                      "Name": "suffix",
+                      "Value": ".jpg"
+                    }
+                  ]
+                }
+              },
+              "Event": {
+                "Ref": "DeleteEvents"
+              }
+            },
+            {
+              "Function": {
+                "Fn::GetAtt": ["ThumbnailFunction", "Arn"]
+              },
+              "Event": {
+                "Ref": "CreateEvents"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ThumbnailFunctionImageBucketDeletesPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        },
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        },
+        "Principal": "s3.amazonaws.com"
+      }
+    },
+    "ThumbnailFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "thumbnails.zip"
+        },
+        "Handler": "index.generate_thumbails",
+        "Role": {
+          "Fn::GetAtt": ["ThumbnailFunctionRole", "Arn"]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -206,6 +206,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "s3_existing_other_notification_configuration",
                 "s3_filter",
                 "s3_multiple_events_same_bucket",
+                "s3_multiple_events_ref_intrinsic_function",
                 "s3_multiple_functions",
                 "s3_with_dependsOn",
                 "sns",


### PR DESCRIPTION
*Issue #, if available:*
#1739

*Description of changes:*
Updating `_inject_notification_configuration` function to handle `Ref` intrinsic function for S3 triggering event types.

*Description of how you validated changes:*
Added a test case using `Ref` intrinsic function.
The fix I made was suggested by this comment : https://github.com/aws/serverless-application-model/issues/1739#issuecomment-716693880

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
