### PR TITLE
fix(AppConfig): Updated AppConfig boto3 Client Timeout

### DIFF
--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -110,7 +110,7 @@ class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
         try:
             # Lambda function has 120 seconds limit
             # (5 + 25) * 2, 60 seconds maximum timeout duration
-            client_config = Config(connect_timeout= 5, read_timeout=25, retries={"total_max_attempts": 2})
+            client_config = Config(connect_timeout=5, read_timeout=25, retries={"total_max_attempts": 2})
             self.app_config_client = boto3.client("appconfig", config=client_config)
             response = self.app_config_client.get_configuration(
                 Application=application_id,

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -4,6 +4,8 @@ import json
 import boto3
 import logging
 
+from botocore.config import Config
+
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, my_path + "/..")
 
@@ -105,8 +107,11 @@ class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
 
     def __init__(self, application_id, environment_id, configuration_profile_id):
         FeatureToggleConfigProvider.__init__(self)
-        self.app_config_client = boto3.client("appconfig")
         try:
+            # Lambda function has 120 seconds limit
+            # (5 + 25) * 2, 60 seconds maximum timeout duration
+            client_config = Config(connect_timeout= 5, read_timeout=25, retries={"total_max_attempts": 2})
+            self.app_config_client = boto3.client("appconfig", config=client_config)
             response = self.app_config_client.get_configuration(
                 Application=application_id,
                 Environment=environment_id,


### PR DESCRIPTION
*Description of changes:*
boto3 client has default 60 seconds timeout for both read and connection.
The worst case would be 360 seconds from 120 seconds timeout * 3 retires.
SAM translator lambda function has 120 seconds timeout which can be exceeded if AppConfig experiences a long response delay issue.

*Description of how you validated changes:*
Tested with 900ms network latency. (1800ms roundt trip)

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
