### PR TITLE
Revert boto3 dependency pin to ~=1.5 (#1810)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,19 @@ image: Ubuntu
 environment:
   matrix:
   - TOXENV: py27
+    PYTHON_VERSION: '2.7'
   - TOXENV: py36
+    PYTHON_VERSION: '3.6'
   - TOXENV: py37
+    PYTHON_VERSION: '3.7'
   - TOXENV: py38
+    PYTHON_VERSION: '3.8'
 
 build: off
 
 install:
+- sh: "source ${HOME}/venv${PYTHON_VERSION}/bin/activate"
+- sh: "python --version"
 - make init
 
 test_script:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 pyrsistent~=0.16.0; python_version<"3"
-boto3~=1.15.16
+boto3~=1.5
 enum34~=1.1; python_version<"3.4"
 jsonschema~=3.2
 six~=1.15

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist = py27, py36, py37, py38
 # resource. Tox tries to simulate Py3 behavior in Py2.7 by setting PYTHONHASHSEED to random values on every run.
 # This results in unit test failures. This happens only within Tox. To fix this, we are unsetting the seed value
 # specifically for Py27 in Tox.
-passenv = AWS*
+passenv = AWS* CODECOV_TOKEN
 setenv = PYTHONHASHSEED = 0
 commands = make pr2.7
            codecov
@@ -26,5 +26,5 @@ commands = make pr2.7
 commands = make pr
            codecov
 deps = codecov>=1.4.0
-passenv = AWS* TONXENV CI TRAVIS TRAVIS_*
-whitelist_externals = make, black
+passenv = AWS* TONXENV CI TRAVIS TRAVIS_* CODECOV_TOKEN
+whitelist_externals = make, black, codecov


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
