### PR TITLE
Fix: Description in AWS::Serverless::HttpApi

### DIFF
--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -112,6 +112,8 @@ class HttpApiGenerator(object):
         if self.disable_execute_api_endpoint is not None:
             self._add_endpoint_configuration()
 
+        self._set_description()
+
         if self.definition_uri:
             http_api.BodyS3Location = self._construct_body_s3_dict()
         elif self.definition_body:
@@ -123,9 +125,6 @@ class HttpApiGenerator(object):
                 "'AWS::Serverless::HttpApi'. Add a value for one of these properties or "
                 "add a 'HttpApi' event to an 'AWS::Serverless::Function'.",
             )
-
-        if self.description:
-            http_api.Description = self.description
 
         return http_api
 
@@ -585,6 +584,27 @@ class HttpApiGenerator(object):
         stage.RouteSettings = self.route_settings
 
         return stage
+
+    def _set_description(self):
+        """Sets Description to DefinitionBody"""
+        if not self.description:
+            return
+
+        if not self.definition_body:
+            raise InvalidResourceException(
+                self.logical_id,
+                "Description works only with inline OpenApi specified in the 'DefinitionBody' property.",
+            )
+        if self.definition_body.get("info", {}).get("description"):
+            raise InvalidResourceException(
+                self.logical_id,
+                "Unable to set Description because it is already defined within inline OpenAPI specified in the "
+                "'DefinitionBody' property.",
+            )
+
+        open_api_editor = OpenApiEditor(self.definition_body)
+        open_api_editor.set_description(self.description)
+        self.definition_body = open_api_editor.openapi
 
     def to_cloudformation(self):
         """Generates CloudFormation resources from a SAM HTTP API resource

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -112,7 +112,7 @@ class HttpApiGenerator(object):
         if self.disable_execute_api_endpoint is not None:
             self._add_endpoint_configuration()
 
-        self._set_description()
+        self._add_description()
 
         if self.definition_uri:
             http_api.BodyS3Location = self._construct_body_s3_dict()
@@ -585,8 +585,8 @@ class HttpApiGenerator(object):
 
         return stage
 
-    def _set_description(self):
-        """Sets Description to DefinitionBody"""
+    def _add_description(self):
+        """Add description to DefinitionBody if Description property is set in SAM"""
         if not self.description:
             return
 
@@ -603,7 +603,7 @@ class HttpApiGenerator(object):
             )
 
         open_api_editor = OpenApiEditor(self.definition_body)
-        open_api_editor.set_description(self.description)
+        open_api_editor.add_description(self.description)
         self.definition_body = open_api_editor.openapi
 
     def to_cloudformation(self):

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -522,8 +522,8 @@ class OpenApiEditor(object):
 
         self._doc[self._X_APIGW_CORS] = cors_configuration
 
-    def set_description(self, description):
-        """Set description in open api definition, if it is not already defined
+    def add_description(self, description):
+        """Add description in open api definition, if it is not already defined
 
         :param string description: Description of the API
         """

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -46,6 +46,7 @@ class OpenApiEditor(object):
         self.security_schemes = self._doc.get("components", {}).get("securitySchemes", {})
         self.definitions = self._doc.get("definitions", {})
         self.tags = self._doc.get("tags", [])
