### PR TITLE
feat(policy-templates): add AcmGetCertificatePolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -2306,6 +2306,34 @@
           }
         ]
       }
+    },
+    "AcmGetCertificatePolicy": {
+      "Description": "Gives permission to retrieve a certificate and its certificate chain from ACM",
+      "Parameters": {
+        "CertificateArn": {
+          "Description": "The ARN of the certificate to grant access to"
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "acm:GetCertificate"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "${certificateArn}",
+                {
+                  "certificateArn": {
+                    "Ref": "CertificateArn"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -168,3 +168,6 @@ Resources:
 
         - EventBridgePutEventsPolicy:
             EventBusName: name
+
+        - AcmGetCertificatePolicy:
+            CertificateArn: arn

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1570,6 +1570,27 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy58",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "acm:GetCertificate"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": [
+                      "${certificateArn}",
+                      {
+                        "certificateArn": "arn"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1570,6 +1570,27 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy58",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "acm:GetCertificate"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": [
+                      "${certificateArn}",
+                      {
+                        "certificateArn": "arn"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1570,6 +1570,27 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy58",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "acm:GetCertificate"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": [
+                      "${certificateArn}",
+                      {
+                        "certificateArn": "arn"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [


### PR DESCRIPTION
### Related issue

#1854

### Description of changes

Added a policy template `AcmGetCertificatePolicy` that give a permission to read a certificate from AWS Certificate Manager. 

- **Granted permission**: [GetCertificate](https://docs.aws.amazon.com/acm/latest/APIReference/API_GetCertificate.html) ( `acm:GetCertificate` )

- **Resource**: The certificate ARN. 
I pass the full certificate's ARN, not the id, because the CloudFormation resource [AWS::CertificateManager::Certificate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html) returns only the ARN.

### Usecase

Lambda function in a private network making HTTPS requests to a private server. The Lambda needs to add the certificate chain to its CA Bundle.

### Checklist

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
