### PR TITLE
fix: propagate condition to sqs queue policy for sqssubscription

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ test:
 	pytest --cov samtranslator --cov-report term-missing --cov-fail-under 95 tests
 
 black:
-	black setup.py samtranslator/**/*.py tests/**/*.py bin/*.py
+	black setup.py samtranslator/* tests/* bin/*.py
 
 black-check:
-	black --check setup.py samtranslator/**/*.py tests/**/*.py bin/*.py
+	black --check setup.py samtranslator/* tests/* bin/*.py
 
 # Command to run everytime you make changes to verify everything works
 dev: test

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ test:
 	pytest --cov samtranslator --cov-report term-missing --cov-fail-under 95 tests
 
 black:
-	black setup.py samtranslator/* tests/* bin/*.py
+	black setup.py samtranslator/**/*.py tests/**/*.py bin/*.py
 
 black-check:
-	black --check setup.py samtranslator/* tests/* bin/*.py
+	black --check setup.py samtranslator/**/*.py tests/**/*.py bin/*.py
 
 # Command to run everytime you make changes to verify everything works
 dev: test

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -407,7 +407,7 @@ class SNS(PushEventSource):
             queue_arn = queue.get_runtime_attr("arn")
             queue_url = queue.get_runtime_attr("queue_url")
 
-            queue_policy = self._inject_sqs_queue_policy(self.Topic, queue_arn, queue_url)
+            queue_policy = self._inject_sqs_queue_policy(self.Topic, queue_arn, queue_url, function.resource_attributes)
             subscription = self._inject_subscription(
                 "sqs", queue_arn, self.Topic, self.Region, self.FilterPolicy, function.resource_attributes
             )
@@ -430,7 +430,9 @@ class SNS(PushEventSource):
         batch_size = self.SqsSubscription.get("BatchSize", None)
         enabled = self.SqsSubscription.get("Enabled", None)
 
-        queue_policy = self._inject_sqs_queue_policy(self.Topic, queue_arn, queue_url, queue_policy_logical_id)
+        queue_policy = self._inject_sqs_queue_policy(
+            self.Topic, queue_arn, queue_url, function.resource_attributes, queue_policy_logical_id
+        )
         subscription = self._inject_subscription(
             "sqs", queue_arn, self.Topic, self.Region, self.FilterPolicy, function.resource_attributes
         )
@@ -466,8 +468,11 @@ class SNS(PushEventSource):
         event_source.Enabled = enabled or True
         return event_source.to_cloudformation(function=function, role=role)
 
-    def _inject_sqs_queue_policy(self, topic_arn, queue_arn, queue_url, logical_id=None):
+    def _inject_sqs_queue_policy(self, topic_arn, queue_arn, queue_url, resource_attributes, logical_id=None):
         policy = SQSQueuePolicy(logical_id or self.logical_id + "QueuePolicy")
+        if CONDITION in resource_attributes:
+            policy.set_resource_attribute(CONDITION, resource_attributes[CONDITION])
+
         policy.PolicyDocument = SQSQueuePolicies.sns_topic_send_message_role_policy(topic_arn, queue_arn)
         policy.Queues = [queue_url]
         return policy

--- a/tests/translator/input/function_event_conditions.yaml
+++ b/tests/translator/input/function_event_conditions.yaml
@@ -79,6 +79,15 @@ Resources:
             Topic:
               Ref: Notifications
 
+        SNSTopicWithSQSSubscription:
+          Type: SNS
+          Properties:
+            Topic:
+              Ref: Notifications
+            SqsSubscription:
+              QueueArn: !GetAtt Queue.Arn
+              QueueUrl: !Ref Queue
+
         KinesisStream:
           Type: Kinesis
           Properties:
@@ -99,3 +108,7 @@ Resources:
 
   Images:
     Type: AWS::S3::Bucket
+
+  Queue:
+    Condition: MyCondition
+    Type: AWS::SQS::Queue

--- a/tests/translator/input/function_event_conditions.yaml
+++ b/tests/translator/input/function_event_conditions.yaml
@@ -88,6 +88,13 @@ Resources:
               QueueArn: !GetAtt Queue.Arn
               QueueUrl: !Ref Queue
 
+        AnotherSNSWithSQSSubscription:
+          Type: SNS
+          Properties:
+            Topic:
+              Ref: Notifications
+            SqsSubscription: true
+
         KinesisStream:
           Type: Kinesis
           Properties:

--- a/tests/translator/output/aws-cn/function_event_conditions.json
+++ b/tests/translator/output/aws-cn/function_event_conditions.json
@@ -528,6 +528,77 @@
       },
       "Condition": "MyCondition"
     },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {}
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "FunctionName": {
+          "Ref": "MyAwesomeFunctionAliasLive"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+            "Arn"
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscription": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+                  "Arn"
+                ]
+              },
+              "Effect": "Allow",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
     "Queue": {
       "Type": "AWS::SQS::Queue",
       "Condition": "MyCondition"

--- a/tests/translator/output/aws-cn/function_event_conditions.json
+++ b/tests/translator/output/aws-cn/function_event_conditions.json
@@ -222,7 +222,8 @@
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole", 
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole"
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole",
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
         ],
         "Tags": [
           {
@@ -459,6 +460,77 @@
       "DependsOn": [
         "FunctionOneImageBucketPermission"
       ]
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscription": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "Queue",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscriptionQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "Queue"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "Queue",
+                  "Arn"
+                ]
+              },
+              "Effect": "Allow",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscriptionEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "FunctionName": {
+          "Ref": "MyAwesomeFunctionAliasLive"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "Queue",
+            "Arn"
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "Queue": {
+      "Type": "AWS::SQS::Queue",
+      "Condition": "MyCondition"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/function_event_conditions.json
+++ b/tests/translator/output/aws-us-gov/function_event_conditions.json
@@ -528,6 +528,77 @@
       },
       "Condition": "MyCondition"
     },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {}
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "FunctionName": {
+          "Ref": "MyAwesomeFunctionAliasLive"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+            "Arn"
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscription": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+                  "Arn"
+                ]
+              },
+              "Effect": "Allow",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
     "Queue": {
       "Type": "AWS::SQS::Queue",
       "Condition": "MyCondition"

--- a/tests/translator/output/aws-us-gov/function_event_conditions.json
+++ b/tests/translator/output/aws-us-gov/function_event_conditions.json
@@ -222,7 +222,8 @@
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole"
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
         ],
         "Tags": [
           {
@@ -459,6 +460,77 @@
       "DependsOn": [
         "FunctionOneImageBucketPermission"
       ]
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscription": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "Queue",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscriptionQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "Queue"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "Queue",
+                  "Arn"
+                ]
+              },
+              "Effect": "Allow",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscriptionEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "FunctionName": {
+          "Ref": "MyAwesomeFunctionAliasLive"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "Queue",
+            "Arn"
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "Queue": {
+      "Type": "AWS::SQS::Queue",
+      "Condition": "MyCondition"
     }
   }
 }

--- a/tests/translator/output/function_event_conditions.json
+++ b/tests/translator/output/function_event_conditions.json
@@ -9,44 +9,44 @@
   },
   "Resources": {
     "MyAwesomeFunctionAliasLive": {
-      "Type": "AWS::Lambda::Alias", 
+      "Type": "AWS::Lambda::Alias",
       "Condition": "MyCondition",
       "Properties": {
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionVersion640128d35d", 
+            "MyAwesomeFunctionVersion640128d35d",
             "Version"
           ]
-        }, 
+        },
         "FunctionName": {
           "Ref": "MyAwesomeFunction"
-        }, 
+        },
         "Name": "Live"
       }
-    }, 
+    },
     "MyAwesomeFunctionNotificationTopicPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Condition": "MyCondition",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "sns.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "sns.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Ref": "Notifications"
         }
       }
     },
     "MyAwesomeFunctionCWEventPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Condition": "MyCondition",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "events.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::GetAtt": [
             "MyAwesomeFunctionCWEvent",
@@ -73,23 +73,23 @@
       }
     },
     "MyAwesomeFunctionDDBStream": {
-      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Type": "AWS::Lambda::EventSourceMapping",
       "Condition": "MyCondition",
       "Properties": {
-        "BatchSize": 200, 
-        "EventSourceArn": "arn:aws:dynamodb:us-west-2:012345678901:table/TestTable/stream/2015-05-11T21:21:33.291", 
+        "BatchSize": 200,
+        "EventSourceArn": "arn:aws:dynamodb:us-west-2:012345678901:table/TestTable/stream/2015-05-11T21:21:33.291",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "StartingPosition": "LATEST"
       }
     },
     "MyAwesomeFunctionIoTRule": {
-      "Type": "AWS::IoT::TopicRule", 
+      "Type": "AWS::IoT::TopicRule",
       "Condition": "MyCondition",
       "Properties": {
         "TopicRulePayload": {
-          "AwsIotSqlVersion": "beta", 
+          "AwsIotSqlVersion": "beta",
           "Actions": [
             {
               "Lambda": {
@@ -98,39 +98,39 @@
                 }
               }
             }
-          ], 
-          "RuleDisabled": false, 
+          ],
+          "RuleDisabled": false,
           "Sql": "SELECT * FROM 'topic/test'"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionKinesisStream": {
-      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Type": "AWS::Lambda::EventSourceMapping",
       "Condition": "MyCondition",
       "Properties": {
-        "BatchSize": 100, 
-        "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream", 
+        "BatchSize": 100,
+        "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "StartingPosition": "TRIM_HORIZON"
       }
     },
     "MyAwesomeFunctionIoTRulePermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Condition": "MyCondition",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "SourceAccount": {
           "Fn::Sub": "${AWS::AccountId}"
-        }, 
-        "Principal": "iot.amazonaws.com", 
+        },
+        "Principal": "iot.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:iot:${AWS::Region}:${AWS::AccountId}:rule/${RuleName}", 
+            "arn:aws:iot:${AWS::Region}:${AWS::AccountId}:rule/${RuleName}",
             {
               "RuleName": {
                 "Ref": "MyAwesomeFunctionIoTRule"
@@ -139,58 +139,58 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionNotificationTopic": {
-      "Type": "AWS::SNS::Subscription", 
+      "Type": "AWS::SNS::Subscription",
       "Condition": "MyCondition",
       "Properties": {
         "Endpoint": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
-        "Protocol": "lambda", 
+        },
+        "Protocol": "lambda",
         "TopicArn": {
           "Ref": "Notifications"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionS3TriggerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Condition": "MyCondition",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "SourceAccount": {
           "Ref": "AWS::AccountId"
-        }, 
+        },
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "Principal": "s3.amazonaws.com"
       }
     },
     "MyAwesomeFunctionCWLogPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Condition": "MyCondition",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "logs.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "logs.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*", 
+            "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*",
             {
               "__LogGroupName__": "MyLogGroup"
             }
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionEBSchedule": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Condition": "MyCondition",
       "Properties": {
-        "ScheduleExpression": "rate(1 minute)", 
+        "ScheduleExpression": "rate(1 minute)",
         "Targets": [
           {
             "Id": "MyAwesomeFunctionEBScheduleLambdaTarget",
@@ -200,29 +200,30 @@
           }
         ]
       }
-    }, 
+    },
     "MyAwesomeFunctionCWLog": {
-      "Type": "AWS::Logs::SubscriptionFilter", 
+      "Type": "AWS::Logs::SubscriptionFilter",
       "Condition": "MyCondition",
       "Properties": {
         "DestinationArn": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
-        "FilterPattern": "My pattern", 
+        },
+        "FilterPattern": "My pattern",
         "LogGroupName": "MyLogGroup"
-      }, 
+      },
       "DependsOn": [
         "MyAwesomeFunctionCWLogPermission"
       ]
-    }, 
+    },
     "MyAwesomeFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Condition": "MyCondition",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole", 
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole"
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
         ],
         "Tags": [
           {
@@ -231,13 +232,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -247,33 +248,33 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Condition": "MyCondition",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionRole", 
+            "MyAwesomeFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyAwesomeFunctionCWEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Condition": "MyCondition",
       "Properties": {
         "EventPattern": {
@@ -282,7 +283,7 @@
               "terminated"
             ]
           }
-        }, 
+        },
         "Targets": [
           {
             "Id": "MyAwesomeFunctionCWEventLambdaTarget",
@@ -315,28 +316,28 @@
       }
     },
     "MyAwesomeFunctionVersion640128d35d": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::Version", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::Version",
       "Condition": "MyCondition",
       "Properties": {
         "FunctionName": {
           "Ref": "MyAwesomeFunction"
         }
       }
-    }, 
+    },
     "Notifications": {
       "Condition": "MyCondition",
       "Type": "AWS::SNS::Topic"
     },
     "MyAwesomeFunctionEBSchedulePermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Condition": "MyCondition",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "events.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::GetAtt": [
             "MyAwesomeFunctionEBSchedule",
@@ -344,7 +345,7 @@
           ]
         }
       }
-    }, 
+    },
     "FunctionOneImageBucketPermission": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -412,7 +413,7 @@
       }
     },
     "Images": {
-      "Type": "AWS::S3::Bucket", 
+      "Type": "AWS::S3::Bucket",
       "Properties": {
         "NotificationConfiguration": {
           "LambdaConfigurations": [
@@ -455,10 +456,81 @@
             }
           }
         ]
-      }, 
+      },
       "DependsOn": [
         "FunctionOneImageBucketPermission"
       ]
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscription": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "Queue",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscriptionQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "Queue"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "Queue",
+                  "Arn"
+                ]
+              },
+              "Effect": "Allow",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionSNSTopicWithSQSSubscriptionEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "FunctionName": {
+          "Ref": "MyAwesomeFunctionAliasLive"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "Queue",
+            "Arn"
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "Queue": {
+      "Type": "AWS::SQS::Queue",
+      "Condition": "MyCondition"
     }
   }
 }

--- a/tests/translator/output/function_event_conditions.json
+++ b/tests/translator/output/function_event_conditions.json
@@ -528,6 +528,77 @@
       },
       "Condition": "MyCondition"
     },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {}
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "FunctionName": {
+          "Ref": "MyAwesomeFunctionAliasLive"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+            "Arn"
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscription": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      },
+      "Condition": "MyCondition"
+    },
+    "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "MyAwesomeFunctionAnotherSNSWithSQSSubscriptionQueue",
+                  "Arn"
+                ]
+              },
+              "Effect": "Allow",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
+      },
+      "Condition": "MyCondition"
+    },
     "Queue": {
       "Type": "AWS::SQS::Queue",
       "Condition": "MyCondition"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This fixes a bug of not having `Condition` propagated to the generated `AWS::SQS::QueuePolicy` resource if a SNS event source is used with `SqsSubscription` in a `AWS::Serverless::Function` resource.

Also updated the black commands in `Makefile` to check only `.py` files

*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
