### PR TITLE
fix: Support new CodeDeploy ManagedPolicy

### DIFF
--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -101,9 +101,17 @@ class DeploymentPreferenceCollection(object):
                 }
             ],
         }
-        iam_role.ManagedPolicyArns = [
-            ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSCodeDeployRoleForLambda")
-        ]
+
+        # CodeDeploy has a new managed policy. We cannot update any existing partitions, without customer reach out
+        # that support AWSCodeDeployRoleForLambda since this could regress stacks that are currently deployed.
+        if ArnGenerator.get_partition_name() in ["aws-iso", "aws-iso-b"]:
+            iam_role.ManagedPolicyArns = [
+                ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSCodeDeployRoleForLambdaLimited")
+            ]
+        else:
+            iam_role.ManagedPolicyArns = [
+                ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSCodeDeployRoleForLambda")
+            ]
 
         return iam_role
 

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -7,8 +7,6 @@ class RegionConfiguration(object):
     class abstracts all region/partition specific configuration.
     """
 
-    partitions = {"govcloud": "aws-us-gov", "iso": "aws-iso", "isob": "aws-iso-b", "china": "aws-cn"}
-
     @classmethod
     def is_apigw_edge_configuration_supported(cls):
         """
@@ -19,8 +17,8 @@ class RegionConfiguration(object):
         """
 
         return ArnGenerator.get_partition_name() not in [
-            cls.partitions["govcloud"],
-            cls.partitions["iso"],
-            cls.partitions["isob"],
-            cls.partitions["china"],
+            "aws-us-gov",
+            "aws-iso",
+            "aws-iso-b",
+            "aws-cn",
         ]

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -7,7 +7,7 @@ class RegionConfiguration(object):
     class abstracts all region/partition specific configuration.
     """
 
-    partitions = {"govcloud": "aws-us-gov", "china": "aws-cn"}
+    partitions = {"govcloud": "aws-us-gov", "iso": "aws-iso", "isob": "aws-iso-b", "china": "aws-cn"}
 
     @classmethod
     def is_apigw_edge_configuration_supported(cls):
@@ -18,4 +18,9 @@ class RegionConfiguration(object):
         :return: True, if API Gateway does not support Edge configuration
         """
 
-        return ArnGenerator.get_partition_name() not in [cls.partitions["govcloud"], cls.partitions["china"]]
+        return ArnGenerator.get_partition_name() not in [
+            cls.partitions["govcloud"],
+            cls.partitions["iso"],
+            cls.partitions["isob"],
+            cls.partitions["china"],
+        ]

--- a/samtranslator/translator/arn_generator.py
+++ b/samtranslator/translator/arn_generator.py
@@ -47,6 +47,10 @@ class ArnGenerator(object):
         region_string = region.lower()
         if region_string.startswith("cn-"):
             return "aws-cn"
+        elif region_string.startswith("us-iso-"):
+            return "aws-iso"
+        elif region_string.startswith("us-isob"):
+            return "aws-iso-b"
         elif region_string.startswith("us-gov"):
             return "aws-us-gov"
         else:

--- a/samtranslator/translator/arn_generator.py
+++ b/samtranslator/translator/arn_generator.py
@@ -39,19 +39,23 @@ class ArnGenerator(object):
         :param region: Optional name of the region
         :return: Partition name
         """
+
         if region is None:
             # Use Boto3 to get the region where code is running. This uses Boto's regular region resolution
             # mechanism, starting from AWS_DEFAULT_REGION environment variable.
             region = boto3.session.Session().region_name
 
+        # setting default partition to aws, this will be overwritten by checking the region below
+        partition = "aws"
+
         region_string = region.lower()
         if region_string.startswith("cn-"):
-            return "aws-cn"
+            partition = "aws-cn"
         elif region_string.startswith("us-iso-"):
-            return "aws-iso"
+            partition = "aws-iso"
         elif region_string.startswith("us-isob"):
-            return "aws-iso-b"
+            partition = "aws-iso-b"
         elif region_string.startswith("us-gov"):
-            return "aws-us-gov"
-        else:
-            return "aws"
+            partition = "aws-us-gov"
+
+        return partition

