### PR TITLE
fix: RecordSetGroups resource overwrites the first

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -381,12 +381,8 @@ class ApiGenerator(object):
                     self.logical_id,
                     "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
                 )
-            logical_id = logical_id_generator.LogicalIdGenerator(
-                "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
-            ).gen()
-            record_set_group = Route53RecordSetGroup(
-                "RecordSetGroup" + logical_id, attributes=self.passthrough_resource_attributes
-            )
+            logical_id = "{}{}".format(self.logical_id, "DomainRecordSetGroup")
+            record_set_group = Route53RecordSetGroup(logical_id, attributes=self.passthrough_resource_attributes)
             if "HostedZoneId" in route53:
                 record_set_group.HostedZoneId = route53.get("HostedZoneId")
             if "HostedZoneName" in route53:

--- a/tests/translator/output/api_with_custom_domain_route53.json
+++ b/tests/translator/output/api_with_custom_domain_route53.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,100 +52,100 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
-    "RecordSetGroupbd00d962a4": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+    },
+    "MyApiDomainRecordSetGroup": {
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneId": "ZQ1UAL4EFZVME", 
+        "HostedZoneId": "ZQ1UAL4EFZVME",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
+    },
     "MyApiDeploymentf643ef7f59": {
-      "Type": "AWS::ApiGateway::Deployment", 
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Description": "RestApi deployment id: f643ef7f592a69a57638dd25e64dc12d2b4abf2d"
       }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
           "Ref": "MyApiDeploymentf643ef7f59"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -153,42 +153,42 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
         }
       }

--- a/tests/translator/output/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,85 +52,85 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
           "Ref": "MyApiDeploymenteb58d7577a"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -138,58 +138,58 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "RecordSetGroup456ebaf280": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+    },
+    "MyApiDomainRecordSetGroup": {
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneName": "www.my-domain.com.", 
+        "HostedZoneName": "www.my-domain.com.",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
+    },
     "MyApiDeploymenteb58d7577a": {
-      "Type": "AWS::ApiGateway::Deployment", 
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Description": "RestApi deployment id: eb58d7577a65af049c9c6f10c9d8b286de6b5aeb"
       }
     }

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,100 +52,100 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
-    "RecordSetGroupbd00d962a4": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+    },
+    "MyApiDomainRecordSetGroup": {
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneId": "ZQ1UAL4EFZVME", 
+        "HostedZoneId": "ZQ1UAL4EFZVME",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApiDeploymentfb330328f1": {
-      "Type": "AWS::ApiGateway::Deployment", 
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Description": "RestApi deployment id: fb330328f152e4bb4b7d68e8b976b009e0558035"
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
           "Ref": "MyApiDeploymentfb330328f1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -153,49 +153,49 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,66 +52,66 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
+    },
     "MyApiDeployment9239fa9a13": {
-      "Type": "AWS::ApiGateway::Deployment", 
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Description": "RestApi deployment id: 9239fa9a13216200ab5bf11c04507c61842a50a7"
       }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
           "Ref": "MyApiDeployment9239fa9a13"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -119,83 +119,83 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "RecordSetGroup456ebaf280": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+    },
+    "MyApiDomainRecordSetGroup": {
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneName": "www.my-domain.com.", 
+        "HostedZoneName": "www.my-domain.com.",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53.json
@@ -62,7 +62,7 @@
         "Description": "RestApi deployment id: 1deeaff6933b892391de7a35e4cf92e79a47aea9"
       }
     },
-    "RecordSetGroupbd00d962a4": {
+    "MyApiDomainRecordSetGroup": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
         "HostedZoneId": "ZQ1UAL4EFZVME",

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,54 +52,54 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiDeployment501f2306c4": {
-      "Type": "AWS::ApiGateway::Deployment", 
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Description": "RestApi deployment id: 501f2306c4860ed198c3020aa43d453cdbdd6b7a"
       }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
           "Ref": "MyApiDeployment501f2306c4"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -107,95 +107,95 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
-    "RecordSetGroup456ebaf280": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+    },
+    "MyApiDomainRecordSetGroup": {
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneName": "www.my-domain.com.", 
+        "HostedZoneName": "www.my-domain.com.",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }


### PR DESCRIPTION
*Issue #, if available:* #1539 

*Description of changes:* Refactor API Custom Domain RecordSetGroup Logical ID to be unique to the `AWS::Serverless::Api` resource

*Description of how you validated changes:* As the logical ID of the API resource must be unique, using this as the prefix to the translated RecordSetGroup ensures uniqueness as well as provides contextual association to the API in question.

*Checklist:*

- [X] Write/update tests
- [X] `make pr` passes
- [x] Update documentation
- [X] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
