### PR TITLE
Sam support for custom checkpointing

### DIFF
--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -35,6 +35,7 @@ class PullEventSource(ResourceMacro):
         "Queues": PropertyType(False, is_type(list)),
         "SourceAccessConfigurations": PropertyType(False, is_type(list)),
         "TumblingWindowInSeconds": PropertyType(False, is_type(int)),
+        "FunctionResponseTypes": PropertyType(False, is_type(list)),
     }
 
     def get_policy_arn(self):
@@ -87,6 +88,7 @@ class PullEventSource(ResourceMacro):
         lambda_eventsourcemapping.Queues = self.Queues
         lambda_eventsourcemapping.SourceAccessConfigurations = self.SourceAccessConfigurations
         lambda_eventsourcemapping.TumblingWindowInSeconds = self.TumblingWindowInSeconds
+        lambda_eventsourcemapping.FunctionResponseTypes = self.FunctionResponseTypes
 
         destination_config_policy = None
         if self.DestinationConfig:

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -76,6 +76,7 @@ class LambdaEventSourceMapping(Resource):
         "Queues": PropertyType(False, is_type(list)),
         "SourceAccessConfigurations": PropertyType(False, is_type(list)),
         "TumblingWindowInSeconds": PropertyType(False, is_type(int)),
+        "FunctionResponseTypes": PropertyType(False, is_type(list)),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}

--- a/tests/translator/input/function_with_event_source_mapping.yaml
+++ b/tests/translator/input/function_with_event_source_mapping.yaml
@@ -53,6 +53,8 @@ Resources:
             MaximumRecordAgeInSeconds: 86400
             StartingPosition: TRIM_HORIZON
             TumblingWindowInSeconds: 60
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
             DestinationConfig:
               OnFailure:
                 Type: SQS

--- a/tests/translator/output/aws-cn/function_with_event_source_mapping.json
+++ b/tests/translator/output/aws-cn/function_with_event_source_mapping.json
@@ -182,7 +182,8 @@
         "ParallelizationFactor": 8,
         "MaximumRetryAttempts": 100,
         "BisectBatchOnFunctionError": true,
-        "TumblingWindowInSeconds": 60
+        "TumblingWindowInSeconds": 60,
+        "FunctionResponseTypes": ["ReportBatchItemFailures"]
       }
     },
     "MyFunctionForBatchingExample": {

--- a/tests/translator/output/aws-us-gov/function_with_event_source_mapping.json
+++ b/tests/translator/output/aws-us-gov/function_with_event_source_mapping.json
@@ -182,7 +182,8 @@
         "ParallelizationFactor": 8,
         "MaximumRetryAttempts": 100,
         "BisectBatchOnFunctionError": true,
-        "TumblingWindowInSeconds": 60
+        "TumblingWindowInSeconds": 60,
+        "FunctionResponseTypes": ["ReportBatchItemFailures"]
       }
     },
     "MyFunctionForBatchingExample": {

--- a/tests/translator/output/function_with_event_source_mapping.json
+++ b/tests/translator/output/function_with_event_source_mapping.json
@@ -182,7 +182,8 @@
         "ParallelizationFactor": 8,
         "MaximumRetryAttempts": 100,
         "BisectBatchOnFunctionError": true,
-        "TumblingWindowInSeconds": 60
+        "TumblingWindowInSeconds": 60,
+        "FunctionResponseTypes": ["ReportBatchItemFailures"]
       }
     },
     "MyFunctionForBatchingExample": {

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -513,6 +513,7 @@ MaximumRecordAgeInSeconds | `integer` | The maximum age of a record that will be
 DestinationConfig | [Destination Config Object](#destination-config-object) | Expired record metadata/retries and exhausted metadata is sent to this destination after they have passed the defined limits.
 ParallelizationFactor | `integer` | Allocates multiple virtual shards, increasing the Lambda invokes by the given factor and speeding up the stream processing.
 TumblingWindowInSeconds | `integer` |  Tumbling window (non-overlapping time window) duration to perform aggregations.
+FunctionResponseTypes | `list` | Response types enabled for your function.
 
 **NOTE:** `SQSSendMessagePolicy` or `SNSPublishMessagePolicy` needs to be added in `Policies` for publishing messages to the `SQS` or `SNS` resource mentioned in `OnFailure` property
 
@@ -536,6 +537,8 @@ Properties:
       Type: SQS
       Destination: !GetAtt MySqsQueue.Arn
   TumblingWindowInSeconds: 0
+  FunctionResponseTypes:
+    - ReportBatchItemFailures
 ```
 
 
@@ -582,6 +585,7 @@ MaximumRecordAgeInSeconds | `integer` | The maximum age of a record that will be
 DestinationConfig | [DestinationConfig Object](#destination-config-object) | Expired record metadata/retries and exhausted metadata is sent to this destination after they have passed the defined limits.
 ParallelizationFactor | `integer` | Allocates multiple virtual shards, increasing the Lambda invokes by the given factor and speeding up the stream processing.
 TumblingWindowInSeconds | `integer` |  Tumbling window (non-overlapping time window) duration to perform aggregations.
+FunctionResponseTypes | `list` | Response types enabled for your function.
 
 ##### Example: DynamoDB event source object
 
@@ -602,6 +606,8 @@ Properties:
       Type: SQS
       Destination: !GetAtt MySqsQueue.Arn
   TumblingWindowInSeconds: 0
+  FunctionResponseTypes
+    - ReportBatchItemFailures
 ```
 
 #### SQS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added support for FuntionResponseTypes in EventSourceMapping model. This is required to support custom checkpointing for Kinesis and DDB streams. 
https://aws.amazon.com/blogs/compute/optimizing-batch-processing-with-custom-checkpoints-in-aws-lambda/

*Description of how you validated changes:*
`make pr` succeeds.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*
Added translator tests which contain a sample input.

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
