### PR TITLE
Add a built-in AWS_IAM authorizer for HTTP APIs

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -1167,7 +1167,8 @@ class HttpApi(PushEventSource):
         # Default auth should already be applied, so apply any other auth here or scope override to default
         api_authorizers = api_auth and api_auth.get("Authorizers")
 
-        if method_authorizer != "NONE" and not api_authorizers:
+        # "NONE" and "AWS_IAM" are placeholder authorizer values so they can be safely skipped.
+        if method_authorizer != "NONE" and method_authorizer != "AWS_IAM" and not api_authorizers:
             raise InvalidEventException(
                 self.relative_id,
                 "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "
@@ -1176,7 +1177,11 @@ class HttpApi(PushEventSource):
                 ),
             )
 
-        if method_authorizer != "NONE" and not api_authorizers.get(method_authorizer):
+        if (
+            method_authorizer != "NONE"
+            and method_authorizer != "AWS_IAM"
+            and not api_authorizers.get(method_authorizer)
+        ):
             raise InvalidEventException(
                 self.relative_id,
                 "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -407,7 +407,7 @@ class OpenApiEditor(object):
             security_dict = dict()
             security_dict[authorizer_name] = []
 
-            if authorizer_name != "NONE":
+            if authorizer_name != "NONE" and authorizer_name != "AWS_IAM":
                 method_authorization_scopes = authorizers[authorizer_name].get("AuthorizationScopes")
                 if authorization_scopes:
                     method_authorization_scopes = authorization_scopes


### PR DESCRIPTION
This is a work in progress and does not yet contain tests. I am sending it out at this stage to get feedback on my approach. This is an **alternate** approach from the other PR I sent out, #1876. The main difference between that PR and this one is that this code change adds a new special `Authorizer` built in called `AWS_IAM` that **cannot** be defined in the `Authorizers` section of an HTTP API.

*Issue #, if available:* #1731

*Description of changes:*

This code change does one thing:
1. Adds a new built-in authorizer, `AWS_IAM`, to be used by HTTP APIs.

*Description of how you validated changes:*

I created the following test template:

```yml
AWSTemplateFormatVersion: "2010-09-09"
Description: AWS SAM template with a simple API definition
Transform: AWS::Serverless-2016-10-31
Resources:
  #######
  # Serverless functions that use the automatically-created AWS::Serverless::HttpApi called "ServerlessHttpApi".
  #######
  # Should have no auth set.
  HttpApiFunctionDefaultApiDefaultAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /default-api/default-auth
            Method: GET
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionDefaultApiDefaultAuth', 'statusCode': 200}\n"
      Runtime: python3.8
  # Should have IAM auth set.
  HttpApiFunctionDefaultApiIAMAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /default-api/iam-auth
            Method: GET
            Auth:
              Authorizer: AWS_IAM
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionDefaultApiIAMAuth', 'statusCode': 200}\n"
      Runtime: python3.8
  #######
  # Serverless functions that use a manually-created AWS::Serverless::HttpApi with the default auth set to the IAM authorizer.
  #######
  # Should have IAM auth set because the default authorizer is the IAM authorizer.
  HttpApiFunctionCustomApiWithDefaultIamAuthDefaultAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-default-iam-auth/default-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithDefaultIamAuth
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithDefaultIamAuthDefaultAuth', 'statusCode':
        200}\n"
      Runtime: python3.8
  # Should have no auth.
  HttpApiFunctionCustomApiWithDefaultIamAuthNoneAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-default-iam-auth/none-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithDefaultIamAuth
            Auth:
              Authorizer: NONE
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithDefaultIamAuthNoneAuth', 'statusCode':
        200}\n"
      Runtime: python3.8
  # Should have IAM auth set because the authorizer is set to the IAM authorizer.
  HttpApiFunctionCustomApiWithDefaultIamAuthIamAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-default-iam-auth/iam-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithDefaultIamAuth
            Auth:
              Authorizer: AWS_IAM
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithDefaultIamAuthIamAuth', 'statusCode':
        200}\n"
      Runtime: python3.8
  # Serverless Http Api with an IAM authorizer (default) and a None authorizer.
  CustomServerlessHttpApiWithDefaultIamAuth:
    Type: AWS::Serverless::HttpApi
    Properties:
      FailOnWarnings: true
      Auth:
        DefaultAuthorizer: AWS_IAM

  #######
  # Serverless functions that use a manually-created AWS::Serverless::HttpApi with the default auth unset.
  #######
  # Should have no auth set because the default authorizer is not set.
  HttpApiFunctionCustomApiWithNoDefaultAuthDefaultAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-no-default-auth/default-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithNoDefault
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithNoDefaultAuthDefaultAuth', 'statusCode':
        200}\n"
      Runtime: python3.8
  # Should have IAM auth set because the authorizer is set to the IAM authorizer.
  HttpApiFunctionCustomApiWithNoDefaultIamAuth:
    Type: AWS::Serverless::Function
    Properties:
      Events:
        ApiEvent:
          Type: HttpApi
          Properties:
            Path: /custom-api-with-no-default-auth/iam-auth
            Method: GET
            ApiId: !Ref CustomServerlessHttpApiWithNoDefault
            Auth:
              Authorizer: AWS_IAM
      Handler: index.handler
      InlineCode:
        "def handler(event, context):\n    return {'body':
        'HttpApiFunctionCustomApiWithNoDefaultIamAuth', 'statusCode': 200}\n"
      Runtime: python3.8
  # Serverless Http Api with an IAM authorizer and a None authorizer.
  CustomServerlessHttpApiWithNoDefault:
    Type: AWS::Serverless::HttpApi
    Properties:
      FailOnWarnings: true
```

I then compiled it using:

```
python ./bin/sam-translate.py --template-file=../project/template.yml
```

I then manually deployed it using CloudFormation in my personal AWS account.

Once deployed I validated all the routes had the expected auth type:

1. https://8gs6je9808.execute-api.us-east-1.amazonaws.com/custom-api-with-no-default-auth/default-auth - has no auth
1. https://8gs6je9808.execute-api.us-east-1.amazonaws.com/custom-api-with-no-default-auth/iam-auth - has IAM auth
1. https://e65p0kxj50.execute-api.us-east-1.amazonaws.com/default-api/default-auth - has no auth
1. https://e65p0kxj50.execute-api.us-east-1.amazonaws.com/default-api/iam-auth - has IAM auth
1. https://ykor2hq2i0.execute-api.us-east-1.amazonaws.com/custom-api-with-default-iam-auth/default-auth - has IAM auth
1. https://ykor2hq2i0.execute-api.us-east-1.amazonaws.com/custom-api-with-default-iam-auth/iam-auth - has IAM auth
1. https://ykor2hq2i0.execute-api.us-east-1.amazonaws.com/custom-api-with-default-iam-auth/none-auth - has no auth

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
