### PR TITLE
Fix: Remove unnecessary use of comprehension

### DIFF
--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -292,7 +292,7 @@ class TestOpenApiEditor_iter_on_path(TestCase):
     def test_must_iterate_on_paths(self):
 
         expected = {"/foo", "/bar", "/baz"}
-        actual = set([path for path in self.editor.iter_on_path()])
+        actual = set(list(self.editor.iter_on_path()))
 
         self.assertEqual(expected, actual)
 

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -302,7 +302,7 @@ class TestSwaggerEditor_iter_on_path(TestCase):
     def test_must_iterate_on_paths(self):
 
         expected = {"/foo", "/bar", "/baz"}
-        actual = set([path for path in self.editor.iter_on_path()])
+        actual = set(list(self.editor.iter_on_path()))
 
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

While browsing through the Repository and the Tests, I found two instances where the List Comprehension has been used unnecessarily. I have fixed that to make the code more readable and understanding. 

*Checklist:*

- [X] Write/update tests
- [X] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