+        self.info = self._doc.get("info", {})
 
     def get_path(self, path):
         """
@@ -521,6 +522,15 @@ class OpenApiEditor(object):
 
         self._doc[self._X_APIGW_CORS] = cors_configuration
 
+    def set_description(self, description):
+        """Set description in open api definition, if it is not already defined
+
+        :param string description: Description of the API
+        """
+        if self.info.get("description"):
+            return
+        self.info["description"] = description
+
     def has_api_gateway_cors(self):
         if self._doc.get(self._X_APIGW_CORS):
             return True
@@ -543,6 +553,9 @@ class OpenApiEditor(object):
         if self.security_schemes:
             self._doc.setdefault("components", {})
             self._doc["components"]["securitySchemes"] = self.security_schemes
+
+        if self.info:
+            self._doc["info"] = self.info
 
         return copy.deepcopy(self._doc)
 

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -416,7 +416,7 @@ class TestOpenApiEditor_get_integration_function(TestCase):
         self.assertFalse(self.editor.get_integration_function_logical_id("/bar", "get"))
 
 
-class TestOpenApiEdit_set_description(TestCase):
+class TestOpenApiEdit_add_description(TestCase):
     def setUp(self):
         self.original_openapi_with_description = {
             "openapi": "3.0.1",
@@ -428,12 +428,12 @@ class TestOpenApiEdit_set_description(TestCase):
             "paths": {},
         }
 
-    def test_must_set_description_if_not_defined(self):
+    def test_must_add_description_if_not_defined(self):
         editor = OpenApiEditor(self.original_openapi_without_description)
-        editor.set_description("New Description")
+        editor.add_description("New Description")
         self.assertEqual(editor.openapi["info"]["description"], "New Description")
 
-    def test_must_not_set_description_if_already_defined(self):
+    def test_must_not_add_description_if_already_defined(self):
         editor = OpenApiEditor(self.original_openapi_with_description)
-        editor.set_description("New Description")
+        editor.add_description("New Description")
         self.assertEqual(editor.openapi["info"]["description"], "Existing Description")

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -414,3 +414,26 @@ class TestOpenApiEditor_get_integration_function(TestCase):
             "HttpApiFunction",
         )
         self.assertFalse(self.editor.get_integration_function_logical_id("/bar", "get"))
+
+
+class TestOpenApiEdit_set_description(TestCase):
+    def setUp(self):
+        self.original_openapi_with_description = {
+            "openapi": "3.0.1",
+            "paths": {},
+            "info": {"description": "Existing Description"},
+        }
+        self.original_openapi_without_description = {
+            "openapi": "3.0.1",
+            "paths": {},
+        }
+
+    def test_must_set_description_if_not_defined(self):
+        editor = OpenApiEditor(self.original_openapi_without_description)
+        editor.set_description("New Description")
+        self.assertEqual(editor.openapi["info"]["description"], "New Description")
+
+    def test_must_not_set_description_if_already_defined(self):
+        editor = OpenApiEditor(self.original_openapi_with_description)
+        editor.set_description("New Description")
+        self.assertEqual(editor.openapi["info"]["description"], "Existing Description")

--- a/tests/translator/input/http_api_description.yaml
+++ b/tests/translator/input/http_api_description.yaml
@@ -2,7 +2,10 @@ Resources:
   HttpApi:
     Type: AWS::Serverless::HttpApi
     Properties:
-      DefinitionUri: s3://bucket/key
+      DefinitionBody:
+        openapi: "3.0.1"
+        paths:
+          "/foo": {}
       Description: my description
 
   Function:

--- a/tests/translator/output/aws-cn/http_api_description.json
+++ b/tests/translator/output/aws-cn/http_api_description.json
@@ -79,17 +79,44 @@
         "ApiId": {
           "Ref": "HttpApi"
         },
+        "Tags": {
+          "httpapi:createdBy": "SAM"
+        },
         "StageName": "$default"
       }
     }, 
     "HttpApi": {
       "Type": "AWS::ApiGatewayV2::Api", 
       "Properties": {
-        "BodyS3Location": {
-          "Bucket": "bucket",
-          "Key": "key"
-        },
-        "Description": "my description"
+        "Body": {
+          "openapi": "3.0.1",
+          "paths": {
+            "/foo": {},
+            "$default": {
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "payloadFormatVersion": "2.0",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function.Arn}/invocations"
+                  }
+                },
+                "isDefaultRoute": true,
+                "responses": {}
+              }
+            }
+          },
+          "tags": [
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ],
+          "info": {
+            "description": "my description"
+          }
+        }
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/http_api_description.json
+++ b/tests/translator/output/aws-us-gov/http_api_description.json
@@ -79,17 +79,44 @@
         "ApiId": {
           "Ref": "HttpApi"
         },
+        "Tags": {
+          "httpapi:createdBy": "SAM"
+        },
         "StageName": "$default"
       }
     }, 
     "HttpApi": {
       "Type": "AWS::ApiGatewayV2::Api", 
       "Properties": {
-        "BodyS3Location": {
-          "Bucket": "bucket",
-          "Key": "key"
-        },
-        "Description": "my description"
+        "Body": {
+          "openapi": "3.0.1",
+          "paths": {
+            "/foo": {},
+            "$default": {
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "payloadFormatVersion": "2.0",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function.Arn}/invocations"
+                  }
+                },
+                "isDefaultRoute": true,
+                "responses": {}
+              }
+            }
+          },
+          "tags": [
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ],
+          "info": {
+            "description": "my description"
+          }
+        }
       }
     }
   }

--- a/tests/translator/output/http_api_description.json
+++ b/tests/translator/output/http_api_description.json
@@ -79,17 +79,44 @@
         "ApiId": {
           "Ref": "HttpApi"
         },
+        "Tags": {
+          "httpapi:createdBy": "SAM"
+        },
         "StageName": "$default"
       }
     }, 
     "HttpApi": {
       "Type": "AWS::ApiGatewayV2::Api", 
       "Properties": {
-        "BodyS3Location": {
-          "Bucket": "bucket",
-          "Key": "key"
-        },
-        "Description": "my description"
+        "Body": {
+          "openapi": "3.0.1",
+          "paths": {
+            "/foo": {},
+            "$default": {
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "payloadFormatVersion": "2.0",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function.Arn}/invocations"
+                  }
+                },
+                "isDefaultRoute": true,
+                "responses": {}
+              }
+            }
+          },
+          "tags": [
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ],
+          "info": {
+            "description": "my description"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes how the `Description` property is handled for a `AWS::Serverless::HttpApi` resource:
When `Description` is set, one of the followings will happen:
* if `DefinitionBody` is not set, an error will be thrown
* if `DefinitionBody` is set and `description` is already set in the OpenAPI definition, an error will be thrown
* if `DefinitionBody` is set and no `description` is set in the OpenAPI definition, `description` will be set in the OpenAPI definition.

Before the changes, deploying a `AWS::Serverless::HttpApi` resource with `Description` set will result in an error:
```
Redundant fields [description="description"] provided when either Body or
BodyS3Location is not empty (Service: null; Status Code: 0; Error Code: null;
Request ID: null; Proxy: null) (Service: null; Status Code: 404; Error Code:
BadRequestException; Request ID: null; Proxy: null)  
```
Note that the same error does not occur for `AWS::Serverless::Api`, but only `AWS::Serverless::HttpApi`.

*Description of how you validated changes:*
Updated and added tests to cover all changes made
```
pytest tests/openapi/test_openapi.py
pytest tests/model/test_sam_resources.py
```
Verified transformed template deploys without error.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
