### PR TITLE
WIP - Add support for IAM authorizers to AWS::Serverless::HttpApi

### DIFF
--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -515,6 +515,7 @@ class HttpApiGenerator(object):
                 identity=authorizer.get("Identity"),
                 authorizer_payload_format_version=authorizer.get("AuthorizerPayloadFormatVersion"),
                 enable_simple_responses=authorizer.get("EnableSimpleResponses"),
+                is_aws_iam_authorizer=authorizer.get("IamAuthorizer"),
             )
         return authorizers
 

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -73,6 +73,7 @@ class ApiGatewayV2Authorizer(object):
         identity=None,
         authorizer_payload_format_version=None,
         enable_simple_responses=None,
+        is_aws_iam_authorizer=False,
     ):
         """
         Creates an authorizer for use in V2 Http Apis
@@ -87,6 +88,7 @@ class ApiGatewayV2Authorizer(object):
         self.identity = identity
         self.authorizer_payload_format_version = authorizer_payload_format_version
         self.enable_simple_responses = enable_simple_responses
+        self.is_aws_iam_authorizer = is_aws_iam_authorizer
 
         self._validate_input_parameters()
 
@@ -100,6 +102,8 @@ class ApiGatewayV2Authorizer(object):
             self._validate_lambda_authorizer()
 
     def _get_auth_type(self):
+        if self.is_aws_iam_authorizer:
+            return "AWS_IAM"
         if self.jwt_configuration:
             return "JWT"
         return "REQUEST"
@@ -173,6 +177,14 @@ class ApiGatewayV2Authorizer(object):
         Generates OAS for the securitySchemes section
         """
         authorizer_type = self._get_auth_type()
+
+        if authorizer_type == "AWS_IAM":
+            openapi = {
+                "type": "apiKey",
+                "name": "Authorization",
+                "in": "header",
+                "x-amazon-apigateway-authtype": "awsSigv4",
+            }
 
         if authorizer_type == "JWT":
             openapi = {"type": "oauth2"}

--- a/samtranslator/plugins/api/implicit_http_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_http_api_plugin.py
@@ -163,7 +163,8 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
 class ImplicitHttpApiResource(SamResource):
     """
     Returns a AWS::Serverless::HttpApi resource representing the Implicit APIs. The returned resource
-    includes the empty OpenApi along with default values for other properties.
+    includes the empty OpenApi along with default values for other properties (except Auth). Auth is
+    configured with a single IAM authorizer called "AWS_IAM".
     """
 
     def __init__(self):
@@ -173,6 +174,7 @@ class ImplicitHttpApiResource(SamResource):
             "Type": SamResourceType.HttpApi.value,
             "Properties": {
                 "DefinitionBody": open_api,
+                "Auth": {"Authorizers": {"AWS_IAM": {"IamAuthorizer": True}}},
                 # Internal property that means Event source code can add Events. Used only for implicit APIs, to
                 # prevent back compatibility issues for explicit APIs
                 "__MANAGE_SWAGGER": True,


### PR DESCRIPTION
This is a work in progress and does not yet contain tests. I am sending it out at this stage to get feedback on my approach.

*Issue #, if available:* #1731

*Description of changes:*

This code change does two things:
1. Adds support for IAM authorizers to AWS::Serverless::HttpApi
1. Adds an IAM authorizer to the automatically generated ServerlessHttpApi

I'd be happy to split this into two separate PRs if people feel that's more appropriate. It's already separate commits.

*Description of how you validated changes:*

I created the following test template:

```yml
AWSTemplateFormatVersion: "2010-09-09"
Description: AWS SAM template with a simple API definition
Transform: AWS::Serverless-2016-10-31
Resources:
  #######
  # Serverless functions that use the automatically-created AWS::Serverless::HttpApi called "ServerlessHttpApi".
  #######
  # Should have no auth set.
  HttpApiFunctionDefaultApiDefaultAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /default-api/default-auth
            Method: GET
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionDefaultApiDefaultAuth', 'statusCode': 200}\n"
      Runtime: python3.8
  # Should have IAM auth set.
  HttpApiFunctionDefaultApiIAMAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /default-api/iam-auth
            Method: GET
            Auth:
              Authorizer: AWS_IAM
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionDefaultApiIAMAuth', 'statusCode': 200}\n"
      Runtime: python3.8
  #######
  # Serverless functions that use a manually-created AWS::Serverless::HttpApi with the default auth set to an IAM authorizer.
  #######
  # Should have IAM auth set because the default authorizer is an IAM authorizer.
  HttpApiFunctionCustomApiWithDefaultIamAuthDefaultAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-default-iam-auth/default-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithDefaultIamAuth
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithDefaultIamAuthDefaultAuth', 'statusCode':
        200}\n"
      Runtime: python3.8
  # Should have IAM auth set because the authorizer is set to an IAM authorizer.
  HttpApiFunctionCustomApiWithDefaultIamAuthIamAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-default-iam-auth/iam-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithDefaultIamAuth
            Auth:
              Authorizer: CustomIamAuthorizer
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithDefaultIamAuthIamAuth', 'statusCode':
        200}\n"
      Runtime: python3.8
  CustomServerlessHttpApiWithDefaultIamAuth:
    Type: AWS::Serverless::HttpApi
    Properties:
      FailOnWarnings: true
      Auth:
        DefaultAuthorizer: CustomIamAuthorizer
        Authorizers:
          CustomIamAuthorizer:
            IamAuthorizer: True
  #######
  # Serverless functions that use a manually-created AWS::Serverless::HttpApi with the default auth unset.
  #######
  # Should have no auth set because the default authorizer is not set.
  HttpApiFunctionCustomApiWithNoDefaultAuthDefaultAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-no-default-auth/default-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithNoDefault
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithNoDefaultAuthDefaultAuth', 'statusCode':
        200}\n"
      Runtime: python3.8
  # Should have IAM auth set because the authorizer is set to an IAM authorizer.
  HttpApiFunctionCustomApiWithNoDefaultIamAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-no-default-auth/iam-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithNoDefault
            Auth:
              Authorizer: CustomIamAuthorizer
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithNoDefaultIamAuth', 'statusCode': 200}\n"
      Runtime: python3.8
  CustomServerlessHttpApiWithNoDefault:
    Type: AWS::Serverless::HttpApi
    Properties:
      FailOnWarnings: true
      Auth:
        Authorizers:
          CustomIamAuthorizer:
            IamAuthorizer: True
```

I then compiled it using:

```
python ./bin/sam-translate.py --template-file=../project/template.yml
```

I then manually deployed it using CloudFormation in my personal AWS account.

Once deployed I validated all the routes had the expected auth type:

1. https://8gs6je9808.execute-api.us-east-1.amazonaws.com/custom-api-with-no-default-auth/default-auth - has no auth
1. https://8gs6je9808.execute-api.us-east-1.amazonaws.com/custom-api-with-no-default-auth/iam-auth - has IAM auth
1. https://e65p0kxj50.execute-api.us-east-1.amazonaws.com/default-api/default-auth - has no auth
1. https://e65p0kxj50.execute-api.us-east-1.amazonaws.com/default-api/iam-auth - has IAM auth
1. https://ykor2hq2i0.execute-api.us-east-1.amazonaws.com/custom-api-with-default-iam-auth/default-auth - has IAM auth
1. https://ykor2hq2i0.execute-api.us-east-1.amazonaws.com/custom-api-with-default-iam-auth/iam-auth - has IAM auth

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
