### PR TITLE
Revert boto3 dependency pin to ~=1.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 pyrsistent~=0.16.0; python_version<"3"
-boto3~=1.15.16
+boto3~=1.5
 enum34~=1.1; python_version<"3.4"
 jsonschema~=3.2
 six~=1.15


### PR DESCRIPTION
*Issue #, if available:*

#1809 

*Description of changes:*

Reverts `boto3` pinned dependency from `~=1.15.16` back to `~=1.5` (original PR: #1762)

*Description of how you validated changes:*

Ran tests locally

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
