### PR TITLE
fix: Better Error Handling of Intrinsics

### DIFF
--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -14,7 +14,7 @@ from samtranslator.model.s3_utils.uri_parser import parse_s3_uri
 from samtranslator.open_api.open_api import OpenApiEditor
 from samtranslator.translator import logical_id_generator
 from samtranslator.model.tags.resource_tagging import get_tag_list
-from samtranslator.model.intrinsics import is_intrinsic
+from samtranslator.model.intrinsics import is_intrinsic, is_intrinsic_no_value
 from samtranslator.model.route53 import Route53RecordSetGroup
 
 _CORS_WILDCARD = "*"
@@ -466,6 +466,15 @@ class HttpApiGenerator(object):
         """
         if not default_authorizer:
             return
+
+        if is_intrinsic_no_value(default_authorizer):
+            return
+
+        if is_intrinsic(default_authorizer):
+            raise InvalidResourceException(
+                self.logical_id,
+                "Unable to set DefaultAuthorizer because intrinsic functions are not supported for this field.",
+            )
 
         if not authorizers.get(default_authorizer):
             raise InvalidResourceException(

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -69,6 +69,13 @@ class TestHttpApiGenerator(TestCase):
         with pytest.raises(InvalidResourceException):
             HttpApiGenerator(**self.kwargs)._construct_http_api()
 
+    def test_auth_intrinsic_default_auth(self):
+        self.kwargs["auth"] = self.authorizers
+        self.kwargs["auth"]["DefaultAuthorizer"] = {"Ref": "SomeValue"}
+        self.kwargs["definition_body"] = OpenApiEditor.gen_skeleton()
+        with pytest.raises(InvalidResourceException):
+            HttpApiGenerator(**self.kwargs)._construct_http_api()
+
     def test_def_uri_invalid_dict(self):
         self.kwargs["auth"] = None
         self.kwargs["definition_body"] = None

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -76,6 +76,12 @@ class TestHttpApiGenerator(TestCase):
         with pytest.raises(InvalidResourceException):
             HttpApiGenerator(**self.kwargs)._construct_http_api()
 
+    def test_auth_novalue_default_does_not_raise(self):
+        self.kwargs["auth"] = self.authorizers
+        self.kwargs["auth"]["DefaultAuthorizer"] = {"Ref": "AWS::NoValue"}
+        self.kwargs["definition_body"] = OpenApiEditor.gen_skeleton()
+        HttpApiGenerator(**self.kwargs)._construct_http_api()
+
     def test_def_uri_invalid_dict(self):
         self.kwargs["auth"] = None
         self.kwargs["definition_body"] = None


### PR DESCRIPTION
In HTTP API authorizers, we don't yet handle intrinsics, and an attempt
to use them creates a crash when it tries to hash the input `dict`. This
change starts by wrapping that use case properly so that a helpful error
is raised until intrinsics are supported here.

Note: Does not yet handle `!Sub`, looking at options for that.

*Checklist:*

- [X] Write/update tests
- [X] `make pr` passes
- [X] Update documentation
- [X] Verify transformed template deploys and application functions as expected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