--- a/tests/unit/model/preferences/test_deployment_preference_collection.py
+++ b/tests/unit/model/preferences/test_deployment_preference_collection.py
@@ -1,0 +1,49 @@
+from unittest import TestCase
+
+from mock import patch
+from parameterized import parameterized
+
+from samtranslator.model.preferences.deployment_preference_collection import DeploymentPreferenceCollection
+
+
+class TestDeploymentPreferenceCollection(TestCase):
+    @parameterized.expand(
+        [
+            ["aws-iso"],
+            ["aws-iso-b"],
+        ]
+    )
+    def test_codedeploy_iam_role_contains_AWSCodeDeployRoleForLambdaLimited_managedpolicy(self, partition):
+
+        with patch(
+            "samtranslator.translator.arn_generator.ArnGenerator.get_partition_name"
+        ) as get_partition_name_patch:
+            get_partition_name_patch.return_value = partition
+
+            iam_role = DeploymentPreferenceCollection().codedeploy_iam_role
+
+            self.assertIn(
+                "arn:{}:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited".format(partition),
+                iam_role.ManagedPolicyArns,
+            )
+
+    @parameterized.expand(
+        [
+            ["aws"],
+            ["aws-cn"],
+            ["aws-us-gov"],
+        ]
+    )
+    def test_codedeploy_iam_role_contains_AWSCodeDeployRoleForLambda_managedpolicy(self, partition):
+
+        with patch(
+            "samtranslator.translator.arn_generator.ArnGenerator.get_partition_name"
+        ) as get_partition_name_patch:
+            get_partition_name_patch.return_value = partition
+
+            iam_role = DeploymentPreferenceCollection().codedeploy_iam_role
+
+            self.assertIn(
+                "arn:{}:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda".format(partition),
+                iam_role.ManagedPolicyArns,
+            )

--- a/tests/unit/test_region_configuration.py
+++ b/tests/unit/test_region_configuration.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+
+from mock import patch
+from parameterized import parameterized
+
+from samtranslator.region_configuration import RegionConfiguration
+
+
+class TestRegionConfiguration(TestCase):
+    @parameterized.expand(
+        [
+            ["aws"],
+        ]
+    )
+    def test_when_apigw_edge_configuration_supported(self, partition):
+
+        with patch(
+            "samtranslator.translator.arn_generator.ArnGenerator.get_partition_name"
+        ) as get_partition_name_patch:
+            get_partition_name_patch.return_value = partition
+
+            self.assertTrue(RegionConfiguration.is_apigw_edge_configuration_supported())
+
+    @parameterized.expand(
+        [
+            ["aws-cn"],
+            ["aws-us-gov"],
+            ["aws-iso"],
+            ["aws-iso-b"],
+        ]
+    )
+    def test_when_apigw_edge_configuration_is_not_supported(self, partition):
+        with patch(
+            "samtranslator.translator.arn_generator.ArnGenerator.get_partition_name"
+        ) as get_partition_name_patch:
+            get_partition_name_patch.return_value = partition
+
+            self.assertFalse(RegionConfiguration.is_apigw_edge_configuration_supported())

--- a/tests/unit/translator/test_arn_generator.py
+++ b/tests/unit/translator/test_arn_generator.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+
+from mock import patch
+from parameterized import parameterized
+
+from samtranslator.translator.arn_generator import ArnGenerator
+
+
+class TestArnGenerator(TestCase):
+    @parameterized.expand(
+        [
+            ["us-east-1", "aws"],
+            ["eu-west-1", "aws"],
+            ["cn-north-1", "aws-cn"],
+            ["us-gov-west-1", "aws-us-gov"],
+            ["us-iso-east-1", "aws-iso"],
+            ["us-isob-east-1", "aws-iso-b"],
+        ]
+    )
+    def test_get_partition_name(self, region, expected_partition):
+        self.assertEqual(expected_partition, ArnGenerator.get_partition_name(region=region))
+
+    @parameterized.expand(
+        [
+            ["us-east-1", "aws"],
+            ["eu-west-1", "aws"],
+            ["cn-north-1", "aws-cn"],
+            ["us-gov-west-1", "aws-us-gov"],
+            ["us-iso-east-1", "aws-iso"],
+            ["us-isob-east-1", "aws-iso-b"],
+        ]
+    )
+    def test_get_partition_name_when_region_not_provided(self, region, expected_partition):
+        with patch("boto3.session.Session.region_name", region):
+            self.assertEqual(expected_partition, ArnGenerator.get_partition_name())


### PR DESCRIPTION
CodeDeploy is migrating from AWSCodeDeployRoleForLambda to AWSCodeDeployRoleForLambdaLimited.
Some partitions do not support AWSCodeDeployRoleForLambda and therefore we need to use the newer
one in those partitions. We cannot widely update to AWSCodeDeployRoleForLambdaLimited since this
can cause customer's stacks to fail unexpectedly.

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
