### PR TITLE
feat: add codebuild startbuild sam policy template

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -2306,6 +2306,32 @@
           }
         ]
       }
+    },
+    "CodebuildStartBuildPolicy": {
+      "Description": "Gives permission to start a new build for a CodeBuild project",
+      "Parameters": {
+        "CodeBuildProject": {
+          "Description": "The name of the Codebuild project"
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Action": ["codebuild:StartBuild"],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/${codebuildProject}",
+                {
+                  "codebuildProject": {
+                    "Ref": "CodeBuildProject"
+                  }
+                }
+              ]
+            },
+            "Effect": "Allow"
+          }
+        ]
+      }
     }
   }
 }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -168,3 +168,6 @@ Resources:
 
         - EventBridgePutEventsPolicy:
             EventBusName: name
+
+        - CodebuildStartBuildPolicy:
+            CodeBuildProject: name


### PR DESCRIPTION
<!-- *Issue #, if available:* -->

*Description of changes:*
This is a sam policy template that allows starting a codebuild build.

*Description of how you validated changes:*
I ran `make pr`

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
