### PR TITLE
Refactor hash generation in API Deployment's logical ID

### DIFF
--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -1,4 +1,5 @@
 import copy
+import json
 
 from samtranslator.feature_toggle.feature_toggle import (
     FeatureToggle,
@@ -67,8 +68,8 @@ class Translator:
                                 resource_dict_copy.get("Properties").get("FunctionName")
                             )
                             if function_name:
-                                self.function_names[api_name] = str(self.function_names.get(api_name, "")) + str(
-                                    function_name
+                                self.function_names[api_name] = self.function_names.get(api_name, "") + json.dumps(
+                                    function_name, sort_keys=True
                                 )
         return self.function_names
 

--- a/tests/model/test_api.py
+++ b/tests/model/test_api.py
@@ -35,12 +35,3 @@ class TestApiGatewayDeployment(TestCase):
         self.assertIn("swagger", expected)
         self.assertIn("domain", expected)
         self.assertIn("function_names", expected)
-
-    def test__make_hash_input_is_deep_sorted(self):
-        deployment = ApiGatewayDeployment(logical_id="logicalIdDeployment")
-        swagger = {"foo": "bar", "nested": {"a": "b", "c": "d"}}
-        swagger_other = {"nested": {"c": "d", "a": "b"}, "foo": "bar"}
-
-        hash_input = deployment._make_hash_input(None, swagger, None, None)
-        hash_input_other = deployment._make_hash_input(None, swagger_other, None, None)
-        self.assertEqual(hash_input, hash_input_other)

--- a/tests/model/test_api.py
+++ b/tests/model/test_api.py
@@ -35,3 +35,12 @@ class TestApiGatewayDeployment(TestCase):
         self.assertIn("swagger", expected)
         self.assertIn("domain", expected)
         self.assertIn("function_names", expected)
+
+    def test__make_hash_input_is_deep_sorted(self):
+        deployment = ApiGatewayDeployment(logical_id="logicalIdDeployment")
+        swagger = {"foo": "bar", "nested": {"a": "b", "c": "d"}}
+        swagger_other = {"nested": {"c": "d", "a": "b"}, "foo": "bar"}
+
+        hash_input = deployment._make_hash_input(None, swagger, None, None)
+        hash_input_other = deployment._make_hash_input(None, swagger_other, None, None)
+        self.assertEqual(hash_input, hash_input_other)

--- a/tests/model/test_api.py
+++ b/tests/model/test_api.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import pytest
 
 from samtranslator.model import InvalidResourceException
-from samtranslator.model.apigateway import ApiGatewayAuthorizer
+from samtranslator.model.apigateway import ApiGatewayAuthorizer, ApiGatewayDeployment
 
 
 class TestApiGatewayAuthorizer(TestCase):
@@ -17,3 +17,21 @@ class TestApiGatewayAuthorizer(TestCase):
             auth = ApiGatewayAuthorizer(
                 api_logical_id="logicalId", name="authName", authorization_scopes="invalid_scope"
             )
+
+
+class TestApiGatewayDeployment(TestCase):
+    def test__make_hash_input_is_dict(self):
+        deployment = ApiGatewayDeployment(logical_id="logicalIdDeployment")
+
+        openapi_version = "3.0.0"
+        swagger = {"foo": "bar", "nested": {"a": "b", "c": "d"}}
+        domain = {"foo": "bar"}
+        redeploy_restapi_parameters = {"function_names": {"logicalId": "functionName"}}
+
+        expected = deployment._make_hash_input(openapi_version, swagger, domain, redeploy_restapi_parameters)
+
+        self.assertIsInstance(expected, dict)
+        self.assertIn("openapi_version", expected)
+        self.assertIn("swagger", expected)
+        self.assertIn("domain", expected)
+        self.assertIn("function_names", expected)

--- a/tests/translator/output/api_cache.json
+++ b/tests/translator/output/api_cache.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "HtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,32 +29,32 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
-        "CacheClusterEnabled": true, 
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "HtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "HtmlApi"
-        }, 
-        "StageName": "Prod", 
+        },
+        "StageName": "Prod",
         "CacheClusterSize": "1.6"
       }
-    }, 
+    },
     "HtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HtmlApi"
@@ -63,46 +63,46 @@
         }
       }
     },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "HtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
         }
       }
-    }, 
+    },
     "HtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "HtmlFunctionRole", 
+            "HtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_description.json
+++ b/tests/translator/output/api_description.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "FunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,30 +29,30 @@
           ]
         }
       }
-    }, 
+    },
     "ApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "Api"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "FunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "Function"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "Api"
@@ -61,47 +61,47 @@
         }
       }
     },
-    "ApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "Api"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "Api": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
         },
         "Description": "my description"
       }
-    }, 
+    },
     "Function": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
             "FunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "Api"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_endpoint_configuration.json
+++ b/tests/translator/output/api_endpoint_configuration.json
@@ -3,33 +3,33 @@
     "EndpointConfig": {
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -41,13 +41,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -57,28 +57,18 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -88,96 +78,106 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "SomeValue"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "SomeValue"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment62b96c1a61"
-        }, 
+          "Ref": "ServerlessRestApiDeployment207d63cbe2"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment62b96c1a61": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 62b96c1a611878eefb13e8ef66dbc71b9ba3dd19", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             {
               "Ref": "EndpointConfig"
             }
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": {
             "Ref": "EndpointConfig"
           }
         }
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment207d63cbe2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 207d63cbe20acce3663f22e907f62096d9d7039c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/api_endpoint_configuration_with_vpcendpoint.json
@@ -6,33 +6,33 @@
     "EndpointConfigType": {
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -44,13 +44,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -60,28 +60,18 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -91,82 +81,72 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "SomeValue"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "SomeValue"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment62b96c1a61"
-        }, 
+          "Ref": "ServerlessRestApiDeployment207d63cbe2"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment62b96c1a61": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 62b96c1a611878eefb13e8ef66dbc71b9ba3dd19", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         },
         "EndpointConfiguration": {
@@ -186,6 +166,26 @@
             "Ref": "EndpointConfigType"
           }
         }
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment207d63cbe2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 207d63cbe20acce3663f22e907f62096d9d7039c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_request_model.json
+++ b/tests/translator/output/api_request_model.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "HtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,30 +29,30 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentdd6198efe6"
-        }, 
+          "Ref": "HtmlApiDeployment58a55b0347"
+        },
         "RestApiId": {
           "Ref": "HtmlApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "HtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HtmlApi"
@@ -61,18 +61,8 @@
         }
       }
     },
-    "HtmlApiDeploymentdd6198efe6": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: dd6198efe68d8db17c8bf6b680a8a6763e4f36b5",
-        "StageName": "Stage"
-      }
-    }, 
     "HtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
@@ -118,28 +108,38 @@
           }
         }
       }
-    }, 
+    },
     "HtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "HtmlFunctionRole", 
+            "HtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment58a55b0347": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 58a55b034716839a5b6ec8c0c177c6a621bc5f9d",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_request_model_openapi_3.json
+++ b/tests/translator/output/api_request_model_openapi_3.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "HtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,30 +29,30 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment59eeb787ee"
-        }, 
+          "Ref": "HtmlApiDeploymentbc83cd76d1"
+        },
         "RestApiId": {
           "Ref": "HtmlApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "HtmlFunctionIamPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/iam", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/iam",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -62,17 +62,17 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/iam": {
               "get": {
@@ -83,25 +83,25 @@
                         "$ref": "#/components/schemas/user"
                       }
                     }
-                  }, 
+                  },
                   "required": true
-                }, 
+                },
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HtmlFunction.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::*:user/*"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/": {
               "get": {
                 "requestBody": {
@@ -111,33 +111,33 @@
                         "$ref": "#/components/schemas/user"
                       }
                     }
-                  }, 
+                  },
                   "required": true
-                }, 
+                },
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0",
           "components": {
             "securitySchemes": {
               "AWS_IAM": {
-                "x-amazon-apigateway-authtype": "awsSigv4", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "x-amazon-apigateway-authtype": "awsSigv4",
+                "type": "apiKey",
+                "name": "Authorization",
                 "in": "header"
               }
-            }, 
+            },
             "schemas": {
               "user": {
-                "type": "object", 
+                "type": "object",
                 "properties": {
                   "username": {
                     "type": "string"
@@ -148,27 +148,18 @@
           }
         }
       }
-    }, 
-    "HtmlApiDeployment59eeb787ee": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: 59eeb787ee1561329a07e10162ac3718998e9f91"
-      }
     },
     "HtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HtmlApi"
@@ -176,28 +167,37 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "HtmlFunctionRole", 
+            "HtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeploymentbc83cd76d1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: bc83cd76d1f101976f27d3479890a29dd0490ef2"
       }
     }
   }

--- a/tests/translator/output/api_with_access_log_setting.json
+++ b/tests/translator/output/api_with_access_log_setting.json
@@ -53,16 +53,6 @@
         }
       }
     },
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
-      }
-    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -101,7 +91,7 @@
           "Format": "$context.requestId"
         },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
+          "Ref": "ExplicitApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -117,22 +107,12 @@
           "Format": "$context.requestId"
         },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment62b96c1a61"
+          "Ref": "ServerlessRestApiDeployment207d63cbe2"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
         "StageName": "Prod"
-      }
-    },
-    "ServerlessRestApiDeployment62b96c1a61": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 62b96c1a611878eefb13e8ef66dbc71b9ba3dd19",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
@@ -161,6 +141,26 @@
           },
           "swagger": "2.0"
         }
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment207d63cbe2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 207d63cbe20acce3663f22e907f62096d9d7039c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_apikey_default_override.json
+++ b/tests/translator/output/api_with_apikey_default_override.json
@@ -1,164 +1,154 @@
 {
-    "Resources": {
-      "MyApiWithAuthProdStage": {
-        "Type": "AWS::ApiGateway::Stage", 
-        "Properties": {
-          "DeploymentId": {
-            "Ref": "MyApiWithAuthDeployment054e605502"
-          }, 
-          "RestApiId": {
-            "Ref": "MyApiWithAuth"
-          }, 
-          "StageName": "Prod"
-        }
-      }, 
-      "MyFunctionWithApiKeyRequiredTrueMyApiWithApiKeyRequiredTruePermissionProd": {
-        "Type": "AWS::Lambda::Permission", 
-        "Properties": {
-          "Action": "lambda:InvokeFunction", 
-          "Principal": "apigateway.amazonaws.com", 
-          "FunctionName": {
-            "Ref": "MyFunctionWithApiKeyRequiredTrue"
-          }, 
-          "SourceArn": {
-            "Fn::Sub": [
-              "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyTrue", 
-              {
-                "__Stage__": "*",
-                "__ApiId__": {
-                  "Ref": "MyApiWithAuth"
-                }
-              }
-            ]
-          }
-        }
-      }, 
-      "MyFunctionWithApiKeyRequiredFalseMyApiWithApiKeyRequiredFalsePermissionProd": {
-        "Type": "AWS::Lambda::Permission", 
-        "Properties": {
-          "Action": "lambda:InvokeFunction", 
-          "Principal": "apigateway.amazonaws.com", 
-          "FunctionName": {
-            "Ref": "MyFunctionWithApiKeyRequiredFalse"
-          }, 
-          "SourceArn": {
-            "Fn::Sub": [
-              "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyFalse", 
-              {
-                "__Stage__": "*",
-                "__ApiId__": {
-                  "Ref": "MyApiWithAuth"
-                }
-              }
-            ]
-          }
-        }
-      },
-      "MyFunctionWithApiKeyRequiredTrue": {
-        "Type": "AWS::Lambda::Function", 
-        "Properties": {
-          "Handler": "index.handler", 
-          "Code": {
-            "S3Bucket": "bucket", 
-            "S3Key": "key"
-          }, 
-          "Role": {
-            "Fn::GetAtt": [
-              "MyFunctionWithApiKeyRequiredTrueRole", 
-              "Arn"
-            ]
-          }, 
-          "Runtime": "nodejs12.x",
-          "Tags": [
+  "Resources": {
+    "MyApiWithAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithAuthDeploymentc2f530abef"
+        },
+        "RestApiId": {
+          "Ref": "MyApiWithAuth"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyFunctionWithApiKeyRequiredTrueMyApiWithApiKeyRequiredTruePermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "MyFunctionWithApiKeyRequiredTrue"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyTrue",
             {
-              "Value": "SAM", 
-              "Key": "lambda:createdBy"
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApiWithAuth"
+              }
             }
           ]
         }
-      }, 
-      "MyFunctionWithApiKeyRequiredDefault": {
-        "Type": "AWS::Lambda::Function", 
-        "Properties": {
-          "Handler": "index.handler", 
-          "Code": {
-            "S3Bucket": "bucket", 
-            "S3Key": "key"
-          }, 
-          "Role": {
-            "Fn::GetAtt": [
-              "MyFunctionWithApiKeyRequiredDefaultRole", 
-              "Arn"
-            ]
-          }, 
-          "Runtime": "nodejs12.x",
-          "Tags": [
+      }
+    },
+    "MyFunctionWithApiKeyRequiredFalseMyApiWithApiKeyRequiredFalsePermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "MyFunctionWithApiKeyRequiredFalse"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyFalse",
             {
-              "Value": "SAM", 
-              "Key": "lambda:createdBy"
-            }
-          ]
-        }
-      }, 
-      "MyFunctionWithApiKeyRequiredDefaultMyApiWithApiKeyRequiredDefaultPermissionProd": {
-        "Type": "AWS::Lambda::Permission", 
-        "Properties": {
-          "Action": "lambda:InvokeFunction", 
-          "Principal": "apigateway.amazonaws.com", 
-          "FunctionName": {
-            "Ref": "MyFunctionWithApiKeyRequiredDefault"
-          }, 
-          "SourceArn": {
-            "Fn::Sub": [
-              "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyDefault", 
-              {
-                "__Stage__": "*",
-                "__ApiId__": {
-                  "Ref": "MyApiWithAuth"
-                }
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApiWithAuth"
               }
-            ]
-          }
-        }
-      }, 
-      "MyApiWithAuthDeployment054e605502": {
-        "Type": "AWS::ApiGateway::Deployment", 
-        "Properties": {
-          "RestApiId": {
-            "Ref": "MyApiWithAuth"
-          }, 
-          "Description": "RestApi deployment id: 054e60550295973114b1bc4384d00c8b641ea20f", 
-          "StageName": "Stage"
-        }
-      }, 
-      "MyFunctionWithApiKeyRequiredFalse": {
-        "Type": "AWS::Lambda::Function", 
-        "Properties": {
-          "Handler": "index.handler", 
-          "Code": {
-            "S3Bucket": "bucket", 
-            "S3Key": "key"
-          }, 
-          "Role": {
-            "Fn::GetAtt": [
-              "MyFunctionWithApiKeyRequiredFalseRole", 
-              "Arn"
-            ]
-          }, 
-          "Runtime": "nodejs12.x",
-          "Tags": [
-            {
-              "Value": "SAM", 
-              "Key": "lambda:createdBy"
             }
           ]
         }
-      }, 
-      "MyFunctionWithApiKeyRequiredFalseRole": {
-        "Type": "AWS::IAM::Role", 
-        "Properties": {
-          "ManagedPolicyArns": [
-            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      }
+    },
+    "MyFunctionWithApiKeyRequiredTrue": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionWithApiKeyRequiredTrueRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyFunctionWithApiKeyRequiredDefault": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionWithApiKeyRequiredDefaultRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyFunctionWithApiKeyRequiredDefaultMyApiWithApiKeyRequiredDefaultPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "MyFunctionWithApiKeyRequiredDefault"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyDefault",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApiWithAuth"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionWithApiKeyRequiredFalse": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionWithApiKeyRequiredFalseRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyFunctionWithApiKeyRequiredFalseRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Tags": [
           {
@@ -167,28 +157,28 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
-            "Statement": [
-              {
-                "Action": [
-                  "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
-                "Principal": {
-                  "Service": [
-                    "lambda.amazonaws.com"
-                  ]
-                }
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
-      }, 
-      "MyFunctionWithApiKeyRequiredDefaultRole": {
-        "Type": "AWS::IAM::Role", 
-        "Properties": {
-          "ManagedPolicyArns": [
-            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      }
+    },
+    "MyFunctionWithApiKeyRequiredDefaultRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Tags": [
           {
@@ -197,28 +187,28 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
-            "Statement": [
-              {
-                "Action": [
-                  "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
-                "Principal": {
-                  "Service": [
-                    "lambda.amazonaws.com"
-                  ]
-                }
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
-      },
-      "MyFunctionWithApiKeyRequiredTrueRole": {
-        "Type": "AWS::IAM::Role", 
-        "Properties": {
-          "ManagedPolicyArns": [
-            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      }
+    },
+    "MyFunctionWithApiKeyRequiredTrueRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Tags": [
           {
@@ -227,92 +217,102 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
-            "Statement": [
-              {
-                "Action": [
-                  "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
-                "Principal": {
-                  "Service": [
-                    "lambda.amazonaws.com"
-                  ]
-                }
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
-      }, 
-      "MyApiWithAuth": {
-        "Type": "AWS::ApiGateway::RestApi", 
-        "Properties": {
-          "Body": {
-            "info": {
-              "version": "1.0", 
-              "title": {
-                "Ref": "AWS::StackName"
+      }
+    },
+    "MyApiWithAuth": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/ApiKeyFalse": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequiredFalse.Arn}/invocations"
+                  }
+                },
+                "security": [],
+                "responses": {}
               }
-            }, 
-            "paths": {
-              "/ApiKeyFalse": {
-                "get": {
-                  "x-amazon-apigateway-integration": {
-                    "httpMethod": "POST", 
-                    "type": "aws_proxy", 
-                    "uri": {
-                      "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequiredFalse.Arn}/invocations"
-                    }
-                  }, 
-                  "security": [], 
-                  "responses": {}
-                }
-              }, 
-              "/ApiKeyTrue": {
-                "get": {
-                  "x-amazon-apigateway-integration": {
-                    "httpMethod": "POST", 
-                    "type": "aws_proxy", 
-                    "uri": {
-                      "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequiredTrue.Arn}/invocations"
-                    }
-                  }, 
-                  "security": [
-                    {
-                      "api_key": []
-                    }
-                  ], 
-                  "responses": {}
-                }
-              }, 
-              "/ApiKeyDefault": {
-                "get": {
-                  "x-amazon-apigateway-integration": {
-                    "httpMethod": "POST", 
-                    "type": "aws_proxy", 
-                    "uri": {
-                      "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequiredDefault.Arn}/invocations"
-                    }
-                  }, 
-                  "security": [
-                    {
-                      "api_key": []
-                    }
-                  ], 
-                  "responses": {}
-                }
+            },
+            "/ApiKeyTrue": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequiredTrue.Arn}/invocations"
+                  }
+                },
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {}
               }
-            }, 
-            "swagger": "2.0", 
-            "securityDefinitions": {
-              "api_key": {
-                "type": "apiKey", 
-                "name": "x-api-key", 
-                "in": "header"
+            },
+            "/ApiKeyDefault": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequiredDefault.Arn}/invocations"
+                  }
+                },
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {}
               }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
             }
           }
         }
       }
+    },
+    "MyApiWithAuthDeploymentc2f530abef": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAuth"
+        },
+        "Description": "RestApi deployment id: c2f530abefb71c9abb379231b7ff0719c4a87f47",
+        "StageName": "Stage"
+      }
     }
   }
+}

--- a/tests/translator/output/api_with_apikey_required.json
+++ b/tests/translator/output/api_with_apikey_required.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "MyFunctionWithApiKeyRequiredRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -31,68 +31,68 @@
       }
     },
     "MyApiWithoutAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/ApiKeyRequiredTrue": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequired.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
         }
       }
-    }, 
+    },
     "MyApiWithoutAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment3ab9d13134"
-        }, 
+          "Ref": "MyApiWithoutAuthDeployment38976ffbaa"
+        },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithApiKeyRequiredMyApiWithApiKeyRequiredPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithApiKeyRequired"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyRequiredTrue", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyRequiredTrue",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -102,37 +102,37 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithApiKeyRequired": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithApiKeyRequiredRole", 
+            "MyFunctionWithApiKeyRequiredRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "MyApiWithoutAuthDeployment3ab9d13134": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "MyApiWithoutAuthDeployment38976ffbaa": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
-        }, 
-        "Description": "RestApi deployment id: 3ab9d13134bf550e275a303c6987801dfb7f9d7b", 
+        },
+        "Description": "RestApi deployment id: 38976ffbaadffb98b3d85e89047003fd3e191e15",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/api_with_apikey_required_openapi_3.json
+++ b/tests/translator/output/api_with_apikey_required_openapi_3.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "MyFunctionWithApiKeyRequiredRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -30,80 +30,71 @@
         }
       }
     },
-    "MyApiWithoutAuthDeployment8770e31c42": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        }, 
-        "Description": "RestApi deployment id: 8770e31c425e4cc01e67db6627300b459720eff9"
-      }
-    }, 
     "MyApiWithoutAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/ApiKeyRequiredTrue": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequired.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "api_key": {
-                "type": "apiKey", 
-                "name": "x-api-key", 
+                "type": "apiKey",
+                "name": "x-api-key",
                 "in": "header"
               }
             }
           }
         }
       }
-    }, 
+    },
     "MyApiWithoutAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment8770e31c42"
-        }, 
+          "Ref": "MyApiWithoutAuthDeployment31548865d1"
+        },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithApiKeyRequiredMyApiWithApiKeyRequiredPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithApiKeyRequired"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyRequiredTrue", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyRequiredTrue",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -113,28 +104,37 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithApiKeyRequired": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithApiKeyRequiredRole", 
+            "MyFunctionWithApiKeyRequiredRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "MyApiWithoutAuthDeployment31548865d1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        },
+        "Description": "RestApi deployment id: 31548865d1ff4bc089eaa01debde6182621aff4a"
       }
     }
   }

--- a/tests/translator/output/api_with_auth_all_maximum.json
+++ b/tests/translator/output/api_with_auth_all_maximum.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -43,16 +43,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -63,16 +63,16 @@
       }
     },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -84,7 +84,7 @@
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -96,13 +96,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -112,218 +112,218 @@
           ]
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "patch": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 0, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuthMultipleUserPools": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader2", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression2", 
+                "identityValidationExpression": "myauthvalidationexpression2",
                 "providerARNs": [
-                  "arn:aws:2", 
+                  "arn:aws:2",
                   "arn:aws:3"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "authorizerResultTtlInSeconds": 0, 
-                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
+                },
                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression", 
+                "identityValidationExpression": "myauthvalidationexpression",
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyCustomAuthHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 20, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
-                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                 "identityValidationExpression": "mycustomauthexpression"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -334,16 +334,16 @@
       }
     },
     "MyFunctionWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -354,25 +354,15 @@
         }
       }
     },
-    "MyApiDeployment0cec4886a5": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 0cec4886a504a36373a7cbd8952ec7aa9643bfbd", 
-        "StageName": "Stage"
-      }
-    }, 
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -381,30 +371,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment0cec4886a5"
-        }, 
+          "Ref": "MyApiDeployment9946b68125"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -414,18 +404,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -434,6 +424,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiDeployment9946b68125": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 9946b6812513d9403c9588b2714336f88d863bbd",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_auth_all_maximum_openapi_3.json
+++ b/tests/translator/output/api_with_auth_all_maximum_openapi_3.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -43,16 +43,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -63,16 +63,16 @@
       }
     },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -84,7 +84,7 @@
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -96,13 +96,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -112,220 +112,220 @@
           ]
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "patch": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
-                  "authorizerResultTtlInSeconds": 0, 
+                  "type": "token",
+                  "authorizerResultTtlInSeconds": 0,
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "MyCognitoAuthMultipleUserPools": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyAuthorizationHeader2", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyAuthorizationHeader2",
                 "x-amazon-apigateway-authorizer": {
-                  "identityValidationExpression": "myauthvalidationexpression2", 
+                  "identityValidationExpression": "myauthvalidationexpression2",
                   "providerARNs": [
-                    "arn:aws:2", 
+                    "arn:aws:2",
                     "arn:aws:3"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyLambdaRequestAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Unused", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "request", 
-                  "authorizerResultTtlInSeconds": 0, 
-                  "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                  "type": "request",
+                  "authorizerResultTtlInSeconds": 0,
+                  "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
-                  }, 
+                  },
                   "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyAuthorizationHeader", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyAuthorizationHeader",
                 "x-amazon-apigateway-authorizer": {
-                  "identityValidationExpression": "myauthvalidationexpression", 
+                  "identityValidationExpression": "myauthvalidationexpression",
                   "providerARNs": [
                     "arn:aws:1"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyLambdaTokenAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyCustomAuthHeader", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyCustomAuthHeader",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
-                  "authorizerResultTtlInSeconds": 20, 
+                  "type": "token",
+                  "authorizerResultTtlInSeconds": 20,
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
-                  }, 
-                  "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                  },
+                  "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                   "identityValidationExpression": "mycustomauthexpression"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "api_key": {
-                "type": "apiKey", 
-                "name": "x-api-key", 
+                "type": "apiKey",
+                "name": "x-api-key",
                 "in": "header"
               }
             }
           }
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -336,16 +336,16 @@
       }
     },
     "MyFunctionWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -357,14 +357,14 @@
       }
     },
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -373,27 +373,18 @@
           ]
         }
       }
-    }, 
-    "MyApiDeployment98ad824f7d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 98ad824f7db83981e747e44ba34d318c7fa410c8"
-      }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -403,30 +394,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment98ad824f7d"
-        }, 
+          "Ref": "MyApiDeploymentb9ad97fac7"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -435,6 +426,15 @@
             }
           ]
         }
+      }
+    },
+    "MyApiDeploymentb9ad97fac7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: b9ad97fac71cc273f648598446c55a58cefa5531"
       }
     }
   }

--- a/tests/translator/output/api_with_auth_all_minimum.json
+++ b/tests/translator/output/api_with_auth_all_minimum.json
@@ -1,83 +1,83 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeployment6e52add211"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeploymentbb2b8c7c7e"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -87,41 +87,31 @@
         }
       }
     },
-    "MyApiWithCognitoAuthDeployment62312fa971": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 62312fa9711ad898b40e76b7a4ae1358305b0bcd", 
-        "StageName": "Stage"
-      }
-    },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -133,13 +123,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -149,30 +139,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment62312fa971"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeploymentea6e21a97d"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -182,21 +172,21 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -205,18 +195,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -226,28 +216,18 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaRequestAuthDeployment6e52add211": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: 6e52add211cda52ae10a7cc0e0afcf4afc682f9f", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -257,58 +237,58 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
+                "type": "token",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
@@ -316,61 +296,51 @@
       }
     },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "MyApiWithLambdaTokenAuthDeployment445c6c96e7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: 445c6c96e7f43bd49f83bd67ae0d6813c517348f", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -382,13 +352,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -398,75 +368,105 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeployment445c6c96e7"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeployment3730bb27e6"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeploymentea6e21a97d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: ea6e21a97d92edf04f476e80f19f2421af287837",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaRequestAuthDeploymentbb2b8c7c7e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: bb2b8c7c7e139f592086480a26893028930b89d8",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeployment3730bb27e6": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        },
+        "Description": "RestApi deployment id: 3730bb27e6f7385068828d48cb0663f35dfdff80",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_auth_all_minimum_openapi.json
+++ b/tests/translator/output/api_with_auth_all_minimum_openapi.json
@@ -1,85 +1,85 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     {
                       "Fn::GetAtt": [
-                        "MyUserPool", 
+                        "MyUserPool",
                         "Arn"
                       ]
                     }
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeployment14ab3ddf12"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeploymentee3a13a5a0"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -90,30 +90,30 @@
       }
     },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucketname", 
+          "S3Bucket": "bucketname",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -125,13 +125,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -141,39 +141,30 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaRequestAuthDeployment14ab3ddf12": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: 14ab3ddf12ee76d46cac076ecffc24b3acd2fb7f"
-      }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment87cdbda651"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeploymentd11552944c"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -183,21 +174,21 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -206,18 +197,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -227,18 +218,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -248,112 +239,112 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaTokenAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
+                  "type": "token",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": {
                           "Fn::GetAtt": [
-                            "MyAuthFn", 
+                            "MyAuthFn",
                             "Arn"
                           ]
                         }
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
               }
             }
           }
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucketname", 
+          "S3Bucket": "bucketname",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -365,13 +356,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -381,95 +372,104 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeployment4fdb5f4e3c"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeploymentc41f53e6b4"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment87cdbda651": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 87cdbda651523df8d04d15fc50f72ae8ead08c1d"
-      }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaRequestAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Unused", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "request", 
-                  "identitySource": "method.request.header.Authorization1", 
+                  "type": "request",
+                  "identitySource": "method.request.header.Authorization1",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": {
                           "Fn::GetAtt": [
-                            "MyAuthFn", 
+                            "MyAuthFn",
                             "Arn"
                           ]
                         }
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
               }
             }
           }
         }
       }
-    }, 
-    "MyApiWithLambdaTokenAuthDeployment4fdb5f4e3c": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "MyApiWithLambdaRequestAuthDeploymentee3a13a5a0": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: ee3a13a5a06b1e8d58937682cac4d75bac85cb42"
+      }
+    },
+    "MyApiWithCognitoAuthDeploymentd11552944c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: d11552944c61db8d48a5bb27b8af1986ef38711f"
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeploymentc41f53e6b4": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: 4fdb5f4e3c6e0e2b12af6d7a637ce66bb5bf7d0a"
+        },
+        "Description": "RestApi deployment id: c41f53e6b41a4a21ce0e1cfce0a4e841ff8b7391"
       }
     }
   }

--- a/tests/translator/output/api_with_auth_and_conditions_all_max.json
+++ b/tests/translator/output/api_with_auth_and_conditions_all_max.json
@@ -2,23 +2,23 @@
   "Conditions": {
     "PathCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -28,16 +28,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -48,271 +48,271 @@
       }
     },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentf5a2efce75"
-        }, 
+          "Ref": "MyApiDeployment5f09f2eb48"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyCognitoAuth": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "patch": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyLambdaTokenAuthNoneFunctionInvokeRole": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyLambdaRequestAuth": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression", 
+                "identityValidationExpression": "myauthvalidationexpression",
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 0, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuthMultipleUserPools": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader2", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression2", 
+                "identityValidationExpression": "myauthvalidationexpression2",
                 "providerARNs": [
-                  "arn:aws:2", 
+                  "arn:aws:2",
                   "arn:aws:3"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyCustomAuthHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 20, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
-                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                 "identityValidationExpression": "mycustomauthexpression"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "authorizerResultTtlInSeconds": 0, 
-                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
+                },
                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -321,18 +321,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -342,41 +342,41 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -388,7 +388,7 @@
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -400,13 +400,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -416,18 +416,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithConditionalWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -436,20 +436,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyFunctionWithConditionalWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -458,18 +458,18 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -478,52 +478,42 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithConditional": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithConditionalRole", 
+            "MyFunctionWithConditionalRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
-    "MyApiDeploymentf5a2efce75": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: f5a2efce75b3ac7637faff7fe6310ec2e9bb05a8", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionWithConditionalWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -532,11 +522,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyFunctionWithConditionalRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -548,13 +538,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -563,8 +553,18 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
+    },
+    "MyApiDeployment5f09f2eb48": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 5f09f2eb4885f29b0301d72a137ce4674c8d71e6",
+        "StageName": "Stage"
+      }
     }
   }
 }

--- a/tests/translator/output/api_with_auth_no_default.json
+++ b/tests/translator/output/api_with_auth_no_default.json
@@ -1,78 +1,78 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeployment7d0d103fdf"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeployment0e9911ae36"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -83,30 +83,30 @@
       }
     },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -118,13 +118,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -134,30 +134,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment039b508d89"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment078f4362f3"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -167,31 +167,21 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment039b508d89": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 039b508d8974255326ad180948c0f232635032d8", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -200,28 +190,18 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaRequestAuthDeployment7d0d103fdf": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: 7d0d103fdf357021c9e3f88a03f27a766045308f", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -231,18 +211,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -252,115 +232,105 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
+                "type": "token",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
         }
       }
-    }, 
-    "MyApiWithLambdaTokenAuthDeployment50695ee60b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: 50695ee60b97eeade77bcc6137fa5dabc526938d", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -372,13 +342,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -388,70 +358,100 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeployment50695ee60b"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeployment9f3ac0ae29"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeployment078f4362f3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 078f4362f370a1cd569f7ef5eb1a9b75dd551e47",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaRequestAuthDeployment0e9911ae36": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: 0e9911ae366b9b48996b32e4d59c7bdfc4629cc1",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeployment9f3ac0ae29": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        },
+        "Description": "RestApi deployment id: 9f3ac0ae29c8bbe303bae5738facd28bdeea3e81",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_auth_with_default_scopes.json
+++ b/tests/translator/output/api_with_auth_with_default_scopes.json
@@ -1,191 +1,191 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognitowithauthnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultauthdefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizerwithdefaultscopes": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "default.delete", 
+                      "default.delete",
                       "default.update"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizercopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesdefaultauthorizer": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "default.write", 
+                      "default.write",
                       "default.read"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuthWithDefaultScopes": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:2"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyDefaultCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -193,30 +193,20 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment442cfe5207": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 442cfe52072a3a5798bee91fd7ffb9d9ac76b9ca", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnCognitoDefaultAuthDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -224,20 +214,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerWithDefaultScopesPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -245,20 +235,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -266,20 +256,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerScopesOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -287,18 +277,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -306,31 +296,31 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoWithAuthNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -338,61 +328,71 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment442cfe5207"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment3b76424402"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesWithOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
             }
           ]
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeployment3b76424402": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 3b764244024b43eabb7355198f101a394dfaba76",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_auth_with_default_scopes_openapi.json
+++ b/tests/translator/output/api_with_auth_with_default_scopes_openapi.json
@@ -1,193 +1,193 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognitowithauthnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultauthdefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizerwithdefaultscopes": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "default.delete", 
+                      "default.delete",
                       "default.update"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizercopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesdefaultauthorizer": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "default.write", 
+                      "default.write",
                       "default.read"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuthWithDefaultScopes": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     "arn:aws:2"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyDefaultCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     "arn:aws:1"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -195,20 +195,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultAuthDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -216,20 +216,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerWithDefaultScopesPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -237,20 +237,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -258,20 +258,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerScopesOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -279,27 +279,18 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment85cd9eefb8": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 85cd9eefb8a3340e269379417aec51cb16416c4f"
-      }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -307,31 +298,31 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoWithAuthNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -339,61 +330,70 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment85cd9eefb8"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment8a290e07ee"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesWithOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
             }
           ]
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeployment8a290e07ee": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 8a290e07ee2f8bf0e68dffcba06400e011ec9af8"
       }
     }
   }

--- a/tests/translator/output/api_with_aws_account_blacklist.json
+++ b/tests/translator/output/api_with_aws_account_blacklist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment58caafe4ca"
-        }, 
+          "Ref": "ServerlessRestApiDeployment620099509a"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment58caafe4ca": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 58caafe4ca843d2d259f522ee6c408cfd9523ea1", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,47 +63,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
-              "Action": "execute-api:Invoke", 
+              "Action": "execute-api:Invoke",
               "Resource": [
                 {
                   "Fn::Sub": [
-                    "execute-api:/${__Stage__}/PUT/get", 
+                    "execute-api:/${__Stage__}/PUT/get",
                     {
                       "__Stage__": "Prod"
                     }
                   ]
                 }
-              ], 
-              "Effect": "Deny", 
+              ],
+              "Effect": "Deny",
               "Principal": {
                 "AWS": [
                   "12345"
@@ -123,26 +113,36 @@
           }
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment620099509a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 620099509a95c4440e599d893a3f5e7e34fa84fe",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_aws_account_whitelist.json
+++ b/tests/translator/output/api_with_aws_account_whitelist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment3727797069": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 3727797069c39cb2513220baab9ed7c4bb74d882", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment3727797069"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentaae0858823"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,67 +63,67 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "AWS": [
                     "12345"
                   ]
                 }
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Principal": {
                   "AWS": [
                     "67890"
@@ -144,26 +134,36 @@
           }
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeploymentaae0858823": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: aae085882321a0d05db9a51c16baabc0f1b8dcbf",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/api_with_aws_iam_auth_overrides.json
@@ -1,88 +1,88 @@
 {
   "Resources": {
     "MyFunctionCustomInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionCustomInvokeRoleRole", 
+            "MyFunctionCustomInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoneAuth": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoneAuthRole", 
+            "MyFunctionNoneAuthRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNullInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNullInvokeRoleRole", 
+            "MyFunctionNullInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeployment3bec5f30f2"
-        }, 
+          "Ref": "MyApiWithAwsIamAuthDeployment8b6869a089"
+        },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithoutAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -94,13 +94,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -110,18 +110,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionCustomInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionCustomInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -131,18 +131,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionMyCognitoAuthAPI1PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionMyCognitoAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -152,75 +152,75 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithAwsIamAuthNoCallerCredentials": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoCallerCredentials.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCallerCredentialsOverride.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::*:user/*"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "AWS_IAM": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
         }
       }
-    }, 
+    },
     "MyFunctionWithoutAuthAPI2PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithoutAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -232,16 +232,16 @@
       }
     },
     "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionDefaultInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -251,32 +251,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionMyCognitoAuth": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionMyCognitoAuthRole", 
+            "MyFunctionMyCognitoAuthRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNullInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -288,13 +288,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -306,39 +306,39 @@
       }
     },
     "MyFunctionNONEInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNONEInvokeRoleRole", 
+            "MyFunctionNONEInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoCallerCredentialsAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNoCallerCredentials"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -348,9 +348,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNoneAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -362,43 +362,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    }, 
-    "MyFunctionCustomInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -409,137 +379,8 @@
         }
       }
     },
-    "MyApiWithAwsIamAuthDeployment3bec5f30f2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        }, 
-        "Description": "RestApi deployment id: 3bec5f30f275272b5feee10af30f848d1ce4400d", 
-        "StageName": "Stage"
-      }
-    }, 
-    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment38c75afec1": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
-        }, 
-        "Description": "RestApi deployment id: 38c75afec1f32ff6e177b0f49a2b9e86958f594e", 
-        "StageName": "Stage"
-      }
-    }, 
-    "MyFunctionCallerCredentialsOverrideAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
-      "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "MyFunctionCallerCredentialsOverride"
-        }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
-              }
-            }
-          ]
-        }
-      }
-    }, 
-    "MyFunctionCallerCredentialsOverride": {
-      "Type": "AWS::Lambda::Function", 
-      "Properties": {
-        "Handler": "index.handler", 
-        "Code": {
-          "S3Bucket": "bucket", 
-          "S3Key": "key"
-        }, 
-        "Role": {
-          "Fn::GetAtt": [
-            "MyFunctionCallerCredentialsOverrideRole", 
-            "Arn"
-          ]
-        }, 
-        "Runtime": "nodejs12.x",
-        "Tags": [
-          {
-            "Value": "SAM", 
-            "Key": "lambda:createdBy"
-          }
-        ]
-      }
-    }, 
-    "MyFunctionWithoutAuth": {
-      "Type": "AWS::Lambda::Function", 
-      "Properties": {
-        "Handler": "index.handler", 
-        "Code": {
-          "S3Bucket": "bucket", 
-          "S3Key": "key"
-        }, 
-        "Role": {
-          "Fn::GetAtt": [
-            "MyFunctionWithoutAuthRole", 
-            "Arn"
-          ]
-        }, 
-        "Runtime": "nodejs12.x",
-        "Tags": [
-          {
-            "Value": "SAM", 
-            "Key": "lambda:createdBy"
-          }
-        ]
-      }
-    }, 
-    "MyFunctionNullInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
-      "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "MyFunctionNullInvokeRole"
-        }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    }, 
-    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
-      "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "MyFunctionNONEInvokeRole"
-        }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    }, 
-    "MyFunctionNoCallerCredentialsRole": {
-      "Type": "AWS::IAM::Role", 
+    "MyFunctionCustomInvokeRoleRole": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -551,13 +392,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -567,9 +408,118 @@
           ]
         }
       }
-    }, 
-    "MyFunctionDefaultInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+    },
+    "MyFunctionCallerCredentialsOverrideAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "MyFunctionCallerCredentialsOverride"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionCallerCredentialsOverride": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionCallerCredentialsOverrideRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyFunctionWithoutAuth": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionWithoutAuthRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyFunctionNullInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "MyFunctionNullInvokeRole"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionNoCallerCredentialsRole": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -581,13 +531,43 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionDefaultInvokeRoleRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -599,7 +579,7 @@
       }
     },
     "MyFunctionCallerCredentialsOverrideRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -611,13 +591,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -629,7 +609,7 @@
       }
     },
     "MyFunctionMyCognitoAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -641,13 +621,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -657,234 +637,234 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithAwsIamAuthNoCallerCredentialsProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment38c75afec1"
-        }, 
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment04a9022df0"
+        },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "MyFunctionDefaultInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionDefaultInvokeRoleRole", 
+            "MyFunctionDefaultInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoCallerCredentials": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoCallerCredentialsRole", 
+            "MyFunctionNoCallerCredentialsRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyApiWithAwsIamAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/MyFunctionWithoutAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithoutAuth.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::123:role/AUTH_AWS_IAM"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNONEInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNONEInvokeRole.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionMyCognitoAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionMyCognitoAuth.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionDefaultInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::*:user/*"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionCustomInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::456::role/something-else"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNullInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNullInvokeRole.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNoneAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:cognito-idp:xxxxxxxxx"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "AWS_IAM": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
         }
       }
-    }, 
+    },
     "MyFunctionNoneAuthAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNoneAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -894,9 +874,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNONEInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -908,13 +888,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -923,6 +903,26 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthDeployment8b6869a089": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: 8b6869a0897f36fb2a7c51bf79b775e18abf7158",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment04a9022df0": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        },
+        "Description": "RestApi deployment id: 04a9022df0a900277a20cf4c276778bf83432d1f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_basic_custom_domain.json
+++ b/tests/translator/output/api_with_basic_custom_domain.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "MyDomainName": {
-      "Default": "another-example.com", 
+      "Default": "another-example.com",
       "Type": "String"
-    }, 
+    },
     "MyDomainCert": {
-      "Default": "another-api-arn", 
+      "Default": "another-api-arn",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionAnotherGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/another/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/another/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyAnotherApi"
               }
@@ -52,11 +52,11 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName23cdccdf9c": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "my-api-cert-arn", 
+        "CertificateArn": "my-api-cert-arn",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
@@ -69,20 +69,20 @@
         "SecurityPolicy": "TLS_1_2",
         "DomainName": "api-example.com"
       }
-    }, 
+    },
     "MyFunctionImplicitGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -90,32 +90,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyAnotherApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeployment48a61be119"
-        }, 
+          "Ref": "MyAnotherApiDeployment95a2752d9c"
+        },
         "RestApiId": {
           "Ref": "MyAnotherApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -123,61 +123,61 @@
           ]
         }
       }
-    }, 
+    },
     "MyAnotherApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/another/get": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
         }
       }
-    }, 
+    },
     "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "fetch", 
+        "BasePath": "fetch",
         "DomainName": {
           "Ref": "ApiGatewayDomainName23cdccdf9c"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -185,212 +185,212 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyApigetBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "get", 
+        "BasePath": "get",
         "DomainName": {
           "Ref": "ApiGatewayDomainName23cdccdf9c"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
         }
       }
-    }, 
+    },
     "MyAnotherApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
         "DomainName": {
           "Ref": "ApiGatewayDomainNameeab65c1531"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyAnotherApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyAnotherApiProdStage"
         }
       }
-    }, 
+    },
     "ApiGatewayDomainNameeab65c1531": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "another-api-arn", 
+        "RegionalCertificateArn": "another-api-arn",
         "DomainName": "another-example.com"
       }
-    }, 
-    "ServerlessRestApiDeployment3c44da8ffd": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 3c44da8ffdf3025dc792391a61590b92e8e2ff48", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment3c44da8ffd"
-        }, 
+          "Ref": "ServerlessRestApiDeployment8676fa84b5"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyApiDeployment347043ff9e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 347043ff9ec72c6ce10317548939c3802eb1dd55"
-      }
-    }, 
+    },
     "ServerlessRestApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
         "DomainName": {
           "Ref": "ApiGatewayDomainNameeab65c1531"
-        }, 
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "Stage": {
           "Ref": "ServerlessRestApiProdStage"
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment347043ff9e"
-        }, 
+          "Ref": "MyApiDeployment5b81fc8425"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyAnotherApiDeployment48a61be119": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyAnotherApi"
-        }, 
-        "Description": "RestApi deployment id: 48a61be119a247807ea0ef8378e6aa16592f90fa"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/implicit": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment8676fa84b5": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 8676fa84b5fed9733b4de70540dd7bae8365bfd4",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiDeployment5b81fc8425": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 5b81fc84254c2a2e3725c996904e9e0aed7b980c"
+      }
+    },
+    "MyAnotherApiDeployment95a2752d9c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyAnotherApi"
+        },
+        "Description": "RestApi deployment id: 95a2752d9c66aee477ea094a3e05e2a52f77f727"
       }
     }
   }

--- a/tests/translator/output/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/api_with_basic_custom_domain_intrinsics.json
@@ -2,18 +2,18 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "MyDomainCert": {
-      "Default": "another-api-arn", 
+      "Default": "another-api-arn",
       "Type": "String"
-    }, 
+    },
     "EndpointConf": {
-      "Default": "REGIONAL", 
+      "Default": "REGIONAL",
       "Type": "String"
     },
     "MyMTLSUri": {
@@ -24,62 +24,62 @@
       "Default": "another-api-truststore-version",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyFunctionImplicitGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "ApiGatewayDomainNamec0ed6fae34": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "RegionalCertificateArn": "another-api-arn", 
+        },
+        "RegionalCertificateArn": "another-api-arn",
         "DomainName": {
           "Fn::Sub": "example-ap-southeast-1.com"
         },
@@ -90,47 +90,47 @@
         "SecurityPolicy": "TLS_1_2"
       },
       "Condition": "C1"
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment43c34b4e46"
-        }, 
+          "Ref": "ServerlessRestApiDeployment53b731c948"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "fetch", 
+        "BasePath": "fetch",
         "DomainName": {
           "Ref": "ApiGatewayDomainNamec0ed6fae34"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -138,195 +138,195 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApigetBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "get", 
+        "BasePath": "get",
         "DomainName": {
           "Ref": "ApiGatewayDomainNamec0ed6fae34"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
                   "put": {
                     "Fn::If": [
-                      "C1", 
+                      "C1",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "C1", 
+                              "C1",
                               {
                                 "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
                   }
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
-          }, 
+          },
           "openapi": "3.0.1"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
-    "ServerlessRestApiDeployment43c34b4e46": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 43c34b4e46d381101dd94b95856a2cea244411b4", 
-        "StageName": "Stage"
-      }, 
-      "Condition": "C1"
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment19c8cf5c63"
-        }, 
+          "Ref": "MyApiDeploymente72ee4811f"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
-      }, 
+      },
       "Condition": "C1"
-    }, 
-    "MyApiDeployment19c8cf5c63": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 19c8cf5c63090f12c5a96f6f57162495bed446c7"
-      }, 
-      "Condition": "C1"
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/implicit": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
                   "post": {
                     "Fn::If": [
-                      "C1", 
+                      "C1",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "C1", 
+                              "C1",
                               {
                                 "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
                   }
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
-          }, 
+          },
           "swagger": "2.0"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
             }
           ]
         }
-      }, 
+      },
+      "Condition": "C1"
+    },
+    "ServerlessRestApiDeployment53b731c948": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 53b731c948a2db57c5f3f9c9be1935d42ff514ed",
+        "StageName": "Stage"
+      },
+      "Condition": "C1"
+    },
+    "MyApiDeploymente72ee4811f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: e72ee4811fdb050c1787eb93a6a83f3a041503d3"
+      },
       "Condition": "C1"
     }
   }

--- a/tests/translator/output/api_with_binary_media_types.json
+++ b/tests/translator/output/api_with_binary_media_types.json
@@ -1,36 +1,36 @@
 {
   "Parameters": {
     "BMT": {
-      "Default": "image~1jpg", 
+      "Default": "image~1jpg",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -42,13 +42,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -60,16 +60,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -79,124 +79,124 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BinaryMediaTypes": [
-          "image~1gif", 
+          "image~1gif",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
-          "application~1octet-stream", 
+          },
+          "application~1octet-stream",
           "image~1jpg"
-        ], 
+        ],
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment4f3fcf6bd1"
-        }, 
+          "Ref": "ServerlessRestApiDeployment7d0a1dce4d"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ServerlessRestApiDeployment4f3fcf6bd1": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 4f3fcf6bd13686961885c787e3a117b084ec6c3a", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/gif", 
+            "image/gif",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
             }
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1gif", 
+          "image~1gif",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
           }
         ]
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment7d0a1dce4d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 7d0a1dce4db8c72f785c9d605f879d9477a91180",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_binary_media_types_definition_body.json
+++ b/tests/translator/output/api_with_binary_media_types_definition_body.json
@@ -1,133 +1,133 @@
 {
   "Parameters": {
     "BMT": {
-      "Default": "image~1jpeg", 
+      "Default": "image~1jpeg",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ExplicitApiManagedSwaggerProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiManagedSwaggerDeploymentfe9c2c09a2"
-        }, 
+          "Ref": "ExplicitApiManagedSwaggerDeployment77c7e2092d"
+        },
         "RestApiId": {
           "Ref": "ExplicitApiManagedSwagger"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiManagedSwaggerDeploymentfe9c2c09a2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApiManagedSwagger"
-        }, 
-        "Description": "RestApi deployment id: fe9c2c09a27ce00c2fa53d5a491cf343e6a3278e", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiDefinitionBody": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "paths": {}, 
-          "swagger": "2.0", 
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/jpeg", 
-            "image/jpg", 
+            "image/jpeg",
+            "image/jpg",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
-            }, 
+            },
             "application/json"
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1jpeg", 
-          "image~1jpg", 
+          "image~1jpeg",
+          "image~1jpg",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
+          },
           "application~1json"
         ]
       }
-    }, 
-    "ExplicitApiDefinitionBodyDeployment1f26996adb": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApiDefinitionBody"
-        }, 
-        "Description": "RestApi deployment id: 1f26996adbe5077359ecb2bb0688a9cc0ae8e4fc", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiDefinitionBodyProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDefinitionBodyDeployment1f26996adb"
-        }, 
+          "Ref": "ExplicitApiDefinitionBodyDeployment8243637415"
+        },
         "RestApiId": {
           "Ref": "ExplicitApiDefinitionBody"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiManagedSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
-          "swagger": "2.0", 
+          },
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/jpeg", 
-            "image/jpg", 
+            "image/jpeg",
+            "image/jpg",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
-            }, 
+            },
             "image/gif"
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1jpeg", 
-          "image~1jpg", 
+          "image~1jpeg",
+          "image~1jpg",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
+          },
           "image~1gif"
         ]
+      }
+    },
+    "ExplicitApiManagedSwaggerDeployment77c7e2092d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApiManagedSwagger"
+        },
+        "Description": "RestApi deployment id: 77c7e2092d31ef078af609150899d4c546e54ade",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDefinitionBodyDeployment8243637415": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApiDefinitionBody"
+        },
+        "Description": "RestApi deployment id: 8243637415ea97b13720e769347272506839bc57",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_canary_setting.json
+++ b/tests/translator/output/api_with_canary_setting.json
@@ -53,16 +53,6 @@
         }
       }
     },
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
-      }
-    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -105,7 +95,7 @@
           }
         },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
+          "Ref": "ExplicitApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -125,22 +115,12 @@
           }
         },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment62b96c1a61"
+          "Ref": "ServerlessRestApiDeployment207d63cbe2"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
         "StageName": "Prod"
-      }
-    },
-    "ServerlessRestApiDeployment62b96c1a61": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 62b96c1a611878eefb13e8ef66dbc71b9ba3dd19",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
@@ -169,6 +149,26 @@
           },
           "swagger": "2.0"
         }
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment207d63cbe2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 207d63cbe20acce3663f22e907f62096d9d7039c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors.json
+++ b/tests/translator/output/api_with_cors.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionAnyApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,145 +73,145 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -223,13 +223,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -239,31 +239,21 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente13d39e2d1"
-        }, 
+          "Ref": "ServerlessRestApiDeployment38f07ad8dc"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymente13d39e2d1": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: e13d39e2d16b8aad18f87490157d347817fa3071", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -275,13 +265,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -291,18 +281,18 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -312,209 +302,219 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment3a5a78688c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 3a5a78688c9bc377d53aa4153a11f0c4f6e7364c", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment3a5a78688c"
-        }, 
+          "Ref": "ExplicitApiDeploymentca189bb326"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ServerlessRestApiDeployment38f07ad8dc": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 38f07ad8dcd0110d47198fd40e9b3700299de52c",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeploymentca189bb326": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: ca189bb3267ef4823d27c85b66213b1d4cf4ed44",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_and_auth_no_preflight_auth.json
+++ b/tests/translator/output/api_with_cors_and_auth_no_preflight_auth.json
@@ -1,130 +1,120 @@
 {
   "Resources": {
-    "ServerlessApiDeploymente70e322247": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessApi"
-        }, 
-        "Description": "RestApi deployment id: e70e322247bd7d33ec444c4732e7f532a222d44e", 
-        "StageName": "Stage"
-      }
-    }, 
     "ServerlessApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
         }
       }
-    }, 
+    },
     "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -136,13 +126,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -154,16 +144,16 @@
       }
     },
     "ApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -173,30 +163,30 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessApiDeploymente70e322247"
-        }, 
+          "Ref": "ServerlessApiDeployment090fd60b03"
+        },
         "RestApiId": {
           "Ref": "ServerlessApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -208,53 +198,53 @@
       }
     },
     "ApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ApiFunctionRole", 
+            "ApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -266,13 +256,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -282,21 +272,21 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessApi"
@@ -304,6 +294,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessApiDeployment090fd60b03": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessApi"
+        },
+        "Description": "RestApi deployment id: 090fd60b03989282c51c7d5b6dcb8fb407e7c1b2",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_and_auth_preflight_auth.json
+++ b/tests/translator/output/api_with_cors_and_auth_preflight_auth.json
@@ -1,135 +1,125 @@
 {
   "Resources": {
     "ServerlessApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "options": {
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
-                ], 
+                ],
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
-                "summary": "CORS support", 
+                },
+                "summary": "CORS support",
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "consumes": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
         }
       }
-    }, 
-    "ServerlessApiDeployment5355b9449d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessApi"
-        }, 
-        "Description": "RestApi deployment id: 5355b9449d512736d24b6b328925b4b0635fee89", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -141,13 +131,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -159,16 +149,16 @@
       }
     },
     "ApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -178,30 +168,30 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessApiDeployment5355b9449d"
-        }, 
+          "Ref": "ServerlessApiDeployment7cf830737a"
+        },
         "RestApiId": {
           "Ref": "ServerlessApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -213,53 +203,53 @@
       }
     },
     "ApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ApiFunctionRole", 
+            "ApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -271,13 +261,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -287,21 +277,21 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessApi"
@@ -309,6 +299,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessApiDeployment7cf830737a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessApi"
+        },
+        "Description": "RestApi deployment id: 7cf830737abd2c27a12556183dbd70b66a9499dc",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_and_conditions_no_definitionbody.json
+++ b/tests/translator/output/api_with_cors_and_conditions_no_definitionbody.json
@@ -1,40 +1,40 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09", 
+  "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "MyCondition"
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -46,13 +46,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -61,20 +61,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
     },
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,152 +83,152 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentae0b2acf4c"
-        }, 
+          "Ref": "ExplicitApiDeployment582f378ccc"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "Fn::If": [
-                  "MyCondition", 
+                  "MyCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "MyCondition", 
+                          "MyCondition",
                           {
                             "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "get": {
                 "Fn::If": [
-                  "MyCondition", 
+                  "MyCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "MyCondition", 
+                          "MyCondition",
                           {
                             "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'www.example.com'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'www.example.com'",
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction2.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -237,21 +237,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
-    }, 
-    "ExplicitApiDeploymentae0b2acf4c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: ae0b2acf4cfdd4c81368721712133182f70ebdae", 
-        "StageName": "Stage"
-      }
     },
     "ImplicitApiFunction2Role": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -263,13 +253,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -279,18 +269,18 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunction2DeleteHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction2"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -300,28 +290,38 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunction2": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunction2Role", 
+            "ImplicitApiFunction2Role",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ExplicitApiDeployment582f378ccc": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 582f378ccc76179555da29e9144ce1e93deb0d7e",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_and_only_credentials_false.json
+++ b/tests/translator/output/api_with_cors_and_only_credentials_false.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,147 +52,147 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment398246867a"
-        }, 
+          "Ref": "ExplicitApiDeployment92400db54c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiDeployment398246867a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 398246867a6d5535e40b46e224e8998486a4b9eb", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
+      }
+    },
+    "ExplicitApiDeployment92400db54c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 92400db54c85c63954529c21fb43966e7e92af8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_and_only_headers.json
+++ b/tests/translator/output/api_with_cors_and_only_headers.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,199 +54,16 @@
       }
     },
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "ServerlessRestApi"
-              }
-            }
-          ]
-        }
-      }
-    }, 
-    "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ExplicitApiDeployment03e65d7ea2"
-        }, 
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment602730b2df"
-        }, 
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod"
-      }
-    }, 
-    "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
-      "Properties": {
-        "Body": {
-          "info": {
-            "version": "1.0", 
-            "title": {
-              "Ref": "AWS::StackName"
-            }
-          }, 
-          "paths": {
-            "/add": {
-              "post": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                  }
-                }, 
-                "responses": {}
-              }, 
-              "options": {
-                "x-amazon-apigateway-integration": {
-                  "type": "mock", 
-                  "requestTemplates": {
-                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
-                  "responses": {
-                    "default": {
-                      "statusCode": "200", 
-                      "responseTemplates": {
-                        "application/json": "{}\n"
-                      }, 
-                      "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'", 
-                        "method.response.header.Access-Control-Allow-Headers": "headers"
-                      }
-                    }
-                  }
-                }, 
-                "consumes": [
-                  "application/json"
-                ], 
-                "summary": "CORS support", 
-                "responses": {
-                  "200": {
-                    "headers": {
-                      "Access-Control-Allow-Origin": {
-                        "type": "string"
-                      }, 
-                      "Access-Control-Allow-Headers": {
-                        "type": "string"
-                      }, 
-                      "Access-Control-Allow-Methods": {
-                        "type": "string"
-                      }
-                    }, 
-                    "description": "Default response for CORS method"
-                  }
-                }, 
-                "produces": [
-                  "application/json"
-                ]
-              }
-            }, 
-            "/{proxy+}": {
-              "options": {
-                "x-amazon-apigateway-integration": {
-                  "type": "mock", 
-                  "requestTemplates": {
-                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
-                  "responses": {
-                    "default": {
-                      "statusCode": "200", 
-                      "responseTemplates": {
-                        "application/json": "{}\n"
-                      }, 
-                      "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'", 
-                        "method.response.header.Access-Control-Allow-Headers": "headers"
-                      }
-                    }
-                  }
-                }, 
-                "consumes": [
-                  "application/json"
-                ], 
-                "summary": "CORS support", 
-                "responses": {
-                  "200": {
-                    "headers": {
-                      "Access-Control-Allow-Origin": {
-                        "type": "string"
-                      }, 
-                      "Access-Control-Allow-Headers": {
-                        "type": "string"
-                      }, 
-                      "Access-Control-Allow-Methods": {
-                        "type": "string"
-                      }
-                    }, 
-                    "description": "Default response for CORS method"
-                  }
-                }, 
-                "produces": [
-                  "application/json"
-                ]
-              }, 
-              "x-amazon-apigateway-any-method": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                  }
-                }, 
-                "responses": {}
-              }
-            }
-          }, 
-          "swagger": "2.0"
-        }
-      }
-    }, 
-    "ExplicitApiDeployment03e65d7ea2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 03e65d7ea2275d648803eecb7fa8e0ae7cd8f0aa", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
-      "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "ImplicitApiFunction"
-        }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -257,96 +74,279 @@
         }
       }
     },
-    "ServerlessRestApiDeployment602730b2df": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeployment9a767e8172"
+        },
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymenta72185c436"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 602730b2df5e973b196e1b91eea6599bb11de5b4", 
-        "StageName": "Stage"
+        },
+        "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+    },
+    "ExplicitApi": {
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
-            "/": {
+            "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'",
                         "method.response.header.Access-Control-Allow-Headers": "headers"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
-              "get": {
+              }
+            },
+            "/{proxy+}": {
+              "options": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "type": "mock",
+                  "requestTemplates": {
+                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
+                  },
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseTemplates": {
+                        "application/json": "{}\n"
+                      },
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+                        "method.response.header.Access-Control-Allow-Headers": "headers"
+                      }
+                    }
+                  }
+                },
+                "consumes": [
+                  "application/json"
+                ],
+                "summary": "CORS support",
+                "responses": {
+                  "200": {
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string"
+                      }
+                    },
+                    "description": "Default response for CORS method"
+                  }
+                },
+                "produces": [
+                  "application/json"
+                ]
+              },
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
+      }
+    },
+    "ImplicitApiFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "ImplicitApiFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              },
+              "options": {
+                "x-amazon-apigateway-integration": {
+                  "type": "mock",
+                  "requestTemplates": {
+                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
+                  },
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseTemplates": {
+                        "application/json": "{}\n"
+                      },
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'",
+                        "method.response.header.Access-Control-Allow-Headers": "headers"
+                      }
+                    }
+                  }
+                },
+                "consumes": [
+                  "application/json"
+                ],
+                "summary": "CORS support",
+                "responses": {
+                  "200": {
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Headers": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string"
+                      }
+                    },
+                    "description": "Default response for CORS method"
+                  }
+                },
+                "produces": [
+                  "application/json"
+                ]
+              },
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            }
+          },
+          "swagger": "2.0"
+        }
+      }
+    },
+    "ExplicitApiDeployment9a767e8172": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 9a767e81727f930f6f8609769c04a6fb37dea1cc",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymenta72185c436": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: a72185c4365ed088f1813f3f2e8e029450f5c546",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_and_only_maxage.json
+++ b/tests/translator/output/api_with_cors_and_only_maxage.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,155 +52,155 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymentb61cfb7d60": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: b61cfb7d602d889bbd9867dcbf0f75d3066dcc56", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentb61cfb7d60"
-        }, 
+          "Ref": "ExplicitApiDeployment3e3e53a12e"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Max-Age": 600, 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Max-Age": 600,
                         "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Max-Age": {
                         "type": "integer"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Max-Age": 600, 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Max-Age": 600,
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Max-Age": {
                         "type": "integer"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
+      }
+    },
+    "ExplicitApiDeployment3e3e53a12e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 3e3e53a12e63aac5b1b6231552a59eb7addad5bc",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_and_only_methods.json
+++ b/tests/translator/output/api_with_cors_and_only_methods.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,95 +73,95 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeploymentfd83ca0941": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: fd83ca0941692bedca5c918b809a21bf44feca9e", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentfd83ca0941"
-        }, 
+          "Ref": "ServerlessRestApiDeployment689457f6b6"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "methods"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
+      }
+    },
+    "ServerlessRestApiDeployment689457f6b6": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 689457f6b68e802b88bb0e9a9fff3aa111e7c6fe",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_and_only_origins.json
+++ b/tests/translator/output/api_with_cors_and_only_origins.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -53,27 +53,17 @@
         }
       }
     },
-    "ExplicitApiDeploymenta7a992bbb6": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a7a992bbb604dcd7667af3caa050bf14af2bf684", 
-        "StageName": "Stage"
-      }
-    }, 
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,172 +73,162 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta7a992bbb6"
-        }, 
+          "Ref": "ExplicitApiDeploymentd7e85f5956"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment4be3cdc28b"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentf371c938d1"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment4be3cdc28b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 4be3cdc28b991a26bed9da1180e59e9cc5467355", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -260,81 +240,101 @@
       }
     },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
+      }
+    },
+    "ExplicitApiDeploymentd7e85f5956": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: d7e85f5956fd5d5fbcee55dcab5860fa11f4b2a4",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentf371c938d1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: f371c938d1508325870f1ac3e71e7fe9bc512ee3",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_cors_no_definitionbody.json
+++ b/tests/translator/output/api_with_cors_no_definitionbody.json
@@ -16,10 +16,12 @@
           ]
         },
         "Runtime": "nodejs12.x",
-        "Tags": [{
-          "Value": "SAM",
-          "Key": "lambda:createdBy"
-        }]
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     },
     "ImplicitApiFunctionRole": {
@@ -36,17 +38,19 @@
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
-          "Statement": [{
-            "Action": [
-              "sts:AssumeRole"
-            ],
-            "Effect": "Allow",
-            "Principal": {
-              "Service": [
-                "lambda.amazonaws.com"
-              ]
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
             }
-          }]
+          ]
         }
       }
     },
@@ -174,7 +178,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment4be3cdc28b"
+          "Ref": "ExplicitApiDeploymentf371c938d1"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -182,13 +186,13 @@
         "StageName": "Prod"
       }
     },
-    "ExplicitApiDeployment4be3cdc28b": {
+    "ExplicitApiDeploymentf371c938d1": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
-        "Description": "RestApi deployment id: 4be3cdc28b991a26bed9da1180e59e9cc5467355",
+        "Description": "RestApi deployment id: f371c938d1508325870f1ac3e71e7fe9bc512ee3",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/api_with_cors_openapi_3.json
+++ b/tests/translator/output/api_with_cors_openapi_3.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionAnyApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,45 +73,45 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
@@ -120,23 +120,23 @@
                 "consumes": [
                   "application/json"
                 ],
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
                 },
@@ -144,24 +144,24 @@
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
@@ -170,48 +170,48 @@
                 "consumes": [
                   "application/json"
                 ],
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
                 },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -223,13 +223,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -239,33 +239,33 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente3fd36e910"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentb81dfcd9d8"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment8cc53ffaa5"
-        }, 
+          "Ref": "ExplicitApiDeployment40a858e0c4"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -277,13 +277,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -293,18 +293,18 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -314,146 +314,70 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment8cc53ffaa5": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 8cc53ffaa59a19b69e73d5b422142c7396739b16"
-      }
-    }, 
-    "ServerlessRestApiDeploymente3fd36e910": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: e3fd36e910d56cf80b1b62823277d19f9b1f1a15"
-      }
-    }, 
+    },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
                 },
-                "summary": "CORS support", 
-                "responses": {
-                  "200": {
-                    "headers": {
-                      "Access-Control-Allow-Origin": {
-                        "schema": {
-                          "type": "string"
-                        }
-                      }, 
-                      "Access-Control-Allow-Methods": {
-                        "schema": {
-                          "type": "string"
-                        }
-                      }
-                    }, 
-                    "description": "Default response for CORS method"
-                  }
-                }
-              }, 
-              "x-amazon-apigateway-any-method": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                  }
-                }, 
-                "responses": {}
-              }
-            }, 
-            "/": {
-              "options": {
-                "x-amazon-apigateway-integration": {
-                  "type": "mock", 
-                  "requestTemplates": {
-                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
-                  "responses": {
-                    "default": {
-                      "statusCode": "200", 
-                      "responseTemplates": {
-                        "application/json": "{}\n"
-                      }, 
-                      "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": {
-                          "Fn::Join": [
-                            ",", 
-                            [
-                              "www.amazon.com", 
-                              "www.google.com"
-                            ]
-                          ]
-                        }, 
-                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
-                      }
-                    }
-                  }
-                },
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
@@ -471,44 +395,120 @@
                     "description": "Default response for CORS method"
                   }
                 }
-              }, 
-              "get": {
+              },
+              "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
+                "responses": {}
+              }
+            },
+            "/": {
+              "options": {
+                "x-amazon-apigateway-integration": {
+                  "type": "mock",
+                  "requestTemplates": {
+                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
+                  },
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseTemplates": {
+                        "application/json": "{}\n"
+                      },
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": {
+                          "Fn::Join": [
+                            ",",
+                            [
+                              "www.amazon.com",
+                              "www.google.com"
+                            ]
+                          ]
+                        },
+                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
+                      }
+                    }
+                  }
+                },
+                "summary": "CORS support",
+                "responses": {
+                  "200": {
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "description": "Default response for CORS method"
+                  }
+                }
+              },
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0"
         }
       }
-    }, 
+    },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ExplicitApiDeployment40a858e0c4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 40a858e0c466e102c414544f548494b70d9fbe8d"
+      }
+    },
+    "ServerlessRestApiDeploymentb81dfcd9d8": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: b81dfcd9d852770bab1f7016b95dd7024b464639"
       }
     }
   }

--- a/tests/translator/output/api_with_custom_domain_route53.json
+++ b/tests/translator/output/api_with_custom_domain_route53.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,100 +52,91 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
+    },
     "RecordSetGroupbd00d962a4": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneId": "ZQ1UAL4EFZVME", 
+        "HostedZoneId": "ZQ1UAL4EFZVME",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
-    "MyApiDeploymentf643ef7f59": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: f643ef7f592a69a57638dd25e64dc12d2b4abf2d"
-      }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentf643ef7f59"
-        }, 
+          "Ref": "MyApiDeployment3db56370f8"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -153,44 +144,53 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
         }
+      }
+    },
+    "MyApiDeployment3db56370f8": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 3db56370f87f3abd6110adb12d220a7bf3f8b8f8"
       }
     }
   }

--- a/tests/translator/output/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,85 +52,85 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymenteb58d7577a"
-        }, 
+          "Ref": "MyApiDeployment697ddeb1b2"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -138,59 +138,59 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "RecordSetGroup456ebaf280": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneName": "www.my-domain.com.", 
+        "HostedZoneName": "www.my-domain.com.",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
-    "MyApiDeploymenteb58d7577a": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "MyApiDeployment697ddeb1b2": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: eb58d7577a65af049c9c6f10c9d8b286de6b5aeb"
+        },
+        "Description": "RestApi deployment id: 697ddeb1b28cd0da7d924e784aff5e82cb06ffb2"
       }
     }
   }

--- a/tests/translator/output/api_with_default_aws_iam_auth.json
+++ b/tests/translator/output/api_with_default_aws_iam_auth.json
@@ -1,15 +1,5 @@
 {
   "Resources": {
-    "MyApiWithAwsIamAuthDeployment3364487a57": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: 3364487a57573f17976c9edc5dad6c3afe02a101",
-        "StageName": "Stage"
-      }
-    },
     "MyFunctionWithAwsIamAuth": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -58,22 +48,12 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeployment3364487a57"
+          "Ref": "MyApiWithAwsIamAuthDeployment99cd89c824"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
         "StageName": "Prod"
-      }
-    },
-    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeployment1edb95497c": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
-        },
-        "Description": "RestApi deployment id: 1edb95497ceb1e912fa65281f21a8f6f1098b5f4",
-        "StageName": "Stage"
       }
     },
     "MyFunctionWithAwsIamAuthMyApiWithAwsIamAuthAndDefaultInvokeRolePermissionProd": {
@@ -95,16 +75,6 @@
             }
           ]
         }
-      }
-    },
-    "MyApiWithAwsIamAuthAndCustomInvokeRoleDeployment61108120cf": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
-        },
-        "Description": "RestApi deployment id: 61108120cf9f293d5cf2fc21044a94dce2ed499a",
-        "StageName": "Stage"
       }
     },
     "MyApiWithAwsIamAuthAndCustomInvokeRole": {
@@ -153,7 +123,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeployment1edb95497c"
+          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeployment5b084d2cac"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
@@ -165,7 +135,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRoleDeployment61108120cf"
+          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRoleDeploymentfe5fac9c4e"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
@@ -306,6 +276,36 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthDeployment99cd89c824": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: 99cd89c82422a2a95065534030ca0f4d06699583",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeployment5b084d2cac": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
+        },
+        "Description": "RestApi deployment id: 5b084d2cacc884ecf3d7e9a8cd7e826bc0f73efa",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthAndCustomInvokeRoleDeploymentfe5fac9c4e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
+        },
+        "Description": "RestApi deployment id: fe5fac9c4e74152069d85754c712d464f53f8f66",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_default_aws_iam_auth_and_no_auth_route.json
+++ b/tests/translator/output/api_with_default_aws_iam_auth_and_no_auth_route.json
@@ -126,22 +126,12 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentd4892df344"
+          "Ref": "MyApiWithAwsIamAuthDeployment47abb83643"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
         "StageName": "Prod"
-      }
-    },
-    "MyApiWithAwsIamAuthDeploymentd4892df344": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: d4892df3448eaab6a467b44ffd4ed87f18f9a5d8",
-        "StageName": "Stage"
       }
     },
     "MyFunctionWithAwsIamAuthRole": {
@@ -172,6 +162,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthDeployment47abb83643": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: 47abb836438fb5e6654bef900bc93dea990f4fea",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_gateway_responses.json
+++ b/tests/translator/output/api_with_gateway_responses.json
@@ -92,21 +92,11 @@
         }
       }
     },
-    "ExplicitApiDeploymentf63e40e7e8": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: f63e40e7e8923689c5fa5f296abf1fc5d4773cc3",
-        "StageName": "Stage"
-      }
-    },
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf63e40e7e8"
+          "Ref": "ExplicitApiDeployment6870154f51"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -133,6 +123,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment6870154f51": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 6870154f512d2860156cdc6f3005a7bf9e3817b6",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_gateway_responses_all.json
+++ b/tests/translator/output/api_with_gateway_responses_all.json
@@ -101,21 +101,11 @@
         }
       }
     },
-    "ExplicitApiDeploymentedbd8aa001": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: edbd8aa001b34e2c5fa4458827ad9f4075fb812d",
-        "StageName": "Stage"
-      }
-    },
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentedbd8aa001"
+          "Ref": "ExplicitApiDeploymentcb96fd575b"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -142,6 +132,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymentcb96fd575b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: cb96fd575bb2b35b43abc17f2a314d86c01e1cfb",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_gateway_responses_all_openapi_3.json
+++ b/tests/translator/output/api_with_gateway_responses_all_openapi_3.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "Function": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "FunctionRole", 
+            "FunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "FunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,87 +52,78 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymenta8fcf1dd74": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a8fcf1dd7480d58309d5673300f397de4f515e47"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0", 
+          },
+          "openapi": "3.0",
           "x-amazon-apigateway-gateway-responses": {
             "QUOTA_EXCEEDED": {
               "responseParameters": {
                 "gatewayresponse.header.Retry-After": "'31536000'"
-              }, 
-              "responseTemplates": {}, 
+              },
+              "responseTemplates": {},
               "statusCode": "429"
-            }, 
+            },
             "UNAUTHORIZED": {
               "responseParameters": {
-                "gatewayresponse.header.WWW-Authenticate": "'Bearer realm=\"admin\"'", 
-                "gatewayresponse.header.Access-Control-Expose-Headers": "'WWW-Authenticate'", 
-                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'", 
-                "gatewayresponse.path.PathKey": "'path-value'", 
+                "gatewayresponse.header.WWW-Authenticate": "'Bearer realm=\"admin\"'",
+                "gatewayresponse.header.Access-Control-Expose-Headers": "'WWW-Authenticate'",
+                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+                "gatewayresponse.path.PathKey": "'path-value'",
                 "gatewayresponse.querystring.QueryStringKey": "'query-string-value'"
-              }, 
-              "responseTemplates": {}, 
+              },
+              "responseTemplates": {},
               "statusCode": "401"
             }
           }
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta8fcf1dd74"
-        }, 
+          "Ref": "ExplicitApiDeployment1bb14548ff"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "FunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "Function"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -141,6 +132,15 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment1bb14548ff": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 1bb14548ff814d0bd4d4ab2ef60c6637baf499cd"
       }
     }
   }

--- a/tests/translator/output/api_with_gateway_responses_implicit.json
+++ b/tests/translator/output/api_with_gateway_responses_implicit.json
@@ -23,16 +23,6 @@
         ]
       }
     },
-    "ServerlessRestApiDeploymentf63e40e7e8": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: f63e40e7e8923689c5fa5f296abf1fc5d4773cc3",
-        "StageName": "Stage"
-      }
-    },
     "FunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -67,7 +57,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentf63e40e7e8"
+          "Ref": "ServerlessRestApiDeployment6870154f51"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -134,6 +124,16 @@
           }
         },
         "Name": "some api"
+      }
+    },
+    "ServerlessRestApiDeployment6870154f51": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 6870154f512d2860156cdc6f3005a7bf9e3817b6",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_gateway_responses_minimal.json
+++ b/tests/translator/output/api_with_gateway_responses_minimal.json
@@ -87,21 +87,11 @@
         }
       }
     },
-    "ExplicitApiDeployment43cede1065": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 43cede1065157a0a0bdea5f4025a38449a7c37e6",
-        "StageName": "Stage"
-      }
-    },
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment43cede1065"
+          "Ref": "ExplicitApiDeploymente804104f7b"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -128,6 +118,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymente804104f7b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: e804104f7b51e8e49410095164d8cad25fc33309",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_gateway_responses_string_status_code.json
+++ b/tests/translator/output/api_with_gateway_responses_string_status_code.json
@@ -92,21 +92,11 @@
         }
       }
     },
-    "ExplicitApiDeploymentf63e40e7e8": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: f63e40e7e8923689c5fa5f296abf1fc5d4773cc3",
-        "StageName": "Stage"
-      }
-    },
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf63e40e7e8"
+          "Ref": "ExplicitApiDeployment6870154f51"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -133,6 +123,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment6870154f51": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 6870154f512d2860156cdc6f3005a7bf9e3817b6",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_if_conditional_with_resource_policy.json
+++ b/tests/translator/output/api_with_if_conditional_with_resource_policy.json
@@ -2,48 +2,48 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionPutHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -51,77 +51,67 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymenta1d4cfbf94": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a1d4cfbf94fc1b83780825310ec70e2a1c5e42b4", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/one": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/three": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/two": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
-                  "Action": "execute-api:Invoke", 
+                  "Action": "execute-api:Invoke",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
@@ -130,32 +120,32 @@
           }
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta1d4cfbf94"
-        }, 
+          "Ref": "ExplicitApiDeployment6e3398ef33"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -163,18 +153,18 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -182,37 +172,47 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment6e3398ef33": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 6e3398ef33585ae6b2674cfecaf1f263d8f1ca2f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_incompatible_stage_name.json
+++ b/tests/translator/output/api_with_incompatible_stage_name.json
@@ -1,53 +1,43 @@
 {
   "Resources": {
-    "HyphenApiDeployment19b8787883": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HyphenApi"
-        }, 
-        "Description": "RestApi deployment id: 19b8787883c74d792cf1ba94de3fd550cf820694", 
-        "StageName": "Stage"
-      }
-    }, 
     "UnderscoreApiStageb34d3ad84e": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "UnderscoreApiDeploymentc6c2bbcee6"
-        }, 
+          "Ref": "UnderscoreApiDeploymentca79588921"
+        },
         "RestApiId": {
           "Ref": "UnderscoreApi"
-        }, 
+        },
         "StageName": "hoge_fuga"
       }
-    }, 
+    },
     "UnderscoreApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UnderscoreFunction.Arn}/invocations"
                   }
-                }, 
-                "responses": {}, 
+                },
+                "responses": {},
                 "parameters": [
                   {
-                    "required": true, 
-                    "in": "body", 
-                    "name": "user", 
+                    "required": true,
+                    "in": "body",
+                    "name": "user",
                     "schema": {
                       "$ref": "#/definitions/user"
                     }
@@ -55,11 +45,11 @@
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "definitions": {
             "user": {
-              "type": "object", 
+              "type": "object",
               "properties": {
                 "username": {
                   "type": "string"
@@ -69,9 +59,9 @@
           }
         }
       }
-    }, 
+    },
     "UnderscoreFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -83,13 +73,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -100,27 +90,17 @@
         }
       }
     },
-    "UnderscoreApiDeploymentc6c2bbcee6": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "UnderscoreApi"
-        }, 
-        "Description": "RestApi deployment id: c6c2bbcee65f47628f0f53f9a9e5134f2f6394b5", 
-        "StageName": "Stage"
-      }
-    }, 
     "HyphenFunctionGetHtmlPermission0c8ecc62cb": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HyphenFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HyphenApi"
@@ -128,53 +108,53 @@
           ]
         }
       }
-    }, 
+    },
     "HyphenApiStage0c8ecc62cb": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HyphenApiDeployment19b8787883"
-        }, 
+          "Ref": "HyphenApiDeployment20155d2bd1"
+        },
         "RestApiId": {
           "Ref": "HyphenApi"
-        }, 
+        },
         "StageName": "hoge-fuga"
       }
-    }, 
+    },
     "UnderscoreFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "UnderscoreFunctionRole", 
+            "UnderscoreFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "UnderscoreFunctionGetHtmlPermissionb34d3ad84e": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "UnderscoreFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "UnderscoreApi"
@@ -184,54 +164,54 @@
       }
     },
     "HyphenFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "HyphenFunctionRole", 
+            "HyphenFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "HyphenApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HyphenFunction.Arn}/invocations"
                   }
-                }, 
-                "responses": {}, 
+                },
+                "responses": {},
                 "parameters": [
                   {
-                    "required": true, 
-                    "in": "body", 
-                    "name": "user", 
+                    "required": true,
+                    "in": "body",
+                    "name": "user",
                     "schema": {
                       "$ref": "#/definitions/user"
                     }
@@ -239,11 +219,11 @@
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "definitions": {
             "user": {
-              "type": "object", 
+              "type": "object",
               "properties": {
                 "username": {
                   "type": "string"
@@ -253,9 +233,9 @@
           }
         }
       }
-    }, 
+    },
     "HyphenFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -267,13 +247,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -282,6 +262,26 @@
             }
           ]
         }
+      }
+    },
+    "HyphenApiDeployment20155d2bd1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        },
+        "Description": "RestApi deployment id: 20155d2bd10f3835cdec06ddbf3b938f1fcf8e72",
+        "StageName": "Stage"
+      }
+    },
+    "UnderscoreApiDeploymentca79588921": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        },
+        "Description": "RestApi deployment id: ca7958892140fa005c37adcdc8132f756efd007b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_ip_range_blacklist.json
+++ b/tests/translator/output/api_with_ip_range_blacklist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeploymentd123ec976c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: d123ec976c2dab1f9d5da42c13d0960b0c7af65e", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentd123ec976c"
-        }, 
+          "Ref": "ServerlessRestApiDeployment1f823c7b4d"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,115 +63,125 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "AWS": [
                     "12345"
                   ]
                 }
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "IpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment1f823c7b4d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 1f823c7b4d0264bce48062db0ffab4dc06efdd0a",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_ip_range_whitelist.json
+++ b/tests/translator/output/api_with_ip_range_whitelist.json
@@ -1,41 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment864f081ed8"
-        }, 
+          "Ref": "ServerlessRestApiDeployment30219f386f"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -47,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -63,128 +63,128 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "NotIpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "IpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
         }
       }
-    }, 
-    "ServerlessRestApiDeployment864f081ed8": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 864f081ed8e2c158aa653c724bfc879fb3f4a78b", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment30219f386f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 30219f386f219dea5dbd69005bd003bfef3d6ea3",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_method_aws_iam_auth.json
+++ b/tests/translator/output/api_with_method_aws_iam_auth.json
@@ -164,22 +164,12 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment0cf1ab8c4c"
+          "Ref": "MyApiWithoutAuthDeploymentdd2ba8471c"
         },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
         },
         "StageName": "Prod"
-      }
-    },
-    "MyApiWithoutAuthDeployment0cf1ab8c4c": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        },
-        "Description": "RestApi deployment id: 0cf1ab8c4caae4435015b3256bce0daaa087bd5e",
-        "StageName": "Stage"
       }
     },
     "MyFunctionWithAwsIamAuthRole": {
@@ -210,6 +200,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithoutAuthDeploymentdd2ba8471c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        },
+        "Description": "RestApi deployment id: dd2ba8471cc598c2c1620fe6587ed15e41475e05",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_method_settings.json
+++ b/tests/translator/output/api_with_method_settings.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,28 +52,18 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,94 +73,104 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "MethodSettings": [
           {
-            "HttpMethod": "*", 
-            "MetricsEnabled": true, 
-            "ResourcePath": "/*", 
-            "DataTraceEnabled": true, 
+            "HttpMethod": "*",
+            "MetricsEnabled": true,
+            "ResourcePath": "/*",
+            "DataTraceEnabled": true,
             "LoggingLevel": "INFO"
           }
-        ], 
+        ],
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "MethodSettings": [
           {
-            "HttpMethod": "*", 
-            "MetricsEnabled": true, 
-            "ResourcePath": "/*", 
-            "DataTraceEnabled": true, 
+            "HttpMethod": "*",
+            "MetricsEnabled": true,
+            "ResourcePath": "/*",
+            "DataTraceEnabled": true,
             "LoggingLevel": "INFO"
           }
-        ], 
+        ],
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment62b96c1a61"
-        }, 
+          "Ref": "ServerlessRestApiDeployment207d63cbe2"
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment62b96c1a61": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 62b96c1a611878eefb13e8ef66dbc71b9ba3dd19", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment207d63cbe2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 207d63cbe20acce3663f22e907f62096d9d7039c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_minimum_compression_size.json
+++ b/tests/translator/output/api_with_minimum_compression_size.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,28 +52,18 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,78 +73,88 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
-        "MinimumCompressionSize": 256, 
+        "MinimumCompressionSize": 256,
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment62b96c1a61"
-        }, 
+          "Ref": "ServerlessRestApiDeployment207d63cbe2"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment62b96c1a61": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 62b96c1a611878eefb13e8ef66dbc71b9ba3dd19", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "MinimumCompressionSize": 1024
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment207d63cbe2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 207d63cbe20acce3663f22e907f62096d9d7039c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_open_api_version.json
+++ b/tests/translator/output/api_with_open_api_version.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -53,26 +53,17 @@
         }
       }
     },
-    "ServerlessRestApiDeployment1471b71104": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 1471b711047af5f4fd8c5c957e2b2075ddcc76be"
-      }
-    }, 
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -82,87 +73,78 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "openapi": "3.0.1"
         }
       }
-    }, 
-    "ExplicitApiDeploymentd9a0f2ae4f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: d9a0f2ae4fe2d97b9b91644934a878b6a08cf1c3"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment1471b71104"
-        }, 
+          "Ref": "ServerlessRestApiDeployment452377c035"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentd9a0f2ae4f"
-        }, 
+          "Ref": "ExplicitApiDeployment8a3d83687a"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "*", 
+                        "method.response.header.Access-Control-Allow-Origin": "*",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
                 },
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
@@ -180,21 +162,39 @@
                     "description": "Default response for CORS method"
                   }
                 }
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
         }
+      }
+    },
+    "ServerlessRestApiDeployment452377c035": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 452377c0356009dc3ac3830056a4f08c63f04000"
+      }
+    },
+    "ExplicitApiDeployment8a3d83687a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 8a3d83687a607eaebbbf1d8749f2949151334aff"
       }
     }
   }

--- a/tests/translator/output/api_with_open_api_version_2.json
+++ b/tests/translator/output/api_with_open_api_version_2.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,130 +73,130 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment4154e1c30c"
-        }, 
+          "Ref": "ExplicitApiDeployment13722dd579"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment32f05a472e"
-        }, 
+          "Ref": "ServerlessRestApiDeployment3eb5bbe219"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment32f05a472e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 32f05a472e885a4cf62d1ae534486511f6152624"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "*", 
+                        "method.response.header.Access-Control-Allow-Origin": "*",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
-    "ExplicitApiDeployment4154e1c30c": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ServerlessRestApiDeployment3eb5bbe219": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 3eb5bbe21905b80e2ecacb235cc0f5df425e9364"
+      }
+    },
+    "ExplicitApiDeployment13722dd579": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 4154e1c30c97469d4946280461125dbfd4324f15"
+        },
+        "Description": "RestApi deployment id: 13722dd579bfec46ba399f3966036bbbe18db618"
       }
     }
   }

--- a/tests/translator/output/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/api_with_openapi_definition_body_no_flag.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,127 +52,107 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment9252467a1e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1", 
-        "StageName": "Stage"
-      }
     },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.1.1", 
+          },
+          "openapi": "3.1.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     {
                       "Fn::GetAtt": [
-                        "MyUserPool", 
+                        "MyUserPool",
                         "Arn"
                       ]
                     }
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
-        }, 
+        },
         "Name": "some api"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentdb4b9da82a"
+          "Ref": "ServerlessRestApiDeployment93d0f104df"
         }
       }
-    }, 
-    "ServerlessRestApiDeploymentdb4b9da82a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: db4b9da82adc6031fcd32bf3a4954485464fc009", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeployment542a922713"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -182,79 +162,99 @@
           ]
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "Name": "some api"
+      }
+    },
+    "ExplicitApiDeployment542a922713": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 542a922713e9c340e3e1940eeb139b17dfcd75cc",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment93d0f104df": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 93d0f104df96ef33407c1c6ae95e12d1b9ac609f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_path_parameters.json
+++ b/tests/translator/output/api_with_path_parameters.json
@@ -34,7 +34,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
+          "Ref": "HtmlApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -59,16 +59,6 @@
             }
           ]
         }
-      }
-    },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "HtmlApi": {
@@ -101,6 +91,16 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_resource_policy.json
+++ b/tests/translator/output/api_with_resource_policy.json
@@ -1,41 +1,41 @@
 {
   "Resources": {
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionPutHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -43,60 +43,60 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/one": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/three": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/two": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
-              "Action": "execute-api:Invoke", 
+              "Action": "execute-api:Invoke",
               "Resource": [
                 "execute-api:/*/*/*"
               ]
@@ -104,32 +104,32 @@
           }
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment215ee6137d"
-        }, 
+          "Ref": "ExplicitApiDeployment5a0571d8b3"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -137,18 +137,18 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -156,47 +156,47 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ExplicitApiDeployment215ee6137d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 215ee6137d74bceebd1cd5a2b8fb2d8f8604e708", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment5a0571d8b3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 5a0571d8b38d6c3c99fe3aa6d89b827a8f869e71",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_resource_policy_global.json
+++ b/tests/translator/output/api_with_resource_policy_global.json
@@ -2,43 +2,43 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "StageName": {
-      "Default": "MyOwnStage", 
+      "Default": "MyOwnStage",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "AnotherApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
-          "swagger": "2.0", 
+          },
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
-                  "Action": "execute-api:Invoke", 
+                  "Action": "execute-api:Invoke",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
-                }, 
+                },
                 {
-                  "Action": "execute-api:Another", 
+                  "Action": "execute-api:Another",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
@@ -48,44 +48,34 @@
           }
         }
       }
-    }, 
-    "ExplicitApiDeploymenta5a5c4e3ff": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a5a5c4e3ff6901cf27436628359ed20300d34aa4", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta5a5c4e3ff"
-        }, 
+          "Ref": "ExplicitApiDeployment4c5e269029"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": {
           "Ref": "StageName"
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -93,51 +83,41 @@
           ]
         }
       }
-    }, 
-    "AnotherApiDeploymentfdf1387e0a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "AnotherApi"
-        }, 
-        "Description": "RestApi deployment id: fdf1387e0a89fa15996401a79284cdaaf2c43844", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -145,78 +125,78 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "AnotherApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "AnotherApiDeploymentfdf1387e0a"
-        }, 
+          "Ref": "AnotherApiDeployment0564df8d4a"
+        },
         "RestApiId": {
           "Ref": "AnotherApi"
-        }, 
+        },
         "StageName": {
           "Ref": "StageName"
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": 2.0, 
+          },
+          "swagger": 2.0,
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "sts:AssumeRole", 
-                "Effect": "Allow", 
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
                 "Principal": {
                   "Service": "lambda.amazonaws.com"
                 }
-              }, 
+              },
               {
                 "Fn::If": [
-                  "C1", 
+                  "C1",
                   {
-                    "Action": "execute-api:Invoke", 
+                    "Action": "execute-api:Invoke",
                     "Resource": [
                       "execute-api:/*/*/*"
                     ]
-                  }, 
+                  },
                   {
-                    "Action": "execute-api:Blah", 
+                    "Action": "execute-api:Blah",
                     "Resource": [
                       "execute-api:/*/*/*"
                     ]
@@ -226,6 +206,26 @@
             ]
           }
         }
+      }
+    },
+    "ExplicitApiDeployment4c5e269029": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 4c5e269029fe10081e5a9d82b311bd327d8fce6e",
+        "StageName": "Stage"
+      }
+    },
+    "AnotherApiDeployment0564df8d4a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "AnotherApi"
+        },
+        "Description": "RestApi deployment id: 0564df8d4a281d58de69686b00180ebd1207a60d",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_resource_policy_global_implicit.json
+++ b/tests/translator/output/api_with_resource_policy_global_implicit.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "MinimalFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MinimalFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -20,9 +20,9 @@
           ]
         }
       }
-    }, 
+    },
     "MinimalFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -34,13 +34,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -50,88 +50,78 @@
           ]
         }
       }
-    }, 
+    },
     "MinimalFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MinimalFunctionRole", 
+            "MinimalFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment1ecad21e32"
-        }, 
+          "Ref": "ServerlessRestApiDeployment8b1482b451"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiDeployment1ecad21e32": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 1ecad21e325b9a3167fd5c2d6399ef59ccab0df9", 
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MinimalFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   "execute-api:/*/*/*"
                 ]
-              }, 
+              },
               {
-                "Action": "execute-api:blah", 
+                "Action": "execute-api:blah",
                 "Resource": [
                   "execute-api:/*/*/*"
                 ]
@@ -139,6 +129,16 @@
             ]
           }
         }
+      }
+    },
+    "ServerlessRestApiDeployment8b1482b451": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 8b1482b451b8b94e81495d246abc5da981c261c1",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_resource_refs.json
+++ b/tests/translator/output/api_with_resource_refs.json
@@ -2,92 +2,72 @@
   "Outputs": {
     "ImplicitApiDeployment": {
       "Value": {
-        "Ref": "ServerlessRestApiDeploymente468b80e17"
+        "Ref": "ServerlessRestApiDeploymentc1ac7f664e"
       }
-    }, 
+    },
     "ExplicitApiDeployment": {
       "Value": {
-        "Ref": "MyApiDeployment359f256a3b"
+        "Ref": "MyApiDeployment8ded5fd20d"
       }
-    }, 
+    },
     "ExplicitApiStage": {
       "Value": {
         "Ref": "MyApifooStage"
       }
-    }, 
+    },
     "ImplicitApiStage": {
       "Value": {
         "Ref": "ServerlessRestApiProdStage"
       }
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "MyApiDeployment359f256a3b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 359f256a3b3ff2e1102e335a4d603f02df9b4988", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApifooStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment359f256a3b"
-        }, 
+          "Ref": "MyApiDeployment8ded5fd20d"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "foo"
       }
-    }, 
-    "ServerlessRestApiDeploymente468b80e17": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: e468b80e1715e63b38c5d140bd0bb264fd0eedf8", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/html", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/html",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -97,21 +77,21 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente468b80e17"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentc1ac7f664e"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -123,13 +103,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -139,42 +119,62 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/html": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "swagger"
         }
+      }
+    },
+    "MyApiDeployment8ded5fd20d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 8ded5fd20d1fa9ee4e4db2c8a8cb513497b18adb",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentc1ac7f664e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: c1ac7f664e492c26c7540b59113782e8cd902c9c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_source_vpc_blacklist.json
+++ b/tests/translator/output/api_with_source_vpc_blacklist.json
@@ -1,60 +1,50 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment0e25d06cd3": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 0e25d06cd3bcb2adf9b3cd988ce86aa2d9370cb3", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment0e25d06cd3"
-        }, 
+          "Ref": "ServerlessRestApiDeployment29ef90e87b"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -62,107 +52,117 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringEquals": {
                     "aws:SourceVpce": [
                       "vpce-3456"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment29ef90e87b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 29ef90e87bdff61f925556024e65462082f8240f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_source_vpc_whitelist.json
+++ b/tests/translator/output/api_with_source_vpc_whitelist.json
@@ -1,46 +1,46 @@
 {
   "Parameters": {
     "Vpc1": {
-      "Default": "vpc-1234", 
+      "Default": "vpc-1234",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -48,64 +48,44 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment5332c373d4"
-        }, 
+          "Ref": "MyApiDeployment5e697a4b30"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment276f3672ac"
-        }, 
+          "Ref": "ServerlessRestApiDeployment51810b5ae7"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyApiDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ServerlessRestApiDeployment276f3672ac": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 276f3672acc0db05468d66e75218112e92b84253", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -113,18 +93,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -132,152 +112,172 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringNotEquals": {
                     "aws:SourceVpc": [
-                      "vpc-1234", 
+                      "vpc-1234",
                       "vpc-5678"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/POST/fetch", 
+                      "execute-api:/${__Stage__}/POST/fetch",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/POST/fetch", 
+                      "execute-api:/${__Stage__}/POST/fetch",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringNotEquals": {
                     "aws:SourceVpc": [
-                      "vpc-1234", 
+                      "vpc-1234",
                       "vpc-5678"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
         }
+      }
+    },
+    "MyApiDeployment5e697a4b30": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 5e697a4b309f0f6b0fef455883aec23936861ff1",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment51810b5ae7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 51810b5ae7fa912597c426c545a96589bbdca10b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_stage_tags.json
+++ b/tests/translator/output/api_with_stage_tags.json
@@ -1,66 +1,66 @@
 {
   "Parameters": {
     "TagValueParam": {
-      "Default": "value", 
+      "Default": "value",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
-    "MyApiWithStageTagsDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithStageTags"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7", 
-        "StageName": "Stage"
-      }
-    }, 
     "MyApiWithStageTags": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "MyApiWithStageTagsProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithStageTagsDeployment5332c373d4"
-        }, 
+          "Ref": "MyApiWithStageTagsDeployment5e697a4b30"
+        },
         "RestApiId": {
           "Ref": "MyApiWithStageTags"
-        }, 
-        "StageName": "Prod", 
+        },
+        "StageName": "Prod",
         "Tags": [
           {
-            "Value": "TagValue1", 
+            "Value": "TagValue1",
             "Key": "TagKey1"
-          }, 
+          },
           {
-            "Value": "", 
+            "Value": "",
             "Key": "TagKey2"
-          }, 
+          },
           {
             "Value": {
               "Ref": "TagValueParam"
-            }, 
+            },
             "Key": "TagKey3"
-          }, 
+          },
           {
-            "Value": "123", 
+            "Value": "123",
             "Key": "TagKey4"
           }
         ]
+      }
+    },
+    "MyApiWithStageTagsDeployment5e697a4b30": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithStageTags"
+        },
+        "Description": "RestApi deployment id: 5e697a4b309f0f6b0fef455883aec23936861ff1",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/api_with_swagger_and_openapi_with_auth.json
+++ b/tests/translator/output/api_with_swagger_and_openapi_with_auth.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,114 +54,104 @@
       }
     },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.1.1", 
-          "swagger": 2.0, 
+          },
+          "openapi": "3.1.1",
+          "swagger": 2.0,
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "Name": "some api"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentdb4b9da82a"
+          "Ref": "ServerlessRestApiDeployment93d0f104df"
         }
       }
-    }, 
-    "ServerlessRestApiDeploymentdb4b9da82a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: db4b9da82adc6031fcd32bf3a4954485464fc009", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment7c4f7dda23"
+          "Ref": "ExplicitApiDeploymentd91576e21e"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -171,88 +161,98 @@
           ]
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "Name": "some api"
       }
-    }, 
-    "ExplicitApiDeployment7c4f7dda23": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ServerlessRestApiDeployment93d0f104df": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 93d0f104df96ef33407c1c6ae95e12d1b9ac609f",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeploymentd91576e21e": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 7c4f7dda23acd71e4a653861510d82ad7809e562", 
+        },
+        "Description": "RestApi deployment id: d91576e21ef46309219ef12cb8601f13cc905189",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/api_with_usageplans.json
+++ b/tests/translator/output/api_with_usageplans.json
@@ -72,7 +72,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment7a26848ac9"
+          "Ref": "ServerlessRestApiDeployment2be6c91669"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -133,16 +133,6 @@
             }
           }
         }
-      }
-    },
-    "ServerlessRestApiDeployment7a26848ac9": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 7a26848ac97d678aaf266a8a883d0abd463b3bbc",
-        "StageName": "Stage"
       }
     },
     "MyFunctionThreeApiKeyPermissionProd": {
@@ -207,16 +197,6 @@
             }
           ]
         }
-      }
-    },
-    "MyApiOneDeployment46fb22a429": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiOne"
-        },
-        "Description": "RestApi deployment id: 46fb22a42926db6f64e09966936d074ec6bb9392",
-        "StageName": "Stage"
       }
     },
     "MyFunctionTwoApiKeyPermissionProd": {
@@ -428,16 +408,6 @@
         "MyApiTwo"
       ]
     },
-    "MyApiThreeDeployment1d9cff47dc": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiThree"
-        },
-        "Description": "RestApi deployment id: 1d9cff47dc9b822750c668c73b4534022483de6d",
-        "StageName": "Stage"
-      }
-    },
     "MyFunctionTwoImplicitApiEventPermissionProd": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -463,7 +433,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeploymente9d97923b9"
+          "Ref": "MyApiTwoDeploymentc53f81eedd"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -475,22 +445,12 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeployment46fb22a429"
+          "Ref": "MyApiOneDeployment4a15b83f92"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
         },
         "StageName": "Prod"
-      }
-    },
-    "MyApiTwoDeploymente9d97923b9": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiTwo"
-        },
-        "Description": "RestApi deployment id: e9d97923b94d0801cd85a8970b3c3f84aa274003",
-        "StageName": "Stage"
       }
     },
     "MyFunctionThree": {
@@ -519,7 +479,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiThreeDeployment1d9cff47dc"
+          "Ref": "MyApiThreeDeployment05f98fd7e0"
         },
         "RestApiId": {
           "Ref": "MyApiThree"
@@ -667,6 +627,46 @@
       "DependsOn": [
         "MyApiTwoUsagePlan"
       ]
+    },
+    "ServerlessRestApiDeployment2be6c91669": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 2be6c9166981ca1a79e77d739b7d19cef21a5af8",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiOneDeployment4a15b83f92": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "Description": "RestApi deployment id: 4a15b83f920bf5b176a6fac6327794670463d010",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiThreeDeployment05f98fd7e0": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "Description": "RestApi deployment id: 05f98fd7e06d2ad49135dd5d80264174029ad6f3",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoDeploymentc53f81eedd": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "Description": "RestApi deployment id: c53f81eedd953df094c4c55e4fa0b1322f0aa1c0",
+        "StageName": "Stage"
+      }
     }
   }
 }

--- a/tests/translator/output/api_with_usageplans_intrinsics.json
+++ b/tests/translator/output/api_with_usageplans_intrinsics.json
@@ -43,15 +43,6 @@
         "MyApiTwoApiKey"
       ]
     },
-    "MyApiTwoDeploymenta78b9db9dd": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiTwo"
-        },
-        "Description": "RestApi deployment id: a78b9db9ddd80dec31c4b3c3e2b6e037345252ce"
-      }
-    },
     "MyApiOneUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
       "Properties": {
@@ -92,7 +83,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeploymenta78b9db9dd"
+          "Ref": "MyApiTwoDeployment9f0a4609e6"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -100,21 +91,11 @@
         "StageName": "Prod"
       }
     },
-    "MyApiOneDeployment37a3a51a0f": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiOne"
-        },
-        "Description": "RestApi deployment id: 37a3a51a0fd9d750b0bd43bdab40046fdc167e8d"
-      },
-      "Condition": "C1"
-    },
     "MyApiOneProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeployment37a3a51a0f"
+          "Ref": "MyApiOneDeployment8b730503db"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -406,6 +387,25 @@
           }
         ]
       }
+    },
+    "MyApiTwoDeployment9f0a4609e6": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "Description": "RestApi deployment id: 9f0a4609e65623f1b3c75b64cf19bad1440118f7"
+      }
+    },
+    "MyApiOneDeployment8b730503db": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "Description": "RestApi deployment id: 8b730503dbef334f318b7c9ab91be400de7cc07f"
+      },
+      "Condition": "C1"
     }
   }
 }

--- a/tests/translator/output/api_with_xray_tracing.json
+++ b/tests/translator/output/api_with_xray_tracing.json
@@ -34,7 +34,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
+          "Ref": "HtmlApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -60,16 +60,6 @@
             }
           ]
         }
-      }
-    },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "HtmlApi": {
@@ -102,6 +92,16 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_cache.json
+++ b/tests/translator/output/aws-cn/api_cache.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "HtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,32 +29,32 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
-        "CacheClusterEnabled": true, 
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "HtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "HtmlApi"
-        }, 
-        "StageName": "Prod", 
+        },
+        "StageName": "Prod",
         "CacheClusterSize": "1.6"
       }
-    }, 
+    },
     "HtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HtmlApi"
@@ -63,54 +63,54 @@
         }
       }
     },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "HtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "HtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "HtmlFunctionRole", 
+            "HtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_description.json
+++ b/tests/translator/output/aws-cn/api_description.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "FunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,27 +29,27 @@
           ]
         }
       }
-    }, 
+    },
     "ApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "Api"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "FunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "Function"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
             "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
@@ -61,21 +61,11 @@
         }
       }
     },
-    "ApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "Api"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "Api": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
         },
         "Description": "my description",
@@ -88,28 +78,38 @@
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "Function": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
             "FunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "Api"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_endpoint_configuration.json
+++ b/tests/translator/output/aws-cn/api_endpoint_configuration.json
@@ -3,33 +3,33 @@
     "EndpointConfig": {
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -41,13 +41,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -59,16 +59,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -78,106 +78,106 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "SomeValue"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "SomeValue"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcb4fb12558"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentd572487786"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymentcb4fb12558": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: cb4fb1255811b7b6a25dd35f23ee7ad133003b89", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             {
               "Ref": "EndpointConfig"
             }
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": {
             "Ref": "EndpointConfig"
           }
         }
+      }
+    },
+    "ServerlessRestApiDeploymentd572487786": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5724877861288ceb1c8be167c55955a3102b187",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/aws-cn/api_endpoint_configuration_with_vpcendpoint.json
@@ -6,33 +6,33 @@
     "EndpointConfigType": {
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -44,13 +44,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -62,16 +62,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -81,92 +81,72 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "SomeValue"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "SomeValue"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcb4fb12558"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentd572487786"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymentcb4fb12558": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: cb4fb1255811b7b6a25dd35f23ee7ad133003b89", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         },
         "EndpointConfiguration": {
@@ -186,6 +166,26 @@
             "Ref": "EndpointConfigType"
           }
         }
+      }
+    },
+    "ServerlessRestApiDeploymentd572487786": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5724877861288ceb1c8be167c55955a3102b187",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_request_model.json
+++ b/tests/translator/output/aws-cn/api_request_model.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "HtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,27 +29,27 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentd7bcfbe715"
-        }, 
+          "Ref": "HtmlApiDeploymentb20300c6cf"
+        },
         "RestApiId": {
           "Ref": "HtmlApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "HtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
             "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
@@ -61,18 +61,8 @@
         }
       }
     },
-    "HtmlApiDeploymentd7bcfbe715": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: d7bcfbe7157513b0b1a2debffbe44655fb332d60",
-        "StageName": "Stage"
-      }
-    }, 
     "HtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
@@ -126,28 +116,38 @@
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "HtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "HtmlFunctionRole", 
+            "HtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeploymentb20300c6cf": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: b20300c6cffbc4b2d4358dec6a9a9e5864ec104e",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_request_model_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_request_model_openapi_3.json
@@ -1,16 +1,7 @@
 {
   "Resources": {
-    "HtmlApiDeployment5ae7e42cea": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: 5ae7e42cea0640a3318bf508535850cd792a52dc"
-      }
-    },
     "HtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -22,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -38,30 +29,30 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment5ae7e42cea"
-        }, 
+          "Ref": "HtmlApiDeployment101bdd050c"
+        },
         "RestApiId": {
           "Ref": "HtmlApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "HtmlFunctionIamPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/iam", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/iam",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -71,17 +62,17 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/iam": {
               "get": {
@@ -92,25 +83,25 @@
                         "$ref": "#/components/schemas/user"
                       }
                     }
-                  }, 
+                  },
                   "required": true
-                }, 
+                },
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HtmlFunction.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::*:user/*"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/": {
               "get": {
                 "requestBody": {
@@ -120,33 +111,33 @@
                         "$ref": "#/components/schemas/user"
                       }
                     }
-                  }, 
+                  },
                   "required": true
-                }, 
+                },
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0",
           "components": {
             "securitySchemes": {
               "AWS_IAM": {
-                "x-amazon-apigateway-authtype": "awsSigv4", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "x-amazon-apigateway-authtype": "awsSigv4",
+                "type": "apiKey",
+                "name": "Authorization",
                 "in": "header"
               }
-            }, 
+            },
             "schemas": {
               "user": {
-                "type": "object", 
+                "type": "object",
                 "properties": {
                   "username": {
                     "type": "string"
@@ -155,28 +146,28 @@
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
     },
     "HtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HtmlApi"
@@ -184,28 +175,37 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "HtmlFunctionRole", 
+            "HtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment101bdd050c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 101bdd050c67a4317fbb3c8d5de951c5e21fe80b"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_access_log_setting.json
+++ b/tests/translator/output/aws-cn/api_with_access_log_setting.json
@@ -99,7 +99,7 @@
           "Format": "$context.requestId"
         },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
+          "Ref": "ExplicitApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -115,32 +115,12 @@
           "Format": "$context.requestId"
         },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcb4fb12558"
+          "Ref": "ServerlessRestApiDeploymentd572487786"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
         "StageName": "Prod"
-      }
-    },
-    "ServerlessRestApiDeploymentcb4fb12558": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: cb4fb1255811b7b6a25dd35f23ee7ad133003b89",
-        "StageName": "Stage"
-      }
-    },
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
@@ -177,6 +157,26 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeploymentd572487786": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5724877861288ceb1c8be167c55955a3102b187",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_apikey_default_override.json
+++ b/tests/translator/output/aws-cn/api_with_apikey_default_override.json
@@ -4,7 +4,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAuthDeployment12e3363002"
+          "Ref": "MyApiWithAuthDeployment2e940d2f88"
         },
         "RestApiId": {
           "Ref": "MyApiWithAuth"
@@ -119,16 +119,6 @@
             }
           ]
         }
-      }
-    },
-    "MyApiWithAuthDeployment12e3363002": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAuth"
-        },
-        "Description": "RestApi deployment id: 12e33630022574b70be75950554db06d81af114d",
-        "StageName": "Stage"
       }
     },
     "MyFunctionWithApiKeyRequiredFalse": {
@@ -320,6 +310,16 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiWithAuthDeployment2e940d2f88": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAuth"
+        },
+        "Description": "RestApi deployment id: 2e940d2f88f6de859af5460d6d624af2f82183e6",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_apikey_required.json
+++ b/tests/translator/output/aws-cn/api_with_apikey_required.json
@@ -30,16 +30,6 @@
         }
       }
     },
-    "MyApiWithoutAuthDeploymentcc6d6fc40a": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        },
-        "Description": "RestApi deployment id: cc6d6fc40a37188fe0115a039b24e397dc149478",
-        "StageName": "Stage"
-      }
-    },
     "MyApiWithoutAuth": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -92,7 +82,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeploymentcc6d6fc40a"
+          "Ref": "MyApiWithoutAuthDeploymentc0f6cc0946"
         },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
@@ -142,6 +132,16 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "MyApiWithoutAuthDeploymentc0f6cc0946": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        },
+        "Description": "RestApi deployment id: c0f6cc0946ba49f9211f2890f24a7c3b2fd96041",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_apikey_required_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_with_apikey_required_openapi_3.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "MyFunctionWithApiKeyRequiredRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -30,88 +30,79 @@
         }
       }
     },
-    "MyApiWithoutAuthDeployment44fb9ac597": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        }, 
-        "Description": "RestApi deployment id: 44fb9ac5971a18de67dd843c5c069f07726ad36c"
-      }
-    }, 
     "MyApiWithoutAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/ApiKeyRequiredTrue": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequired.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "api_key": {
-                "type": "apiKey", 
-                "name": "x-api-key", 
+                "type": "apiKey",
+                "name": "x-api-key",
                 "in": "header"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiWithoutAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment44fb9ac597"
-        }, 
+          "Ref": "MyApiWithoutAuthDeploymentc758ef1da5"
+        },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithApiKeyRequiredMyApiWithApiKeyRequiredPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithApiKeyRequired"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyRequiredTrue", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyRequiredTrue",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -121,28 +112,37 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithApiKeyRequired": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithApiKeyRequiredRole", 
+            "MyFunctionWithApiKeyRequiredRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "MyApiWithoutAuthDeploymentc758ef1da5": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        },
+        "Description": "RestApi deployment id: c758ef1da59cd34e07cd41df0271208ab8598ac6"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_auth_all_maximum.json
+++ b/tests/translator/output/aws-cn/api_with_auth_all_maximum.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -43,16 +43,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -63,16 +63,16 @@
       }
     },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -84,7 +84,7 @@
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -96,13 +96,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -112,226 +112,226 @@
           ]
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "patch": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 0, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuthMultipleUserPools": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader2", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression2", 
+                "identityValidationExpression": "myauthvalidationexpression2",
                 "providerARNs": [
-                  "arn:aws:2", 
+                  "arn:aws:2",
                   "arn:aws:3"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "authorizerResultTtlInSeconds": 0, 
-                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
+                },
                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression", 
+                "identityValidationExpression": "myauthvalidationexpression",
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyCustomAuthHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 20, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
-                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                 "identityValidationExpression": "mycustomauthexpression"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -342,16 +342,16 @@
       }
     },
     "MyFunctionWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -363,14 +363,14 @@
       }
     },
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -379,40 +379,30 @@
           ]
         }
       }
-    }, 
-    "MyApiDeployment2b4f028142": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 2b4f028142eb38900e00f362b76751032ac4e464", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment2b4f028142"
-        }, 
+          "Ref": "MyApiDeploymenta0fd3cdbbe"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -422,18 +412,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -442,6 +432,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiDeploymenta0fd3cdbbe": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: a0fd3cdbbedc7fdda46428511a0bcce7ed72180a",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_auth_all_maximum_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_with_auth_all_maximum_openapi_3.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -43,16 +43,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -61,18 +61,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -84,7 +84,7 @@
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -96,13 +96,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -112,228 +112,228 @@
           ]
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "patch": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
-                  "authorizerResultTtlInSeconds": 0, 
+                  "type": "token",
+                  "authorizerResultTtlInSeconds": 0,
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "MyCognitoAuthMultipleUserPools": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyAuthorizationHeader2", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyAuthorizationHeader2",
                 "x-amazon-apigateway-authorizer": {
-                  "identityValidationExpression": "myauthvalidationexpression2", 
+                  "identityValidationExpression": "myauthvalidationexpression2",
                   "providerARNs": [
-                    "arn:aws:2", 
+                    "arn:aws:2",
                     "arn:aws:3"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyLambdaRequestAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Unused", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "request", 
-                  "authorizerResultTtlInSeconds": 0, 
-                  "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                  "type": "request",
+                  "authorizerResultTtlInSeconds": 0,
+                  "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
-                  }, 
+                  },
                   "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyAuthorizationHeader", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyAuthorizationHeader",
                 "x-amazon-apigateway-authorizer": {
-                  "identityValidationExpression": "myauthvalidationexpression", 
+                  "identityValidationExpression": "myauthvalidationexpression",
                   "providerARNs": [
                     "arn:aws:1"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyLambdaTokenAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyCustomAuthHeader", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyCustomAuthHeader",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
-                  "authorizerResultTtlInSeconds": 20, 
+                  "type": "token",
+                  "authorizerResultTtlInSeconds": 20,
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
-                  }, 
-                  "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                  },
+                  "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                   "identityValidationExpression": "mycustomauthexpression"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "api_key": {
-                "type": "apiKey", 
-                "name": "x-api-key", 
+                "type": "apiKey",
+                "name": "x-api-key",
                 "in": "header"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -344,16 +344,16 @@
       }
     },
     "MyFunctionWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -364,24 +364,15 @@
         }
       }
     },
-    "MyApiDeploymentcc3ee70601": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: cc3ee706016a512ef6fe9e3608b7b637fd4c7abd"
-      }
-    }, 
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -390,30 +381,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentcc3ee70601"
-        }, 
+          "Ref": "MyApiDeployment62e25cb4ad"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -423,18 +414,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -443,6 +434,15 @@
             }
           ]
         }
+      }
+    },
+    "MyApiDeployment62e25cb4ad": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 62e25cb4ad7b1946573a11261ede437a7e0ed60d"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_auth_all_minimum.json
+++ b/tests/translator/output/aws-cn/api_with_auth_all_minimum.json
@@ -1,91 +1,91 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeploymentd3ee2721bc"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeployment6a65c3ac12"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -96,30 +96,30 @@
       }
     },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -131,13 +131,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -147,30 +147,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeploymenta9cf768eaa"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeploymenta3c15c8255"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -180,21 +180,21 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -203,28 +203,18 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaTokenAuthDeploymenta48b731095": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: a48b7310952ed029bd212c380e89a1bd39c74eae", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -234,18 +224,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -255,138 +245,118 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
+                "type": "token",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeploymenta9cf768eaa": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: a9cf768eaa1ac6804c7a7b05b79d7ee79d369fcf", 
-        "StageName": "Stage"
-      }
-    }, 
-    "MyApiWithLambdaRequestAuthDeploymentd3ee2721bc": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: d3ee2721bcff60c4d00d26138ccf8007434bb862", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -398,13 +368,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -414,83 +384,113 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeploymenta48b731095"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeployment27edc11a54"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeployment27edc11a54": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        },
+        "Description": "RestApi deployment id: 27edc11a54483580ea19be53043d15d7cc1217af",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithCognitoAuthDeploymenta3c15c8255": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: a3c15c8255270bf4b9301066259a8feb62e32f80",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaRequestAuthDeployment6a65c3ac12": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: 6a65c3ac1202913135589a21812076dccfaa0c8d",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_auth_all_minimum_openapi.json
+++ b/tests/translator/output/aws-cn/api_with_auth_all_minimum_openapi.json
@@ -1,102 +1,93 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     {
                       "Fn::GetAtt": [
-                        "MyUserPool", 
+                        "MyUserPool",
                         "Arn"
                       ]
                     }
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment1ecccf8f28": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 1ecccf8f2823a4777fc271569a1688db777f1302"
-      }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeployment81b8e9784c"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeployment5297e05815"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -107,30 +98,30 @@
       }
     },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucketname", 
+          "S3Bucket": "bucketname",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -142,13 +133,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -158,33 +149,33 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment1ecccf8f28"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeploymentf5835f554e"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -193,18 +184,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -214,36 +205,18 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaRequestAuthDeployment81b8e9784c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: 81b8e9784c9a74f2875713fd92384bb67e756f82"
-      }
-    }, 
-    "MyApiWithLambdaTokenAuthDeployment53baac2c0b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: 53baac2c0b5f582d951d933f66c102f8f467770b"
-      }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -253,18 +226,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -274,120 +247,120 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaTokenAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
+                  "type": "token",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": {
                           "Fn::GetAtt": [
-                            "MyAuthFn", 
+                            "MyAuthFn",
                             "Arn"
                           ]
                         }
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucketname", 
+          "S3Bucket": "bucketname",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -399,13 +372,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -415,85 +388,112 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeployment53baac2c0b"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeployment1c05f42d45"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaRequestAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Unused", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "request", 
-                  "identitySource": "method.request.header.Authorization1", 
+                  "type": "request",
+                  "identitySource": "method.request.header.Authorization1",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": {
                           "Fn::GetAtt": [
-                            "MyAuthFn", 
+                            "MyAuthFn",
                             "Arn"
                           ]
                         }
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeploymentf5835f554e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: f5835f554ec7e540d071cfe3bbca37a40caddfbd"
+      }
+    },
+    "MyApiWithLambdaRequestAuthDeployment5297e05815": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: 5297e0581595c98a49b0f22d91518730b9b6daf3"
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeployment1c05f42d45": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        },
+        "Description": "RestApi deployment id: 1c05f42d4573dff3a04484eddf47689495fcffd0"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_auth_and_conditions_all_max.json
+++ b/tests/translator/output/aws-cn/api_with_auth_and_conditions_all_max.json
@@ -2,23 +2,23 @@
   "Conditions": {
     "PathCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -28,16 +28,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -48,289 +48,279 @@
       }
     },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentfcb8b173a9"
-        }, 
+          "Ref": "MyApiDeployment4f437b7dee"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyApiDeploymentfcb8b173a9": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: fcb8b173a913f4b3a03025dc7c0b11cb18ad0e04", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyCognitoAuth": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "patch": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyLambdaTokenAuthNoneFunctionInvokeRole": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyLambdaRequestAuth": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression", 
+                "identityValidationExpression": "myauthvalidationexpression",
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 0, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuthMultipleUserPools": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader2", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression2", 
+                "identityValidationExpression": "myauthvalidationexpression2",
                 "providerARNs": [
-                  "arn:aws:2", 
+                  "arn:aws:2",
                   "arn:aws:3"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyCustomAuthHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 20, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
-                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                 "identityValidationExpression": "mycustomauthexpression"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "authorizerResultTtlInSeconds": 0, 
-                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
+                },
                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -339,18 +329,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -360,41 +350,41 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -406,7 +396,7 @@
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -418,13 +408,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -434,18 +424,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithConditionalWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -454,20 +444,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyFunctionWithConditionalWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -476,18 +466,18 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -498,16 +488,16 @@
       }
     },
     "MyFunctionWithConditionalWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -516,11 +506,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyFunctionWithConditionalRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -532,13 +522,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -547,32 +537,42 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyFunctionWithConditional": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithConditionalRole", 
+            "MyFunctionWithConditionalRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "PathCondition"
+    },
+    "MyApiDeployment4f437b7dee": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 4f437b7dee2723167188901a4adaddefa0f0465a",
+        "StageName": "Stage"
+      }
     }
   }
 }

--- a/tests/translator/output/aws-cn/api_with_auth_no_default.json
+++ b/tests/translator/output/aws-cn/api_with_auth_no_default.json
@@ -1,71 +1,71 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -75,43 +75,33 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment6a169547ee": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 6a169547eef02f4a0cd9fdc97aca9d1e8a106b11", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeployment93e0147508"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeployment3ede4e64bb"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -122,30 +112,30 @@
       }
     },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -157,13 +147,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -173,40 +163,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment6a169547ee"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeploymentbef95eb1b6"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyApiWithLambdaTokenAuthDeploymente838608f2f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: e838608f2f6897932f7883ba5afaa855145e38f5", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -216,21 +196,21 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -239,18 +219,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -260,123 +240,113 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaRequestAuthDeployment93e0147508": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: 93e01475088ff4675852021a99279d60fc93cd6a", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
+                "type": "token",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -388,13 +358,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -404,78 +374,108 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeploymente838608f2f"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeployment08f25eb263"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeploymentbef95eb1b6": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: bef95eb1b62562f6001b3785758e7aeb3da40e03",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeployment08f25eb263": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        },
+        "Description": "RestApi deployment id: 08f25eb263c154d3c4feb26a220140c5bbe00bba",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaRequestAuthDeployment3ede4e64bb": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: 3ede4e64bbbbe09ce8570e2142035b7ba0291c63",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_auth_with_default_scopes.json
+++ b/tests/translator/output/aws-cn/api_with_auth_with_default_scopes.json
@@ -1,199 +1,199 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognitowithauthnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultauthdefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizerwithdefaultscopes": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "default.delete", 
+                      "default.delete",
                       "default.update"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizercopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesdefaultauthorizer": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "default.write", 
+                      "default.write",
                       "default.read"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuthWithDefaultScopes": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:2"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyDefaultCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -201,20 +201,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultAuthDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -222,20 +222,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerWithDefaultScopesPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -243,30 +243,20 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeploymentcddf4840d1": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: cddf4840d137b720341f7a44922956a392747061", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnCognitoDefaultScopesDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -274,20 +264,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerScopesOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -295,18 +285,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -314,31 +304,31 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoWithAuthNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -346,61 +336,71 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeploymentcddf4840d1"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeploymentbcdc98acaa"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesWithOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
             }
           ]
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeploymentbcdc98acaa": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: bcdc98acaac2e5743b2fdd419d9f8d73a772a055",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_auth_with_default_scopes_openapi.json
+++ b/tests/translator/output/aws-cn/api_with_auth_with_default_scopes_openapi.json
@@ -1,201 +1,201 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognitowithauthnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultauthdefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizerwithdefaultscopes": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "default.delete", 
+                      "default.delete",
                       "default.update"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizercopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesdefaultauthorizer": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "default.write", 
+                      "default.write",
                       "default.read"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuthWithDefaultScopes": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     "arn:aws:2"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyDefaultCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     "arn:aws:1"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -203,20 +203,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultAuthDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -224,20 +224,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerWithDefaultScopesPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -245,20 +245,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -266,20 +266,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerScopesOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -287,27 +287,18 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment815f0fba0e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 815f0fba0e3496a1f5576f705305124b291b7c03"
-      }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -315,31 +306,31 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoWithAuthNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -347,61 +338,70 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment815f0fba0e"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment43ded84101"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesWithOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
             }
           ]
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeployment43ded84101": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 43ded841016227c0e0c636046d6f4c505d797643"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_aws_account_blacklist.json
+++ b/tests/translator/output/aws-cn/api_with_aws_account_blacklist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc4450d906c"
-        }, 
+          "Ref": "ServerlessRestApiDeployment0cb20a8d28"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymentc4450d906c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: c4450d906c6986feebcc880fb891417511ce0106", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,47 +63,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
-              "Action": "execute-api:Invoke", 
+              "Action": "execute-api:Invoke",
               "Resource": [
                 {
                   "Fn::Sub": [
-                    "execute-api:/${__Stage__}/PUT/get", 
+                    "execute-api:/${__Stage__}/PUT/get",
                     {
                       "__Stage__": "Prod"
                     }
                   ]
                 }
-              ], 
-              "Effect": "Deny", 
+              ],
+              "Effect": "Deny",
               "Principal": {
                 "AWS": [
                   "12345"
@@ -121,36 +111,46 @@
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment0cb20a8d28": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 0cb20a8d280b26d935f92fc9218b11658454781b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_aws_account_whitelist.json
+++ b/tests/translator/output/aws-cn/api_with_aws_account_whitelist.json
@@ -1,52 +1,52 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment441a70783b"
-        }, 
+          "Ref": "ServerlessRestApiDeployment093196d864"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -54,9 +54,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -68,13 +68,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -84,67 +84,67 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "AWS": [
                     "12345"
                   ]
                 }
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Principal": {
                   "AWS": [
                     "67890"
@@ -153,24 +153,24 @@
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ServerlessRestApiDeployment441a70783b": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ServerlessRestApiDeployment093196d864": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 441a70783b8bddfd09ec6cd4033f27e5094e7511", 
+        },
+        "Description": "RestApi deployment id: 093196d864a7b30195b934c2417a8ae7001c29b9",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-cn/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/aws-cn/api_with_aws_iam_auth_overrides.json
@@ -1,98 +1,88 @@
 {
   "Resources": {
     "MyFunctionCustomInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionCustomInvokeRoleRole", 
+            "MyFunctionCustomInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoneAuth": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoneAuthRole", 
+            "MyFunctionNoneAuthRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNullInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNullInvokeRoleRole", 
+            "MyFunctionNullInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeployment4253f994cd"
-        }, 
+          "Ref": "MyApiWithAwsIamAuthDeploymentc9446e6adc"
+        },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
-        }, 
+        },
         "StageName": "Prod"
-      }
-    }, 
-    "MyApiWithAwsIamAuthDeployment4253f994cd": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        }, 
-        "Description": "RestApi deployment id: 4253f994cdaf14767907decd5cb875cbafc08704", 
-        "StageName": "Stage"
       }
     },
     "MyFunctionWithoutAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -104,13 +94,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -120,18 +110,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionCustomInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionCustomInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -141,18 +131,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionMyCognitoAuthAPI1PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionMyCognitoAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -162,93 +152,83 @@
           ]
         }
       }
-    }, 
-    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment07ee28f86e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
-        }, 
-        "Description": "RestApi deployment id: 07ee28f86edc705d064d88266db4dea8f5c305b1", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiWithAwsIamAuthNoCallerCredentials": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoCallerCredentials.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCallerCredentialsOverride.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::*:user/*"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "AWS_IAM": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionWithoutAuthAPI2PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithoutAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -260,16 +240,16 @@
       }
     },
     "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionDefaultInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -279,32 +259,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionMyCognitoAuth": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionMyCognitoAuthRole", 
+            "MyFunctionMyCognitoAuthRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNullInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -316,13 +296,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -334,39 +314,39 @@
       }
     },
     "MyFunctionNONEInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNONEInvokeRoleRole", 
+            "MyFunctionNONEInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoCallerCredentialsAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNoCallerCredentials"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -376,9 +356,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNoneAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -390,13 +370,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -406,9 +386,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionCustomInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -420,13 +400,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -438,16 +418,16 @@
       }
     },
     "MyFunctionCallerCredentialsOverrideAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionCallerCredentialsOverride"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -457,64 +437,64 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionCallerCredentialsOverride": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionCallerCredentialsOverrideRole", 
+            "MyFunctionCallerCredentialsOverrideRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionWithoutAuth": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithoutAuthRole", 
+            "MyFunctionWithoutAuthRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNullInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNullInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -524,18 +504,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNONEInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -545,9 +525,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNoCallerCredentialsRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -559,13 +539,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -575,9 +555,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionDefaultInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -589,13 +569,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -607,7 +587,7 @@
       }
     },
     "MyFunctionCallerCredentialsOverrideRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -619,13 +599,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -637,7 +617,7 @@
       }
     },
     "MyFunctionMyCognitoAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -649,13 +629,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -665,242 +645,242 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithAwsIamAuthNoCallerCredentialsProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment07ee28f86e"
-        }, 
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeploymentc3fe11bb90"
+        },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "MyFunctionDefaultInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionDefaultInvokeRoleRole", 
+            "MyFunctionDefaultInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoCallerCredentials": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoCallerCredentialsRole", 
+            "MyFunctionNoCallerCredentialsRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyApiWithAwsIamAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/MyFunctionWithoutAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithoutAuth.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::123:role/AUTH_AWS_IAM"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNONEInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNONEInvokeRole.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionMyCognitoAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionMyCognitoAuth.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionDefaultInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::*:user/*"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionCustomInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::456::role/something-else"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNullInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNullInvokeRole.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNoneAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:cognito-idp:xxxxxxxxx"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "AWS_IAM": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionNoneAuthAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNoneAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -910,9 +890,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNONEInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -924,13 +904,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -939,6 +919,26 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthDeploymentc9446e6adc": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: c9446e6adcbdeaf0233bd113e10691d92f8282d4",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthNoCallerCredentialsDeploymentc3fe11bb90": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        },
+        "Description": "RestApi deployment id: c3fe11bb906786cd2378a3bb887a7e46ba1bdd86",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_basic_custom_domain.json
+++ b/tests/translator/output/aws-cn/api_with_basic_custom_domain.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "MyDomainName": {
-      "Default": "another-example.com", 
+      "Default": "another-example.com",
       "Type": "String"
-    }, 
+    },
     "MyDomainCert": {
-      "Default": "another-api-arn", 
+      "Default": "another-api-arn",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionAnotherGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/another/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/another/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyAnotherApi"
               }
@@ -52,32 +52,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment92d6d51a5e"
-        }, 
+          "Ref": "MyApiDeployment8b5a44252a"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionImplicitGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -85,32 +85,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyAnotherApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeployment989ae20f23"
-        }, 
+          "Ref": "MyAnotherApiDeploymentf8317504a1"
+        },
         "RestApiId": {
           "Ref": "MyAnotherApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -118,69 +118,69 @@
           ]
         }
       }
-    }, 
+    },
     "MyAnotherApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/another/get": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "fetch", 
+        "BasePath": "fetch",
         "DomainName": {
           "Ref": "ApiGatewayDomainName23cdccdf9c"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -188,111 +188,111 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyApigetBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "get", 
+        "BasePath": "get",
         "DomainName": {
           "Ref": "ApiGatewayDomainName23cdccdf9c"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyAnotherApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
         "DomainName": {
           "Ref": "ApiGatewayDomainNameeab65c1531"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyAnotherApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyAnotherApiProdStage"
         }
       }
-    }, 
+    },
     "ApiGatewayDomainNameeab65c1531": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "another-api-arn", 
+        "RegionalCertificateArn": "another-api-arn",
         "DomainName": "another-example.com"
       }
-    }, 
+    },
     "ApiGatewayDomainName23cdccdf9c": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "my-api-cert-arn", 
+        "CertificateArn": "my-api-cert-arn",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
@@ -305,116 +305,116 @@
         "SecurityPolicy": "TLS_1_2",
         "DomainName": "api-example.com"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment6aef2b756e"
-        }, 
+          "Ref": "ServerlessRestApiDeployment4cb36d08eb"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyApiDeployment92d6d51a5e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 92d6d51a5e324a2836c79d3645d7e678f063037e"
-      }
-    }, 
+    },
     "ServerlessRestApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
         "DomainName": {
           "Ref": "ApiGatewayDomainNameeab65c1531"
-        }, 
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "Stage": {
           "Ref": "ServerlessRestApiProdStage"
         }
       }
-    }, 
-    "ServerlessRestApiDeployment6aef2b756e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 6aef2b756ee814f8722e71ca5e3f0d187e05aed5", 
-        "StageName": "Stage"
-      }
-    }, 
-    "MyAnotherApiDeployment989ae20f23": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyAnotherApi"
-        }, 
-        "Description": "RestApi deployment id: 989ae20f23c53c333389afc4e570683e5665c797"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/implicit": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
             }
           ]
         }
+      }
+    },
+    "MyApiDeployment8b5a44252a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 8b5a44252a833cc13030e1bd809cc0cc01da1f9b"
+      }
+    },
+    "ServerlessRestApiDeployment4cb36d08eb": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 4cb36d08ebffaa58916fb74a8fdcf365a0a096f8",
+        "StageName": "Stage"
+      }
+    },
+    "MyAnotherApiDeploymentf8317504a1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyAnotherApi"
+        },
+        "Description": "RestApi deployment id: f8317504a172b1ecfcc2e3453d6cb05ac3ca7902"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics.json
@@ -2,18 +2,18 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "MyDomainCert": {
-      "Default": "another-api-arn", 
+      "Default": "another-api-arn",
       "Type": "String"
-    }, 
+    },
     "EndpointConf": {
-      "Default": "REGIONAL", 
+      "Default": "REGIONAL",
       "Type": "String"
     },
     "MyMTLSUri": {
@@ -24,114 +24,93 @@
       "Default": "another-api-truststore-version",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyFunctionImplicitGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "fetch", 
+        "BasePath": "fetch",
         "DomainName": {
           "Ref": "ApiGatewayDomainNamec0cd2d9dfc"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
-    "MyApiDeployment4f2c19d290": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 4f2c19d290875d88d8e30124f0953f1784e1b54d"
-      }, 
-      "Condition": "C1"
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment599c0b434d"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentc48ee48be3"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
-      }, 
+      },
       "Condition": "C1"
-    }, 
-    "ServerlessRestApiDeployment599c0b434d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 599c0b434d7122049846aedc74269bb6020bd9d3", 
-        "StageName": "Stage"
-      }, 
-      "Condition": "C1"
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -139,111 +118,111 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApigetBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "get", 
+        "BasePath": "get",
         "DomainName": {
           "Ref": "ApiGatewayDomainNamec0cd2d9dfc"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
                   "put": {
                     "Fn::If": [
-                      "C1", 
+                      "C1",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "C1", 
+                              "C1",
                               {
                                 "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
                   }
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment4f2c19d290"
-        }, 
+          "Ref": "MyApiDeploymentd209a67526"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "ApiGatewayDomainNamec0cd2d9dfc": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
@@ -255,94 +234,115 @@
           "TruststoreVersion": "another-api-truststore-version"
         },
         "SecurityPolicy": "TLS_1_2",
-        "RegionalCertificateArn": "another-api-arn", 
+        "RegionalCertificateArn": "another-api-arn",
         "DomainName": {
           "Fn::Sub": "example-cn-north-1.com"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/implicit": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
                   "post": {
                     "Fn::If": [
-                      "C1", 
+                      "C1",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "C1", 
+                              "C1",
                               {
                                 "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
                   }
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
             }
           ]
         }
-      }, 
+      },
+      "Condition": "C1"
+    },
+    "MyApiDeploymentd209a67526": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: d209a675260efe648a8408b5f8003e7fec08c08b"
+      },
+      "Condition": "C1"
+    },
+    "ServerlessRestApiDeploymentc48ee48be3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: c48ee48be33e63d0d7b6e09b1a245079ee9c271a",
+        "StageName": "Stage"
+      },
       "Condition": "C1"
     }
   }

--- a/tests/translator/output/aws-cn/api_with_binary_media_types.json
+++ b/tests/translator/output/aws-cn/api_with_binary_media_types.json
@@ -1,36 +1,36 @@
 {
   "Parameters": {
     "BMT": {
-      "Default": "image~1jpg", 
+      "Default": "image~1jpg",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -42,13 +42,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -60,16 +60,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -79,140 +79,140 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BinaryMediaTypes": [
-          "image~1gif", 
+          "image~1gif",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
-          "application~1octet-stream", 
+          },
+          "application~1octet-stream",
           "image~1jpg"
-        ], 
+        ],
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcc75b253a7"
-        }, 
+          "Ref": "ServerlessRestApiDeployment737691a3ef"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymentcc75b253a7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: cc75b253a750cc6450a4de493f56a526d23b52d4", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/gif", 
+            "image/gif",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
             }
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1gif", 
+          "image~1gif",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
           }
-        ], 
+        ],
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment737691a3ef": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 737691a3efe4e0fc7ad5f51f2fd1335dc856187b",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_binary_media_types_definition_body.json
+++ b/tests/translator/output/aws-cn/api_with_binary_media_types_definition_body.json
@@ -1,149 +1,149 @@
 {
   "Parameters": {
     "BMT": {
-      "Default": "image~1jpeg", 
+      "Default": "image~1jpeg",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ExplicitApiManagedSwaggerProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiManagedSwaggerDeploymentfe9c2c09a2"
-        }, 
+          "Ref": "ExplicitApiManagedSwaggerDeployment77c7e2092d"
+        },
         "RestApiId": {
           "Ref": "ExplicitApiManagedSwagger"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiManagedSwaggerDeploymentfe9c2c09a2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApiManagedSwagger"
-        }, 
-        "Description": "RestApi deployment id: fe9c2c09a27ce00c2fa53d5a491cf343e6a3278e", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiDefinitionBody": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "paths": {}, 
-          "swagger": "2.0", 
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/jpeg", 
-            "image/jpg", 
+            "image/jpeg",
+            "image/jpg",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
-            }, 
+            },
             "application/json"
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1jpeg", 
-          "image~1jpg", 
+          "image~1jpeg",
+          "image~1jpg",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
+          },
           "application~1json"
-        ], 
+        ],
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDefinitionBodyDeployment1f26996adb": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApiDefinitionBody"
-        }, 
-        "Description": "RestApi deployment id: 1f26996adbe5077359ecb2bb0688a9cc0ae8e4fc", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiDefinitionBodyProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDefinitionBodyDeployment1f26996adb"
-        }, 
+          "Ref": "ExplicitApiDefinitionBodyDeployment8243637415"
+        },
         "RestApiId": {
           "Ref": "ExplicitApiDefinitionBody"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiManagedSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
-          "swagger": "2.0", 
+          },
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/jpeg", 
-            "image/jpg", 
+            "image/jpeg",
+            "image/jpg",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
-            }, 
+            },
             "image/gif"
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1jpeg", 
-          "image~1jpg", 
+          "image~1jpeg",
+          "image~1jpg",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
+          },
           "image~1gif"
-        ], 
+        ],
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiManagedSwaggerDeployment77c7e2092d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApiManagedSwagger"
+        },
+        "Description": "RestApi deployment id: 77c7e2092d31ef078af609150899d4c546e54ade",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDefinitionBodyDeployment8243637415": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApiDefinitionBody"
+        },
+        "Description": "RestApi deployment id: 8243637415ea97b13720e769347272506839bc57",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_canary_setting.json
+++ b/tests/translator/output/aws-cn/api_with_canary_setting.json
@@ -103,7 +103,7 @@
           }
         },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
+          "Ref": "ExplicitApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -123,32 +123,12 @@
           }
         },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcb4fb12558"
+          "Ref": "ServerlessRestApiDeploymentd572487786"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
         "StageName": "Prod"
-      }
-    },
-    "ServerlessRestApiDeploymentcb4fb12558": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: cb4fb1255811b7b6a25dd35f23ee7ad133003b89",
-        "StageName": "Stage"
-      }
-    },
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
@@ -185,6 +165,26 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeploymentd572487786": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5724877861288ceb1c8be167c55955a3102b187",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors.json
+++ b/tests/translator/output/aws-cn/api_with_cors.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionAnyApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,153 +73,153 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -231,13 +231,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -247,33 +247,33 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentdb43b8746d"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentae6bea3401"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment3a5a78688c"
-        }, 
+          "Ref": "ExplicitApiDeploymentca189bb326"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -285,13 +285,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -301,18 +301,18 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -322,215 +322,215 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment3a5a78688c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 3a5a78688c9bc377d53aa4153a11f0c4f6e7364c", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeploymentdb43b8746d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: db43b8746d8595bef1c820446f63555bf6a6fb10", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ExplicitApiDeploymentca189bb326": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: ca189bb3267ef4823d27c85b66213b1d4cf4ed44",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentae6bea3401": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: ae6bea3401d4f5a717ce09104e48dcc53dea06ab",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_and_auth_no_preflight_auth.json
+++ b/tests/translator/output/aws-cn/api_with_cors_and_auth_no_preflight_auth.json
@@ -1,138 +1,128 @@
 {
   "Resources": {
     "ServerlessApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ServerlessApiDeployment6050a96a0f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessApi"
-        }, 
-        "Description": "RestApi deployment id: 6050a96a0f36baa9bc42da60f16427b8e3f34291", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -144,13 +134,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -162,16 +152,16 @@
       }
     },
     "ApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -181,30 +171,30 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessApiDeployment6050a96a0f"
-        }, 
+          "Ref": "ServerlessApiDeployment0349187e90"
+        },
         "RestApiId": {
           "Ref": "ServerlessApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -216,53 +206,53 @@
       }
     },
     "ApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ApiFunctionRole", 
+            "ApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -274,13 +264,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -290,21 +280,21 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessApi"
@@ -312,6 +302,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessApiDeployment0349187e90": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessApi"
+        },
+        "Description": "RestApi deployment id: 0349187e90c2b1187861fe61791b69f06b1a20c3",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_and_auth_preflight_auth.json
+++ b/tests/translator/output/aws-cn/api_with_cors_and_auth_preflight_auth.json
@@ -1,133 +1,133 @@
 {
   "Resources": {
     "ServerlessApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "options": {
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
-                ], 
+                ],
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
-                "summary": "CORS support", 
+                },
+                "summary": "CORS support",
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "consumes": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -139,13 +139,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -155,28 +155,18 @@
           ]
         }
       }
-    }, 
-    "ServerlessApiDeployment25b7a1be29": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessApi"
-        }, 
-        "Description": "RestApi deployment id: 25b7a1be294e163c52d9c94528502872e4fced34", 
-        "StageName": "Stage"
-      }
     },
     "ApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -186,30 +176,30 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessApiDeployment25b7a1be29"
-        }, 
+          "Ref": "ServerlessApiDeployment36c0b627cf"
+        },
         "RestApiId": {
           "Ref": "ServerlessApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -221,53 +211,53 @@
       }
     },
     "ApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ApiFunctionRole", 
+            "ApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -279,13 +269,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -295,21 +285,21 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessApi"
@@ -317,6 +307,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessApiDeployment36c0b627cf": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessApi"
+        },
+        "Description": "RestApi deployment id: 36c0b627cf2371ce770d35c8c4107558c88b6e9b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_and_conditions_no_definitionbody.json
+++ b/tests/translator/output/aws-cn/api_with_cors_and_conditions_no_definitionbody.json
@@ -1,40 +1,40 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09", 
+  "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "MyCondition"
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -46,13 +46,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -61,20 +61,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
     },
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,158 +83,148 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
-    }, 
-    "ExplicitApiDeployment7ad5aed108": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 7ad5aed108e331557a5b989ae8809e26632b89df", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "Fn::If": [
-                  "MyCondition", 
+                  "MyCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "MyCondition", 
+                          "MyCondition",
                           {
                             "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "get": {
                 "Fn::If": [
-                  "MyCondition", 
+                  "MyCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "MyCondition", 
+                          "MyCondition",
                           {
                             "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'www.example.com'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'www.example.com'",
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction2.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -243,11 +233,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
     },
     "ImplicitApiFunction2Role": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -259,13 +249,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -275,30 +265,30 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment7ad5aed108"
-        }, 
+          "Ref": "ExplicitApiDeploymentddd104acb0"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ImplicitApiFunction2DeleteHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction2"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -308,28 +298,38 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunction2": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunction2Role", 
+            "ImplicitApiFunction2Role",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ExplicitApiDeploymentddd104acb0": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: ddd104acb040997ef149024c7c59c52ae5fabe1a",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_and_only_credentials_false.json
+++ b/tests/translator/output/aws-cn/api_with_cors_and_only_credentials_false.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,155 +52,155 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment398246867a"
-        }, 
+          "Ref": "ExplicitApiDeployment92400db54c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiDeployment398246867a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 398246867a6d5535e40b46e224e8998486a4b9eb", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment92400db54c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 92400db54c85c63954529c21fb43966e7e92af8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_and_only_headers.json
+++ b/tests/translator/output/aws-cn/api_with_cors_and_only_headers.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,186 +73,166 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeployment9467cf1cd5": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 9467cf1cd5e9d5da97f5af035e6044f12dd258cd", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment9467cf1cd5"
-        }, 
+          "Ref": "ServerlessRestApiDeployment33347595b0"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'",
                         "method.response.header.Access-Control-Allow-Headers": "headers"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
                         "method.response.header.Access-Control-Allow-Headers": "headers"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDeployment03e65d7ea2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 03e65d7ea2275d648803eecb7fa8e0ae7cd8f0aa", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -264,105 +244,125 @@
       }
     },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment03e65d7ea2"
-        }, 
+          "Ref": "ExplicitApiDeployment9a767e8172"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'",
                         "method.response.header.Access-Control-Allow-Headers": "headers"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment33347595b0": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 33347595b0123ff4958e0c7414e3bf975ff2474a",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment9a767e8172": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 9a767e81727f930f6f8609769c04a6fb37dea1cc",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_and_only_maxage.json
+++ b/tests/translator/output/aws-cn/api_with_cors_and_only_maxage.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,163 +52,163 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymentb61cfb7d60": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: b61cfb7d602d889bbd9867dcbf0f75d3066dcc56", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentb61cfb7d60"
-        }, 
+          "Ref": "ExplicitApiDeployment3e3e53a12e"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Max-Age": 600, 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Max-Age": 600,
                         "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Max-Age": {
                         "type": "integer"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Max-Age": 600, 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Max-Age": 600,
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Max-Age": {
                         "type": "integer"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment3e3e53a12e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 3e3e53a12e63aac5b1b6231552a59eb7addad5bc",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_and_only_methods.json
+++ b/tests/translator/output/aws-cn/api_with_cors_and_only_methods.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,103 +73,103 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment06ae8f0cfb"
-        }, 
+          "Ref": "ServerlessRestApiDeployment7db0ae9eb4"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment06ae8f0cfb": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 06ae8f0cfbb76234c64a9c7491fcceaca003887b", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "methods"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment7db0ae9eb4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 7db0ae9eb412fdb7ecd7cb56a69ffec6df35290a",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_and_only_origins.json
+++ b/tests/translator/output/aws-cn/api_with_cors_and_only_origins.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -53,27 +53,17 @@
         }
       }
     },
-    "ExplicitApiDeploymenta7a992bbb6": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a7a992bbb604dcd7667af3caa050bf14af2bf684", 
-        "StageName": "Stage"
-      }
-    }, 
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,180 +73,170 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta7a992bbb6"
-        }, 
+          "Ref": "ExplicitApiDeploymentd7e85f5956"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentb4ba0b8ae8"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentbfef063ab4"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ServerlessRestApiDeploymentb4ba0b8ae8": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: b4ba0b8ae8163e6dd52040648ae4ebda76cc5d99", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -268,89 +248,109 @@
       }
     },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeploymentd7e85f5956": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: d7e85f5956fd5d5fbcee55dcab5860fa11f4b2a4",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentbfef063ab4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: bfef063ab4b444c84093a510eb9b643c5fcc0b76",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_no_definitionbody.json
+++ b/tests/translator/output/aws-cn/api_with_cors_no_definitionbody.json
@@ -16,10 +16,12 @@
           ]
         },
         "Runtime": "nodejs12.x",
-        "Tags": [{
-          "Value": "SAM",
-          "Key": "lambda:createdBy"
-        }]
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     },
     "ImplicitApiFunctionRole": {
@@ -36,17 +38,19 @@
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
-          "Statement": [{
-            "Action": [
-              "sts:AssumeRole"
-            ],
-            "Effect": "Allow",
-            "Principal": {
-              "Service": [
-                "lambda.amazonaws.com"
-              ]
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
             }
-          }]
+          ]
         }
       }
     },
@@ -182,7 +186,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentb4ba0b8ae8"
+          "Ref": "ExplicitApiDeploymentbfef063ab4"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -190,13 +194,13 @@
         "StageName": "Prod"
       }
     },
-    "ExplicitApiDeploymentb4ba0b8ae8": {
+    "ExplicitApiDeploymentbfef063ab4": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
-        "Description": "RestApi deployment id: b4ba0b8ae8163e6dd52040648ae4ebda76cc5d99",
+        "Description": "RestApi deployment id: bfef063ab4b444c84093a510eb9b643c5fcc0b76",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-cn/api_with_cors_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_with_cors_openapi_3.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,27 +52,18 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeployment147347629d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 147347629dc3d0f3815602132def464c995d7245"
-      }
     },
     "ImplicitApiFunctionAnyApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -82,153 +73,153 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -240,13 +231,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -256,33 +247,33 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment147347629d"
-        }, 
+          "Ref": "ServerlessRestApiDeployment903376576d"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment8cc53ffaa5"
-        }, 
+          "Ref": "ExplicitApiDeployment40a858e0c4"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -294,13 +285,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -310,18 +301,18 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -331,79 +322,70 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment8cc53ffaa5": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 8cc53ffaa59a19b69e73d5b422142c7396739b16"
-      }
-    }, 
+    },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
                 },
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
@@ -411,57 +393,57 @@
                         "schema": {
                           "type": "string"
                         }
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "schema": {
                           "type": "string"
                         }
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
                 }
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
                 },
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
@@ -469,62 +451,80 @@
                         "schema": {
                           "type": "string"
                         }
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "schema": {
                           "type": "string"
                         }
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
                 }
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ServerlessRestApiDeployment903376576d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 903376576dc72da463c54c8bc6adc93654d019a0"
+      }
+    },
+    "ExplicitApiDeployment40a858e0c4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 40a858e0c466e102c414544f548494b70d9fbe8d"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,100 +52,91 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
+    },
     "RecordSetGroupbd00d962a4": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneId": "ZQ1UAL4EFZVME", 
+        "HostedZoneId": "ZQ1UAL4EFZVME",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
-    "MyApiDeploymentfb330328f1": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: fb330328f152e4bb4b7d68e8b976b009e0558035"
-      }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentfb330328f1"
-        }, 
+          "Ref": "MyApiDeploymentd1617c473e"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -153,52 +144,61 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiDeploymentd1617c473e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: d1617c473efb159907ff1733b0f43a9c528ceecf"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,66 +52,57 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
-    "MyApiDeployment9239fa9a13": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 9239fa9a13216200ab5bf11c04507c61842a50a7"
-      }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment9239fa9a13"
-        }, 
+          "Ref": "MyApiDeploymenta1b0b65ca8"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -119,86 +110,95 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "RecordSetGroup456ebaf280": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneName": "www.my-domain.com.", 
+        "HostedZoneName": "www.my-domain.com.",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiDeploymenta1b0b65ca8": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: a1b0b65ca8e95947908ef4430074c9d5b0881ceb"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_default_aws_iam_auth.json
+++ b/tests/translator/output/aws-cn/api_with_default_aws_iam_auth.json
@@ -23,16 +23,6 @@
         ]
       }
     },
-    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentd0103947f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
-        },
-        "Description": "RestApi deployment id: d0103947f7e2e1d52ca7afac92f5afc8339a051b",
-        "StageName": "Stage"
-      }
-    },
     "MyFunctionWithAwsIamAuthMyApiWithAwsIamAuthPermissionProd": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -58,7 +48,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentc8adfb74cf"
+          "Ref": "MyApiWithAwsIamAuthDeployment887cc1248a"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
@@ -70,7 +60,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentd0103947f7"
+          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentc6f3a437ce"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
@@ -97,16 +87,6 @@
             }
           ]
         }
-      }
-    },
-    "MyApiWithAwsIamAuthDeploymentc8adfb74cf": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: c8adfb74cfae8b8052802a21a258ecbd5178d144",
-        "StageName": "Stage"
       }
     },
     "MyApiWithAwsIamAuthAndCustomInvokeRole": {
@@ -163,7 +143,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRoleDeployment2a6ecd9264"
+          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRoleDeploymentd4d32aebb7"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
@@ -219,16 +199,6 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }
-    },
-    "MyApiWithAwsIamAuthAndCustomInvokeRoleDeployment2a6ecd9264": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
-        },
-        "Description": "RestApi deployment id: 2a6ecd9264d4f59054caa89a94960604594cd94f",
-        "StageName": "Stage"
       }
     },
     "MyApiWithAwsIamAuth": {
@@ -330,6 +300,36 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentc6f3a437ce": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
+        },
+        "Description": "RestApi deployment id: c6f3a437ce1e535949842d208b049e87313a1969",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthDeployment887cc1248a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: 887cc1248a02331bcabf9fc639accbcbda096695",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthAndCustomInvokeRoleDeploymentd4d32aebb7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
+        },
+        "Description": "RestApi deployment id: d4d32aebb7b6e1d50761082334369ae4be5501b0",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_default_aws_iam_auth_and_no_auth_route.json
+++ b/tests/translator/output/aws-cn/api_with_default_aws_iam_auth_and_no_auth_route.json
@@ -4,7 +4,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeployment0c9ba99bc2"
+          "Ref": "MyApiWithAwsIamAuthDeployment5ea3617d5d"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
@@ -142,16 +142,6 @@
         }
       }
     },
-    "MyApiWithAwsIamAuthDeployment0c9ba99bc2": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: 0c9ba99bc2ed182c6a3d16969b5a717b081713a6",
-        "StageName": "Stage"
-      }
-    },
     "MyFunctionWithAwsIamAuthRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -180,6 +170,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthDeployment5ea3617d5d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: 5ea3617d5d3d685c76d7a9d26de6cf06a1642db9",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_gateway_responses.json
+++ b/tests/translator/output/aws-cn/api_with_gateway_responses.json
@@ -23,16 +23,6 @@
         ]
       }
     },
-    "ExplicitApiDeployment9196b651da": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 9196b651da2a4564831de870a4b6cf9c6bed29b0",
-        "StageName": "Stage"
-      }
-    },
     "FunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -114,7 +104,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9196b651da"
+          "Ref": "ExplicitApiDeploymentfecad8c573"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -141,6 +131,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymentfecad8c573": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: fecad8c573f257f8baeaf4bb7b8db02e3025f058",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_gateway_responses_all.json
+++ b/tests/translator/output/aws-cn/api_with_gateway_responses_all.json
@@ -53,16 +53,6 @@
         }
       }
     },
-    "ExplicitApiDeploymenta27cf1b1d7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: a27cf1b1d762583a4e0873d7a1eb25bea7966067",
-        "StageName": "Stage"
-      }
-    },
     "ExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -123,7 +113,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta27cf1b1d7"
+          "Ref": "ExplicitApiDeploymente51760e7e5"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -150,6 +140,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymente51760e7e5": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: e51760e7e5d20048ba7642e80afac1e4a07faaed",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_gateway_responses_all_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_with_gateway_responses_all_openapi_3.json
@@ -1,39 +1,30 @@
 {
   "Resources": {
     "Function": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "FunctionRole", 
+            "FunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ExplicitApiDeploymenta2f31986fe": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a2f31986fe718bd69858a109ac2b401fb7d8560f"
-      }
-    }, 
+    },
     "FunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -45,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -61,86 +52,86 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0", 
+          },
+          "openapi": "3.0",
           "x-amazon-apigateway-gateway-responses": {
             "QUOTA_EXCEEDED": {
               "responseParameters": {
                 "gatewayresponse.header.Retry-After": "'31536000'"
-              }, 
-              "responseTemplates": {}, 
+              },
+              "responseTemplates": {},
               "statusCode": "429"
-            }, 
+            },
             "UNAUTHORIZED": {
               "responseParameters": {
-                "gatewayresponse.header.WWW-Authenticate": "'Bearer realm=\"admin\"'", 
-                "gatewayresponse.header.Access-Control-Expose-Headers": "'WWW-Authenticate'", 
-                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'", 
-                "gatewayresponse.path.PathKey": "'path-value'", 
+                "gatewayresponse.header.WWW-Authenticate": "'Bearer realm=\"admin\"'",
+                "gatewayresponse.header.Access-Control-Expose-Headers": "'WWW-Authenticate'",
+                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+                "gatewayresponse.path.PathKey": "'path-value'",
                 "gatewayresponse.querystring.QueryStringKey": "'query-string-value'"
-              }, 
-              "responseTemplates": {}, 
+              },
+              "responseTemplates": {},
               "statusCode": "401"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta2f31986fe"
-        }, 
+          "Ref": "ExplicitApiDeployment0d27c44486"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "FunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "Function"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -149,6 +140,15 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment0d27c44486": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 0d27c4448689d9cc426686de480d4c2613d5733b"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_gateway_responses_implicit.json
+++ b/tests/translator/output/aws-cn/api_with_gateway_responses_implicit.json
@@ -53,21 +53,11 @@
         }
       }
     },
-    "ServerlessRestApiDeployment9196b651da": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 9196b651da2a4564831de870a4b6cf9c6bed29b0",
-        "StageName": "Stage"
-      }
-    },
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment9196b651da"
+          "Ref": "ServerlessRestApiDeploymentfecad8c573"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -142,6 +132,16 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeploymentfecad8c573": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: fecad8c573f257f8baeaf4bb7b8db02e3025f058",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_gateway_responses_minimal.json
+++ b/tests/translator/output/aws-cn/api_with_gateway_responses_minimal.json
@@ -95,21 +95,11 @@
         }
       }
     },
-    "ExplicitApiDeployment8f2919f3e3": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 8f2919f3e3e2816355b75920c4482c085c6124a2",
-        "StageName": "Stage"
-      }
-    },
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment8f2919f3e3"
+          "Ref": "ExplicitApiDeploymente323b1732b"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -136,6 +126,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymente323b1732b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: e323b1732bab3b203ac3935ba909e0f6d041bb8e",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_gateway_responses_string_status_code.json
+++ b/tests/translator/output/aws-cn/api_with_gateway_responses_string_status_code.json
@@ -23,16 +23,6 @@
         ]
       }
     },
-    "ExplicitApiDeployment9196b651da": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 9196b651da2a4564831de870a4b6cf9c6bed29b0",
-        "StageName": "Stage"
-      }
-    },
     "FunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -114,7 +104,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9196b651da"
+          "Ref": "ExplicitApiDeploymentfecad8c573"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -141,6 +131,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymentfecad8c573": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: fecad8c573f257f8baeaf4bb7b8db02e3025f058",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_if_conditional_with_resource_policy.json
+++ b/tests/translator/output/aws-cn/api_with_if_conditional_with_resource_policy.json
@@ -2,48 +2,48 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionPutHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -51,119 +51,109 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment1864127303": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 1864127303922f015249dddc233722580882c9ad", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/one": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/three": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/two": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
-                  "Action": "execute-api:Invoke", 
+                  "Action": "execute-api:Invoke",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment1864127303"
-        }, 
+          "Ref": "ExplicitApiDeploymentf2c56ef0a2"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -171,18 +161,18 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -190,37 +180,47 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymentf2c56ef0a2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: f2c56ef0a2f5eaaf81f4f1922b0794c20266b980",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_incompatible_stage_name.json
+++ b/tests/translator/output/aws-cn/api_with_incompatible_stage_name.json
@@ -1,43 +1,43 @@
 {
   "Resources": {
     "UnderscoreApiStageb34d3ad84e": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "UnderscoreApiDeploymentd4074182ff"
-        }, 
+          "Ref": "UnderscoreApiDeployment128412b2ae"
+        },
         "RestApiId": {
           "Ref": "UnderscoreApi"
-        }, 
+        },
         "StageName": "hoge_fuga"
       }
-    }, 
+    },
     "UnderscoreApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UnderscoreFunction.Arn}/invocations"
                   }
-                }, 
-                "responses": {}, 
+                },
+                "responses": {},
                 "parameters": [
                   {
-                    "required": true, 
-                    "in": "body", 
-                    "name": "user", 
+                    "required": true,
+                    "in": "body",
+                    "name": "user",
                     "schema": {
                       "$ref": "#/definitions/user"
                     }
@@ -45,11 +45,11 @@
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "definitions": {
             "user": {
-              "type": "object", 
+              "type": "object",
               "properties": {
                 "username": {
                   "type": "string"
@@ -57,19 +57,19 @@
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "UnderscoreFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -81,13 +81,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -98,27 +98,17 @@
         }
       }
     },
-    "UnderscoreApiDeploymentd4074182ff": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "UnderscoreApi"
-        }, 
-        "Description": "RestApi deployment id: d4074182ff399887934824aa702b5573c9ad3f7c", 
-        "StageName": "Stage"
-      }
-    }, 
     "HyphenFunctionGetHtmlPermission0c8ecc62cb": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HyphenFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HyphenApi"
@@ -126,53 +116,53 @@
           ]
         }
       }
-    }, 
+    },
     "HyphenApiStage0c8ecc62cb": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HyphenApiDeployment52a312db45"
-        }, 
+          "Ref": "HyphenApiDeploymentc336000148"
+        },
         "RestApiId": {
           "Ref": "HyphenApi"
-        }, 
+        },
         "StageName": "hoge-fuga"
       }
-    }, 
+    },
     "UnderscoreFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "UnderscoreFunctionRole", 
+            "UnderscoreFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "UnderscoreFunctionGetHtmlPermissionb34d3ad84e": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "UnderscoreFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "UnderscoreApi"
@@ -182,64 +172,54 @@
       }
     },
     "HyphenFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "HyphenFunctionRole", 
+            "HyphenFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "HyphenApiDeployment52a312db45": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HyphenApi"
-        }, 
-        "Description": "RestApi deployment id: 52a312db455cee5b3a5fca6c9c078593381e179b", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "HyphenApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HyphenFunction.Arn}/invocations"
                   }
-                }, 
-                "responses": {}, 
+                },
+                "responses": {},
                 "parameters": [
                   {
-                    "required": true, 
-                    "in": "body", 
-                    "name": "user", 
+                    "required": true,
+                    "in": "body",
+                    "name": "user",
                     "schema": {
                       "$ref": "#/definitions/user"
                     }
@@ -247,11 +227,11 @@
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "definitions": {
             "user": {
-              "type": "object", 
+              "type": "object",
               "properties": {
                 "username": {
                   "type": "string"
@@ -259,19 +239,19 @@
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "HyphenFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -283,13 +263,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -298,6 +278,26 @@
             }
           ]
         }
+      }
+    },
+    "UnderscoreApiDeployment128412b2ae": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        },
+        "Description": "RestApi deployment id: 128412b2ae4af1a659907663b6733ba3760d6df5",
+        "StageName": "Stage"
+      }
+    },
+    "HyphenApiDeploymentc336000148": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        },
+        "Description": "RestApi deployment id: c3360001481d577eeafaee6c20e119cbbdb7486d",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_ip_range_blacklist.json
+++ b/tests/translator/output/aws-cn/api_with_ip_range_blacklist.json
@@ -1,52 +1,52 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5e467ed97e"
-        }, 
+          "Ref": "ServerlessRestApiDeployment6b29cb7c67"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -54,9 +54,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -68,13 +68,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -84,112 +84,112 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeployment5e467ed97e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 5e467ed97e429eadbf1e8e5a36ac9738d37bb79f", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "AWS": [
                     "12345"
                   ]
                 }
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "IpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment6b29cb7c67": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 6b29cb7c6724e2e9c5a59a7ba3af05d71291c8e0",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_ip_range_whitelist.json
+++ b/tests/translator/output/aws-cn/api_with_ip_range_whitelist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment4dbd43b8e2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 4dbd43b8e229c09245208ff5a44c9a083227a560", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment4dbd43b8e2"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentefe342142b"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,126 +63,136 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "NotIpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "IpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeploymentefe342142b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: efe342142bfa977ae12c94de9f82c91a75fea2ff",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_method_aws_iam_auth.json
+++ b/tests/translator/output/aws-cn/api_with_method_aws_iam_auth.json
@@ -21,16 +21,6 @@
         }
       }
     },
-    "MyApiWithoutAuthDeployment82d56c6578": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        },
-        "Description": "RestApi deployment id: 82d56c65786c0de97eebda5ce6fdc9561ae3ee1f",
-        "StageName": "Stage"
-      }
-    },
     "MyApiWithoutAuth": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -161,7 +151,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment82d56c6578"
+          "Ref": "MyApiWithoutAuthDeploymentb83726efaa"
         },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
@@ -218,6 +208,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithoutAuthDeploymentb83726efaa": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        },
+        "Description": "RestApi deployment id: b83726efaad9b7b0f273701c49f442634e576988",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_method_settings.json
+++ b/tests/translator/output/aws-cn/api_with_method_settings.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,120 +73,120 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "MethodSettings": [
           {
-            "HttpMethod": "*", 
-            "MetricsEnabled": true, 
-            "ResourcePath": "/*", 
-            "DataTraceEnabled": true, 
+            "HttpMethod": "*",
+            "MetricsEnabled": true,
+            "ResourcePath": "/*",
+            "DataTraceEnabled": true,
             "LoggingLevel": "INFO"
           }
-        ], 
+        ],
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "MethodSettings": [
           {
-            "HttpMethod": "*", 
-            "MetricsEnabled": true, 
-            "ResourcePath": "/*", 
-            "DataTraceEnabled": true, 
+            "HttpMethod": "*",
+            "MetricsEnabled": true,
+            "ResourcePath": "/*",
+            "DataTraceEnabled": true,
             "LoggingLevel": "INFO"
           }
-        ], 
+        ],
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcb4fb12558"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentd572487786"
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymentcb4fb12558": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: cb4fb1255811b7b6a25dd35f23ee7ad133003b89", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeploymentd572487786": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5724877861288ceb1c8be167c55955a3102b187",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_minimum_compression_size.json
+++ b/tests/translator/output/aws-cn/api_with_minimum_compression_size.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,104 +73,104 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
-        "MinimumCompressionSize": 256, 
+        "MinimumCompressionSize": 256,
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcb4fb12558"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentd572487786"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymentcb4fb12558": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: cb4fb1255811b7b6a25dd35f23ee7ad133003b89", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
-        "MinimumCompressionSize": 1024, 
+        },
+        "MinimumCompressionSize": 1024,
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeploymentd572487786": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5724877861288ceb1c8be167c55955a3102b187",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_open_api_version.json
+++ b/tests/translator/output/aws-cn/api_with_open_api_version.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -97,20 +97,11 @@
         }
       }
     },
-    "ExplicitApiDeploymentd9a0f2ae4f": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: d9a0f2ae4fe2d97b9b91644934a878b6a08cf1c3"
-      }
-    },
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment75f93f5c08"
+          "Ref": "ServerlessRestApiDeployment11caa2bc07"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -122,7 +113,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentd9a0f2ae4f"
+          "Ref": "ExplicitApiDeployment8a3d83687a"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -204,13 +195,22 @@
         }
       }
     },
-    "ServerlessRestApiDeployment75f93f5c08": {
+    "ExplicitApiDeployment8a3d83687a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 8a3d83687a607eaebbbf1d8749f2949151334aff"
+      }
+    },
+    "ServerlessRestApiDeployment11caa2bc07": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
-        "Description": "RestApi deployment id: 75f93f5c08b6bd3326e74e6b22854de32481e155"
+        "Description": "RestApi deployment id: 11caa2bc07479fd46741ae1f3b659ddaaf4db804"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_open_api_version_2.json
+++ b/tests/translator/output/aws-cn/api_with_open_api_version_2.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,146 +73,146 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ServerlessRestApiDeployment3146d7e6fb": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 3146d7e6fbaece0e0eb82d0c91c86c9b74dc217b"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment3146d7e6fb"
-        }, 
+          "Ref": "ServerlessRestApiDeployment004d4aa43d"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiDeployment4154e1c30c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 4154e1c30c97469d4946280461125dbfd4324f15"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "*", 
+                        "method.response.header.Access-Control-Allow-Origin": "*",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment4154e1c30c"
-        }, 
+          "Ref": "ExplicitApiDeployment13722dd579"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
+      }
+    },
+    "ServerlessRestApiDeployment004d4aa43d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 004d4aa43d572dcb83996274c7e4cb03364352d7"
+      }
+    },
+    "ExplicitApiDeployment13722dd579": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 13722dd579bfec46ba399f3966036bbbe18db618"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/aws-cn/api_with_openapi_definition_body_no_flag.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,135 +52,115 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment9252467a1e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1", 
-        "StageName": "Stage"
-      }
     },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.1.1", 
+          },
+          "openapi": "3.1.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     {
                       "Fn::GetAtt": [
-                        "MyUserPool", 
+                        "MyUserPool",
                         "Arn"
                       ]
                     }
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente1212668e0"
+          "Ref": "ServerlessRestApiDeploymente0a0dcc4ba"
         }
       }
-    }, 
-    "ServerlessRestApiDeploymente1212668e0": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: e1212668e096994ab32167666f5a877bd6ac5fad", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeployment542a922713"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -190,87 +170,107 @@
           ]
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment542a922713": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 542a922713e9c340e3e1940eeb139b17dfcd75cc",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymente0a0dcc4ba": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: e0a0dcc4ba42a5012be5a8fb58531db3f6ed1dfd",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_path_parameters.json
+++ b/tests/translator/output/aws-cn/api_with_path_parameters.json
@@ -34,7 +34,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
+          "Ref": "HtmlApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -59,16 +59,6 @@
             }
           ]
         }
-      }
-    },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "HtmlApi": {
@@ -109,6 +99,16 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_resource_policy.json
+++ b/tests/translator/output/aws-cn/api_with_resource_policy.json
@@ -1,41 +1,41 @@
 {
   "Resources": {
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionPutHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -43,101 +43,101 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/one": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/three": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/two": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
-              "Action": "execute-api:Invoke", 
+              "Action": "execute-api:Invoke",
               "Resource": [
                 "execute-api:/*/*/*"
               ]
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment39d7eca1e3"
-        }, 
+          "Ref": "ExplicitApiDeploymentf2c31f4845"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -145,18 +145,18 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -164,31 +164,31 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -196,14 +196,14 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment39d7eca1e3": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ExplicitApiDeploymentf2c31f4845": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 39d7eca1e3352a144ce8a9f729862b19b28a8734", 
+        },
+        "Description": "RestApi deployment id: f2c31f4845e8d141b97c0a5a818e7fe405152485",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-cn/api_with_resource_policy_global.json
+++ b/tests/translator/output/aws-cn/api_with_resource_policy_global.json
@@ -2,43 +2,43 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "StageName": {
-      "Default": "MyOwnStage", 
+      "Default": "MyOwnStage",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "AnotherApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
-          "swagger": "2.0", 
+          },
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
-                  "Action": "execute-api:Invoke", 
+                  "Action": "execute-api:Invoke",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
-                }, 
+                },
                 {
-                  "Action": "execute-api:Another", 
+                  "Action": "execute-api:Another",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
@@ -46,54 +46,44 @@
               ]
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDeploymenta5a5c4e3ff": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a5a5c4e3ff6901cf27436628359ed20300d34aa4", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta5a5c4e3ff"
-        }, 
+          "Ref": "ExplicitApiDeployment4c5e269029"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": {
           "Ref": "StageName"
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -101,51 +91,41 @@
           ]
         }
       }
-    }, 
-    "AnotherApiDeploymentfdf1387e0a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "AnotherApi"
-        }, 
-        "Description": "RestApi deployment id: fdf1387e0a89fa15996401a79284cdaaf2c43844", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -153,78 +133,78 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "AnotherApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "AnotherApiDeploymentfdf1387e0a"
-        }, 
+          "Ref": "AnotherApiDeployment0564df8d4a"
+        },
         "RestApiId": {
           "Ref": "AnotherApi"
-        }, 
+        },
         "StageName": {
           "Ref": "StageName"
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": 2.0, 
+          },
+          "swagger": 2.0,
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "sts:AssumeRole", 
-                "Effect": "Allow", 
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
                 "Principal": {
                   "Service": "lambda.amazonaws.com"
                 }
-              }, 
+              },
               {
                 "Fn::If": [
-                  "C1", 
+                  "C1",
                   {
-                    "Action": "execute-api:Invoke", 
+                    "Action": "execute-api:Invoke",
                     "Resource": [
                       "execute-api:/*/*/*"
                     ]
-                  }, 
+                  },
                   {
-                    "Action": "execute-api:Blah", 
+                    "Action": "execute-api:Blah",
                     "Resource": [
                       "execute-api:/*/*/*"
                     ]
@@ -233,15 +213,35 @@
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment4c5e269029": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 4c5e269029fe10081e5a9d82b311bd327d8fce6e",
+        "StageName": "Stage"
+      }
+    },
+    "AnotherApiDeployment0564df8d4a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "AnotherApi"
+        },
+        "Description": "RestApi deployment id: 0564df8d4a281d58de69686b00180ebd1207a60d",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_resource_policy_global_implicit.json
+++ b/tests/translator/output/aws-cn/api_with_resource_policy_global_implicit.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "MinimalFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MinimalFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -20,9 +20,9 @@
           ]
         }
       }
-    }, 
+    },
     "MinimalFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -34,13 +34,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -50,103 +50,103 @@
           ]
         }
       }
-    }, 
+    },
     "MinimalFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MinimalFunctionRole", 
+            "MinimalFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment0ff9f5a989"
-        }, 
+          "Ref": "ServerlessRestApiDeployment1351a8cd0e"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiDeployment0ff9f5a989": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 0ff9f5a9899528e1cb050311c49f15a88071a275", 
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MinimalFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   "execute-api:/*/*/*"
                 ]
-              }, 
+              },
               {
-                "Action": "execute-api:blah", 
+                "Action": "execute-api:blah",
                 "Resource": [
                   "execute-api:/*/*/*"
                 ]
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment1351a8cd0e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 1351a8cd0ef219698b94168267cb5473c223f9a6",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_resource_refs.json
+++ b/tests/translator/output/aws-cn/api_with_resource_refs.json
@@ -2,92 +2,72 @@
   "Outputs": {
     "ImplicitApiDeployment": {
       "Value": {
-        "Ref": "ServerlessRestApiDeployment8b5ecabf9b"
+        "Ref": "ServerlessRestApiDeployment4fc4c0c8ef"
       }
-    }, 
+    },
     "ExplicitApiDeployment": {
       "Value": {
-        "Ref": "MyApiDeployment359f256a3b"
+        "Ref": "MyApiDeployment8ded5fd20d"
       }
-    }, 
+    },
     "ExplicitApiStage": {
       "Value": {
         "Ref": "MyApifooStage"
       }
-    }, 
+    },
     "ImplicitApiStage": {
       "Value": {
         "Ref": "ServerlessRestApiProdStage"
       }
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "MyApiDeployment359f256a3b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 359f256a3b3ff2e1102e335a4d603f02df9b4988", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApifooStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment359f256a3b"
-        }, 
+          "Ref": "MyApiDeployment8ded5fd20d"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "foo"
       }
-    }, 
-    "ServerlessRestApiDeployment8b5ecabf9b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 8b5ecabf9b24c707a9734a6b94b0e0565572efb6", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/html", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/html",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -97,21 +77,21 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment8b5ecabf9b"
-        }, 
+          "Ref": "ServerlessRestApiDeployment4fc4c0c8ef"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -123,13 +103,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -139,58 +119,78 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/html": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "swagger"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiDeployment8ded5fd20d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 8ded5fd20d1fa9ee4e4db2c8a8cb513497b18adb",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment4fc4c0c8ef": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 4fc4c0c8ef758644eaa648fe3e1d6ae76b64fa22",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_source_vpc_blacklist.json
+++ b/tests/translator/output/aws-cn/api_with_source_vpc_blacklist.json
@@ -1,60 +1,50 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeploymentb8219b2586": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: b8219b2586b8c860b699470c380956bb09244f77", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentb8219b2586"
-        }, 
+          "Ref": "ServerlessRestApiDeployment533b50ab46"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -62,115 +52,125 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringEquals": {
                     "aws:SourceVpce": [
                       "vpce-3456"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment533b50ab46": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 533b50ab46275fabba5dd268a3fb090d2dc0eb66",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_source_vpc_whitelist.json
+++ b/tests/translator/output/aws-cn/api_with_source_vpc_whitelist.json
@@ -1,46 +1,46 @@
 {
   "Parameters": {
     "Vpc1": {
-      "Default": "vpc-1234", 
+      "Default": "vpc-1234",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -48,64 +48,44 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment5332c373d4"
-        }, 
+          "Ref": "MyApiDeployment5e697a4b30"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymentf39840708b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: f39840708b20c848b8e57aa8a8b97de327b40de6", 
-        "StageName": "Stage"
-      }
-    }, 
-    "MyApiDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentf39840708b"
-        }, 
+          "Ref": "ServerlessRestApiDeployment8dd0199f75"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -113,18 +93,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -132,168 +112,188 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringNotEquals": {
                     "aws:SourceVpc": [
-                      "vpc-1234", 
+                      "vpc-1234",
                       "vpc-5678"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/POST/fetch", 
+                      "execute-api:/${__Stage__}/POST/fetch",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/POST/fetch", 
+                      "execute-api:/${__Stage__}/POST/fetch",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringNotEquals": {
                     "aws:SourceVpc": [
-                      "vpc-1234", 
+                      "vpc-1234",
                       "vpc-5678"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment8dd0199f75": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 8dd0199f75864bbbb2e6e6699bf33e37a1f8af0d",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiDeployment5e697a4b30": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 5e697a4b309f0f6b0fef455883aec23936861ff1",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_stage_tags.json
+++ b/tests/translator/output/aws-cn/api_with_stage_tags.json
@@ -1,74 +1,74 @@
 {
   "Parameters": {
     "TagValueParam": {
-      "Default": "value", 
+      "Default": "value",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
-    "MyApiWithStageTagsDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithStageTags"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7", 
-        "StageName": "Stage"
-      }
-    }, 
     "MyApiWithStageTags": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiWithStageTagsProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithStageTagsDeployment5332c373d4"
-        }, 
+          "Ref": "MyApiWithStageTagsDeployment5e697a4b30"
+        },
         "RestApiId": {
           "Ref": "MyApiWithStageTags"
-        }, 
-        "StageName": "Prod", 
+        },
+        "StageName": "Prod",
         "Tags": [
           {
-            "Value": "TagValue1", 
+            "Value": "TagValue1",
             "Key": "TagKey1"
-          }, 
+          },
           {
-            "Value": "", 
+            "Value": "",
             "Key": "TagKey2"
-          }, 
+          },
           {
             "Value": {
               "Ref": "TagValueParam"
-            }, 
+            },
             "Key": "TagKey3"
-          }, 
+          },
           {
-            "Value": "123", 
+            "Value": "123",
             "Key": "TagKey4"
           }
         ]
+      }
+    },
+    "MyApiWithStageTagsDeployment5e697a4b30": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithStageTags"
+        },
+        "Description": "RestApi deployment id: 5e697a4b309f0f6b0fef455883aec23936861ff1",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_swagger_and_openapi_with_auth.json
+++ b/tests/translator/output/aws-cn/api_with_swagger_and_openapi_with_auth.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,122 +54,112 @@
       }
     },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.1.1", 
-          "swagger": 2.0, 
+          },
+          "openapi": "3.1.1",
+          "swagger": 2.0,
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente1212668e0"
+          "Ref": "ServerlessRestApiDeploymente0a0dcc4ba"
         }
       }
-    }, 
-    "ServerlessRestApiDeploymente1212668e0": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: e1212668e096994ab32167666f5a877bd6ac5fad", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment7c4f7dda23"
+          "Ref": "ExplicitApiDeploymentd91576e21e"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -179,96 +169,106 @@
           ]
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDeployment7c4f7dda23": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ServerlessRestApiDeploymente0a0dcc4ba": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: e0a0dcc4ba42a5012be5a8fb58531db3f6ed1dfd",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeploymentd91576e21e": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 7c4f7dda23acd71e4a653861510d82ad7809e562", 
+        },
+        "Description": "RestApi deployment id: d91576e21ef46309219ef12cb8601f13cc905189",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-cn/api_with_usageplans.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans.json
@@ -68,21 +68,11 @@
         ]
       }
     },
-    "MyApiOneDeployment7997029260": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiOne"
-        },
-        "Description": "RestApi deployment id: 79970292604071da8105ffd8503f82af32b30550",
-        "StageName": "Stage"
-      }
-    },
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment40b50dc688"
+          "Ref": "ServerlessRestApiDeploymenta026edcc69"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -368,16 +358,6 @@
         ]
       }
     },
-    "ServerlessRestApiDeployment40b50dc688": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 40b50dc6888e5b556b1073ba4304ec9b550659db",
-        "StageName": "Stage"
-      }
-    },
     "ServerlessUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
       "Properties": {
@@ -469,7 +449,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment03730b64c4"
+          "Ref": "MyApiTwoDeployment3d6c6dd58e"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -481,22 +461,12 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeployment7997029260"
+          "Ref": "MyApiOneDeployment1f6a9f6fe8"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
         },
         "StageName": "Prod"
-      }
-    },
-    "MyApiTwoDeployment03730b64c4": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiTwo"
-        },
-        "Description": "RestApi deployment id: 03730b64c486cc490deefb3b8225244b0fe85d34",
-        "StageName": "Stage"
       }
     },
     "MyFunctionThree": {
@@ -525,7 +495,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiThreeDeploymentfa9f73f027"
+          "Ref": "MyApiThreeDeployment223f7fbbed"
         },
         "RestApiId": {
           "Ref": "MyApiThree"
@@ -671,16 +641,6 @@
         }
       }
     },
-    "MyApiThreeDeploymentfa9f73f027": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiThree"
-        },
-        "Description": "RestApi deployment id: fa9f73f0272017527c24cc93cc4440dd4476b9f4",
-        "StageName": "Stage"
-      }
-    },
     "MyApiTwoApiKey": {
       "Type": "AWS::ApiGateway::ApiKey",
       "Properties": {
@@ -699,6 +659,46 @@
       "DependsOn": [
         "MyApiTwoUsagePlan"
       ]
+    },
+    "MyApiOneDeployment1f6a9f6fe8": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "Description": "RestApi deployment id: 1f6a9f6fe81391d645a410c38d51885e07808e9d",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymenta026edcc69": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: a026edcc698e2c25f4d9233700433dbc5b0fd44c",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoDeployment3d6c6dd58e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "Description": "RestApi deployment id: 3d6c6dd58e53f371270509ea4e9d663d7b44e765",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiThreeDeployment223f7fbbed": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "Description": "RestApi deployment id: 223f7fbbedcd84caa38aeae40c6683d0e59040ba",
+        "StageName": "Stage"
+      }
     }
   }
 }

--- a/tests/translator/output/aws-cn/api_with_usageplans_intrinsics.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans_intrinsics.json
@@ -79,15 +79,6 @@
         "MyApiTwo"
       ]
     },
-    "MyApiTwoDeploymenta997b9e562": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiTwo"
-        },
-        "Description": "RestApi deployment id: a997b9e562a05ea9cb87782748d6df042f6a82d4"
-      }
-    },
     "MyApiOneUsagePlanKey": {
       "Type": "AWS::ApiGateway::UsagePlanKey",
       "Properties": {
@@ -107,7 +98,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeploymenta997b9e562"
+          "Ref": "MyApiTwoDeploymentbf024374d9"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -119,7 +110,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeploymentd8cca8c82b"
+          "Ref": "MyApiOneDeploymente8b9a105da"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -176,16 +167,6 @@
           }
         ]
       }
-    },
-    "MyApiOneDeploymentd8cca8c82b": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiOne"
-        },
-        "Description": "RestApi deployment id: d8cca8c82bb70492b08f8ad3e95b75b30fb6ce14"
-      },
-      "Condition": "C1"
     },
     "MyApiTwoApiKey": {
       "Type": "AWS::ApiGateway::ApiKey",
@@ -422,6 +403,25 @@
           }
         ]
       }
+    },
+    "MyApiTwoDeploymentbf024374d9": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "Description": "RestApi deployment id: bf024374d9451533a7351c5295d6d753cf9d49ff"
+      }
+    },
+    "MyApiOneDeploymente8b9a105da": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "Description": "RestApi deployment id: e8b9a105da2fa5b34e5d83491180a6b6888a58cb"
+      },
+      "Condition": "C1"
     }
   }
 }

--- a/tests/translator/output/aws-cn/api_with_xray_tracing.json
+++ b/tests/translator/output/aws-cn/api_with_xray_tracing.json
@@ -34,7 +34,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
+          "Ref": "HtmlApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -60,16 +60,6 @@
             }
           ]
         }
-      }
-    },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "HtmlApi": {
@@ -110,6 +100,16 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/depends_on.json
+++ b/tests/translator/output/aws-cn/depends_on.json
@@ -27,16 +27,6 @@
         "MySamTable"
       ]
     },
-    "MyExplicitApiDeployment74b681ce04": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyExplicitApi"
-        },
-        "Description": "RestApi deployment id: 74b681ce04601a2cf69b6d05d53782b216cf96bb",
-        "StageName": "Stage"
-      }
-    },
     "MyExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -84,7 +74,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment74b681ce04"
+          "Ref": "MyExplicitApiDeployment98d1d7451d"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"
@@ -157,6 +147,16 @@
             }
           ]
         }
+      }
+    },
+    "MyExplicitApiDeployment98d1d7451d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyExplicitApi"
+        },
+        "Description": "RestApi deployment id: 98d1d7451d36eeb109d8152b3c842314ceec54e5",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/explicit_api.json
+++ b/tests/translator/output/aws-cn/explicit_api.json
@@ -1,67 +1,57 @@
 {
   "Parameters": {
     "something": {
-      "Default": "something", 
+      "Default": "something",
       "Type": "String"
-    }, 
+    },
     "MyStageName": {
-      "Default": "Production", 
+      "Default": "Production",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "webpage.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiWithInlineSwaggerStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment09cda3d97b"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeploymentd6e4241aec"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
     },
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-cn:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -70,15 +60,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -88,35 +77,35 @@
           ]
         }
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "inline swagger"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -126,52 +115,62 @@
           ]
         }
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
-        }, 
+        },
         "Name": "MyGetApi"
       }
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "EndpointUri": {
             "Ref": "something"
-          }, 
+          },
           "EndpointUri2": "http://example.com"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
-    }, 
-    "ApiWithInlineSwaggerDeployment09cda3d97b": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithInlineSwaggerDeploymentd6e4241aec": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 09cda3d97b008bed7bd4ebb1b5304ed622492941", 
+        },
+        "Description": "RestApi deployment id: d6e4241aecafd12a5d34fa32f427f71867e30751",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-cn/explicit_api_openapi_3.json
+++ b/tests/translator/output/aws-cn/explicit_api_openapi_3.json
@@ -1,76 +1,57 @@
 {
   "Parameters": {
     "something": {
-      "Default": "something", 
+      "Default": "something",
       "Type": "String"
-    }, 
+    },
     "MyStageName": {
-      "Default": "Production", 
+      "Default": "Production",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "webpage.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiWithInlineSwaggerStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment74abcb3a5b"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeploymenteaabc1f332"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
     },
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ApiWithInlineSwaggerDeployment74abcb3a5b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 74abcb3a5bbe7ad58dfc543740af3be156736130"
-      }
-    }, 
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-cn:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -79,15 +60,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -97,35 +77,35 @@
           ]
         }
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "inline swagger"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -135,43 +115,62 @@
           ]
         }
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
-        }, 
+        },
         "Name": "MyGetApi"
       }
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "EndpointUri": {
             "Ref": "something"
-          }, 
+          },
           "EndpointUri2": "http://example.com"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
+      }
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithInlineSwaggerDeploymenteaabc1f332": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        },
+        "Description": "RestApi deployment id: eaabc1f3328d9cc3200d9b5c1f0afa15cd7a3343"
       }
     }
   }

--- a/tests/translator/output/aws-cn/explicit_api_with_invalid_events_config.json
+++ b/tests/translator/output/aws-cn/explicit_api_with_invalid_events_config.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.restapi", 
+        },
+        "Handler": "index.restapi",
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionAddApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": "ApiWithInlineSwagger"
@@ -43,65 +43,55 @@
       }
     },
     "ApiWithInlineSwaggerProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment22d399868d"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeployment039e5eb1f1"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ApiWithInlineSwaggerDeployment22d399868d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 22d399868d5755a0d5204deae1ee870cf95a7737", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -113,13 +103,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -128,6 +118,16 @@
             }
           ]
         }
+      }
+    },
+    "ApiWithInlineSwaggerDeployment039e5eb1f1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        },
+        "Description": "RestApi deployment id: 039e5eb1f1de15b72c5917efd628d0b7a75c5fa5",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_event_sources.json
@@ -1,72 +1,62 @@
 {
   "Parameters": {
     "MyStageName": {
-      "Default": "beta", 
+      "Default": "beta",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyAwesomeFunctionAliasLive": {
-      "Type": "AWS::Lambda::Alias", 
+      "Type": "AWS::Lambda::Alias",
       "Properties": {
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionVersion640128d35d", 
+            "MyAwesomeFunctionVersion640128d35d",
             "Version"
           ]
-        }, 
+        },
         "FunctionName": {
           "Ref": "MyAwesomeFunction"
-        }, 
+        },
         "Name": "Live"
       }
-    }, 
+    },
     "MyAwesomeFunctionNotificationTopicPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "sns.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "sns.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Ref": "Notifications"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment042edc7e2e"
-        }, 
+          "Ref": "ServerlessRestApiDeployment176216bd2d"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyAwesomeFunctionCWEventPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "events.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionCWEvent", 
+            "MyAwesomeFunctionCWEvent",
             "Arn"
           ]
         }
@@ -89,21 +79,21 @@
       }
     },
     "MyAwesomeFunctionDDBStream": {
-      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
-        "BatchSize": 200, 
-        "EventSourceArn": "arn:aws:dynamodb:us-west-2:012345678901:table/TestTable/stream/2015-05-11T21:21:33.291", 
+        "BatchSize": 200,
+        "EventSourceArn": "arn:aws:dynamodb:us-west-2:012345678901:table/TestTable/stream/2015-05-11T21:21:33.291",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "StartingPosition": "LATEST"
       }
     },
     "MyAwesomeFunctionIoTRule": {
-      "Type": "AWS::IoT::TopicRule", 
+      "Type": "AWS::IoT::TopicRule",
       "Properties": {
         "TopicRulePayload": {
-          "AwsIotSqlVersion": "beta", 
+          "AwsIotSqlVersion": "beta",
           "Actions": [
             {
               "Lambda": {
@@ -112,34 +102,34 @@
                 }
               }
             }
-          ], 
-          "RuleDisabled": false, 
+          ],
+          "RuleDisabled": false,
           "Sql": "SELECT * FROM 'topic/test'"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionKinesisStream": {
-      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
-        "BatchSize": 100, 
-        "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream", 
+        "BatchSize": 100,
+        "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "StartingPosition": "TRIM_HORIZON"
       }
-    }, 
+    },
     "MyAwesomeFunctionImplicitApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -149,21 +139,21 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionIoTRulePermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "SourceAccount": {
           "Fn::Sub": "${AWS::AccountId}"
-        }, 
-        "Principal": "iot.amazonaws.com", 
+        },
+        "Principal": "iot.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:iot:${AWS::Region}:${AWS::AccountId}:rule/${RuleName}", 
+            "arn:aws-cn:iot:${AWS::Region}:${AWS::AccountId}:rule/${RuleName}",
             {
               "RuleName": {
                 "Ref": "MyAwesomeFunctionIoTRule"
@@ -172,72 +162,72 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionNotificationTopic": {
-      "Type": "AWS::SNS::Subscription", 
+      "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Endpoint": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
-        "Protocol": "lambda", 
+        },
+        "Protocol": "lambda",
         "TopicArn": {
           "Ref": "Notifications"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionS3TriggerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "SourceAccount": {
           "Ref": "AWS::AccountId"
-        }, 
+        },
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "Principal": "s3.amazonaws.com"
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
-        }, 
+        },
         "Name": "MyGetApi"
       }
     },
     "MyAwesomeFunctionCWLogPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "logs.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "logs.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*", 
+            "arn:aws-cn:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*",
             {
               "__LogGroupName__": "MyLogGroup"
             }
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionEBSchedule": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "rate(1 minute)", 
+        "ScheduleExpression": "rate(1 minute)",
         "Targets": [
           {
             "Id": "MyAwesomeFunctionEBScheduleLambdaTarget",
@@ -247,26 +237,26 @@
           }
         ]
       }
-    }, 
+    },
     "MyAwesomeFunctionCWLog": {
-      "Type": "AWS::Logs::SubscriptionFilter", 
+      "Type": "AWS::Logs::SubscriptionFilter",
       "Properties": {
         "DestinationArn": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
-        "FilterPattern": "My pattern", 
+        },
+        "FilterPattern": "My pattern",
         "LogGroupName": "MyLogGroup"
-      }, 
+      },
       "DependsOn": [
         "MyAwesomeFunctionCWLogPermission"
       ]
-    }, 
+    },
     "MyAwesomeFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole", 
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole",
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole"
         ],
         "Tags": [
@@ -276,13 +266,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -292,32 +282,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionRole", 
+            "MyAwesomeFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAwesomeFunctionCWEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
           "detail": {
@@ -325,10 +315,10 @@
               "terminated"
             ]
           }
-        }, 
+        },
         "Targets": [
           {
-            "Id": "MyAwesomeFunctionCWEventLambdaTarget", 
+            "Id": "MyAwesomeFunctionCWEventLambdaTarget",
             "Arn": {
               "Ref": "MyAwesomeFunctionAliasLive"
             }
@@ -357,61 +347,61 @@
       }
     },
     "MyAwesomeFunctionVersion640128d35d": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::Version", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::Version",
       "Properties": {
         "FunctionName": {
           "Ref": "MyAwesomeFunction"
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyAwesomeFunctionAliasLive}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "Notifications": {
       "Type": "AWS::SNS::Topic"
-    }, 
+    },
     "MyAwesomeFunctionEBSchedulePermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "events.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::GetAtt": [
             "MyAwesomeFunctionEBSchedule",
@@ -419,55 +409,55 @@
           ]
         }
       }
-    }, 
+    },
     "Images": {
-      "Type": "AWS::S3::Bucket", 
+      "Type": "AWS::S3::Bucket",
       "Properties": {
         "NotificationConfiguration": {
           "LambdaConfigurations": [
             {
               "Function": {
                 "Ref": "MyAwesomeFunctionAliasLive"
-              }, 
+              },
               "Event": "s3:ObjectCreated:*"
             }
           ]
         }
-      }, 
+      },
       "DependsOn": [
         "MyAwesomeFunctionS3TriggerPermission"
       ]
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "LambdaFunction": {
             "Ref": "MyAwesomeFunction"
           }
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionExplicitApiPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -477,14 +467,24 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeployment042edc7e2e": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment176216bd2d": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 042edc7e2e15e52c1da7abc216d273b4d7761e9a", 
+        },
+        "Description": "RestApi deployment id: 176216bd2d557d1d943318ac9e347b1132f09722",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-cn/function_with_request_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_request_parameters.json
@@ -53,16 +53,6 @@
         }
       }
     },
-    "ServerlessRestApiDeploymentc2741b5220": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: c2741b5220c940a753e3d1e18da6763aaba1c19b",
-        "StageName": "Stage"
-      }
-    },
     "ApiParameterFunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -118,22 +108,12 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc2741b5220"
+          "Ref": "ServerlessRestApiDeploymentc622a9d8fe"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
         "StageName": "Prod"
-      }
-    },
-    "ApiDeploymentd779e9df57": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "Api"
-        },
-        "Description": "RestApi deployment id: d779e9df577321942ace63ca5592fbc8ba6fa9ec",
-        "StageName": "Stage"
       }
     },
     "Api": {
@@ -206,7 +186,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiDeploymentd779e9df57"
+          "Ref": "ApiDeploymentcda848f3dd"
         },
         "RestApiId": {
           "Ref": "Api"
@@ -285,6 +265,26 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ServerlessRestApiDeploymentc622a9d8fe": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: c622a9d8feb76e1fc1e8a9b2ce115657d3ea2377",
+        "StageName": "Stage"
+      }
+    },
+    "ApiDeploymentcda848f3dd": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "Api"
+        },
+        "Description": "RestApi deployment id: cda848f3ddb68014da459e73cd12a0a60e99d215",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/global_handle_path_level_parameter.json
+++ b/tests/translator/output/aws-cn/global_handle_path_level_parameter.json
@@ -136,18 +136,8 @@
         },
         "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente1212668e0"
+          "Ref": "ServerlessRestApiDeploymente0a0dcc4ba"
         }
-      }
-    },
-    "ServerlessRestApiDeploymente1212668e0": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: e1212668e096994ab32167666f5a877bd6ac5fad",
-        "StageName": "Stage"
       }
     },
     "ExplicitApiSomeStageStage": {
@@ -163,7 +153,7 @@
         },
         "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9a254aa466"
+          "Ref": "ExplicitApiDeployment24b17d3335"
         }
       }
     },
@@ -207,16 +197,6 @@
             "Name": "email"
           }
         ]
-      }
-    },
-    "ExplicitApiDeployment9a254aa466": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 9a254aa466c6f818951dfb6e45fde65489beb153",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
@@ -278,6 +258,26 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeploymente0a0dcc4ba": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: e0a0dcc4ba42a5012be5a8fb58531db3f6ed1dfd",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment24b17d3335": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 24b17d33358d1e9ca30ab2a0967848d74f40c3de",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/globals_for_api.json
+++ b/tests/translator/output/aws-cn/globals_for_api.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,139 +54,119 @@
       }
     },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": 2.0, 
+          },
+          "swagger": 2.0,
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentf6c326a165"
+          "Ref": "ServerlessRestApiDeployment8f9878ed3d"
         }
       }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment43e01e673d"
+          "Ref": "ExplicitApiDeploymentf64bb7c4a4"
         }
       }
-    }, 
-    "ServerlessRestApiDeploymentf6c326a165": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: f6c326a1656cc9fbb0106cc645598d88575554eb", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeployment43e01e673d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 43e01e673d7acbd09e4c38ff78dd6ddaf2ed1d55", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -196,95 +176,115 @@
           ]
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment8f9878ed3d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 8f9878ed3d179b928125db0c21731129dcd747f3",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeploymentf64bb7c4a4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: f64bb7c4a498f204e281c987b181d884fdec35b7",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/implicit_and_explicit_api_with_conditions.json
+++ b/tests/translator/output/aws-cn/implicit_and_explicit_api_with_conditions.json
@@ -118,22 +118,11 @@
       },
       "Condition": "explicithello1condition"
     },
-    "ServerlessRestApiDeploymentafcab1755e": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: afcab1755e409da73b339b6deff571f5b8a821da",
-        "StageName": "Stage"
-      },
-      "Condition": "ServerlessRestApiCondition"
-    },
     "explicitapiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "explicitapiDeploymentc5102c0776"
+          "Ref": "explicitapiDeployment0c06491332"
         },
         "RestApiId": {
           "Ref": "explicitapi"
@@ -145,7 +134,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentafcab1755e"
+          "Ref": "ServerlessRestApiDeployment5d339629f1"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -253,16 +242,6 @@
         }
       },
       "Condition": "implicithello1condition"
-    },
-    "explicitapiDeploymentc5102c0776": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "explicitapi"
-        },
-        "Description": "RestApi deployment id: c5102c077632f46b21ecf1230d4056848be72538",
-        "StageName": "Stage"
-      }
     },
     "implicithello1": {
       "Type": "AWS::Lambda::Function",
@@ -587,6 +566,27 @@
         }
       },
       "Condition": "implicithello1condition"
+    },
+    "ServerlessRestApiDeployment5d339629f1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 5d339629f14d2bee6fc1a8f59211a820c979e566",
+        "StageName": "Stage"
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "explicitapiDeployment0c06491332": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "explicitapi"
+        },
+        "Description": "RestApi deployment id: 0c06491332c1d38b7e494e3da01920a6e46b602f",
+        "StageName": "Stage"
+      }
     }
   },
   "Description": "A template to test for API condition handling with a mix of explicit and implicit api events."

--- a/tests/translator/output/aws-cn/implicit_api.json
+++ b/tests/translator/output/aws-cn/implicit_api.json
@@ -1,10 +1,10 @@
 {
   "Resources": {
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-cn:iam::aws:policy/AmazonDynamoDBFullAccess"
         ],
         "Tags": [
@@ -14,13 +14,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -32,16 +32,16 @@
       }
     },
     "RestApiFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -53,16 +53,16 @@
       }
     },
     "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -72,47 +72,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentb5184bf2cc"
-        }, 
+          "Ref": "ServerlessRestApiDeployment74a1d1ee92"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-cn:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -122,13 +122,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -140,49 +140,39 @@
       }
     },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.restapi", 
+        },
+        "Handler": "index.restapi",
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeploymentb5184bf2cc": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: b5184bf2cccc18d4a1efae523c2c88fd5282c8a3", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "RestApiFunctionGetListPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -192,90 +182,90 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/{proxy+}": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/getlist": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/complete": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "RestApiFunctionCompleteItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -284,6 +274,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment74a1d1ee92": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 74a1d1ee923aecdc41cb0bccf57421b40103962f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/implicit_api_with_auth_and_conditions_max.json
+++ b/tests/translator/output/aws-cn/implicit_api_with_auth_and_conditions_max.json
@@ -201,7 +201,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment6b0de9dc9a"
+          "Ref": "ServerlessRestApiDeployment8aaf85d88a"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -566,17 +566,6 @@
         }
       },
       "Condition": "FunctionCondition"
-    },
-    "ServerlessRestApiDeployment6b0de9dc9a": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 6b0de9dc9a2450a248988d39c61e2ee23b257724",
-        "StageName": "Stage"
-      },
-      "Condition": "ServerlessRestApiCondition"
     },
     "MyFunction3WithLambdaTokenAuthorizerPermissionProd": {
       "Type": "AWS::Lambda::Permission",
@@ -945,6 +934,17 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "ServerlessRestApiDeployment8aaf85d88a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 8aaf85d88a7ac4896b7aa5d376d66bcd15a8698b",
+        "StageName": "Stage"
       },
       "Condition": "ServerlessRestApiCondition"
     }

--- a/tests/translator/output/aws-cn/implicit_api_with_many_conditions.json
+++ b/tests/translator/output/aws-cn/implicit_api_with_many_conditions.json
@@ -149,7 +149,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5d9ff7b9fd"
+          "Ref": "ServerlessRestApiDeploymente88b4a8373"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -529,17 +529,6 @@
         }
       },
       "Condition": "Cond6"
-    },
-    "ServerlessRestApiDeployment5d9ff7b9fd": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 5d9ff7b9fd3c20ed584298527fb932741f6a34fa",
-        "StageName": "Stage"
-      },
-      "Condition": "ServerlessRestApiCondition"
     },
     "helloworld4Role": {
       "Type": "AWS::IAM::Role",
@@ -1413,6 +1402,17 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "ServerlessRestApiDeploymente88b4a8373": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: e88b4a83738442e392120b3a04ba4a9f4c63f2fe",
+        "StageName": "Stage"
       },
       "Condition": "ServerlessRestApiCondition"
     }

--- a/tests/translator/output/aws-cn/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/aws-cn/implicit_api_with_serverless_rest_api_resource.json
@@ -1,10 +1,10 @@
 {
   "Resources": {
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-cn:iam::aws:policy/AmazonDynamoDBFullAccess"
         ],
         "Tags": [
@@ -14,13 +14,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -32,16 +32,16 @@
       }
     },
     "RestApiFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -53,16 +53,16 @@
       }
     },
     "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -72,47 +72,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentb5184bf2cc"
-        }, 
+          "Ref": "ServerlessRestApiDeployment74a1d1ee92"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-cn:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -122,13 +122,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -140,49 +140,39 @@
       }
     },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.restapi", 
+        },
+        "Handler": "index.restapi",
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeploymentb5184bf2cc": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: b5184bf2cccc18d4a1efae523c2c88fd5282c8a3", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "RestApiFunctionGetListPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -192,90 +182,90 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/{proxy+}": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/getlist": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/complete": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "RestApiFunctionCompleteItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -284,6 +274,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment74a1d1ee92": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 74a1d1ee923aecdc41cb0bccf57421b40103962f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-cn/intrinsic_functions.json
+++ b/tests/translator/output/aws-cn/intrinsic_functions.json
@@ -2,33 +2,33 @@
   "Conditions": {
     "TrueCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "CodeKey": {
-      "Default": "key", 
+      "Default": "key",
       "Type": "String"
-    }, 
+    },
     "CodeBucket": {
-      "Default": "sam-demo-bucket", 
+      "Default": "sam-demo-bucket",
       "Type": "String"
-    }, 
+    },
     "FunctionName": {
-      "Default": "MySuperFunctionName", 
+      "Default": "MySuperFunctionName",
       "Type": "String"
-    }, 
+    },
     "MyExplicitApiName": {
-      "Default": "SomeName", 
+      "Default": "SomeName",
       "Type": "String"
-    }, 
+    },
     "TracingConfigParam": {
-      "Default": "PassThrough", 
+      "Default": "PassThrough",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi",
@@ -129,16 +129,6 @@
         }
       },
       "Condition": "TrueCondition"
-    },
-    "MyExplicitApiDeployment7145dd00ce": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyExplicitApi"
-        },
-        "Description": "RestApi deployment id: 7145dd00cea59b4a62b4d7855add490c587f3f62",
-        "StageName": "Stage"
-      }
     },
     "FunctionWithExplicitS3Uri": {
       "Type": "AWS::Lambda::Function",
@@ -425,7 +415,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithExplicitS3UriDeploymenta227798f00"
+          "Ref": "ApiWithExplicitS3UriDeploymentdf00ae04c1"
         },
         "RestApiId": {
           "Ref": "ApiWithExplicitS3Uri"
@@ -449,17 +439,6 @@
         },
         "StartingPosition": "LATEST"
       }
-    },
-    "ApiWithExplicitS3UriDeploymenta227798f00": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithExplicitS3Uri"
-        },
-        "Description": "RestApi deployment id: a227798f004a50b665fe47a20bb9afbf076bd85d",
-        "StageName": "Stage"
-      },
-      "Condition": "TrueCondition"
     },
     "MySqsDlqLambdaFunctionRole": {
       "Type": "AWS::IAM::Role",
@@ -515,7 +494,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment7145dd00ce"
+          "Ref": "MyExplicitApiDeploymentac5370c463"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"
@@ -540,7 +519,7 @@
     "MyFunctionMyApiPermissiondev": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
@@ -557,6 +536,27 @@
           ]
         }
       }
+    },
+    "MyExplicitApiDeploymentac5370c463": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyExplicitApi"
+        },
+        "Description": "RestApi deployment id: ac5370c463a1506e2d2d574f796b90853a805218",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithExplicitS3UriDeploymentdf00ae04c1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithExplicitS3Uri"
+        },
+        "Description": "RestApi deployment id: df00ae04c10d650fc54bbd3b1444d09ff6ee0ae6",
+        "StageName": "Stage"
+      },
+      "Condition": "TrueCondition"
     }
   }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_auth_default_scopes.json
@@ -1,733 +1,733 @@
 {
-    "Resources": {
-        "MyApiWithCognitoAuth": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/cognitowithauthnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoWithAuthNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "NONE": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultauthdefaultscopesnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitoauthorizerwithdefaultscopes": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": [
-                                            "default.delete", 
-                                            "default.update"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitoauthorizercopesoverwritten": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": [
-                                            "overwritten.read", 
-                                            "overwritten.write"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesoverwritten": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": [
-                                            "overwritten.read", 
-                                            "overwritten.write"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesdefaultauthorizer": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": [
-                                            "default.write", 
-                                            "default.read"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "openapi": "3.0.1", 
-                    "components": {
-                        "securitySchemes": {
-                            "MyCognitoAuthWithDefaultScopes": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
-                                "x-amazon-apigateway-authorizer": {
-                                    "providerARNs": [
-                                        "arn:aws:2"
-                                    ], 
-                                    "type": "cognito_user_pools"
-                                }, 
-                                "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }, 
-                            "MyDefaultCognitoAuth": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
-                                "x-amazon-apigateway-authorizer": {
-                                    "providerARNs": [
-                                        "arn:aws:1"
-                                    ], 
-                                    "type": "cognito_user_pools"
-                                }, 
-                                "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }
-                        }
+  "Resources": {
+    "MyApiWithCognitoAuth": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/cognitowithauthnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
-        }, 
-        "MyStateMachineCognitoWithAuthNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                     }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiWithCognitoAuthProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiWithCognitoAuthDeployment57b57dfc88"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApiWithCognitoAuth"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "MyApiWithCognitoAuthDeployment57b57dfc88": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApiWithCognitoAuth"
-                }, 
-                "Description": "RestApi deployment id: 57b57dfc88b1b438a0437eadd869d77e938eedb6"
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
+                  },
+                  "credentials": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
-                        "Arn"
+                      "MyStateMachineCognitoWithAuthNoneRole",
+                      "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "NONE": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
                 }
-            }
-        }, 
-        "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
+              }
+            },
+            "/cognitodefaultauthdefaultscopesnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole",
+                      "Arn"
                     ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
                 }
-            }
-        }, 
-        "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
+              }
+            },
+            "/cognitodefaultscopesnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesNoneRole",
+                      "Arn"
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitoauthorizerwithdefaultscopes": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                     }
-                ]
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoAuthorizerWithDefaultScopesRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": [
+                      "default.delete",
+                      "default.update"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitoauthorizercopesoverwritten": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoAuthorizerScopesOverwrittenRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": [
+                      "overwritten.read",
+                      "overwritten.write"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitodefaultscopesoverwritten": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesWithOverwrittenRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": [
+                      "overwritten.read",
+                      "overwritten.write"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitodefaultscopesdefaultauthorizer": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": [
+                      "default.write",
+                      "default.read"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
             }
+          },
+          "openapi": "3.0.1",
+          "components": {
+            "securitySchemes": {
+              "MyCognitoAuthWithDefaultScopes": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    "arn:aws:2"
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
+              },
+              "MyDefaultCognitoAuth": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    "arn:aws:1"
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
+              }
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyStateMachineCognitoWithAuthNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiWithCognitoAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithCognitoAuthDeploymentd0339f6a6f"
+        },
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiWithCognitoAuthDeploymentd0339f6a6f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: d0339f6a6febe05cf298904934b8af368bd689c2"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_authorizer.json
@@ -1,384 +1,384 @@
 {
-    "Resources": {
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
+  "Resources": {
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentd5411ae9d3"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startNoAuth": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
+                      "StateMachineWithNoAuthorizerRole",
+                      "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeploymentaaffc688ce"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startNoAuth": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
                 }
+              }
             }
-        }, 
-        "StateMachineWithLambdaTokenAuthRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startWithLambdaToken": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaTokenAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "securityDefinitions": {
-                        "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
-                            "in": "header"
-                        }, 
-                        "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
-                                "identityValidationExpression": "mycustomauthexpression"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }
-                    }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeployment2d6a709a2a"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeploymentaaffc688ce": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiDeployment2d6a709a2a": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 2d6a709a2a2b67ee19ca14fe4594114921c537d0", 
-                "StageName": "Stage"
-            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "StateMachineWithLambdaTokenAuthRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiMyLambdaTokenAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startWithLambdaToken": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaTokenAuthRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaTokenAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            },
+            "MyLambdaTokenAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
+                "identityValidationExpression": "mycustomauthexpression"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeploymente1e355f5d2"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineWithNoAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessRestApiDeploymentd5411ae9d3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5411ae9d3cfb9e3457f9f276ef3d7ae53e1b07d",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiDeploymente1e355f5d2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: e1e355f5d20ca4ebd402c62fb3489ccc8434ef5c",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_authorizer_maximum.json
@@ -1,690 +1,690 @@
 {
-    "Resources": {
-        "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
+  "Resources": {
+    "MyApiMyLambdaRequestAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
             }
-        }, 
-        "StateMachineWithLambdaRequestAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "StateMachineWithDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "NONE": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/users": {
-                            "put": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithDefaultAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthMultipleUserPools": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "patch": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "delete": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaRequestAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaRequestAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "securityDefinitions": {
-                        "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Authorization", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "MyCognitoAuthMultipleUserPools": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader2", 
-                            "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression2", 
-                                "providerARNs": [
-                                    "arn:aws:2", 
-                                    "arn:aws:3"
-                                ], 
-                                "type": "cognito_user_pools"
-                            }, 
-                            "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
-                        "MyLambdaRequestAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Unused", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "request", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "MyCognitoAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression", 
-                                "providerARNs": [
-                                    "arn:aws:1"
-                                ], 
-                                "type": "cognito_user_pools"
-                            }, 
-                            "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
-                        "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
-                                "identityValidationExpression": "mycustomauthexpression"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
-                            "in": "header"
-                        }
-                    }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
-        }, 
-        "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "StateMachineWithLambdaTokenAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiDeployment704a2ea820": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 704a2ea8202a6b11b22e31524b5e5dfa2b528378", 
-                "StageName": "Stage"
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeployment704a2ea820"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachineWithLambdaRequestAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachineWithDefaultAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithNoAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "NONE": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/users": {
+              "put": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithDefaultAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthMultipleUserPools": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "patch": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaTokenAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaTokenAuthNoneFunctionInvokeRole": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "delete": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaRequestAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaRequestAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "MyLambdaTokenAuthNoneFunctionInvokeRole": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                }
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "MyCognitoAuthMultipleUserPools": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
+              "x-amazon-apigateway-authorizer": {
+                "identityValidationExpression": "myauthvalidationexpression2",
+                "providerARNs": [
+                  "arn:aws:2",
+                  "arn:aws:3"
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyLambdaRequestAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
+              "x-amazon-apigateway-authorizer": {
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "MyCognitoAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
+              "x-amazon-apigateway-authorizer": {
+                "identityValidationExpression": "myauthvalidationexpression",
+                "providerARNs": [
+                  "arn:aws:1"
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyLambdaTokenAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
+                "identityValidationExpression": "mycustomauthexpression"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "MyApiMyLambdaTokenAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachineWithLambdaTokenAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment83893ad3fa"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachineWithNoAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiDeployment83893ad3fa": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 83893ad3fa6246bf965f755f5bddf0aef6044b8e",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_resource_policy.json
@@ -1,482 +1,482 @@
 {
-    "Resources": {
-        "MyStateMachineGetHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "MyStateMachineGetHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "ExplicitApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/one": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineGetHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/three": {
-                            "put": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachinePutHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/two": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachinePostHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
-                        "Statement": [
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Allow", 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "NotIpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "IpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Allow", 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "NotIpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "IpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }
-                        ]
-                    }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
-        }, 
-        "ExplicitApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ExplicitApiDeployment17065a95ba"
-                }, 
-                "RestApiId": {
-                    "Ref": "ExplicitApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "MyStateMachinePutHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "MyStateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ExplicitApiDeployment17065a95ba": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ExplicitApi"
-                }, 
-                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2", 
-                "StageName": "Stage"
-            }
-        }, 
-        "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyStateMachinePostHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
+          ]
         }
+      }
+    },
+    "ExplicitApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineGetHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/three": {
+              "put": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachinePutHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/two": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachinePostHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Allow",
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "NotIpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "IpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Allow",
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "NotIpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "IpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              }
+            ]
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeploymente0026ec516"
+        },
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyStateMachinePutHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachinePostHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ExplicitApiDeploymente0026ec516": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: e0026ec516d4da624aa0d0e56caf9ccf79e409b2",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_condition_and_events.json
+++ b/tests/translator/output/aws-cn/state_machine_with_condition_and_events.json
@@ -1,305 +1,305 @@
 {
-    "Conditions": {
-        "TestCondition": {
-            "Fn::Equals": [
-                "test", 
-                "test"
-            ]
-        }
-    }, 
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole", 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionS3Location": {
-                    "Version": 3, 
-                    "Bucket": "sam-demo-bucket", 
-                    "Key": "my-state-machine.asl.json"
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineScheduleEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "events.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeploymentaeae651245"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineScheduleEvent": {
-            "Type": "AWS::Events::Rule", 
-            "Properties": {
-                "ScheduleExpression": "rate(1 minute)", 
-                "Targets": [
-                    {
-                        "RoleArn": {
-                            "Fn::GetAtt": [
-                                "StateMachineScheduleEventRole", 
-                                "Arn"
-                            ]
-                        }, 
-                        "Id": "StateMachineScheduleEventStepFunctionsTarget", 
-                        "Arn": {
-                            "Ref": "StateMachine"
-                        }
-                    }
-                ], 
-                "Name": "TestSchedule"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineCWEvent": {
-            "Type": "AWS::Events::Rule", 
-            "Properties": {
-                "EventPattern": {
-                    "detail": {
-                        "state": [
-                            "terminated"
-                        ]
-                    }
-                }, 
-                "Targets": [
-                    {
-                        "RoleArn": {
-                            "Fn::GetAtt": [
-                                "StateMachineCWEventRole", 
-                                "Arn"
-                            ]
-                        }, 
-                        "Id": "StateMachineCWEventStepFunctionsTarget", 
-                        "Arn": {
-                            "Ref": "StateMachine"
-                        }
-                    }
-                ]
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "Fn::If": [
-                                "TestCondition", 
-                                {
-                                    "post": {
-                                        "Fn::If": [
-                                            "TestCondition", 
-                                            {
-                                                "x-amazon-apigateway-integration": {
-                                                    "responses": {
-                                                        "200": {
-                                                            "statusCode": "200"
-                                                        }, 
-                                                        "400": {
-                                                            "statusCode": "400"
-                                                        }
-                                                    }, 
-                                                    "uri": {
-                                                        "Fn::If": [
-                                                            "TestCondition", 
-                                                            {
-                                                                "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                                            }, 
-                                                            {
-                                                                "Ref": "AWS::NoValue"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "httpMethod": "POST", 
-                                                    "requestTemplates": {
-                                                        "application/json": {
-                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                                        }
-                                                    }, 
-                                                    "credentials": {
-                                                        "Fn::GetAtt": [
-                                                            "StateMachineMyApiEventRole", 
-                                                            "Arn"
-                                                        ]
-                                                    }, 
-                                                    "type": "aws"
-                                                }, 
-                                                "responses": {
-                                                    "200": {
-                                                        "description": "OK"
-                                                    }, 
-                                                    "400": {
-                                                        "description": "Bad Request"
-                                                    }
-                                                }
-                                            }, 
-                                            {
-                                                "Ref": "AWS::NoValue"
-                                            }
-                                        ]
-                                    }
-                                }, 
-                                {
-                                    "Ref": "AWS::NoValue"
-                                }
-                            ]
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApiDeploymentaeae651245": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aeae651245fe7d417a17f2bea50b255f2727e2b8", 
-                "StageName": "Stage"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineCWEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "events.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }
+  "Conditions": {
+    "TestCondition": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
     }
+  },
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
+        "StateMachineName": "MyStateMachine",
+        "DefinitionS3Location": {
+          "Version": 3,
+          "Bucket": "sam-demo-bucket",
+          "Key": "my-state-machine.asl.json"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentf22928ca9f"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)",
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole",
+                "Arn"
+              ]
+            },
+            "Id": "StateMachineScheduleEventStepFunctionsTarget",
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ],
+        "Name": "TestSchedule"
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        },
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole",
+                "Arn"
+              ]
+            },
+            "Id": "StateMachineCWEventStepFunctionsTarget",
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "Fn::If": [
+                "TestCondition",
+                {
+                  "post": {
+                    "Fn::If": [
+                      "TestCondition",
+                      {
+                        "x-amazon-apigateway-integration": {
+                          "responses": {
+                            "200": {
+                              "statusCode": "200"
+                            },
+                            "400": {
+                              "statusCode": "400"
+                            }
+                          },
+                          "uri": {
+                            "Fn::If": [
+                              "TestCondition",
+                              {
+                                "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                              },
+                              {
+                                "Ref": "AWS::NoValue"
+                              }
+                            ]
+                          },
+                          "httpMethod": "POST",
+                          "requestTemplates": {
+                            "application/json": {
+                              "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                            }
+                          },
+                          "credentials": {
+                            "Fn::GetAtt": [
+                              "StateMachineMyApiEventRole",
+                              "Arn"
+                            ]
+                          },
+                          "type": "aws"
+                        },
+                        "responses": {
+                          "200": {
+                            "description": "OK"
+                          },
+                          "400": {
+                            "description": "Bad Request"
+                          }
+                        }
+                      },
+                      {
+                        "Ref": "AWS::NoValue"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "Ref": "AWS::NoValue"
+                }
+              ]
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApiDeploymentf22928ca9f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: f22928ca9fa163df139e3c1f896167ecefffa178",
+        "StageName": "Stage"
+      },
+      "Condition": "TestCondition"
+    }
+  }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_explicit_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_explicit_api.json
@@ -1,210 +1,210 @@
 {
-    "Resources": {
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+  "Resources": {
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment0e07112b2c"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "MyApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-                "StageName": "Stage"
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeployment05bc9f394c"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
+          ]
         }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "MyApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_implicit_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_implicit_api.json
@@ -1,210 +1,210 @@
 {
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeployment05bc9f394c"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment0e07112b2c"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ServerlessRestApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/aws-cn/state_machine_with_implicit_api_globals.json
@@ -1,232 +1,232 @@
 {
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeployment1f01b589d4"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeployment1f01b589d4": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
-                        "Statement": {
-                            "Action": "execute-api:Invoke", 
-                            "Resource": [
-                                {
-                                    "Fn::Sub": [
-                                        "execute-api:/${__Stage__}/POST/startMyExecution", 
-                                        {
-                                            "__Stage__": "Prod"
-                                        }
-                                    ]
-                                }
-                            ], 
-                            "Effect": "Deny", 
-                            "Principal": {
-                                "AWS": [
-                                    "12345"
-                                ]
-                            }
-                        }
-                    }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentc81fbad89e"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17",
+            "Statement": {
+              "Action": "execute-api:Invoke",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "execute-api:/${__Stage__}/POST/startMyExecution",
+                    {
+                      "__Stage__": "Prod"
+                    }
+                  ]
+                }
+              ],
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": [
+                  "12345"
+                ]
+              }
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ServerlessRestApiDeploymentc81fbad89e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: c81fbad89effca825bf52acf474877e98e597381",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/aws-cn/state_machine_with_permissions_boundary.json
@@ -1,57 +1,57 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
-        ], 
-        "ReservedConcurrentExecutions": 100, 
-        "Handler": "hello.handler", 
+        ],
+        "ReservedConcurrentExecutions": 100,
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "python2.7"
       }
-    }, 
+    },
     "StateMachineMyApiEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "apigateway.amazonaws.com"
@@ -61,54 +61,44 @@
           ]
         }
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyStateMachine", 
+        },
+        "StateMachineName": "MyStateMachine",
         "DefinitionS3Location": {
-          "Version": 3, 
-          "Bucket": "sam-demo-bucket", 
+          "Version": 3,
+          "Bucket": "sam-demo-bucket",
           "Key": "my-state-machine.asl.json"
-        }, 
+        },
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment05bc9f394c"
-        }, 
+          "Ref": "ServerlessRestApiDeployment0e07112b2c"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment05bc9f394c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "StateMachineCWEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
           "detail": {
@@ -116,34 +106,34 @@
               "terminated"
             ]
           }
-        }, 
+        },
         "Targets": [
           {
             "RoleArn": {
               "Fn::GetAtt": [
-                "StateMachineCWEventRole", 
+                "StateMachineCWEventRole",
                 "Arn"
               ]
-            }, 
-            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            },
+            "Id": "StateMachineCWEventStepFunctionsTarget",
             "Arn": {
               "Ref": "StateMachine"
             }
           }
         ]
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -151,28 +141,28 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/startMyExecution": {
               "post": {
@@ -180,62 +170,62 @@
                   "responses": {
                     "200": {
                       "statusCode": "200"
-                    }, 
+                    },
                     "400": {
                       "statusCode": "400"
                     }
-                  }, 
+                  },
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                  }, 
-                  "httpMethod": "POST", 
+                  },
+                  "httpMethod": "POST",
                   "requestTemplates": {
                     "application/json": {
                       "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                     }
-                  }, 
+                  },
                   "credentials": {
                     "Fn::GetAtt": [
-                      "StateMachineMyApiEventRole", 
+                      "StateMachineMyApiEventRole",
                       "Arn"
                     ]
-                  }, 
+                  },
                   "type": "aws"
-                }, 
+                },
                 "responses": {
                   "200": {
                     "description": "OK"
-                  }, 
+                  },
                   "400": {
                     "description": "Bad Request"
                   }
                 }
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -243,70 +233,70 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        },
+        "ManagedPolicyArns": [],
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "lambda:InvokeFunction"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*",
                       {
                         "functionName": {
                           "Ref": "MyFunction"
                         }
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "StateMachineScheduleEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "events.amazonaws.com"
@@ -316,56 +306,56 @@
           ]
         }
       }
-    }, 
+    },
     "StateMachineScheduleEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "rate(1 minute)", 
+        "ScheduleExpression": "rate(1 minute)",
         "Targets": [
           {
             "RoleArn": {
               "Fn::GetAtt": [
-                "StateMachineScheduleEventRole", 
+                "StateMachineScheduleEventRole",
                 "Arn"
               ]
-            }, 
-            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            },
+            "Id": "StateMachineScheduleEventStepFunctionsTarget",
             "Arn": {
               "Ref": "StateMachine"
             }
           }
-        ], 
+        ],
         "Name": "TestSchedule"
       }
-    }, 
+    },
     "StateMachineCWEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "events.amazonaws.com"
@@ -374,6 +364,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_cache.json
+++ b/tests/translator/output/aws-us-gov/api_cache.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "HtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,32 +29,32 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
-        "CacheClusterEnabled": true, 
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "HtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "HtmlApi"
-        }, 
-        "StageName": "Prod", 
+        },
+        "StageName": "Prod",
         "CacheClusterSize": "1.6"
       }
-    }, 
+    },
     "HtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HtmlApi"
@@ -63,54 +63,54 @@
         }
       }
     },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "HtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "HtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "HtmlFunctionRole", 
+            "HtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_description.json
+++ b/tests/translator/output/aws-us-gov/api_description.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "FunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,27 +29,27 @@
           ]
         }
       }
-    }, 
+    },
     "ApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "Api"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "FunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "Function"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
             "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
@@ -61,21 +61,11 @@
         }
       }
     },
-    "ApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "Api"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "Api": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
         },
         "Description": "my description",
@@ -88,28 +78,38 @@
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "Function": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
             "FunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "Api"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_endpoint_configuration.json
+++ b/tests/translator/output/aws-us-gov/api_endpoint_configuration.json
@@ -3,33 +3,33 @@
     "EndpointConfig": {
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -41,13 +41,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -59,16 +59,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -78,106 +78,106 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "SomeValue"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "SomeValue"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment5b2cb4ba8f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 5b2cb4ba8fce8a9445b1914c6c6fbeef81a9075a", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5b2cb4ba8f"
-        }, 
+          "Ref": "ServerlessRestApiDeployment48b9be5f17"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             {
               "Ref": "EndpointConfig"
             }
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": {
             "Ref": "EndpointConfig"
           }
         }
+      }
+    },
+    "ServerlessRestApiDeployment48b9be5f17": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 48b9be5f1703467615aff7539d0d6987624f84c5",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/aws-us-gov/api_endpoint_configuration_with_vpcendpoint.json
@@ -6,33 +6,33 @@
     "EndpointConfigType": {
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -44,13 +44,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -62,16 +62,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -81,92 +81,72 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "SomeValue"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "SomeValue"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment5b2cb4ba8f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 5b2cb4ba8fce8a9445b1914c6c6fbeef81a9075a", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5b2cb4ba8f"
-        }, 
+          "Ref": "ServerlessRestApiDeployment48b9be5f17"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         },
         "EndpointConfiguration": {
@@ -186,6 +166,26 @@
             "Ref": "EndpointConfigType"
           }
         }
+      }
+    },
+    "ServerlessRestApiDeployment48b9be5f17": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 48b9be5f1703467615aff7539d0d6987624f84c5",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_request_model.json
+++ b/tests/translator/output/aws-us-gov/api_request_model.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "HtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -29,27 +29,27 @@
           ]
         }
       }
-    }, 
+    },
     "HtmlApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment3744537077"
-        }, 
+          "Ref": "HtmlApiDeployment9fa756eff2"
+        },
         "RestApiId": {
           "Ref": "HtmlApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "HtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
             "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
@@ -61,18 +61,8 @@
         }
       }
     },
-    "HtmlApiDeployment3744537077": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: 374453707756d2ce5439fb8f0995a4ced3659a0e",
-        "StageName": "Stage"
-      }
-    }, 
     "HtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
@@ -126,28 +116,38 @@
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "HtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "HtmlFunctionRole", 
+            "HtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment9fa756eff2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 9fa756eff2da92d60ae10383ffbbc642775dc851",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_request_model_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_request_model_openapi_3.json
@@ -34,7 +34,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymenta488cfa4f9"
+          "Ref": "HtmlApiDeployment73a5f6d270"
         },
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -157,15 +157,6 @@
         }
       }
     },
-    "HtmlApiDeploymenta488cfa4f9": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: a488cfa4f9c73604187a3a5dfa5f333ef2c52e1e"
-      }
-    },
     "HtmlFunctionGetHtmlPermissionProd": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -206,6 +197,15 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment73a5f6d270": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 73a5f6d270d72d0979cca86fc31a4d550aa35311"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_access_log_setting.json
+++ b/tests/translator/output/aws-us-gov/api_with_access_log_setting.json
@@ -99,32 +99,12 @@
           "Format": "$context.requestId"
         },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
+          "Ref": "ExplicitApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
         "StageName": "Prod"
-      }
-    },
-    "ServerlessRestApiDeployment5b2cb4ba8f": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 5b2cb4ba8fce8a9445b1914c6c6fbeef81a9075a",
-        "StageName": "Stage"
-      }
-    },
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApiProdStage": {
@@ -135,7 +115,7 @@
           "Format": "$context.requestId"
         },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5b2cb4ba8f"
+          "Ref": "ServerlessRestApiDeployment48b9be5f17"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -177,6 +157,26 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment48b9be5f17": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 48b9be5f1703467615aff7539d0d6987624f84c5",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_apikey_default_override.json
+++ b/tests/translator/output/aws-us-gov/api_with_apikey_default_override.json
@@ -1,15 +1,5 @@
 {
   "Resources": {
-    "MyApiWithAuthDeployment084855ab6d": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAuth"
-        },
-        "Description": "RestApi deployment id: 084855ab6d04ef5b762ac75de403810cd5f0c166",
-        "StageName": "Stage"
-      }
-    },
     "MyFunctionWithApiKeyRequiredTrueMyApiWithApiKeyRequiredTruePermissionProd": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -56,7 +46,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAuthDeployment084855ab6d"
+          "Ref": "MyApiWithAuthDeploymentd185af4c11"
         },
         "RestApiId": {
           "Ref": "MyApiWithAuth"
@@ -320,6 +310,16 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiWithAuthDeploymentd185af4c11": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAuth"
+        },
+        "Description": "RestApi deployment id: d185af4c113b3307353bafba7307ada78d383dbf",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_apikey_required.json
+++ b/tests/translator/output/aws-us-gov/api_with_apikey_required.json
@@ -82,7 +82,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment1f6bf4c0d5"
+          "Ref": "MyApiWithoutAuthDeploymenta9d373201f"
         },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
@@ -134,13 +134,13 @@
         ]
       }
     },
-    "MyApiWithoutAuthDeployment1f6bf4c0d5": {
+    "MyApiWithoutAuthDeploymenta9d373201f": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
         },
-        "Description": "RestApi deployment id: 1f6bf4c0d5babf513c5623a65931134211ad3d0b",
+        "Description": "RestApi deployment id: a9d373201f0268022c291baacea8c1fa73bdbbfe",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-us-gov/api_with_apikey_required_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_with_apikey_required_openapi_3.json
@@ -1,7 +1,7 @@
 {
   "Resources": {
     "MyFunctionWithApiKeyRequiredRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -13,13 +13,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -30,88 +30,79 @@
         }
       }
     },
-    "MyApiWithoutAuthDeployment36e0aae784": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        }, 
-        "Description": "RestApi deployment id: 36e0aae784b2c12681164079395d2d416638051f"
-      }
-    }, 
     "MyApiWithoutAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/ApiKeyRequiredTrue": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithApiKeyRequired.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "api_key": {
-                "type": "apiKey", 
-                "name": "x-api-key", 
+                "type": "apiKey",
+                "name": "x-api-key",
                 "in": "header"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiWithoutAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment36e0aae784"
-        }, 
+          "Ref": "MyApiWithoutAuthDeployment75c501e20f"
+        },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithApiKeyRequiredMyApiWithApiKeyRequiredPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithApiKeyRequired"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyRequiredTrue", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/ApiKeyRequiredTrue",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -121,28 +112,37 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithApiKeyRequired": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithApiKeyRequiredRole", 
+            "MyFunctionWithApiKeyRequiredRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "MyApiWithoutAuthDeployment75c501e20f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        },
+        "Description": "RestApi deployment id: 75c501e20f85252d3ba6af5639b6314e0ada2653"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_auth_all_maximum.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_all_maximum.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -43,16 +43,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -63,16 +63,16 @@
       }
     },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,18 +83,8 @@
         }
       }
     },
-    "MyApiDeployment7939ed72e3": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 7939ed72e39cf5e3c86aaa365a531790a1d244e6", 
-        "StageName": "Stage"
-      }
-    }, 
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -106,13 +96,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -122,226 +112,226 @@
           ]
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "patch": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 0, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuthMultipleUserPools": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader2", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression2", 
+                "identityValidationExpression": "myauthvalidationexpression2",
                 "providerARNs": [
-                  "arn:aws:2", 
+                  "arn:aws:2",
                   "arn:aws:3"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "authorizerResultTtlInSeconds": 0, 
-                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
+                },
                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression", 
+                "identityValidationExpression": "myauthvalidationexpression",
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyCustomAuthHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 20, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
-                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                 "identityValidationExpression": "mycustomauthexpression"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -352,16 +342,16 @@
       }
     },
     "MyFunctionWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -373,14 +363,14 @@
       }
     },
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -389,30 +379,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment7939ed72e3"
-        }, 
+          "Ref": "MyApiDeployment3f1717842c"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -422,18 +412,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -442,6 +432,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiDeployment3f1717842c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 3f1717842c11f943efef1bd5f5fa30660bc2143a",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_auth_all_maximum_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_all_maximum_openapi_3.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -43,16 +43,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -63,16 +63,16 @@
       }
     },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -84,7 +84,7 @@
       }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -96,13 +96,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -112,237 +112,228 @@
           ]
         }
       }
-    }, 
-    "MyApiDeployment57e8e73ac5": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 57e8e73ac5d3dea833fbbfb4d0d67328fb198a35"
-      }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "patch": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
-                  "authorizerResultTtlInSeconds": 0, 
+                  "type": "token",
+                  "authorizerResultTtlInSeconds": 0,
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "MyCognitoAuthMultipleUserPools": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyAuthorizationHeader2", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyAuthorizationHeader2",
                 "x-amazon-apigateway-authorizer": {
-                  "identityValidationExpression": "myauthvalidationexpression2", 
+                  "identityValidationExpression": "myauthvalidationexpression2",
                   "providerARNs": [
-                    "arn:aws:2", 
+                    "arn:aws:2",
                     "arn:aws:3"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyLambdaRequestAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Unused", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "request", 
-                  "authorizerResultTtlInSeconds": 0, 
-                  "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                  "type": "request",
+                  "authorizerResultTtlInSeconds": 0,
+                  "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
-                  }, 
+                  },
                   "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyAuthorizationHeader", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyAuthorizationHeader",
                 "x-amazon-apigateway-authorizer": {
-                  "identityValidationExpression": "myauthvalidationexpression", 
+                  "identityValidationExpression": "myauthvalidationexpression",
                   "providerARNs": [
                     "arn:aws:1"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyLambdaTokenAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "MyCustomAuthHeader", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "MyCustomAuthHeader",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
-                  "authorizerResultTtlInSeconds": 20, 
+                  "type": "token",
+                  "authorizerResultTtlInSeconds": 20,
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": "arn:aws"
                       }
                     ]
-                  }, 
-                  "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                  },
+                  "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                   "identityValidationExpression": "mycustomauthexpression"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
-              }, 
+              },
               "api_key": {
-                "type": "apiKey", 
-                "name": "x-api-key", 
+                "type": "apiKey",
+                "name": "x-api-key",
                 "in": "header"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -353,16 +344,16 @@
       }
     },
     "MyFunctionWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -374,14 +365,14 @@
       }
     },
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -390,30 +381,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment57e8e73ac5"
-        }, 
+          "Ref": "MyApiDeployment77a772bf56"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -423,18 +414,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -443,6 +434,15 @@
             }
           ]
         }
+      }
+    },
+    "MyApiDeployment77a772bf56": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 77a772bf5635b3b8658bd034ac90026bb1ad7d09"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_auth_all_minimum.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_all_minimum.json
@@ -1,91 +1,91 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeploymentca86749bcd"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeployment981db51c80"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -96,40 +96,30 @@
       }
     },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "MyApiWithLambdaTokenAuthDeployment5192789870": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: 5192789870157c12b0fb5a78c7e570d22c4e46f5", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -141,13 +131,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -157,30 +147,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment9b695a6dd5"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment1228cb3cf9"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -190,21 +180,21 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -213,18 +203,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -234,18 +224,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -255,128 +245,118 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
+                "type": "token",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "MyApiWithLambdaRequestAuthDeploymentca86749bcd": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: ca86749bcd339b4d6564954e2e12b20ebf9fb2ff", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -388,13 +368,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -404,93 +384,113 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeployment5192789870"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeployment3cfb033887"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment9b695a6dd5": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 9b695a6dd5c12bb346b4163227f398c34128a49a", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeployment3cfb033887": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        },
+        "Description": "RestApi deployment id: 3cfb033887b0f08657da1dd363c4d6a769f0d515",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaRequestAuthDeployment981db51c80": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: 981db51c8006e142db3b96bc3a5e8d60976cd267",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithCognitoAuthDeployment1228cb3cf9": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 1228cb3cf9381ee600eb46ae0c7faa0e64dba4a4",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_auth_all_minimum_openapi.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_all_minimum_openapi.json
@@ -1,111 +1,93 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     {
                       "Fn::GetAtt": [
-                        "MyUserPool", 
+                        "MyUserPool",
                         "Arn"
                       ]
                     }
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "MyApiWithLambdaRequestAuthDeployment7c3972b020": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: 7c3972b020afc5a3f348a527f9cbf5108557b930"
-      }
-    }, 
-    "MyApiWithCognitoAuthDeploymente1765ad6c1": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: e1765ad6c129adfb32be52dea3fa053e2ce02d51"
-      }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeployment7c3972b020"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeployment2bd5d5cc4b"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -114,41 +96,32 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaTokenAuthDeploymentfc5424e34c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: fc5424e34c86d9c2c71ee87d32bc82555a3c577d"
-      }
     },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucketname", 
+          "S3Bucket": "bucketname",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -160,13 +133,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -176,30 +149,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeploymente1765ad6c1"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment93dc9d4d36"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -209,21 +182,21 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -232,18 +205,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -253,18 +226,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -274,120 +247,120 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaTokenAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "token", 
+                  "type": "token",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": {
                           "Fn::GetAtt": [
-                            "MyAuthFn", 
+                            "MyAuthFn",
                             "Arn"
                           ]
                         }
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucketname", 
+          "S3Bucket": "bucketname",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -399,13 +372,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -415,85 +388,112 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeploymentfc5424e34c"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeployment90a736302f"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyLambdaRequestAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Unused", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
                 "x-amazon-apigateway-authorizer": {
-                  "type": "request", 
-                  "identitySource": "method.request.header.Authorization1", 
+                  "type": "request",
+                  "identitySource": "method.request.header.Authorization1",
                   "authorizerUri": {
                     "Fn::Sub": [
-                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                       {
                         "__FunctionArn__": {
                           "Fn::GetAtt": [
-                            "MyAuthFn", 
+                            "MyAuthFn",
                             "Arn"
                           ]
                         }
                       }
                     ]
                   }
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "custom"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiWithLambdaRequestAuthDeployment2bd5d5cc4b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: 2bd5d5cc4b867532a66749764091132aed3e1614"
+      }
+    },
+    "MyApiWithCognitoAuthDeployment93dc9d4d36": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 93dc9d4d3658fb47c547f18c0e59f0edd6860b6a"
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeployment90a736302f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        },
+        "Description": "RestApi deployment id: 90a736302f0cf6d3989a2f7606db1c3c304b85fb"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_auth_and_conditions_all_max.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_and_conditions_all_max.json
@@ -2,23 +2,23 @@
   "Conditions": {
     "PathCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "MyFunctionWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -28,16 +28,16 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -48,279 +48,279 @@
       }
     },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment5d64bc1235"
-        }, 
+          "Ref": "MyApiDeployment94f35ff514"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/users": {
               "put": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyCognitoAuth": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "patch": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyLambdaTokenAuthNoneFunctionInvokeRole": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthMultipleUserPools": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaTokenAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "delete": {
                 "Fn::If": [
-                  "PathCondition", 
+                  "PathCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "PathCondition", 
+                          "PathCondition",
                           {
                             "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithConditional.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "security": [
                       {
                         "MyLambdaRequestAuth": []
                       }
-                    ], 
+                    ],
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression", 
+                "identityValidationExpression": "myauthvalidationexpression",
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 0, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuthMultipleUserPools": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader2", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression2", 
+                "identityValidationExpression": "myauthvalidationexpression2",
                 "providerARNs": [
-                  "arn:aws:2", 
+                  "arn:aws:2",
                   "arn:aws:3"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyCustomAuthHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 20, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
-                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                 "identityValidationExpression": "mycustomauthexpression"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "authorizerResultTtlInSeconds": 0, 
-                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
+                },
                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -329,18 +329,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -350,41 +350,41 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -395,18 +395,8 @@
         }
       }
     },
-    "MyApiDeployment5d64bc1235": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 5d64bc123529878594c2e91158f7e6f22a4b7c78", 
-        "StageName": "Stage"
-      }
-    }, 
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -418,13 +408,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -434,18 +424,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionWithConditionalWithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -454,20 +444,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyFunctionWithConditionalWithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -476,18 +466,18 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApi"
@@ -498,16 +488,16 @@
       }
     },
     "MyFunctionWithConditionalWithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithConditional"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -516,11 +506,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyFunctionWithConditionalRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -532,13 +522,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -547,32 +537,42 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "PathCondition"
-    }, 
+    },
     "MyFunctionWithConditional": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithConditionalRole", 
+            "MyFunctionWithConditionalRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "PathCondition"
+    },
+    "MyApiDeployment94f35ff514": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 94f35ff51414c2c89e91fefeeeeef2fe295460fc",
+        "StageName": "Stage"
+      }
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/api_with_auth_no_default.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_no_default.json
@@ -1,86 +1,86 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognito": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeployment9a21d88fe2"
-        }, 
+          "Ref": "MyApiWithLambdaRequestAuthDeployment25a2cc7f17"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaTokenAuth"
@@ -91,30 +91,30 @@
       }
     },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -126,13 +126,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -142,30 +142,30 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment2da3114321"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment15afb1c613"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFnCognitoPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -175,31 +175,21 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeployment2da3114321": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 2da3114321f3a31e83ea7029e5b167e14f36e7fb", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "MyApiWithLambdaRequestAuth"
@@ -208,28 +198,18 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaTokenAuthDeployment613e605d96": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: 613e605d962dfc3e8ac8e456357d807af4264223", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnLambdaTokenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-token",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -239,18 +219,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnLambdaRequestPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -260,113 +240,113 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithLambdaTokenAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-token": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
+                "type": "token",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -378,13 +358,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -394,88 +374,108 @@
           ]
         }
       }
-    }, 
-    "MyApiWithLambdaRequestAuthDeployment9a21d88fe2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: 9a21d88fe25a74e9f2ca61175f4dd4d281b61d12", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiWithLambdaTokenAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeployment613e605d96"
-        }, 
+          "Ref": "MyApiWithLambdaTokenAuthDeploymenta8e43697e3"
+        },
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyApiWithLambdaRequestAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/lambda-request": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeployment15afb1c613": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 15afb1c613f80b8063c0e423f63e4c6b8465bdb1",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaTokenAuthDeploymenta8e43697e3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        },
+        "Description": "RestApi deployment id: a8e43697e3470850b70316558854b9cb7b0c904d",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithLambdaRequestAuthDeployment25a2cc7f17": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        },
+        "Description": "RestApi deployment id: 25a2cc7f1768303149f290b1f687713c6d5b2aa0",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_auth_with_default_scopes.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_with_default_scopes.json
@@ -1,199 +1,199 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognitowithauthnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultauthdefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizerwithdefaultscopes": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "default.delete", 
+                      "default.delete",
                       "default.update"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizercopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesdefaultauthorizer": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "default.write", 
+                      "default.write",
                       "default.read"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuthWithDefaultScopes": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:2"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyDefaultCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -201,20 +201,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultAuthDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -222,20 +222,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerWithDefaultScopesPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -243,20 +243,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -264,20 +264,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerScopesOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -285,28 +285,18 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeploymentba9bfa6490": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: ba9bfa649000ecc8dd6b649807472d08fe19ec39", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -314,31 +304,31 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoWithAuthNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -346,61 +336,71 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeploymentba9bfa6490"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment5c8fadf89b"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesWithOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
             }
           ]
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeployment5c8fadf89b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 5c8fadf89b6b86fff6556fab680e1c9020f19c30",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_auth_with_default_scopes_openapi.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_with_default_scopes_openapi.json
@@ -1,201 +1,201 @@
 {
   "Resources": {
     "MyApiWithCognitoAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/cognitowithauthnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultauthdefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesnone": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizerwithdefaultscopes": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "default.delete", 
+                      "default.delete",
                       "default.update"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitoauthorizercopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuthWithDefaultScopes": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesoverwritten": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "overwritten.read", 
+                      "overwritten.read",
                       "overwritten.write"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/cognitodefaultscopesdefaultauthorizer": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyDefaultCognitoAuth": [
-                      "default.write", 
+                      "default.write",
                       "default.read"
                     ]
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0.1", 
+          },
+          "openapi": "3.0.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuthWithDefaultScopes": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     "arn:aws:2"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-              }, 
+              },
               "MyDefaultCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     "arn:aws:1"
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -203,20 +203,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoDefaultAuthDefaultScopesNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultauthdefaultscopesnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -224,20 +224,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerWithDefaultScopesPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizerwithdefaultscopes",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -245,32 +245,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithCognitoAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeploymentddb4f4405b"
-        }, 
+          "Ref": "MyApiWithCognitoAuthDeployment796370425d"
+        },
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesdefaultauthorizer",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -278,20 +278,20 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnCognitoAuthorizerScopesOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitoauthorizercopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -299,18 +299,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -318,31 +318,31 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoWithAuthNonePermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitowithauthnone",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
@@ -350,58 +350,58 @@
           ]
         }
       }
-    }, 
-    "MyApiWithCognitoAuthDeploymentddb4f4405b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: ddb4f4405befb5324c4f18cdc69c3dd8489bc520"
-      }
-    }, 
+    },
     "MyFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFnRole", 
+            "MyFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFnCognitoDefaultScopesWithOverwrittenPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFn"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognitodefaultscopesoverwritten",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApiWithCognitoAuth"
               }
             }
           ]
         }
+      }
+    },
+    "MyApiWithCognitoAuthDeployment796370425d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: 796370425d453f9e67f898148cbe8bb19b79a18f"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_aws_account_blacklist.json
+++ b/tests/translator/output/aws-us-gov/api_with_aws_account_blacklist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment589bc02957": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 589bc02957d5c0cd37766f5b4ad15db34e339c67", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment589bc02957"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentb8c324dad1"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,47 +63,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
-              "Action": "execute-api:Invoke", 
+              "Action": "execute-api:Invoke",
               "Resource": [
                 {
                   "Fn::Sub": [
-                    "execute-api:/${__Stage__}/PUT/get", 
+                    "execute-api:/${__Stage__}/PUT/get",
                     {
                       "__Stage__": "Prod"
                     }
                   ]
                 }
-              ], 
-              "Effect": "Deny", 
+              ],
+              "Effect": "Deny",
               "Principal": {
                 "AWS": [
                   "12345"
@@ -121,36 +111,46 @@
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeploymentb8c324dad1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: b8c324dad11e5c679222f0a7fc602344551a6839",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_aws_account_whitelist.json
+++ b/tests/translator/output/aws-us-gov/api_with_aws_account_whitelist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment1455f86734": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 1455f86734ed594d0b04ccd0bfb035c00f838cca", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment1455f86734"
-        }, 
+          "Ref": "ServerlessRestApiDeployment0d39175c01"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,67 +63,67 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "AWS": [
                     "12345"
                   ]
                 }
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Principal": {
                   "AWS": [
                     "67890"
@@ -142,36 +132,46 @@
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment0d39175c01": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 0d39175c0188bba16b118602e57c8a5b45e9142a",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/aws-us-gov/api_with_aws_iam_auth_overrides.json
@@ -1,88 +1,88 @@
 {
   "Resources": {
     "MyFunctionCustomInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionCustomInvokeRoleRole", 
+            "MyFunctionCustomInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoneAuth": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoneAuthRole", 
+            "MyFunctionNoneAuthRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNullInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNullInvokeRoleRole", 
+            "MyFunctionNullInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentc7d4214444"
-        }, 
+          "Ref": "MyApiWithAwsIamAuthDeployment9944ee3dca"
+        },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "MyFunctionWithoutAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -94,13 +94,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -110,18 +110,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionCustomInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionCustomInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -131,18 +131,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionMyCognitoAuthAPI1PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionMyCognitoAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -152,93 +152,83 @@
           ]
         }
       }
-    }, 
-    "MyApiWithAwsIamAuthDeploymentc7d4214444": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        }, 
-        "Description": "RestApi deployment id: c7d4214444b325ee43f7a16744a5a74d01b268b2", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApiWithAwsIamAuthNoCallerCredentials": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoCallerCredentials.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCallerCredentialsOverride.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::*:user/*"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "AWS_IAM": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionWithoutAuthAPI2PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionWithoutAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -250,16 +240,16 @@
       }
     },
     "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionDefaultInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -269,32 +259,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionMyCognitoAuth": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionMyCognitoAuthRole", 
+            "MyFunctionMyCognitoAuthRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNullInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -306,13 +296,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -324,39 +314,39 @@
       }
     },
     "MyFunctionNONEInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNONEInvokeRoleRole", 
+            "MyFunctionNONEInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoCallerCredentialsAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNoCallerCredentials"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -366,9 +356,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNoneAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -380,13 +370,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -396,9 +386,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionCustomInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -410,13 +400,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -426,18 +416,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionCallerCredentialsOverrideAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionCallerCredentialsOverride"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -447,64 +437,64 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionCallerCredentialsOverride": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionCallerCredentialsOverrideRole", 
+            "MyFunctionCallerCredentialsOverrideRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionWithoutAuth": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithoutAuthRole", 
+            "MyFunctionWithoutAuthRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNullInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNullInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -514,18 +504,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNONEInvokeRole"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -535,9 +525,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionNoCallerCredentialsRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -549,13 +539,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -565,9 +555,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionDefaultInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -579,13 +569,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -597,7 +587,7 @@
       }
     },
     "MyFunctionCallerCredentialsOverrideRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -609,13 +599,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -627,7 +617,7 @@
       }
     },
     "MyFunctionMyCognitoAuthRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -639,13 +629,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -655,242 +645,242 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiWithAwsIamAuthNoCallerCredentialsProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment673da6c5e9"
-        }, 
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment39c8e6b09f"
+        },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "MyFunctionDefaultInvokeRole": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionDefaultInvokeRoleRole", 
+            "MyFunctionDefaultInvokeRoleRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionNoCallerCredentials": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoCallerCredentialsRole", 
+            "MyFunctionNoCallerCredentialsRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
     },
     "MyApiWithAwsIamAuth": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/MyFunctionWithoutAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithoutAuth.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::123:role/AUTH_AWS_IAM"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNONEInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNONEInvokeRole.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionMyCognitoAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionMyCognitoAuth.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionDefaultInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::*:user/*"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionCustomInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
-                  }, 
+                  },
                   "credentials": "arn:aws:iam::456::role/something-else"
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNullInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNullInvokeRole.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
-            }, 
+            },
             "/MyFunctionNoneAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "NONE": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:cognito-idp:xxxxxxxxx"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "AWS_IAM": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionNoneAuthAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunctionNoneAuth"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -900,19 +890,9 @@
           ]
         }
       }
-    }, 
-    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment673da6c5e9": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
-        }, 
-        "Description": "RestApi deployment id: 673da6c5e9481163e7b1cbf6d5604eb84cf64fd0", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionNONEInvokeRoleRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -924,13 +904,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -939,6 +919,26 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthDeployment9944ee3dca": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: 9944ee3dca7c2b9bd0920c1797c1fceb9269bf87",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment39c8e6b09f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        },
+        "Description": "RestApi deployment id: 39c8e6b09f577310178cdb747962b91ced4dc557",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_basic_custom_domain.json
+++ b/tests/translator/output/aws-us-gov/api_with_basic_custom_domain.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "MyDomainName": {
-      "Default": "another-example.com", 
+      "Default": "another-example.com",
       "Type": "String"
-    }, 
+    },
     "MyDomainCert": {
-      "Default": "another-api-arn", 
+      "Default": "another-api-arn",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionAnotherGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/another/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/another/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyAnotherApi"
               }
@@ -52,11 +52,11 @@
           ]
         }
       }
-    }, 
+    },
     "ApiGatewayDomainName23cdccdf9c": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "my-api-cert-arn", 
+        "CertificateArn": "my-api-cert-arn",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
@@ -69,20 +69,20 @@
         "SecurityPolicy": "TLS_1_2",
         "DomainName": "api-example.com"
       }
-    }, 
+    },
     "MyFunctionImplicitGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -90,42 +90,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyAnotherApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeploymenteb8302ec1b"
-        }, 
+          "Ref": "MyAnotherApiDeployment5da6d23613"
+        },
         "RestApiId": {
           "Ref": "MyAnotherApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment790a4e6aa6": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 790a4e6aa6ad06f44702e52a66e5fec0cd96be99", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -133,69 +123,69 @@
           ]
         }
       }
-    }, 
+    },
     "MyAnotherApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/another/get": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApigetBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "get", 
+        "BasePath": "get",
         "DomainName": {
           "Ref": "ApiGatewayDomainName23cdccdf9c"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -203,218 +193,228 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "MyApiDeploymentb34773e43a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: b34773e43ad9a98f27deed4374d3a49449abd947"
-      }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyAnotherApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
         "DomainName": {
           "Ref": "ApiGatewayDomainNameeab65c1531"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyAnotherApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyAnotherApiProdStage"
         }
       }
-    }, 
+    },
     "ApiGatewayDomainNameeab65c1531": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "another-api-arn", 
+        "RegionalCertificateArn": "another-api-arn",
         "DomainName": "another-example.com"
       }
-    }, 
+    },
     "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "fetch", 
+        "BasePath": "fetch",
         "DomainName": {
           "Ref": "ApiGatewayDomainName23cdccdf9c"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment790a4e6aa6"
-        }, 
+          "Ref": "ServerlessRestApiDeployment9f4a276626"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyAnotherApiDeploymenteb8302ec1b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyAnotherApi"
-        }, 
-        "Description": "RestApi deployment id: eb8302ec1bd45ce6bb547e74633c4bbb3e503d4a"
-      }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentb34773e43a"
-        }, 
+          "Ref": "MyApiDeployment9881fc48bc"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
         "DomainName": {
           "Ref": "ApiGatewayDomainNameeab65c1531"
-        }, 
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "Stage": {
           "Ref": "ServerlessRestApiProdStage"
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/implicit": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment9f4a276626": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 9f4a27662674ed61f216067d75ed7e5b52783a5a",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiDeployment9881fc48bc": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 9881fc48bc9ba18cd1f661cb0f177db25ce45eb9"
+      }
+    },
+    "MyAnotherApiDeployment5da6d23613": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyAnotherApi"
+        },
+        "Description": "RestApi deployment id: 5da6d2361309ed8d1d12f7445dce8797db3a25bc"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics.json
@@ -2,18 +2,18 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "MyDomainCert": {
-      "Default": "another-api-arn", 
+      "Default": "another-api-arn",
       "Type": "String"
-    }, 
+    },
     "EndpointConf": {
-      "Default": "REGIONAL", 
+      "Default": "REGIONAL",
       "Type": "String"
     },
     "MyMTLSUri": {
@@ -24,93 +24,93 @@
       "Default": "another-api-truststore-version",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyFunctionImplicitGetPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/implicit",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment0294e6b48a"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentb3b446d9f5"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "fetch", 
+        "BasePath": "fetch",
         "DomainName": {
           "Ref": "ApiGatewayDomainName9c93aac102"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -118,132 +118,111 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApigetBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "get", 
+        "BasePath": "get",
         "DomainName": {
           "Ref": "ApiGatewayDomainName9c93aac102"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
-    "ServerlessRestApiDeployment0294e6b48a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 0294e6b48a4d409ae8dbd2333cd092c27cbee6fe", 
-        "StageName": "Stage"
-      }, 
-      "Condition": "C1"
-    }, 
-    "MyApiDeployment32e59613e2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 32e59613e2e02a1f1d264849167ea359f10342f0"
-      }, 
-      "Condition": "C1"
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
                   "put": {
                     "Fn::If": [
-                      "C1", 
+                      "C1",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "C1", 
+                              "C1",
                               {
                                 "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
                   }
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment32e59613e2"
-        }, 
+          "Ref": "MyApiDeployment608fc52b12"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "ApiGatewayDomainName9c93aac102": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
@@ -255,94 +234,115 @@
           "TruststoreVersion": "another-api-truststore-version"
         },
         "SecurityPolicy": "TLS_1_2",
-        "RegionalCertificateArn": "another-api-arn", 
+        "RegionalCertificateArn": "another-api-arn",
         "DomainName": {
           "Fn::Sub": "example-us-gov-west-1.com"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/implicit": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
                   "post": {
                     "Fn::If": [
-                      "C1", 
+                      "C1",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "C1", 
+                              "C1",
                               {
                                 "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
                   }
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }, 
+      },
       "Condition": "C1"
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
-        "Principal": "apigateway.amazonaws.com", 
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
             }
           ]
         }
-      }, 
+      },
+      "Condition": "C1"
+    },
+    "ServerlessRestApiDeploymentb3b446d9f5": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: b3b446d9f5aef53ec215f95565813fa57c64ed73",
+        "StageName": "Stage"
+      },
+      "Condition": "C1"
+    },
+    "MyApiDeployment608fc52b12": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 608fc52b12f6b4a0b084632945dbb70e0f61d8b7"
+      },
       "Condition": "C1"
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_binary_media_types.json
+++ b/tests/translator/output/aws-us-gov/api_with_binary_media_types.json
@@ -1,36 +1,36 @@
 {
   "Parameters": {
     "BMT": {
-      "Default": "image~1jpg", 
+      "Default": "image~1jpg",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -42,13 +42,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -58,28 +58,18 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -89,130 +79,140 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BinaryMediaTypes": [
-          "image~1gif", 
+          "image~1gif",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
-          "application~1octet-stream", 
+          },
+          "application~1octet-stream",
           "image~1jpg"
-        ], 
+        ],
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment9746c8328e"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentbc05a73d9e"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment9746c8328e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 9746c8328eca81d7b29fed89d9203021b42242ec", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/gif", 
+            "image/gif",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
             }
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1gif", 
+          "image~1gif",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
           }
-        ], 
+        ],
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentbc05a73d9e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: bc05a73d9e32a2133afec6027d3079923cbd3fc2",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_binary_media_types_definition_body.json
+++ b/tests/translator/output/aws-us-gov/api_with_binary_media_types_definition_body.json
@@ -1,149 +1,149 @@
 {
   "Parameters": {
     "BMT": {
-      "Default": "image~1jpeg", 
+      "Default": "image~1jpeg",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ExplicitApiManagedSwaggerProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiManagedSwaggerDeploymentfe9c2c09a2"
-        }, 
+          "Ref": "ExplicitApiManagedSwaggerDeployment77c7e2092d"
+        },
         "RestApiId": {
           "Ref": "ExplicitApiManagedSwagger"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiManagedSwaggerDeploymentfe9c2c09a2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApiManagedSwagger"
-        }, 
-        "Description": "RestApi deployment id: fe9c2c09a27ce00c2fa53d5a491cf343e6a3278e", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiDefinitionBody": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "paths": {}, 
-          "swagger": "2.0", 
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/jpeg", 
-            "image/jpg", 
+            "image/jpeg",
+            "image/jpg",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
-            }, 
+            },
             "application/json"
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1jpeg", 
-          "image~1jpg", 
+          "image~1jpeg",
+          "image~1jpg",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
+          },
           "application~1json"
-        ], 
+        ],
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDefinitionBodyDeployment1f26996adb": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApiDefinitionBody"
-        }, 
-        "Description": "RestApi deployment id: 1f26996adbe5077359ecb2bb0688a9cc0ae8e4fc", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiDefinitionBodyProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDefinitionBodyDeployment1f26996adb"
-        }, 
+          "Ref": "ExplicitApiDefinitionBodyDeployment8243637415"
+        },
         "RestApiId": {
           "Ref": "ExplicitApiDefinitionBody"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiManagedSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
-          "swagger": "2.0", 
+          },
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-binary-media-types": [
-            "image/jpeg", 
-            "image/jpg", 
+            "image/jpeg",
+            "image/jpg",
             {
               "Fn::Join": [
-                "/", 
+                "/",
                 [
-                  "image", 
+                  "image",
                   "png"
                 ]
               ]
-            }, 
+            },
             "image/gif"
           ]
-        }, 
+        },
         "BinaryMediaTypes": [
-          "image~1jpeg", 
-          "image~1jpg", 
+          "image~1jpeg",
+          "image~1jpg",
           {
             "Fn::Join": [
-              "~1", 
+              "~1",
               [
-                "image", 
+                "image",
                 "png"
               ]
             ]
-          }, 
+          },
           "image~1gif"
-        ], 
+        ],
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiManagedSwaggerDeployment77c7e2092d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApiManagedSwagger"
+        },
+        "Description": "RestApi deployment id: 77c7e2092d31ef078af609150899d4c546e54ade",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDefinitionBodyDeployment8243637415": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApiDefinitionBody"
+        },
+        "Description": "RestApi deployment id: 8243637415ea97b13720e769347272506839bc57",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_canary_setting.json
+++ b/tests/translator/output/aws-us-gov/api_with_canary_setting.json
@@ -103,32 +103,12 @@
           }
         },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
+          "Ref": "ExplicitApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
         "StageName": "Prod"
-      }
-    },
-    "ServerlessRestApiDeployment5b2cb4ba8f": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 5b2cb4ba8fce8a9445b1914c6c6fbeef81a9075a",
-        "StageName": "Stage"
-      }
-    },
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApiProdStage": {
@@ -143,7 +123,7 @@
           }
         },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5b2cb4ba8f"
+          "Ref": "ServerlessRestApiDeployment48b9be5f17"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -185,6 +165,26 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment48b9be5f17": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 48b9be5f1703467615aff7539d0d6987624f84c5",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionAnyApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,163 +73,153 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeployment1754a26207": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 1754a26207ccaa4f36c763f1f3993638ba8e8d0a", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -241,13 +231,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -257,33 +247,33 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment1754a26207"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentb5c71f6544"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment3a5a78688c"
-        }, 
+          "Ref": "ExplicitApiDeploymentca189bb326"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -295,13 +285,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -311,18 +301,18 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -332,205 +322,215 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment3a5a78688c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 3a5a78688c9bc377d53aa4153a11f0c4f6e7364c", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ServerlessRestApiDeploymentb5c71f6544": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: b5c71f65440671834c5532ca416c28b120150f37",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeploymentca189bb326": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: ca189bb3267ef4823d27c85b66213b1d4cf4ed44",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors_and_auth_no_preflight_auth.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_and_auth_no_preflight_auth.json
@@ -1,128 +1,128 @@
 {
   "Resources": {
     "ServerlessApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -134,13 +134,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -151,39 +151,29 @@
         }
       }
     },
-    "ServerlessApiDeployment0aae939ae6": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessApi"
-        }, 
-        "Description": "RestApi deployment id: 0aae939ae622ada18aa063187fce7bef5605e7a6", 
-        "StageName": "Stage"
-      }
-    }, 
     "ServerlessApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessApiDeployment0aae939ae6"
-        }, 
+          "Ref": "ServerlessApiDeployment6d463948f3"
+        },
         "RestApiId": {
           "Ref": "ServerlessApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -195,62 +185,62 @@
       }
     },
     "ApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ApiFunctionRole", 
+            "ApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -260,9 +250,9 @@
           ]
         }
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -274,13 +264,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -290,21 +280,21 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessApi"
@@ -312,6 +302,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessApiDeployment6d463948f3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessApi"
+        },
+        "Description": "RestApi deployment id: 6d463948f3e6da37c467ca667080e68ca883e18a",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors_and_auth_preflight_auth.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_and_auth_preflight_auth.json
@@ -1,133 +1,133 @@
 {
   "Resources": {
     "ServerlessApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
-              }, 
+              },
               "options": {
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
-                ], 
+                ],
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
-                "summary": "CORS support", 
+                },
+                "summary": "CORS support",
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "consumes": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyLambdaRequestAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "identitySource": "method.request.header.Authorization1", 
+                "type": "request",
+                "identitySource": "method.request.header.Authorization1",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": {
                         "Fn::GetAtt": [
-                          "MyAuthFn", 
+                          "MyAuthFn",
                           "Arn"
                         ]
                       }
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -139,13 +139,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -155,28 +155,18 @@
           ]
         }
       }
-    }, 
-    "ServerlessApiDeployment1aab931299": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessApi"
-        }, 
-        "Description": "RestApi deployment id: 1aab931299afa9c61fe2f0d56427e1f4ce6191e8", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -188,16 +178,16 @@
       }
     },
     "ApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -209,53 +199,53 @@
       }
     },
     "ApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ApiFunctionRole", 
+            "ApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFn": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "bucket", 
+          "S3Bucket": "bucket",
           "S3Key": "key"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAuthFnRole", 
+            "MyAuthFnRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAuthFnRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -267,13 +257,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -283,33 +273,33 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessApiDeployment1aab931299"
-        }, 
+          "Ref": "ServerlessApiDeployment96875acc3f"
+        },
         "RestApiId": {
           "Ref": "ServerlessApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Fn::GetAtt": [
-            "MyAuthFn", 
+            "MyAuthFn",
             "Arn"
           ]
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessApi"
@@ -317,6 +307,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessApiDeployment96875acc3f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessApi"
+        },
+        "Description": "RestApi deployment id: 96875acc3f0cb40f0deb7b1a077b2444bc10ccce",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors_and_conditions_no_definitionbody.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_and_conditions_no_definitionbody.json
@@ -1,40 +1,40 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09", 
+  "AWSTemplateFormatVersion": "2010-09-09",
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "MyCondition"
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -46,13 +46,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -61,20 +61,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
     },
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,160 +83,160 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentc140480269"
-        }, 
+          "Ref": "ExplicitApiDeployment772a25fd05"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "Fn::If": [
-                  "MyCondition", 
+                  "MyCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "MyCondition", 
+                          "MyCondition",
                           {
                             "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "get": {
                 "Fn::If": [
-                  "MyCondition", 
+                  "MyCondition",
                   {
                     "x-amazon-apigateway-integration": {
-                      "httpMethod": "POST", 
-                      "type": "aws_proxy", 
+                      "httpMethod": "POST",
+                      "type": "aws_proxy",
                       "uri": {
                         "Fn::If": [
-                          "MyCondition", 
+                          "MyCondition",
                           {
                             "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                          }, 
+                          },
                           {
                             "Ref": "AWS::NoValue"
                           }
                         ]
                       }
-                    }, 
+                    },
                     "responses": {}
-                  }, 
+                  },
                   {
                     "Ref": "AWS::NoValue"
                   }
                 ]
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'www.example.com'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'www.example.com'",
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "delete": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction2.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -245,21 +245,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "MyCondition"
     },
-    "ExplicitApiDeploymentc140480269": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: c1404802698c32d804a36387b8267984809dad27", 
-        "StageName": "Stage"
-      }
-    }, 
     "ImplicitApiFunction2Role": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -271,13 +261,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -287,18 +277,18 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunction2DeleteHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction2"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -308,28 +298,38 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunction2": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunction2Role", 
+            "ImplicitApiFunction2Role",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ExplicitApiDeployment772a25fd05": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 772a25fd051a3186ccbbee26dd3e7f0a285b919b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors_and_only_credentials_false.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_and_only_credentials_false.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,155 +52,155 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment398246867a"
-        }, 
+          "Ref": "ExplicitApiDeployment92400db54c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiDeployment398246867a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 398246867a6d5535e40b46e224e8998486a4b9eb", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment92400db54c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 92400db54c85c63954529c21fb43966e7e92af8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors_and_only_headers.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_and_only_headers.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -53,27 +53,17 @@
         }
       }
     },
-    "ServerlessRestApiDeployment8e16bddf6b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 8e16bddf6b1212fc4a42840a3a6722842de272ca", 
-        "StageName": "Stage"
-      }
-    }, 
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -83,188 +73,178 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment03e65d7ea2"
-        }, 
+          "Ref": "ExplicitApiDeployment9a767e8172"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment8e16bddf6b"
-        }, 
+          "Ref": "ServerlessRestApiDeployment54f2362149"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'",
                         "method.response.header.Access-Control-Allow-Headers": "headers"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
                         "method.response.header.Access-Control-Allow-Headers": "headers"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDeployment03e65d7ea2": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 03e65d7ea2275d648803eecb7fa8e0ae7cd8f0aa", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -276,93 +256,113 @@
       }
     },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'",
                         "method.response.header.Access-Control-Allow-Headers": "headers"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment54f2362149": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 54f2362149dd6cdc49d69627d3075711492cbcb4",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment9a767e8172": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 9a767e81727f930f6f8609769c04a6fb37dea1cc",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors_and_only_maxage.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_and_only_maxage.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,163 +52,163 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymentb61cfb7d60": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: b61cfb7d602d889bbd9867dcbf0f75d3066dcc56", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentb61cfb7d60"
-        }, 
+          "Ref": "ExplicitApiDeployment3e3e53a12e"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Max-Age": 600, 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Max-Age": 600,
                         "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Max-Age": {
                         "type": "integer"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
-                        "method.response.header.Access-Control-Max-Age": 600, 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
+                        "method.response.header.Access-Control-Max-Age": 600,
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Max-Age": {
                         "type": "integer"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment3e3e53a12e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 3e3e53a12e63aac5b1b6231552a59eb7addad5bc",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors_and_only_methods.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_and_only_methods.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,102 +73,102 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment50aa0cc33c"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentfab5bf1e98"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "'*'", 
+                        "method.response.header.Access-Control-Allow-Origin": "'*'",
                         "method.response.header.Access-Control-Allow-Methods": "methods"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ServerlessRestApiDeployment50aa0cc33c": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ServerlessRestApiDeploymentfab5bf1e98": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 50aa0cc33c04fa6949a5f0e9cd22667b2677d9af", 
+        },
+        "Description": "RestApi deployment id: fab5bf1e98a813cd2a8e050f5606381171e110f4",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-us-gov/api_with_cors_and_only_origins.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_and_only_origins.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -53,200 +53,17 @@
         }
       }
     },
-    "ExplicitApiDeploymenta7a992bbb6": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a7a992bbb604dcd7667af3caa050bf14af2bf684", 
-        "StageName": "Stage"
-      }
-    }, 
     "ImplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "ServerlessRestApi"
-              }
-            }
-          ]
-        }
-      }
-    }, 
-    "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta7a992bbb6"
-        }, 
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc934a493f3"
-        }, 
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod"
-      }
-    }, 
-    "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
-      "Properties": {
-        "Body": {
-          "info": {
-            "version": "1.0", 
-            "title": {
-              "Ref": "AWS::StackName"
-            }
-          }, 
-          "paths": {
-            "/add": {
-              "post": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                  }
-                }, 
-                "responses": {}
-              }, 
-              "options": {
-                "x-amazon-apigateway-integration": {
-                  "type": "mock", 
-                  "requestTemplates": {
-                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
-                  "responses": {
-                    "default": {
-                      "statusCode": "200", 
-                      "responseTemplates": {
-                        "application/json": "{}\n"
-                      }, 
-                      "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
-                      }
-                    }
-                  }
-                }, 
-                "consumes": [
-                  "application/json"
-                ], 
-                "summary": "CORS support", 
-                "responses": {
-                  "200": {
-                    "headers": {
-                      "Access-Control-Allow-Origin": {
-                        "type": "string"
-                      }, 
-                      "Access-Control-Allow-Methods": {
-                        "type": "string"
-                      }
-                    }, 
-                    "description": "Default response for CORS method"
-                  }
-                }, 
-                "produces": [
-                  "application/json"
-                ]
-              }
-            }, 
-            "/{proxy+}": {
-              "options": {
-                "x-amazon-apigateway-integration": {
-                  "type": "mock", 
-                  "requestTemplates": {
-                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
-                  "responses": {
-                    "default": {
-                      "statusCode": "200", 
-                      "responseTemplates": {
-                        "application/json": "{}\n"
-                      }, 
-                      "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
-                      }
-                    }
-                  }
-                }, 
-                "consumes": [
-                  "application/json"
-                ], 
-                "summary": "CORS support", 
-                "responses": {
-                  "200": {
-                    "headers": {
-                      "Access-Control-Allow-Origin": {
-                        "type": "string"
-                      }, 
-                      "Access-Control-Allow-Methods": {
-                        "type": "string"
-                      }
-                    }, 
-                    "description": "Default response for CORS method"
-                  }
-                }, 
-                "produces": [
-                  "application/json"
-                ]
-              }, 
-              "x-amazon-apigateway-any-method": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
-                  }
-                }, 
-                "responses": {}
-              }
-            }
-          }, 
-          "swagger": "2.0"
-        }, 
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL"
-          ]
-        }, 
-        "Parameters": {
-          "endpointConfigurationTypes": "REGIONAL"
-        }
-      }
-    }, 
-    "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
-      "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "ImplicitApiFunction"
-        }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -257,100 +74,283 @@
         }
       }
     },
-    "ServerlessRestApiDeploymentc934a493f3": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeploymentd7e85f5956"
+        },
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment576056a97f"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: c934a493f3473efce5bb2acbf1d54e9c2ce0fef3", 
-        "StageName": "Stage"
+        },
+        "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+    },
+    "ExplicitApi": {
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
-            "/": {
+            "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
-              "get": {
+              }
+            },
+            "/{proxy+}": {
+              "options": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
-                  "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  "type": "mock",
+                  "requestTemplates": {
+                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
+                  },
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseTemplates": {
+                        "application/json": "{}\n"
+                      },
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
+                      }
+                    }
                   }
-                }, 
+                },
+                "consumes": [
+                  "application/json"
+                ],
+                "summary": "CORS support",
+                "responses": {
+                  "200": {
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string"
+                      }
+                    },
+                    "description": "Default response for CORS method"
+                  }
+                },
+                "produces": [
+                  "application/json"
+                ]
+              },
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ImplicitApiFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "ImplicitApiFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              },
+              "options": {
+                "x-amazon-apigateway-integration": {
+                  "type": "mock",
+                  "requestTemplates": {
+                    "application/json": "{\n  \"statusCode\" : 200\n}\n"
+                  },
+                  "responses": {
+                    "default": {
+                      "statusCode": "200",
+                      "responseTemplates": {
+                        "application/json": "{}\n"
+                      },
+                      "responseParameters": {
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS,POST'"
+                      }
+                    }
+                  }
+                },
+                "consumes": [
+                  "application/json"
+                ],
+                "summary": "CORS support",
+                "responses": {
+                  "200": {
+                    "headers": {
+                      "Access-Control-Allow-Origin": {
+                        "type": "string"
+                      },
+                      "Access-Control-Allow-Methods": {
+                        "type": "string"
+                      }
+                    },
+                    "description": "Default response for CORS method"
+                  }
+                },
+                "produces": [
+                  "application/json"
+                ]
+              },
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ExplicitApiDeploymentd7e85f5956": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: d7e85f5956fd5d5fbcee55dcab5860fa11f4b2a4",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment576056a97f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 576056a97f7b8812d2cfd96adc568d19ea891ae0",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_cors_no_definitionbody.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_no_definitionbody.json
@@ -16,10 +16,12 @@
           ]
         },
         "Runtime": "nodejs12.x",
-        "Tags": [{
-          "Value": "SAM",
-          "Key": "lambda:createdBy"
-        }]
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     },
     "ImplicitApiFunctionRole": {
@@ -36,17 +38,19 @@
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
-          "Statement": [{
-            "Action": [
-              "sts:AssumeRole"
-            ],
-            "Effect": "Allow",
-            "Principal": {
-              "Service": [
-                "lambda.amazonaws.com"
-              ]
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
             }
-          }]
+          ]
         }
       }
     },
@@ -182,7 +186,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentc934a493f3"
+          "Ref": "ExplicitApiDeployment576056a97f"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -190,13 +194,13 @@
         "StageName": "Prod"
       }
     },
-    "ExplicitApiDeploymentc934a493f3": {
+    "ExplicitApiDeployment576056a97f": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
-        "Description": "RestApi deployment id: c934a493f3473efce5bb2acbf1d54e9c2ce0fef3",
+        "Description": "RestApi deployment id: 576056a97f7b8812d2cfd96adc568d19ea891ae0",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-us-gov/api_with_cors_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_openapi_3.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionAnyApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,153 +73,153 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
-              }, 
+              },
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
               }
-            }, 
+            },
             "/{proxy+}": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Headers": "headers", 
-                        "method.response.header.Access-Control-Allow-Origin": "origins", 
-                        "method.response.header.Access-Control-Allow-Methods": "methods", 
+                        "method.response.header.Access-Control-Allow-Headers": "headers",
+                        "method.response.header.Access-Control-Allow-Origin": "origins",
+                        "method.response.header.Access-Control-Allow-Methods": "methods",
                         "method.response.header.Access-Control-Allow-Credentials": "'true'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Headers": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Credentials": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -231,13 +231,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -247,33 +247,33 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment8493e7adfe"
-        }, 
+          "Ref": "ServerlessRestApiDeployment32306c15e9"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment8cc53ffaa5"
-        }, 
+          "Ref": "ExplicitApiDeployment40a858e0c4"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -285,13 +285,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -301,18 +301,18 @@
           ]
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -322,88 +322,70 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment8cc53ffaa5": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 8cc53ffaa59a19b69e73d5b422142c7396739b16"
-      }
-    }, 
+    },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment8493e7adfe": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 8493e7adfe1ae5a1112328c0633eea5cdce0633c"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
                       }
                     }
                   }
                 },
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
@@ -411,57 +393,57 @@
                         "schema": {
                           "type": "string"
                         }
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "schema": {
                           "type": "string"
                         }
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
                 }
-              }, 
+              },
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
                         "method.response.header.Access-Control-Allow-Origin": {
                           "Fn::Join": [
-                            ",", 
+                            ",",
                             [
-                              "www.amazon.com", 
+                              "www.amazon.com",
                               "www.google.com"
                             ]
                           ]
-                        }, 
+                        },
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
                 },
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
@@ -469,62 +451,80 @@
                         "schema": {
                           "type": "string"
                         }
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "schema": {
                           "type": "string"
                         }
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
                 }
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ExplicitApiDeployment40a858e0c4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 40a858e0c466e102c414544f548494b70d9fbe8d"
+      }
+    },
+    "ServerlessRestApiDeployment32306c15e9": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 32306c15e9283545cd51f08e018ef67d18238122"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53.json
@@ -53,15 +53,6 @@
         }
       }
     },
-    "MyApiDeployment1deeaff693": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "Description": "RestApi deployment id: 1deeaff6933b892391de7a35e4cf92e79a47aea9"
-      }
-    },
     "RecordSetGroupbd00d962a4": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
@@ -115,7 +106,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment1deeaff693"
+          "Ref": "MyApiDeployment7452a804af"
         },
         "RestApiId": {
           "Ref": "MyApi"
@@ -199,6 +190,15 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiDeployment7452a804af": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 7452a804afa36533c64861ac23cdf3f3a247f6f9"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,50 +1,50 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1", 
+      "Default": "cert-arn-in-us-east-1",
       "Type": "String"
-    }, 
+    },
     "DomainName": {
-      "Default": "example.com", 
+      "Default": "example.com",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "MyApi"
               }
@@ -52,54 +52,45 @@
           ]
         }
       }
-    }, 
-    "MyApiDeployment501f2306c4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 501f2306c4860ed198c3020aa43d453cdbdd6b7a"
-      }
-    }, 
+    },
     "MyApioneBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Type": "AWS::ApiGateway::BasePathMapping",
       "Properties": {
-        "BasePath": "one", 
+        "BasePath": "one",
         "DomainName": {
           "Ref": "ApiGatewayDomainName0caaf24ab1"
-        }, 
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "Stage": {
           "Ref": "MyApiProdStage"
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment501f2306c4"
-        }, 
+          "Ref": "MyApiDeployment55274683a0"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -107,98 +98,107 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+      "Type": "AWS::ApiGateway::DomainName",
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
+        "CertificateArn": "cert-arn-in-us-east-1",
         "EndpointConfiguration": {
           "Types": [
             "EDGE"
           ]
-        }, 
+        },
         "DomainName": "example.com"
       }
-    }, 
+    },
     "RecordSetGroup456ebaf280": {
-      "Type": "AWS::Route53::RecordSetGroup", 
+      "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
-        "HostedZoneName": "www.my-domain.com.", 
+        "HostedZoneName": "www.my-domain.com.",
         "RecordSets": [
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "A", 
+            },
+            "Type": "A",
             "Name": "example.com"
-          }, 
+          },
           {
             "AliasTarget": {
-              "HostedZoneId": "Z2FDTNDATAQYW2", 
+              "HostedZoneId": "Z2FDTNDATAQYW2",
               "DNSName": {
                 "Fn::GetAtt": [
-                  "ApiGatewayDomainName0caaf24ab1", 
+                  "ApiGatewayDomainName0caaf24ab1",
                   "DistributionDomainName"
                 ]
               }
-            }, 
-            "Type": "AAAA", 
+            },
+            "Type": "AAAA",
             "Name": "example.com"
           }
         ]
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiDeployment55274683a0": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 55274683a05227813b5982e3046c148c098e5a38"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_default_aws_iam_auth.json
+++ b/tests/translator/output/aws-us-gov/api_with_default_aws_iam_auth.json
@@ -23,16 +23,6 @@
         ]
       }
     },
-    "MyApiWithAwsIamAuthDeploymentf9a4964a7d": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: f9a4964a7df5021874e5a094662f1a2443982e0a",
-        "StageName": "Stage"
-      }
-    },
     "MyFunctionWithAwsIamAuthMyApiWithAwsIamAuthPermissionProd": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -58,7 +48,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentf9a4964a7d"
+          "Ref": "MyApiWithAwsIamAuthDeploymentaaf619b844"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
@@ -70,7 +60,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentce2dead7de"
+          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymente97d5a51f3"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
@@ -97,26 +87,6 @@
             }
           ]
         }
-      }
-    },
-    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentce2dead7de": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
-        },
-        "Description": "RestApi deployment id: ce2dead7ded0bb502db5bd0c105948c27bc96729",
-        "StageName": "Stage"
-      }
-    },
-    "MyApiWithAwsIamAuthAndCustomInvokeRoleDeploymentb31aa75bb2": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
-        },
-        "Description": "RestApi deployment id: b31aa75bb2284229d40917a9b424c8ea1cf98217",
-        "StageName": "Stage"
       }
     },
     "MyApiWithAwsIamAuthAndCustomInvokeRole": {
@@ -173,7 +143,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRoleDeploymentb31aa75bb2"
+          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRoleDeployment434127af11"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
@@ -330,6 +300,36 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthDeploymentaaf619b844": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: aaf619b84462de2aa91a2097278180a79a3b9e80",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymente97d5a51f3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
+        },
+        "Description": "RestApi deployment id: e97d5a51f361b0d799ed41436c58b33f00e6fd08",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiWithAwsIamAuthAndCustomInvokeRoleDeployment434127af11": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthAndCustomInvokeRole"
+        },
+        "Description": "RestApi deployment id: 434127af11c169c470a582ee9b33e2532186ba35",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_default_aws_iam_auth_and_no_auth_route.json
+++ b/tests/translator/output/aws-us-gov/api_with_default_aws_iam_auth_and_no_auth_route.json
@@ -134,22 +134,12 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentce96ce9f89"
+          "Ref": "MyApiWithAwsIamAuthDeployment2410bdfe90"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
         "StageName": "Prod"
-      }
-    },
-    "MyApiWithAwsIamAuthDeploymentce96ce9f89": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: ce96ce9f89cd76c41cf8194b117ee9ae6a81e240",
-        "StageName": "Stage"
       }
     },
     "MyFunctionWithAwsIamAuthRole": {
@@ -180,6 +170,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithAwsIamAuthDeployment2410bdfe90": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        },
+        "Description": "RestApi deployment id: 2410bdfe9098f493a02741eff554a88392c05394",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_gateway_responses.json
+++ b/tests/translator/output/aws-us-gov/api_with_gateway_responses.json
@@ -23,16 +23,6 @@
         ]
       }
     },
-    "ExplicitApiDeployment929d2126a7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 929d2126a7a3b228757ccb4aa5e896c1bd5c76e8",
-        "StageName": "Stage"
-      }
-    },
     "FunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -114,7 +104,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment929d2126a7"
+          "Ref": "ExplicitApiDeployment4a15f1add4"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -141,6 +131,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment4a15f1add4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 4a15f1add42b24f6d7f36cb2a8a9308b2b1bcb01",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_gateway_responses_all.json
+++ b/tests/translator/output/aws-us-gov/api_with_gateway_responses_all.json
@@ -23,16 +23,6 @@
         ]
       }
     },
-    "ExplicitApiDeployment42329c77b0": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 42329c77b0faabe3a86487f92af32b9afe0a0fa1",
-        "StageName": "Stage"
-      }
-    },
     "FunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -123,7 +113,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment42329c77b0"
+          "Ref": "ExplicitApiDeployment4531c2496c"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -150,6 +140,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment4531c2496c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 4531c2496ca3df29d266563475c1a96be1eef8a6",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_gateway_responses_all_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_with_gateway_responses_all_openapi_3.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "Function": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "FunctionRole", 
+            "FunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "FunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,86 +52,86 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.0", 
+          },
+          "openapi": "3.0",
           "x-amazon-apigateway-gateway-responses": {
             "QUOTA_EXCEEDED": {
               "responseParameters": {
                 "gatewayresponse.header.Retry-After": "'31536000'"
-              }, 
-              "responseTemplates": {}, 
+              },
+              "responseTemplates": {},
               "statusCode": "429"
-            }, 
+            },
             "UNAUTHORIZED": {
               "responseParameters": {
-                "gatewayresponse.header.WWW-Authenticate": "'Bearer realm=\"admin\"'", 
-                "gatewayresponse.header.Access-Control-Expose-Headers": "'WWW-Authenticate'", 
-                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'", 
-                "gatewayresponse.path.PathKey": "'path-value'", 
+                "gatewayresponse.header.WWW-Authenticate": "'Bearer realm=\"admin\"'",
+                "gatewayresponse.header.Access-Control-Expose-Headers": "'WWW-Authenticate'",
+                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+                "gatewayresponse.path.PathKey": "'path-value'",
                 "gatewayresponse.querystring.QueryStringKey": "'query-string-value'"
-              }, 
-              "responseTemplates": {}, 
+              },
+              "responseTemplates": {},
               "statusCode": "401"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment0f8408588e"
-        }, 
+          "Ref": "ExplicitApiDeploymentfed5c13a39"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "FunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "Function"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -141,14 +141,14 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment0f8408588e": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ExplicitApiDeploymentfed5c13a39": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 0f8408588e16013e6d4fa0f1fd2390d0a7ec15ed"
+        },
+        "Description": "RestApi deployment id: fed5c13a399f167b437f6804979eecadccef3058"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_gateway_responses_implicit.json
+++ b/tests/translator/output/aws-us-gov/api_with_gateway_responses_implicit.json
@@ -57,22 +57,12 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment929d2126a7"
+          "Ref": "ServerlessRestApiDeployment4a15f1add4"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
         "StageName": "Prod"
-      }
-    },
-    "ServerlessRestApiDeployment929d2126a7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 929d2126a7a3b228757ccb4aa5e896c1bd5c76e8",
-        "StageName": "Stage"
       }
     },
     "FunctionGetHtmlPermissionProd": {
@@ -142,6 +132,16 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment4a15f1add4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 4a15f1add42b24f6d7f36cb2a8a9308b2b1bcb01",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_gateway_responses_minimal.json
+++ b/tests/translator/output/aws-us-gov/api_with_gateway_responses_minimal.json
@@ -95,21 +95,11 @@
         }
       }
     },
-    "ExplicitApiDeployment40cf320ad7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 40cf320ad73ddd78e84f215f113837bc07a54769",
-        "StageName": "Stage"
-      }
-    },
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment40cf320ad7"
+          "Ref": "ExplicitApiDeploymentc5ddc40fbe"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -136,6 +126,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymentc5ddc40fbe": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: c5ddc40fbe3a04411665f73513d0c37f310f9354",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_gateway_responses_string_status_code.json
+++ b/tests/translator/output/aws-us-gov/api_with_gateway_responses_string_status_code.json
@@ -23,16 +23,6 @@
         ]
       }
     },
-    "ExplicitApiDeployment929d2126a7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 929d2126a7a3b228757ccb4aa5e896c1bd5c76e8",
-        "StageName": "Stage"
-      }
-    },
     "FunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -114,7 +104,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment929d2126a7"
+          "Ref": "ExplicitApiDeployment4a15f1add4"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -141,6 +131,16 @@
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeployment4a15f1add4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 4a15f1add42b24f6d7f36cb2a8a9308b2b1bcb01",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_if_conditional_with_resource_policy.json
+++ b/tests/translator/output/aws-us-gov/api_with_if_conditional_with_resource_policy.json
@@ -2,48 +2,48 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Resources": {
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionPutHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -51,119 +51,109 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeploymente252ad8b51": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: e252ad8b5121d1fcb94bf7ef489dbbd46a3dd461", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/one": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/three": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/two": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
-                  "Action": "execute-api:Invoke", 
+                  "Action": "execute-api:Invoke",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymente252ad8b51"
-        }, 
+          "Ref": "ExplicitApiDeploymentdbd7e0cd6a"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -171,18 +161,18 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -190,37 +180,47 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymentdbd7e0cd6a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: dbd7e0cd6a247b8d762877c6a2798077c0fb4cde",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_incompatible_stage_name.json
+++ b/tests/translator/output/aws-us-gov/api_with_incompatible_stage_name.json
@@ -1,43 +1,43 @@
 {
   "Resources": {
     "UnderscoreApiStageb34d3ad84e": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "UnderscoreApiDeployment94459366c6"
-        }, 
+          "Ref": "UnderscoreApiDeployment2317792e01"
+        },
         "RestApiId": {
           "Ref": "UnderscoreApi"
-        }, 
+        },
         "StageName": "hoge_fuga"
       }
-    }, 
+    },
     "UnderscoreApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UnderscoreFunction.Arn}/invocations"
                   }
-                }, 
-                "responses": {}, 
+                },
+                "responses": {},
                 "parameters": [
                   {
-                    "required": true, 
-                    "in": "body", 
-                    "name": "user", 
+                    "required": true,
+                    "in": "body",
+                    "name": "user",
                     "schema": {
                       "$ref": "#/definitions/user"
                     }
@@ -45,11 +45,11 @@
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "definitions": {
             "user": {
-              "type": "object", 
+              "type": "object",
               "properties": {
                 "username": {
                   "type": "string"
@@ -57,19 +57,19 @@
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "UnderscoreFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -81,13 +81,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -99,16 +99,16 @@
       }
     },
     "HyphenFunctionGetHtmlPermission0c8ecc62cb": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "HyphenFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "HyphenApi"
@@ -116,53 +116,53 @@
           ]
         }
       }
-    }, 
+    },
     "HyphenApiStage0c8ecc62cb": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HyphenApiDeploymente60ebb9f56"
-        }, 
+          "Ref": "HyphenApiDeployment3dd12b0e6c"
+        },
         "RestApiId": {
           "Ref": "HyphenApi"
-        }, 
+        },
         "StageName": "hoge-fuga"
       }
-    }, 
+    },
     "UnderscoreFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "UnderscoreFunctionRole", 
+            "UnderscoreFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "UnderscoreFunctionGetHtmlPermissionb34d3ad84e": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "UnderscoreFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": "UnderscoreApi"
@@ -172,74 +172,54 @@
       }
     },
     "HyphenFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "HyphenFunctionRole", 
+            "HyphenFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "HyphenApiDeploymente60ebb9f56": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HyphenApi"
-        }, 
-        "Description": "RestApi deployment id: e60ebb9f56220ac12550230674d09ed8085afc74", 
-        "StageName": "Stage"
-      }
-    }, 
-    "UnderscoreApiDeployment94459366c6": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "UnderscoreApi"
-        }, 
-        "Description": "RestApi deployment id: 94459366c6f9a344235ddf7db2a7cd5115d60da4", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "HyphenApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HyphenFunction.Arn}/invocations"
                   }
-                }, 
-                "responses": {}, 
+                },
+                "responses": {},
                 "parameters": [
                   {
-                    "required": true, 
-                    "in": "body", 
-                    "name": "user", 
+                    "required": true,
+                    "in": "body",
+                    "name": "user",
                     "schema": {
                       "$ref": "#/definitions/user"
                     }
@@ -247,11 +227,11 @@
                 ]
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "definitions": {
             "user": {
-              "type": "object", 
+              "type": "object",
               "properties": {
                 "username": {
                   "type": "string"
@@ -259,19 +239,19 @@
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "HyphenFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -283,13 +263,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -298,6 +278,26 @@
             }
           ]
         }
+      }
+    },
+    "HyphenApiDeployment3dd12b0e6c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        },
+        "Description": "RestApi deployment id: 3dd12b0e6ce0b2684fdbf21b217a544f762ec188",
+        "StageName": "Stage"
+      }
+    },
+    "UnderscoreApiDeployment2317792e01": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        },
+        "Description": "RestApi deployment id: 2317792e015ccabec2fb4604e8779b5163bf38c2",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_ip_range_blacklist.json
+++ b/tests/translator/output/aws-us-gov/api_with_ip_range_blacklist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment7a90608509"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentc954a5b404"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment7a90608509": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 7a906085093a57bc5b444a0158449c6725a507cc", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,123 +63,133 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "AWS": [
                     "12345"
                   ]
                 }
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "IpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeploymentc954a5b404": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: c954a5b40427caa12062ceb58cde2191a637a82f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_ip_range_whitelist.json
+++ b/tests/translator/output/aws-us-gov/api_with_ip_range_whitelist.json
@@ -1,51 +1,41 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment05e180d91b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 05e180d91bfb84481403ba5b028afe1db84437dc", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment05e180d91b"
-        }, 
+          "Ref": "ServerlessRestApiDeployment71daf74541"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -57,13 +47,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -73,126 +63,136 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "NotIpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "IpAddress": {
                     "aws:SourceIp": [
                       "1.2.3.4"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment71daf74541": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 71daf745411f8159ecfe95153b7d88191242ff3b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_method_aws_iam_auth.json
+++ b/tests/translator/output/aws-us-gov/api_with_method_aws_iam_auth.json
@@ -147,21 +147,11 @@
         ]
       }
     },
-    "MyApiWithoutAuthDeploymentd7b0de15e2": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        },
-        "Description": "RestApi deployment id: d7b0de15e29c2d947cc5a2004fd545fec3260faf",
-        "StageName": "Stage"
-      }
-    },
     "MyApiWithoutAuthProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeploymentd7b0de15e2"
+          "Ref": "MyApiWithoutAuthDeployment36b5195d85"
         },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
@@ -218,6 +208,16 @@
             }
           ]
         }
+      }
+    },
+    "MyApiWithoutAuthDeployment36b5195d85": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        },
+        "Description": "RestApi deployment id: 36b5195d8508bb21595257c2f601a109e4c95490",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_method_settings.json
+++ b/tests/translator/output/aws-us-gov/api_with_method_settings.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,120 +73,120 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "MethodSettings": [
           {
-            "HttpMethod": "*", 
-            "MetricsEnabled": true, 
-            "ResourcePath": "/*", 
-            "DataTraceEnabled": true, 
+            "HttpMethod": "*",
+            "MetricsEnabled": true,
+            "ResourcePath": "/*",
+            "DataTraceEnabled": true,
             "LoggingLevel": "INFO"
           }
-        ], 
+        ],
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment5b2cb4ba8f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 5b2cb4ba8fce8a9445b1914c6c6fbeef81a9075a", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "MethodSettings": [
           {
-            "HttpMethod": "*", 
-            "MetricsEnabled": true, 
-            "ResourcePath": "/*", 
-            "DataTraceEnabled": true, 
+            "HttpMethod": "*",
+            "MetricsEnabled": true,
+            "ResourcePath": "/*",
+            "DataTraceEnabled": true,
             "LoggingLevel": "INFO"
           }
-        ], 
+        ],
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5b2cb4ba8f"
-        }, 
+          "Ref": "ServerlessRestApiDeployment48b9be5f17"
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment48b9be5f17": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 48b9be5f1703467615aff7539d0d6987624f84c5",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_minimum_compression_size.json
+++ b/tests/translator/output/aws-us-gov/api_with_minimum_compression_size.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,104 +73,104 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
-        "MinimumCompressionSize": 256, 
+        "MinimumCompressionSize": 256,
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+          "Ref": "ExplicitApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment5b2cb4ba8f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 5b2cb4ba8fce8a9445b1914c6c6fbeef81a9075a", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5b2cb4ba8f"
-        }, 
+          "Ref": "ServerlessRestApiDeployment48b9be5f17"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
-        "MinimumCompressionSize": 1024, 
+        },
+        "MinimumCompressionSize": 1024,
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment48b9be5f17": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 48b9be5f1703467615aff7539d0d6987624f84c5",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_open_api_version.json
+++ b/tests/translator/output/aws-us-gov/api_with_open_api_version.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,92 +73,74 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDeploymentd9a0f2ae4f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: d9a0f2ae4fe2d97b9b91644934a878b6a08cf1c3"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymenta4ffcdf019"
-        }, 
+          "Ref": "ServerlessRestApiDeployment58dd6f208f"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymenta4ffcdf019": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: a4ffcdf0196ece94bc157dc06c21dfa3c2df13a1"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "*", 
+                        "method.response.header.Access-Control-Allow-Origin": "*",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
                 },
-                "summary": "CORS support", 
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
@@ -166,51 +148,69 @@
                         "schema": {
                           "type": "string"
                         }
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "schema": {
                           "type": "string"
                         }
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
                 }
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "openapi": "3.0.1"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentd9a0f2ae4f"
-        }, 
+          "Ref": "ExplicitApiDeployment8a3d83687a"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
+      }
+    },
+    "ExplicitApiDeployment8a3d83687a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 8a3d83687a607eaebbbf1d8749f2949151334aff"
+      }
+    },
+    "ServerlessRestApiDeployment58dd6f208f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 58dd6f208f7e4ef66e3658d67dc8c96a2ca15aa4"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_open_api_version_2.json
+++ b/tests/translator/output/aws-us-gov/api_with_open_api_version_2.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,16 +54,16 @@
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,146 +73,146 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment4154e1c30c"
-        }, 
+          "Ref": "ExplicitApiDeployment13722dd579"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment2ce765616b"
-        }, 
+          "Ref": "ServerlessRestApiDeployment76e14b2fe4"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ExplicitApiDeployment4154e1c30c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 4154e1c30c97469d4946280461125dbfd4324f15"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "options": {
                 "x-amazon-apigateway-integration": {
-                  "type": "mock", 
+                  "type": "mock",
                   "requestTemplates": {
                     "application/json": "{\n  \"statusCode\" : 200\n}\n"
-                  }, 
+                  },
                   "responses": {
                     "default": {
-                      "statusCode": "200", 
+                      "statusCode": "200",
                       "responseTemplates": {
                         "application/json": "{}\n"
-                      }, 
+                      },
                       "responseParameters": {
-                        "method.response.header.Access-Control-Allow-Origin": "*", 
+                        "method.response.header.Access-Control-Allow-Origin": "*",
                         "method.response.header.Access-Control-Allow-Methods": "'GET,OPTIONS'"
                       }
                     }
                   }
-                }, 
+                },
                 "consumes": [
                   "application/json"
-                ], 
-                "summary": "CORS support", 
+                ],
+                "summary": "CORS support",
                 "responses": {
                   "200": {
                     "headers": {
                       "Access-Control-Allow-Origin": {
                         "type": "string"
-                      }, 
+                      },
                       "Access-Control-Allow-Methods": {
                         "type": "string"
                       }
-                    }, 
+                    },
                     "description": "Default response for CORS method"
                   }
-                }, 
+                },
                 "produces": [
                   "application/json"
                 ]
-              }, 
+              },
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ServerlessRestApiDeployment2ce765616b": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ExplicitApiDeployment13722dd579": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 13722dd579bfec46ba399f3966036bbbe18db618"
+      }
+    },
+    "ServerlessRestApiDeployment76e14b2fe4": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 2ce765616b7cfaba8ae0ad0877bd94cfbe0bc0fb"
+        },
+        "Description": "RestApi deployment id: 76e14b2fe411ea1459c71faa0ef42c717f3f5d6d"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/aws-us-gov/api_with_openapi_definition_body_no_flag.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -52,125 +52,115 @@
           ]
         }
       }
-    }, 
-    "ExplicitApiDeployment9252467a1e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1", 
-        "StageName": "Stage"
-      }
     },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.1.1", 
+          },
+          "openapi": "3.1.1",
           "components": {
             "securitySchemes": {
               "MyCognitoAuth": {
-                "in": "header", 
-                "type": "apiKey", 
-                "name": "Authorization", 
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
                 "x-amazon-apigateway-authorizer": {
                   "providerARNs": [
                     {
                       "Fn::GetAtt": [
-                        "MyUserPool", 
+                        "MyUserPool",
                         "Arn"
                       ]
                     }
-                  ], 
+                  ],
                   "type": "cognito_user_pools"
-                }, 
+                },
                 "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc969c99f9d"
+          "Ref": "ServerlessRestApiDeployment1c1409477a"
         }
       }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeployment542a922713"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -180,97 +170,107 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeploymentc969c99f9d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: c969c99f9d6b6921dff605a206e8989bdb7d1bc7", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment542a922713": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 542a922713e9c340e3e1940eeb139b17dfcd75cc",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment1c1409477a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 1c1409477a0000846b81d69bf0da3f53a6043783",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_path_parameters.json
+++ b/tests/translator/output/aws-us-gov/api_with_path_parameters.json
@@ -34,7 +34,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
+          "Ref": "HtmlApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -59,16 +59,6 @@
             }
           ]
         }
-      }
-    },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "HtmlApi": {
@@ -109,6 +99,16 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_resource_policy.json
+++ b/tests/translator/output/aws-us-gov/api_with_resource_policy.json
@@ -1,41 +1,41 @@
 {
   "Resources": {
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionPutHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/three",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -43,101 +43,101 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/one": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/three": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/two": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
-              "Action": "execute-api:Invoke", 
+              "Action": "execute-api:Invoke",
               "Resource": [
                 "execute-api:/*/*/*"
               ]
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymentb5a112ecdf"
-        }, 
+          "Ref": "ExplicitApiDeploymentaab730ba81"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ExplicitApiFunctionPostHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/two",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -145,18 +145,18 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -164,47 +164,47 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ExplicitApiDeploymentb5a112ecdf": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: b5a112ecdfe9f71fbad3f114ad9aeddc73ce44e5", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/one",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
             }
           ]
         }
+      }
+    },
+    "ExplicitApiDeploymentaab730ba81": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: aab730ba81c25ad94fa4c24bcf37191769396389",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_resource_policy_global.json
+++ b/tests/translator/output/aws-us-gov/api_with_resource_policy_global.json
@@ -2,43 +2,43 @@
   "Conditions": {
     "C1": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "StageName": {
-      "Default": "MyOwnStage", 
+      "Default": "MyOwnStage",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "AnotherApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
-          "swagger": "2.0", 
+          },
+          "paths": {},
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": {
               "Fn::If": [
-                "C1", 
+                "C1",
                 {
-                  "Action": "execute-api:Invoke", 
+                  "Action": "execute-api:Invoke",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
-                }, 
+                },
                 {
-                  "Action": "execute-api:Another", 
+                  "Action": "execute-api:Another",
                   "Resource": [
                     "execute-api:/*/*/*"
                   ]
@@ -46,54 +46,44 @@
               ]
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDeploymenta5a5c4e3ff": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: a5a5c4e3ff6901cf27436628359ed20300d34aa4", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeploymenta5a5c4e3ff"
-        }, 
+          "Ref": "ExplicitApiDeployment4c5e269029"
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": {
           "Ref": "StageName"
         }
       }
-    }, 
+    },
     "ExplicitApiFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ExplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ExplicitApi"
               }
@@ -101,51 +91,41 @@
           ]
         }
       }
-    }, 
-    "AnotherApiDeploymentfdf1387e0a": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "AnotherApi"
-        }, 
-        "Description": "RestApi deployment id: fdf1387e0a89fa15996401a79284cdaaf2c43844", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ExplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ExplicitApiFunctionRole", 
+            "ExplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "nodejs12.x", 
+        },
+        "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ExplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -153,78 +133,78 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "AnotherApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "AnotherApiDeploymentfdf1387e0a"
-        }, 
+          "Ref": "AnotherApiDeployment0564df8d4a"
+        },
         "RestApiId": {
           "Ref": "AnotherApi"
-        }, 
+        },
         "StageName": {
           "Ref": "StageName"
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ExplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": 2.0, 
+          },
+          "swagger": 2.0,
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "sts:AssumeRole", 
-                "Effect": "Allow", 
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
                 "Principal": {
                   "Service": "lambda.amazonaws.com"
                 }
-              }, 
+              },
               {
                 "Fn::If": [
-                  "C1", 
+                  "C1",
                   {
-                    "Action": "execute-api:Invoke", 
+                    "Action": "execute-api:Invoke",
                     "Resource": [
                       "execute-api:/*/*/*"
                     ]
-                  }, 
+                  },
                   {
-                    "Action": "execute-api:Blah", 
+                    "Action": "execute-api:Blah",
                     "Resource": [
                       "execute-api:/*/*/*"
                     ]
@@ -233,15 +213,35 @@
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeployment4c5e269029": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 4c5e269029fe10081e5a9d82b311bd327d8fce6e",
+        "StageName": "Stage"
+      }
+    },
+    "AnotherApiDeployment0564df8d4a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "AnotherApi"
+        },
+        "Description": "RestApi deployment id: 0564df8d4a281d58de69686b00180ebd1207a60d",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_resource_policy_global_implicit.json
+++ b/tests/translator/output/aws-us-gov/api_with_resource_policy_global_implicit.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "MinimalFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MinimalFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -20,9 +20,9 @@
           ]
         }
       }
-    }, 
+    },
     "MinimalFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -34,13 +34,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -50,102 +50,102 @@
           ]
         }
       }
-    }, 
+    },
     "MinimalFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MinimalFunctionRole", 
+            "MinimalFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment9558094c1e"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentdc83b1ed7d"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MinimalFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   "execute-api:/*/*/*"
                 ]
-              }, 
+              },
               {
-                "Action": "execute-api:blah", 
+                "Action": "execute-api:blah",
                 "Resource": [
                   "execute-api:/*/*/*"
                 ]
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ServerlessRestApiDeployment9558094c1e": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ServerlessRestApiDeploymentdc83b1ed7d": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 9558094c1ecacce5e02be40fdb03356118d9ccac", 
+        },
+        "Description": "RestApi deployment id: dc83b1ed7d3c351b5c70f65737e1db973c690721",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-us-gov/api_with_resource_refs.json
+++ b/tests/translator/output/aws-us-gov/api_with_resource_refs.json
@@ -2,94 +2,84 @@
   "Outputs": {
     "ImplicitApiDeployment": {
       "Value": {
-        "Ref": "ServerlessRestApiDeployment2657ea030d"
+        "Ref": "ServerlessRestApiDeploymenta8be8971c1"
       }
-    }, 
+    },
     "ExplicitApiDeployment": {
       "Value": {
-        "Ref": "MyApiDeployment359f256a3b"
+        "Ref": "MyApiDeployment8ded5fd20d"
       }
-    }, 
+    },
     "ExplicitApiStage": {
       "Value": {
         "Ref": "MyApifooStage"
       }
-    }, 
+    },
     "ImplicitApiStage": {
       "Value": {
         "Ref": "ServerlessRestApiProdStage"
       }
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "MyApiDeployment359f256a3b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 359f256a3b3ff2e1102e335a4d603f02df9b4988", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyApifooStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment359f256a3b"
-        }, 
+          "Ref": "MyApiDeployment8ded5fd20d"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "foo"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment2657ea030d"
-        }, 
+          "Ref": "ServerlessRestApiDeploymenta8be8971c1"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/html", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/html",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -99,19 +89,9 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeployment2657ea030d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 2657ea030d72028e06bfb9d0bd82ced7c574f4b5", 
-        "StageName": "Stage"
-      }
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -123,13 +103,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -139,58 +119,78 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/html": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "swagger"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiDeployment8ded5fd20d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 8ded5fd20d1fa9ee4e4db2c8a8cb513497b18adb",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymenta8be8971c1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: a8be8971c1d031972fd1b7aac2f86bfc2bdae3a1",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_source_vpc_blacklist.json
+++ b/tests/translator/output/aws-us-gov/api_with_source_vpc_blacklist.json
@@ -1,60 +1,50 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment8123e1b4d0": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 8123e1b4d0dbc08e51be7b4c910cacad26d29673", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment8123e1b4d0"
-        }, 
+          "Ref": "ServerlessRestApiDeployment9607e4d7c2"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -62,115 +52,125 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringEquals": {
                     "aws:SourceVpce": [
                       "vpce-3456"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment9607e4d7c2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 9607e4d7c26b7346b987e41d00a85da8091baa48",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_source_vpc_whitelist.json
+++ b/tests/translator/output/aws-us-gov/api_with_source_vpc_whitelist.json
@@ -1,46 +1,46 @@
 {
   "Parameters": {
     "Vpc1": {
-      "Default": "vpc-1234", 
+      "Default": "vpc-1234",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
           "ZipFile": "exports.handler = async (event) => {\n  const response = {\n    statusCode: 200,\n    body: JSON.stringify('Hello from Lambda!'),\n  };\n  return response;\n};\n"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionFetchPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/fetch",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -48,64 +48,44 @@
           ]
         }
       }
-    }, 
+    },
     "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment5332c373d4"
-        }, 
+          "Ref": "MyApiDeployment5e697a4b30"
+        },
         "RestApiId": {
           "Ref": "MyApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "MyApiDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ServerlessRestApiDeploymente6268e43cf": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: e6268e43cf1f64034297b37a261d5d5a0cc7375b", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente6268e43cf"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentaf9ed0302d"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "MyFunctionApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/get",
             {
-              "__Stage__": "*", 
+              "__Stage__": "*",
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
               }
@@ -113,18 +93,18 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -132,168 +112,188 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/get": {
               "put": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/fetch": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "x-amazon-apigateway-policy": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/PUT/get", 
+                      "execute-api:/${__Stage__}/PUT/get",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringNotEquals": {
                     "aws:SourceVpc": [
-                      "vpc-1234", 
+                      "vpc-1234",
                       "vpc-5678"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/POST/fetch", 
+                      "execute-api:/${__Stage__}/POST/fetch",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": "*"
-              }, 
+              },
               {
-                "Action": "execute-api:Invoke", 
+                "Action": "execute-api:Invoke",
                 "Resource": [
                   {
                     "Fn::Sub": [
-                      "execute-api:/${__Stage__}/POST/fetch", 
+                      "execute-api:/${__Stage__}/POST/fetch",
                       {
                         "__Stage__": "Prod"
                       }
                     ]
                   }
-                ], 
-                "Effect": "Deny", 
+                ],
+                "Effect": "Deny",
                 "Condition": {
                   "StringNotEquals": {
                     "aws:SourceVpc": [
-                      "vpc-1234", 
+                      "vpc-1234",
                       "vpc-5678"
                     ]
                   }
-                }, 
+                },
                 "Principal": "*"
               }
             ]
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyApiDeployment5e697a4b30": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 5e697a4b309f0f6b0fef455883aec23936861ff1",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentaf9ed0302d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: af9ed0302d65c9f7143caa975985eed1381768c3",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_stage_tags.json
+++ b/tests/translator/output/aws-us-gov/api_with_stage_tags.json
@@ -1,74 +1,74 @@
 {
   "Parameters": {
     "TagValueParam": {
-      "Default": "value", 
+      "Default": "value",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
-    "MyApiWithStageTagsDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithStageTags"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7", 
-        "StageName": "Stage"
-      }
-    }, 
     "MyApiWithStageTags": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "paths": {}, 
+          },
+          "paths": {},
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "MyApiWithStageTagsProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithStageTagsDeployment5332c373d4"
-        }, 
+          "Ref": "MyApiWithStageTagsDeployment5e697a4b30"
+        },
         "RestApiId": {
           "Ref": "MyApiWithStageTags"
-        }, 
-        "StageName": "Prod", 
+        },
+        "StageName": "Prod",
         "Tags": [
           {
-            "Value": "TagValue1", 
+            "Value": "TagValue1",
             "Key": "TagKey1"
-          }, 
+          },
           {
-            "Value": "", 
+            "Value": "",
             "Key": "TagKey2"
-          }, 
+          },
           {
             "Value": {
               "Ref": "TagValueParam"
-            }, 
+            },
             "Key": "TagKey3"
-          }, 
+          },
           {
-            "Value": "123", 
+            "Value": "123",
             "Key": "TagKey4"
           }
         ]
+      }
+    },
+    "MyApiWithStageTagsDeployment5e697a4b30": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithStageTags"
+        },
+        "Description": "RestApi deployment id: 5e697a4b309f0f6b0fef455883aec23936861ff1",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_swagger_and_openapi_with_auth.json
+++ b/tests/translator/output/aws-us-gov/api_with_swagger_and_openapi_with_auth.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,112 +54,112 @@
       }
     },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "openapi": "3.1.1", 
-          "swagger": 2.0, 
+          },
+          "openapi": "3.1.1",
+          "swagger": 2.0,
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc969c99f9d"
+          "Ref": "ServerlessRestApiDeployment1c1409477a"
         }
       }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment7c4f7dda23"
+          "Ref": "ExplicitApiDeploymentd91576e21e"
         }
       }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -169,106 +169,106 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeploymentc969c99f9d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: c969c99f9d6b6921dff605a206e8989bdb7d1bc7", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ExplicitApiDeployment7c4f7dda23": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ServerlessRestApiDeployment1c1409477a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 1c1409477a0000846b81d69bf0da3f53a6043783",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeploymentd91576e21e": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 7c4f7dda23acd71e4a653861510d82ad7809e562", 
+        },
+        "Description": "RestApi deployment id: d91576e21ef46309219ef12cb8601f13cc905189",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-us-gov/api_with_usageplans.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans.json
@@ -72,7 +72,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentd197b03bdf"
+          "Ref": "ServerlessRestApiDeployment572026881f"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -470,26 +470,6 @@
         "MyApiTwo"
       ]
     },
-    "ServerlessRestApiDeploymentd197b03bdf": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: d197b03bdfab8dddfb221e8c7f1becff9a9b1d9d",
-        "StageName": "Stage"
-      }
-    },
-    "MyApiTwoDeployment0e45b81469": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiTwo"
-        },
-        "Description": "RestApi deployment id: 0e45b814691166a59217a088512ee30710a12369",
-        "StageName": "Stage"
-      }
-    },
     "MyFunctionTwoImplicitApiEventPermissionProd": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
@@ -515,7 +495,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment0e45b81469"
+          "Ref": "MyApiTwoDeploymentc6f38eb4e4"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -527,7 +507,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeploymentdccbc5fda1"
+          "Ref": "MyApiOneDeploymentb3f5ccafe2"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -535,21 +515,11 @@
         "StageName": "Prod"
       }
     },
-    "MyApiThreeDeployment5206882d23": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiThree"
-        },
-        "Description": "RestApi deployment id: 5206882d23d2cf7913f0fffea98644f959b433f2",
-        "StageName": "Stage"
-      }
-    },
     "MyApiThreeProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiThreeDeployment5206882d23"
+          "Ref": "MyApiThreeDeployment691d5be7a5"
         },
         "RestApiId": {
           "Ref": "MyApiThree"
@@ -620,16 +590,6 @@
         }
       }
     },
-    "MyApiOneDeploymentdccbc5fda1": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiOne"
-        },
-        "Description": "RestApi deployment id: dccbc5fda163e1abe712073ffacdcc47776a5a09",
-        "StageName": "Stage"
-      }
-    },
     "ServerlessRestApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -698,6 +658,46 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ServerlessRestApiDeployment572026881f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 572026881fc42748ea3ba531d30f8acfbd4e9166",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoDeploymentc6f38eb4e4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "Description": "RestApi deployment id: c6f38eb4e4a64670138f571e2948143d359f2436",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiThreeDeployment691d5be7a5": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "Description": "RestApi deployment id: 691d5be7a5af608e16abb5460c07b09e44d2fbe3",
+        "StageName": "Stage"
+      }
+    },
+    "MyApiOneDeploymentb3f5ccafe2": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "Description": "RestApi deployment id: b3f5ccafe20f2d72d954c4c2d275305f3ce2882c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_usageplans_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans_intrinsics.json
@@ -43,15 +43,6 @@
         "MyApiTwoApiKey"
       ]
     },
-    "MyApiTwoDeployment802c3b471d": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiTwo"
-        },
-        "Description": "RestApi deployment id: 802c3b471de66f79d6d2cac656e6c9319fa0ba51"
-      }
-    },
     "MyApiOneUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
       "Properties": {
@@ -69,16 +60,6 @@
       "DependsOn": [
         "MyApiOne"
       ]
-    },
-    "MyApiOneDeployment8b73115419": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiOne"
-        },
-        "Description": "RestApi deployment id: 8b731154198483502cc4b2bff739c404e88bfe41"
-      },
-      "Condition": "C1"
     },
     "MyApiTwoUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
@@ -102,7 +83,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment802c3b471d"
+          "Ref": "MyApiTwoDeployment7bf63abfd5"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -114,7 +95,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeployment8b73115419"
+          "Ref": "MyApiOneDeploymentb5ca569a5d"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -422,6 +403,25 @@
           }
         ]
       }
+    },
+    "MyApiTwoDeployment7bf63abfd5": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "Description": "RestApi deployment id: 7bf63abfd57b28c5c571dbb5b861077d36bae7f4"
+      }
+    },
+    "MyApiOneDeploymentb5ca569a5d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "Description": "RestApi deployment id: b5ca569a5d7fdd43b261bbd3c840c606e16590eb"
+      },
+      "Condition": "C1"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/api_with_xray_tracing.json
+++ b/tests/translator/output/aws-us-gov/api_with_xray_tracing.json
@@ -34,7 +34,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf117c932f7"
+          "Ref": "HtmlApiDeployment53cc66445c"
         },
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -60,16 +60,6 @@
             }
           ]
         }
-      }
-    },
-    "HtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        },
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
-        "StageName": "Stage"
       }
     },
     "HtmlApi": {
@@ -110,6 +100,16 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "HtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/depends_on.json
+++ b/tests/translator/output/aws-us-gov/depends_on.json
@@ -27,16 +27,6 @@
         "MySamTable"
       ]
     },
-    "MyExplicitApiDeployment74b681ce04": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyExplicitApi"
-        },
-        "Description": "RestApi deployment id: 74b681ce04601a2cf69b6d05d53782b216cf96bb",
-        "StageName": "Stage"
-      }
-    },
     "MyExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -84,7 +74,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment74b681ce04"
+          "Ref": "MyExplicitApiDeployment98d1d7451d"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"
@@ -157,6 +147,16 @@
             }
           ]
         }
+      }
+    },
+    "MyExplicitApiDeployment98d1d7451d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyExplicitApi"
+        },
+        "Description": "RestApi deployment id: 98d1d7451d36eeb109d8152b3c842314ceec54e5",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/explicit_api.json
+++ b/tests/translator/output/aws-us-gov/explicit_api.json
@@ -1,67 +1,57 @@
 {
   "Parameters": {
     "something": {
-      "Default": "something", 
+      "Default": "something",
       "Type": "String"
-    }, 
+    },
     "MyStageName": {
-      "Default": "Production", 
+      "Default": "Production",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "webpage.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiWithInlineSwaggerStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment09cda3d97b"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeploymentd6e4241aec"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
     },
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -70,15 +60,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -88,35 +77,35 @@
           ]
         }
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "inline swagger"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -126,52 +115,62 @@
           ]
         }
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
-        }, 
+        },
         "Name": "MyGetApi"
       }
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "EndpointUri": {
             "Ref": "something"
-          }, 
+          },
           "EndpointUri2": "http://example.com"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
-    }, 
-    "ApiWithInlineSwaggerDeployment09cda3d97b": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithInlineSwaggerDeploymentd6e4241aec": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 09cda3d97b008bed7bd4ebb1b5304ed622492941", 
+        },
+        "Description": "RestApi deployment id: d6e4241aecafd12a5d34fa32f427f71867e30751",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/aws-us-gov/explicit_api_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/explicit_api_openapi_3.json
@@ -1,76 +1,57 @@
 {
   "Parameters": {
     "something": {
-      "Default": "something", 
+      "Default": "something",
       "Type": "String"
-    }, 
+    },
     "MyStageName": {
-      "Default": "Production", 
+      "Default": "Production",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "webpage.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiWithInlineSwaggerStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment74abcb3a5b"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeploymenteaabc1f332"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
     },
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ApiWithInlineSwaggerDeployment74abcb3a5b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 74abcb3a5bbe7ad58dfc543740af3be156736130"
-      }
-    }, 
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -79,15 +60,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -97,35 +77,35 @@
           ]
         }
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "inline swagger"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -135,43 +115,62 @@
           ]
         }
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
-        }, 
+        },
         "Name": "MyGetApi"
       }
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "EndpointUri": {
             "Ref": "something"
-          }, 
+          },
           "EndpointUri2": "http://example.com"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
+      }
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithInlineSwaggerDeploymenteaabc1f332": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        },
+        "Description": "RestApi deployment id: eaabc1f3328d9cc3200d9b5c1f0afa15cd7a3343"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/explicit_api_with_invalid_events_config.json
+++ b/tests/translator/output/aws-us-gov/explicit_api_with_invalid_events_config.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.restapi", 
+        },
+        "Handler": "index.restapi",
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionAddApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": "ApiWithInlineSwagger"
@@ -43,65 +43,55 @@
       }
     },
     "ApiWithInlineSwaggerProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment22d399868d"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeployment039e5eb1f1"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
-    "ApiWithInlineSwaggerDeployment22d399868d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 22d399868d5755a0d5204deae1ee870cf95a7737", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -113,13 +103,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -128,6 +118,16 @@
             }
           ]
         }
+      }
+    },
+    "ApiWithInlineSwaggerDeployment039e5eb1f1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        },
+        "Description": "RestApi deployment id: 039e5eb1f1de15b72c5917efd628d0b7a75c5fa5",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_event_sources.json
@@ -1,72 +1,62 @@
 {
   "Parameters": {
     "MyStageName": {
-      "Default": "beta", 
+      "Default": "beta",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyAwesomeFunctionAliasLive": {
-      "Type": "AWS::Lambda::Alias", 
+      "Type": "AWS::Lambda::Alias",
       "Properties": {
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionVersion640128d35d", 
+            "MyAwesomeFunctionVersion640128d35d",
             "Version"
           ]
-        }, 
+        },
         "FunctionName": {
           "Ref": "MyAwesomeFunction"
-        }, 
+        },
         "Name": "Live"
       }
-    }, 
+    },
     "MyAwesomeFunctionNotificationTopicPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "sns.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "sns.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Ref": "Notifications"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentd696835fbb"
-        }, 
+          "Ref": "ServerlessRestApiDeploymentd9a95c600f"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyAwesomeFunctionCWEventPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "events.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionCWEvent", 
+            "MyAwesomeFunctionCWEvent",
             "Arn"
           ]
         }
@@ -89,21 +79,21 @@
       }
     },
     "MyAwesomeFunctionDDBStream": {
-      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
-        "BatchSize": 200, 
-        "EventSourceArn": "arn:aws:dynamodb:us-west-2:012345678901:table/TestTable/stream/2015-05-11T21:21:33.291", 
+        "BatchSize": 200,
+        "EventSourceArn": "arn:aws:dynamodb:us-west-2:012345678901:table/TestTable/stream/2015-05-11T21:21:33.291",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "StartingPosition": "LATEST"
       }
     },
     "MyAwesomeFunctionIoTRule": {
-      "Type": "AWS::IoT::TopicRule", 
+      "Type": "AWS::IoT::TopicRule",
       "Properties": {
         "TopicRulePayload": {
-          "AwsIotSqlVersion": "beta", 
+          "AwsIotSqlVersion": "beta",
           "Actions": [
             {
               "Lambda": {
@@ -112,34 +102,34 @@
                 }
               }
             }
-          ], 
-          "RuleDisabled": false, 
+          ],
+          "RuleDisabled": false,
           "Sql": "SELECT * FROM 'topic/test'"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionKinesisStream": {
-      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
-        "BatchSize": 100, 
-        "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream", 
+        "BatchSize": 100,
+        "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "StartingPosition": "TRIM_HORIZON"
       }
-    }, 
+    },
     "MyAwesomeFunctionImplicitApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -149,31 +139,21 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeploymentd696835fbb": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: d696835fbb61a45adb53a4391054f7f7404dfb2c", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyAwesomeFunctionIoTRulePermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "SourceAccount": {
           "Fn::Sub": "${AWS::AccountId}"
-        }, 
-        "Principal": "iot.amazonaws.com", 
+        },
+        "Principal": "iot.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:iot:${AWS::Region}:${AWS::AccountId}:rule/${RuleName}", 
+            "arn:aws-us-gov:iot:${AWS::Region}:${AWS::AccountId}:rule/${RuleName}",
             {
               "RuleName": {
                 "Ref": "MyAwesomeFunctionIoTRule"
@@ -182,72 +162,72 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionNotificationTopic": {
-      "Type": "AWS::SNS::Subscription", 
+      "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Endpoint": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
-        "Protocol": "lambda", 
+        },
+        "Protocol": "lambda",
         "TopicArn": {
           "Ref": "Notifications"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionS3TriggerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "SourceAccount": {
           "Ref": "AWS::AccountId"
-        }, 
+        },
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "Principal": "s3.amazonaws.com"
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
-        }, 
+        },
         "Name": "MyGetApi"
       }
     },
     "MyAwesomeFunctionCWLogPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "logs.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "logs.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*", 
+            "arn:aws-us-gov:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*",
             {
               "__LogGroupName__": "MyLogGroup"
             }
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionEBSchedule": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "rate(1 minute)", 
+        "ScheduleExpression": "rate(1 minute)",
         "Targets": [
           {
             "Id": "MyAwesomeFunctionEBScheduleLambdaTarget",
@@ -257,26 +237,26 @@
           }
         ]
       }
-    }, 
+    },
     "MyAwesomeFunctionCWLog": {
-      "Type": "AWS::Logs::SubscriptionFilter", 
+      "Type": "AWS::Logs::SubscriptionFilter",
       "Properties": {
         "DestinationArn": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
-        "FilterPattern": "My pattern", 
+        },
+        "FilterPattern": "My pattern",
         "LogGroupName": "MyLogGroup"
-      }, 
+      },
       "DependsOn": [
         "MyAwesomeFunctionCWLogPermission"
       ]
-    }, 
+    },
     "MyAwesomeFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole", 
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole",
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole"
         ],
         "Tags": [
@@ -286,13 +266,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -302,32 +282,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionRole", 
+            "MyAwesomeFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAwesomeFunctionCWEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
           "detail": {
@@ -335,10 +315,10 @@
               "terminated"
             ]
           }
-        }, 
+        },
         "Targets": [
           {
-            "Id": "MyAwesomeFunctionCWEventLambdaTarget", 
+            "Id": "MyAwesomeFunctionCWEventLambdaTarget",
             "Arn": {
               "Ref": "MyAwesomeFunctionAliasLive"
             }
@@ -367,61 +347,61 @@
       }
     },
     "MyAwesomeFunctionVersion640128d35d": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::Version", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::Version",
       "Properties": {
         "FunctionName": {
           "Ref": "MyAwesomeFunction"
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyAwesomeFunctionAliasLive}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "Notifications": {
       "Type": "AWS::SNS::Topic"
-    }, 
+    },
     "MyAwesomeFunctionEBSchedulePermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "events.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::GetAtt": [
             "MyAwesomeFunctionEBSchedule",
@@ -429,55 +409,55 @@
           ]
         }
       }
-    }, 
+    },
     "Images": {
-      "Type": "AWS::S3::Bucket", 
+      "Type": "AWS::S3::Bucket",
       "Properties": {
         "NotificationConfiguration": {
           "LambdaConfigurations": [
             {
               "Function": {
                 "Ref": "MyAwesomeFunctionAliasLive"
-              }, 
+              },
               "Event": "s3:ObjectCreated:*"
             }
           ]
         }
-      }, 
+      },
       "DependsOn": [
         "MyAwesomeFunctionS3TriggerPermission"
       ]
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "LambdaFunction": {
             "Ref": "MyAwesomeFunction"
           }
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionExplicitApiPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -486,6 +466,26 @@
             }
           ]
         }
+      }
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentd9a95c600f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d9a95c600f98dc587706f5ead26caf5d7166e3d7",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/function_with_request_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_request_parameters.json
@@ -53,26 +53,6 @@
         }
       }
     },
-    "ServerlessRestApiDeployment7c706bcd56": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 7c706bcd56e685afb5882e0219515c9413bcd13b",
-        "StageName": "Stage"
-      }
-    },
-    "ApiDeployment5e67eb8be3": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "Api"
-        },
-        "Description": "RestApi deployment id: 5e67eb8be3d6956bbeadcb3ffdae9abcac90f01e",
-        "StageName": "Stage"
-      }
-    },
     "ApiParameterFunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -128,7 +108,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment7c706bcd56"
+          "Ref": "ServerlessRestApiDeploymentc3033d78a8"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -206,7 +186,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiDeployment5e67eb8be3"
+          "Ref": "ApiDeploymentab93381864"
         },
         "RestApiId": {
           "Ref": "Api"
@@ -285,6 +265,26 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ServerlessRestApiDeploymentc3033d78a8": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: c3033d78a8a749f43919fb95e1746af8aa03e4ff",
+        "StageName": "Stage"
+      }
+    },
+    "ApiDeploymentab93381864": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "Api"
+        },
+        "Description": "RestApi deployment id: ab93381864395f26ac5a7d7ccac2bca0d0fef644",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/global_handle_path_level_parameter.json
+++ b/tests/translator/output/aws-us-gov/global_handle_path_level_parameter.json
@@ -136,7 +136,7 @@
         },
         "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc969c99f9d"
+          "Ref": "ServerlessRestApiDeployment1c1409477a"
         }
       }
     },
@@ -153,7 +153,7 @@
         },
         "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9a254aa466"
+          "Ref": "ExplicitApiDeployment24b17d3335"
         }
       }
     },
@@ -178,16 +178,6 @@
         }
       }
     },
-    "ServerlessRestApiDeploymentc969c99f9d": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: c969c99f9d6b6921dff605a206e8989bdb7d1bc7",
-        "StageName": "Stage"
-      }
-    },
     "MyUserPool": {
       "Type": "AWS::Cognito::UserPool",
       "Properties": {
@@ -207,16 +197,6 @@
             "Name": "email"
           }
         ]
-      }
-    },
-    "ExplicitApiDeployment9a254aa466": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 9a254aa466c6f818951dfb6e45fde65489beb153",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
@@ -278,6 +258,26 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ServerlessRestApiDeployment1c1409477a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 1c1409477a0000846b81d69bf0da3f53a6043783",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment24b17d3335": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 24b17d33358d1e9ca30ab2a0967848d74f40c3de",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/globals_for_api.json
+++ b/tests/translator/output/aws-us-gov/globals_for_api.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -54,129 +54,119 @@
       }
     },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": 2.0, 
+          },
+          "swagger": 2.0,
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment6fd1928d9b"
+          "Ref": "ServerlessRestApiDeployment1c245bd679"
         }
       }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment43e01e673d"
+          "Ref": "ExplicitApiDeploymentf64bb7c4a4"
         }
       }
-    }, 
-    "ExplicitApiDeployment43e01e673d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 43e01e673d7acbd09e4c38ff78dd6ddaf2ed1d55", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -186,105 +176,115 @@
           ]
         }
       }
-    }, 
-    "ServerlessRestApiDeployment6fd1928d9b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 6fd1928d9b9ad3c711a371e1337306458029f8bd", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
-        "Name": "some api", 
+        },
+        "Name": "some api",
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "ExplicitApiDeploymentf64bb7c4a4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: f64bb7c4a498f204e281c987b181d884fdec35b7",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment1c245bd679": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 1c245bd6792bb3cc5be556edf335def23a47b5bc",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/implicit_and_explicit_api_with_conditions.json
+++ b/tests/translator/output/aws-us-gov/implicit_and_explicit_api_with_conditions.json
@@ -122,7 +122,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "explicitapiDeploymentc8f1a3b6da"
+          "Ref": "explicitapiDeployment29f93aa52a"
         },
         "RestApiId": {
           "Ref": "explicitapi"
@@ -134,7 +134,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment0270cbc16b"
+          "Ref": "ServerlessRestApiDeployment723df5a540"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -243,17 +243,6 @@
       },
       "Condition": "implicithello1condition"
     },
-    "ServerlessRestApiDeployment0270cbc16b": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 0270cbc16b8a9cded2c076b6ab6e50254430918b",
-        "StageName": "Stage"
-      },
-      "Condition": "ServerlessRestApiCondition"
-    },
     "implicithello1": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -300,16 +289,6 @@
         }
       },
       "Condition": "explicithello2condition"
-    },
-    "explicitapiDeploymentc8f1a3b6da": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "explicitapi"
-        },
-        "Description": "RestApi deployment id: c8f1a3b6da24370ce143b6ab046e51dded1bfc36",
-        "StageName": "Stage"
-      }
     },
     "explicitapi": {
       "Type": "AWS::ApiGateway::RestApi",
@@ -587,6 +566,27 @@
         }
       },
       "Condition": "implicithello1condition"
+    },
+    "ServerlessRestApiDeployment723df5a540": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 723df5a540c1c381aec9fa5b8c0e527f744e3047",
+        "StageName": "Stage"
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "explicitapiDeployment29f93aa52a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "explicitapi"
+        },
+        "Description": "RestApi deployment id: 29f93aa52aa305b05b968e41e131e48b0bc5a1f7",
+        "StageName": "Stage"
+      }
     }
   },
   "Description": "A template to test for API condition handling with a mix of explicit and implicit api events."

--- a/tests/translator/output/aws-us-gov/implicit_api.json
+++ b/tests/translator/output/aws-us-gov/implicit_api.json
@@ -1,10 +1,10 @@
 {
   "Resources": {
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBFullAccess"
         ],
         "Tags": [
@@ -13,15 +13,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -33,16 +32,16 @@
       }
     },
     "RestApiFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -54,16 +53,16 @@
       }
     },
     "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,57 +72,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentaaf8bd4588"
-        }, 
+          "Ref": "ServerlessRestApiDeployment52a8c8ee79"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiDeploymentaaf8bd4588": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: aaf8bd4588f47e1167b22b3aadb5fdf6f2d306aa", 
-        "StageName": "Stage"
       }
     },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -132,15 +121,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -152,39 +140,39 @@
       }
     },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.restapi", 
+        },
+        "Handler": "index.restapi",
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "RestApiFunctionGetListPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -194,90 +182,90 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/{proxy+}": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/getlist": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/complete": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "RestApiFunctionCompleteItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -286,6 +274,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment52a8c8ee79": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 52a8c8ee79645bcd91683f367f0ac33844817c8f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/implicit_api_with_auth_and_conditions_max.json
+++ b/tests/translator/output/aws-us-gov/implicit_api_with_auth_and_conditions_max.json
@@ -4,140 +4,140 @@
       "Fn::Or": [
         {
           "Condition": "FunctionCondition"
-        }, 
+        },
         {
           "Condition": "FunctionCondition2"
-        }, 
+        },
         {
           "Condition": "FunctionCondition3"
-        }, 
+        },
         {
           "Condition": "FunctionCondition4"
-        }, 
+        },
         {
           "Condition": "FunctionCondition5"
-        }, 
+        },
         {
           "Condition": "FunctionCondition6"
         }
       ]
-    }, 
+    },
     "FunctionCondition6": {
       "Fn::Equals": [
-        true, 
+        true,
         false
       ]
-    }, 
+    },
     "FunctionCondition5": {
       "Fn::Equals": [
-        true, 
+        true,
         false
       ]
-    }, 
+    },
     "FunctionCondition4": {
       "Fn::Equals": [
-        true, 
+        true,
         false
       ]
-    }, 
+    },
     "FunctionCondition3": {
       "Fn::Equals": [
-        true, 
+        true,
         false
       ]
-    }, 
+    },
     "FunctionCondition2": {
       "Fn::Equals": [
-        true, 
+        true,
         false
       ]
-    }, 
+    },
     "ServerlessRestApiSLASHusersPathCondition": {
       "Fn::Or": [
         {
           "Condition": "FunctionCondition2"
-        }, 
+        },
         {
           "Condition": "FunctionCondition3"
-        }, 
+        },
         {
           "Condition": "FunctionCondition4"
-        }, 
+        },
         {
           "Condition": "FunctionCondition5"
-        }, 
+        },
         {
           "Condition": "FunctionCondition6"
         }
       ]
-    }, 
+    },
     "FunctionCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         false
       ]
     }
-  }, 
+  },
   "Resources": {
     "MyFunction4": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunction4Role", 
+            "MyFunction4Role",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "FunctionCondition4"
-    }, 
+    },
     "MyFunction6": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunction6Role", 
+            "MyFunction6Role",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "FunctionCondition6"
-    }, 
+    },
     "MyFunction2WithCognitoMultipleUserPoolsAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction2"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -146,72 +146,72 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition2"
-    }, 
+    },
     "MyFunction3": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunction3Role", 
+            "MyFunction3Role",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "FunctionCondition3"
-    }, 
+    },
     "MyFunction2": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunction2Role", 
+            "MyFunction2Role",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "FunctionCondition2"
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment91a6380656"
-        }, 
+          "Ref": "ServerlessRestApiDeployment337a1301d5"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
-      }, 
+      },
       "Condition": "ServerlessRestApiCondition"
-    }, 
+    },
     "MyFunction5Role": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -223,13 +223,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -238,11 +238,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition5"
-    }, 
+    },
     "MyFunction2Role": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -254,13 +254,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -269,11 +269,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition2"
-    }, 
+    },
     "MyFunction4Role": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -285,13 +285,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -300,35 +300,35 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition4"
     },
     "MyFunction5": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunction5Role", 
+            "MyFunction5Role",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "FunctionCondition5"
-    }, 
+    },
     "MyFunction6Role": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -340,13 +340,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -355,18 +355,18 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition6"
-    }, 
+    },
     "ServerlessRestApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
@@ -374,20 +374,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "ServerlessRestApiCondition"
-    }, 
+    },
     "MyFunctionWithNoAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -396,11 +396,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition"
     },
     "MyFunction3Role": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -412,13 +412,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -427,44 +427,44 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition3"
-    }, 
+    },
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.handler", 
+        "Handler": "index.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "thumbnails.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
-      }, 
+      },
       "Condition": "FunctionCondition"
-    }, 
+    },
     "MyFunction4WithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction4"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PATCH/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -473,18 +473,18 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition4"
-    }, 
+    },
     "ServerlessRestApiMyLambdaRequestAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
@@ -492,20 +492,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "ServerlessRestApiCondition"
-    }, 
+    },
     "MyFunction5WithLambdaRequestAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction5"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/DELETE/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -514,18 +514,18 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition5"
-    }, 
+    },
     "ServerlessRestApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
             {
               "__ApiId__": {
                 "Ref": "ServerlessRestApi"
@@ -533,11 +533,11 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "ServerlessRestApiCondition"
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -549,13 +549,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -564,31 +564,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition"
     },
-    "ServerlessRestApiDeployment91a6380656": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 91a63806562bbe4a3ad1c14c2444bc7d8d27397c", 
-        "StageName": "Stage"
-      }, 
-      "Condition": "ServerlessRestApiCondition"
-    }, 
     "MyFunction3WithLambdaTokenAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction3"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -597,20 +586,20 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition3"
-    }, 
+    },
     "MyFunction6WithDefaultAuthorizerPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction6"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/PUT/users",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -619,333 +608,344 @@
             }
           ]
         }
-      }, 
+      },
       "Condition": "FunctionCondition6"
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "Fn::If": [
-                "FunctionCondition", 
+                "FunctionCondition",
                 {
                   "get": {
                     "Fn::If": [
-                      "FunctionCondition", 
+                      "FunctionCondition",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "FunctionCondition", 
+                              "FunctionCondition",
                               {
                                 "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "security": [
                           {
                             "NONE": []
                           }
-                        ], 
+                        ],
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
                   }
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
-            }, 
+            },
             "/users": {
               "Fn::If": [
-                "ServerlessRestApiSLASHusersPathCondition", 
+                "ServerlessRestApiSLASHusersPathCondition",
                 {
                   "put": {
                     "Fn::If": [
-                      "FunctionCondition6", 
+                      "FunctionCondition6",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "FunctionCondition6", 
+                              "FunctionCondition6",
                               {
                                 "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction6.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "security": [
                           {
                             "api_key": []
-                          }, 
+                          },
                           {
                             "MyCognitoAuth": []
                           }
-                        ], 
+                        ],
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
-                  }, 
+                  },
                   "patch": {
                     "Fn::If": [
-                      "FunctionCondition4", 
+                      "FunctionCondition4",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "FunctionCondition4", 
+                              "FunctionCondition4",
                               {
                                 "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction4.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "security": [
                           {
                             "MyLambdaTokenAuthNoneFunctionInvokeRole": []
                           }
-                        ], 
+                        ],
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
-                  }, 
+                  },
                   "post": {
                     "Fn::If": [
-                      "FunctionCondition2", 
+                      "FunctionCondition2",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "FunctionCondition2", 
+                              "FunctionCondition2",
                               {
                                 "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction2.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "security": [
                           {
                             "MyCognitoAuthMultipleUserPools": []
                           }
-                        ], 
+                        ],
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
-                  }, 
+                  },
                   "get": {
                     "Fn::If": [
-                      "FunctionCondition3", 
+                      "FunctionCondition3",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "FunctionCondition3", 
+                              "FunctionCondition3",
                               {
                                 "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction3.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "security": [
                           {
                             "MyLambdaTokenAuth": []
                           }
-                        ], 
+                        ],
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
-                  }, 
+                  },
                   "delete": {
                     "Fn::If": [
-                      "FunctionCondition5", 
+                      "FunctionCondition5",
                       {
                         "x-amazon-apigateway-integration": {
-                          "httpMethod": "POST", 
-                          "type": "aws_proxy", 
+                          "httpMethod": "POST",
+                          "type": "aws_proxy",
                           "uri": {
                             "Fn::If": [
-                              "FunctionCondition5", 
+                              "FunctionCondition5",
                               {
                                 "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction5.Arn}/invocations"
-                              }, 
+                              },
                               {
                                 "Ref": "AWS::NoValue"
                               }
                             ]
                           }
-                        }, 
+                        },
                         "security": [
                           {
                             "MyLambdaRequestAuth": []
                           }
-                        ], 
+                        ],
                         "responses": {}
-                      }, 
+                      },
                       {
                         "Ref": "AWS::NoValue"
                       }
                     ]
                   }
-                }, 
+                },
                 {
                   "Ref": "AWS::NoValue"
                 }
               ]
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 0, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
                 }
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
-            }, 
+            },
             "MyLambdaRequestAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Unused", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
               "x-amazon-apigateway-authorizer": {
-                "type": "request", 
-                "authorizerResultTtlInSeconds": 0, 
-                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
+                },
                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression", 
+                "identityValidationExpression": "myauthvalidationexpression",
                 "providerARNs": [
                   "arn:aws:1"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "MyLambdaTokenAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyCustomAuthHeader", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
               "x-amazon-apigateway-authorizer": {
-                "type": "token", 
-                "authorizerResultTtlInSeconds": 20, 
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
                 "authorizerUri": {
                   "Fn::Sub": [
-                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                     {
                       "__FunctionArn__": "arn:aws"
                     }
                   ]
-                }, 
-                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                 "identityValidationExpression": "mycustomauthexpression"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "custom"
-            }, 
+            },
             "MyCognitoAuthMultipleUserPools": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "MyAuthorizationHeader2", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
               "x-amazon-apigateway-authorizer": {
-                "identityValidationExpression": "myauthvalidationexpression2", 
+                "identityValidationExpression": "myauthvalidationexpression2",
                 "providerARNs": [
-                  "arn:aws:2", 
+                  "arn:aws:2",
                   "arn:aws:3"
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
             }
           }
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }, 
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "ServerlessRestApiDeployment337a1301d5": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 337a1301d5a2006a2d4392c8be3e2a61fe66baf1",
+        "StageName": "Stage"
+      },
       "Condition": "ServerlessRestApiCondition"
     }
   }

--- a/tests/translator/output/aws-us-gov/implicit_api_with_many_conditions.json
+++ b/tests/translator/output/aws-us-gov/implicit_api_with_many_conditions.json
@@ -149,7 +149,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment8fffc54734"
+          "Ref": "ServerlessRestApiDeploymentb0e1e9d112"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -801,17 +801,6 @@
       },
       "Condition": "MyCondition"
     },
-    "ServerlessRestApiDeployment8fffc54734": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 8fffc547345988f48beab2ad190a4c762fa2a92a",
-        "StageName": "Stage"
-      },
-      "Condition": "ServerlessRestApiCondition"
-    },
     "helloworld5": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1413,6 +1402,17 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "ServerlessRestApiDeploymentb0e1e9d112": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: b0e1e9d1121f5fd53f1a45eebe26befffc40ed6a",
+        "StageName": "Stage"
       },
       "Condition": "ServerlessRestApiCondition"
     }

--- a/tests/translator/output/aws-us-gov/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/aws-us-gov/implicit_api_with_serverless_rest_api_resource.json
@@ -1,10 +1,10 @@
 {
   "Resources": {
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBFullAccess"
         ],
         "Tags": [
@@ -14,13 +14,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -32,16 +32,16 @@
       }
     },
     "RestApiFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -53,16 +53,16 @@
       }
     },
     "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -72,57 +72,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentaaf8bd4588"
-        }, 
+          "Ref": "ServerlessRestApiDeployment52a8c8ee79"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiDeploymentaaf8bd4588": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: aaf8bd4588f47e1167b22b3aadb5fdf6f2d306aa", 
-        "StageName": "Stage"
       }
     },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -132,13 +122,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -150,39 +140,39 @@
       }
     },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.restapi", 
+        "Handler": "index.restapi",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "RestApiFunctionGetListPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -192,90 +182,90 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/{proxy+}": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/getlist": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/complete": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "RestApiFunctionCompleteItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -284,6 +274,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment52a8c8ee79": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 52a8c8ee79645bcd91683f367f0ac33844817c8f",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/intrinsic_functions.json
+++ b/tests/translator/output/aws-us-gov/intrinsic_functions.json
@@ -2,33 +2,33 @@
   "Conditions": {
     "TrueCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "CodeKey": {
-      "Default": "key", 
+      "Default": "key",
       "Type": "String"
-    }, 
+    },
     "CodeBucket": {
-      "Default": "sam-demo-bucket", 
+      "Default": "sam-demo-bucket",
       "Type": "String"
-    }, 
+    },
     "FunctionName": {
       "Default": "MySuperFunctionName",
       "Type": "String"
-    }, 
+    },
     "MyExplicitApiName": {
-      "Default": "SomeName", 
+      "Default": "SomeName",
       "Type": "String"
-    }, 
+    },
     "TracingConfigParam": {
-      "Default": "PassThrough", 
+      "Default": "PassThrough",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi",
@@ -129,16 +129,6 @@
         }
       },
       "Condition": "TrueCondition"
-    },
-    "MyExplicitApiDeployment7145dd00ce": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyExplicitApi"
-        },
-        "Description": "RestApi deployment id: 7145dd00cea59b4a62b4d7855add490c587f3f62",
-        "StageName": "Stage"
-      }
     },
     "FunctionWithExplicitS3Uri": {
       "Type": "AWS::Lambda::Function",
@@ -425,7 +415,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithExplicitS3UriDeploymenta227798f00"
+          "Ref": "ApiWithExplicitS3UriDeploymentdf00ae04c1"
         },
         "RestApiId": {
           "Ref": "ApiWithExplicitS3Uri"
@@ -449,17 +439,6 @@
         },
         "StartingPosition": "LATEST"
       }
-    },
-    "ApiWithExplicitS3UriDeploymenta227798f00": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithExplicitS3Uri"
-        },
-        "Description": "RestApi deployment id: a227798f004a50b665fe47a20bb9afbf076bd85d",
-        "StageName": "Stage"
-      },
-      "Condition": "TrueCondition"
     },
     "MySqsDlqLambdaFunctionRole": {
       "Type": "AWS::IAM::Role",
@@ -515,7 +494,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment7145dd00ce"
+          "Ref": "MyExplicitApiDeploymentac5370c463"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"
@@ -540,7 +519,7 @@
     "MyFunctionMyApiPermissiondev": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
@@ -557,6 +536,27 @@
           ]
         }
       }
+    },
+    "MyExplicitApiDeploymentac5370c463": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyExplicitApi"
+        },
+        "Description": "RestApi deployment id: ac5370c463a1506e2d2d574f796b90853a805218",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithExplicitS3UriDeploymentdf00ae04c1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithExplicitS3Uri"
+        },
+        "Description": "RestApi deployment id: df00ae04c10d650fc54bbd3b1444d09ff6ee0ae6",
+        "StageName": "Stage"
+      },
+      "Condition": "TrueCondition"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_auth_default_scopes.json
@@ -1,733 +1,733 @@
 {
-    "Resources": {
-        "MyApiWithCognitoAuth": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/cognitowithauthnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoWithAuthNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "NONE": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultauthdefaultscopesnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitoauthorizerwithdefaultscopes": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": [
-                                            "default.delete", 
-                                            "default.update"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitoauthorizercopesoverwritten": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": [
-                                            "overwritten.read", 
-                                            "overwritten.write"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesoverwritten": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": [
-                                            "overwritten.read", 
-                                            "overwritten.write"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesdefaultauthorizer": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": [
-                                            "default.write", 
-                                            "default.read"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "openapi": "3.0.1", 
-                    "components": {
-                        "securitySchemes": {
-                            "MyCognitoAuthWithDefaultScopes": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
-                                "x-amazon-apigateway-authorizer": {
-                                    "providerARNs": [
-                                        "arn:aws:2"
-                                    ], 
-                                    "type": "cognito_user_pools"
-                                }, 
-                                "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }, 
-                            "MyDefaultCognitoAuth": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
-                                "x-amazon-apigateway-authorizer": {
-                                    "providerARNs": [
-                                        "arn:aws:1"
-                                    ], 
-                                    "type": "cognito_user_pools"
-                                }, 
-                                "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }
-                        }
+  "Resources": {
+    "MyApiWithCognitoAuth": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/cognitowithauthnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
-        }, 
-        "MyStateMachineCognitoWithAuthNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                     }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiWithCognitoAuthProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiWithCognitoAuthDeployment57b57dfc88"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApiWithCognitoAuth"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "MyApiWithCognitoAuthDeployment57b57dfc88": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApiWithCognitoAuth"
-                }, 
-                "Description": "RestApi deployment id: 57b57dfc88b1b438a0437eadd869d77e938eedb6"
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
+                  },
+                  "credentials": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
-                        "Arn"
+                      "MyStateMachineCognitoWithAuthNoneRole",
+                      "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "NONE": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
                 }
-            }
-        }, 
-        "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
+              }
+            },
+            "/cognitodefaultauthdefaultscopesnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole",
+                      "Arn"
                     ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
                 }
-            }
-        }, 
-        "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
+              }
+            },
+            "/cognitodefaultscopesnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesNoneRole",
+                      "Arn"
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitoauthorizerwithdefaultscopes": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                     }
-                ]
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoAuthorizerWithDefaultScopesRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": [
+                      "default.delete",
+                      "default.update"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitoauthorizercopesoverwritten": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoAuthorizerScopesOverwrittenRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": [
+                      "overwritten.read",
+                      "overwritten.write"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitodefaultscopesoverwritten": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesWithOverwrittenRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": [
+                      "overwritten.read",
+                      "overwritten.write"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitodefaultscopesdefaultauthorizer": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": [
+                      "default.write",
+                      "default.read"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
             }
+          },
+          "openapi": "3.0.1",
+          "components": {
+            "securitySchemes": {
+              "MyCognitoAuthWithDefaultScopes": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    "arn:aws:2"
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
+              },
+              "MyDefaultCognitoAuth": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    "arn:aws:1"
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
+              }
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "MyStateMachineCognitoWithAuthNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiWithCognitoAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithCognitoAuthDeploymentd0339f6a6f"
+        },
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiWithCognitoAuthDeploymentd0339f6a6f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: d0339f6a6febe05cf298904934b8af368bd689c2"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer.json
@@ -1,384 +1,384 @@
 {
-    "Resources": {
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
+  "Resources": {
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentd5411ae9d3"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startNoAuth": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
+                      "StateMachineWithNoAuthorizerRole",
+                      "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeploymentaaffc688ce"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startNoAuth": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
                 }
+              }
             }
-        }, 
-        "StateMachineWithLambdaTokenAuthRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyApiDeployment3c26186470": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 3c2618647036e31ff3ebf6ae8d4602ba63997fd7", 
-                "StageName": "Stage"
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeployment3c26186470"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeploymentaaffc688ce": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startWithLambdaToken": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaTokenAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "securityDefinitions": {
-                        "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
-                            "in": "header"
-                        }, 
-                        "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
-                                "identityValidationExpression": "mycustomauthexpression"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }
-                    }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    },
+    "StateMachineWithLambdaTokenAuthRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiMyLambdaTokenAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment531f20fc65"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineWithNoAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startWithLambdaToken": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaTokenAuthRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaTokenAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            },
+            "MyLambdaTokenAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
+                "identityValidationExpression": "mycustomauthexpression"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "MyApiDeployment531f20fc65": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 531f20fc650bb518f1c2ac293f5e70387f14dab7",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentd5411ae9d3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5411ae9d3cfb9e3457f9f276ef3d7ae53e1b07d",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer_maximum.json
@@ -1,690 +1,690 @@
 {
-    "Resources": {
-        "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
+  "Resources": {
+    "MyApiMyLambdaRequestAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
             }
-        }, 
-        "StateMachineWithLambdaRequestAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyApiDeployment2120b73f3e": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 2120b73f3e7efc28dc4baca314ee3b30d8d8c783", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineWithDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "StateMachineWithLambdaTokenAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeployment2120b73f3e"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "NONE": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/users": {
-                            "put": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithDefaultAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthMultipleUserPools": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "patch": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "delete": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaRequestAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaRequestAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "securityDefinitions": {
-                        "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Authorization", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "MyCognitoAuthMultipleUserPools": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader2", 
-                            "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression2", 
-                                "providerARNs": [
-                                    "arn:aws:2", 
-                                    "arn:aws:3"
-                                ], 
-                                "type": "cognito_user_pools"
-                            }, 
-                            "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
-                        "MyLambdaRequestAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Unused", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "request", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "MyCognitoAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression", 
-                                "providerARNs": [
-                                    "arn:aws:1"
-                                ], 
-                                "type": "cognito_user_pools"
-                            }, 
-                            "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
-                        "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
-                                "identityValidationExpression": "mycustomauthexpression"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
-                            "in": "header"
-                        }
-                    }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachineWithLambdaRequestAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachineWithDefaultAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiMyLambdaTokenAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachineWithLambdaTokenAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment476b23f35b"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachineWithNoAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithNoAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "NONE": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/users": {
+              "put": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithDefaultAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthMultipleUserPools": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "patch": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaTokenAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaTokenAuthNoneFunctionInvokeRole": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "delete": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaRequestAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaRequestAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "MyLambdaTokenAuthNoneFunctionInvokeRole": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                }
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "MyCognitoAuthMultipleUserPools": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
+              "x-amazon-apigateway-authorizer": {
+                "identityValidationExpression": "myauthvalidationexpression2",
+                "providerARNs": [
+                  "arn:aws:2",
+                  "arn:aws:3"
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyLambdaRequestAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
+              "x-amazon-apigateway-authorizer": {
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "MyCognitoAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
+              "x-amazon-apigateway-authorizer": {
+                "identityValidationExpression": "myauthvalidationexpression",
+                "providerARNs": [
+                  "arn:aws:1"
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyLambdaTokenAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
+                "identityValidationExpression": "mycustomauthexpression"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "MyApiDeployment476b23f35b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 476b23f35b61868f784304c2ea5d193627e7498b",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_resource_policy.json
@@ -1,482 +1,482 @@
 {
-    "Resources": {
-        "MyStateMachineGetHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "MyStateMachineGetHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "ExplicitApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/one": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineGetHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/three": {
-                            "put": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachinePutHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/two": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachinePostHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
-                        "Statement": [
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Allow", 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "NotIpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "IpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Allow", 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "NotIpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "IpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }
-                        ]
-                    }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
-        }, 
-        "ExplicitApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ExplicitApiDeployment17065a95ba"
-                }, 
-                "RestApiId": {
-                    "Ref": "ExplicitApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "MyStateMachinePutHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "MyStateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ExplicitApiDeployment17065a95ba": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ExplicitApi"
-                }, 
-                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2", 
-                "StageName": "Stage"
-            }
-        }, 
-        "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyStateMachinePostHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
+          ]
         }
+      }
+    },
+    "ExplicitApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineGetHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/three": {
+              "put": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachinePutHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/two": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachinePostHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Allow",
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "NotIpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "IpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Allow",
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "NotIpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "IpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              }
+            ]
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeploymente0026ec516"
+        },
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyStateMachinePutHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachinePostHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ExplicitApiDeploymente0026ec516": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: e0026ec516d4da624aa0d0e56caf9ccf79e409b2",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_condition_and_events.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_condition_and_events.json
@@ -1,305 +1,305 @@
 {
-    "Conditions": {
-        "TestCondition": {
-            "Fn::Equals": [
-                "test", 
-                "test"
-            ]
-        }
-    }, 
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole", 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionS3Location": {
-                    "Version": 3, 
-                    "Bucket": "sam-demo-bucket", 
-                    "Key": "my-state-machine.asl.json"
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineScheduleEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "events.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeploymentaeae651245"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineScheduleEvent": {
-            "Type": "AWS::Events::Rule", 
-            "Properties": {
-                "ScheduleExpression": "rate(1 minute)", 
-                "Targets": [
-                    {
-                        "RoleArn": {
-                            "Fn::GetAtt": [
-                                "StateMachineScheduleEventRole", 
-                                "Arn"
-                            ]
-                        }, 
-                        "Id": "StateMachineScheduleEventStepFunctionsTarget", 
-                        "Arn": {
-                            "Ref": "StateMachine"
-                        }
-                    }
-                ], 
-                "Name": "TestSchedule"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineCWEvent": {
-            "Type": "AWS::Events::Rule", 
-            "Properties": {
-                "EventPattern": {
-                    "detail": {
-                        "state": [
-                            "terminated"
-                        ]
-                    }
-                }, 
-                "Targets": [
-                    {
-                        "RoleArn": {
-                            "Fn::GetAtt": [
-                                "StateMachineCWEventRole", 
-                                "Arn"
-                            ]
-                        }, 
-                        "Id": "StateMachineCWEventStepFunctionsTarget", 
-                        "Arn": {
-                            "Ref": "StateMachine"
-                        }
-                    }
-                ]
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "Fn::If": [
-                                "TestCondition", 
-                                {
-                                    "post": {
-                                        "Fn::If": [
-                                            "TestCondition", 
-                                            {
-                                                "x-amazon-apigateway-integration": {
-                                                    "responses": {
-                                                        "200": {
-                                                            "statusCode": "200"
-                                                        }, 
-                                                        "400": {
-                                                            "statusCode": "400"
-                                                        }
-                                                    }, 
-                                                    "uri": {
-                                                        "Fn::If": [
-                                                            "TestCondition", 
-                                                            {
-                                                                "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                                            }, 
-                                                            {
-                                                                "Ref": "AWS::NoValue"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "httpMethod": "POST", 
-                                                    "requestTemplates": {
-                                                        "application/json": {
-                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                                        }
-                                                    }, 
-                                                    "credentials": {
-                                                        "Fn::GetAtt": [
-                                                            "StateMachineMyApiEventRole", 
-                                                            "Arn"
-                                                        ]
-                                                    }, 
-                                                    "type": "aws"
-                                                }, 
-                                                "responses": {
-                                                    "200": {
-                                                        "description": "OK"
-                                                    }, 
-                                                    "400": {
-                                                        "description": "Bad Request"
-                                                    }
-                                                }
-                                            }, 
-                                            {
-                                                "Ref": "AWS::NoValue"
-                                            }
-                                        ]
-                                    }
-                                }, 
-                                {
-                                    "Ref": "AWS::NoValue"
-                                }
-                            ]
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApiDeploymentaeae651245": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aeae651245fe7d417a17f2bea50b255f2727e2b8", 
-                "StageName": "Stage"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineCWEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "events.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }
+  "Conditions": {
+    "TestCondition": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
     }
+  },
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
+        "StateMachineName": "MyStateMachine",
+        "DefinitionS3Location": {
+          "Version": 3,
+          "Bucket": "sam-demo-bucket",
+          "Key": "my-state-machine.asl.json"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentf22928ca9f"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)",
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole",
+                "Arn"
+              ]
+            },
+            "Id": "StateMachineScheduleEventStepFunctionsTarget",
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ],
+        "Name": "TestSchedule"
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        },
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole",
+                "Arn"
+              ]
+            },
+            "Id": "StateMachineCWEventStepFunctionsTarget",
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "Fn::If": [
+                "TestCondition",
+                {
+                  "post": {
+                    "Fn::If": [
+                      "TestCondition",
+                      {
+                        "x-amazon-apigateway-integration": {
+                          "responses": {
+                            "200": {
+                              "statusCode": "200"
+                            },
+                            "400": {
+                              "statusCode": "400"
+                            }
+                          },
+                          "uri": {
+                            "Fn::If": [
+                              "TestCondition",
+                              {
+                                "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                              },
+                              {
+                                "Ref": "AWS::NoValue"
+                              }
+                            ]
+                          },
+                          "httpMethod": "POST",
+                          "requestTemplates": {
+                            "application/json": {
+                              "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                            }
+                          },
+                          "credentials": {
+                            "Fn::GetAtt": [
+                              "StateMachineMyApiEventRole",
+                              "Arn"
+                            ]
+                          },
+                          "type": "aws"
+                        },
+                        "responses": {
+                          "200": {
+                            "description": "OK"
+                          },
+                          "400": {
+                            "description": "Bad Request"
+                          }
+                        }
+                      },
+                      {
+                        "Ref": "AWS::NoValue"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "Ref": "AWS::NoValue"
+                }
+              ]
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApiDeploymentf22928ca9f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: f22928ca9fa163df139e3c1f896167ecefffa178",
+        "StageName": "Stage"
+      },
+      "Condition": "TestCondition"
+    }
+  }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_explicit_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_explicit_api.json
@@ -1,210 +1,210 @@
 {
-    "Resources": {
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+  "Resources": {
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment0e07112b2c"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "MyApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-                "StageName": "Stage"
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeployment05bc9f394c"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
+          ]
         }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "MyApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_implicit_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_implicit_api.json
@@ -1,210 +1,210 @@
 {
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeployment05bc9f394c"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment0e07112b2c"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ServerlessRestApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_implicit_api_globals.json
@@ -1,232 +1,232 @@
 {
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeployment1f01b589d4"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeployment1f01b589d4": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
-                        "Statement": {
-                            "Action": "execute-api:Invoke", 
-                            "Resource": [
-                                {
-                                    "Fn::Sub": [
-                                        "execute-api:/${__Stage__}/POST/startMyExecution", 
-                                        {
-                                            "__Stage__": "Prod"
-                                        }
-                                    ]
-                                }
-                            ], 
-                            "Effect": "Deny", 
-                            "Principal": {
-                                "AWS": [
-                                    "12345"
-                                ]
-                            }
-                        }
-                    }
-                }, 
-                "EndpointConfiguration": {
-                    "Types": [
-                        "REGIONAL"
-                    ]
-                }, 
-                "Parameters": {
-                    "endpointConfigurationTypes": "REGIONAL"
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentc81fbad89e"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17",
+            "Statement": {
+              "Action": "execute-api:Invoke",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "execute-api:/${__Stage__}/POST/startMyExecution",
+                    {
+                      "__Stage__": "Prod"
+                    }
+                  ]
+                }
+              ],
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": [
+                  "12345"
+                ]
+              }
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ServerlessRestApiDeploymentc81fbad89e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: c81fbad89effca825bf52acf474877e98e597381",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_permissions_boundary.json
@@ -1,57 +1,57 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
-        ], 
-        "ReservedConcurrentExecutions": 100, 
-        "Handler": "hello.handler", 
+        ],
+        "ReservedConcurrentExecutions": 100,
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "python2.7"
       }
-    }, 
+    },
     "StateMachineMyApiEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "apigateway.amazonaws.com"
@@ -61,54 +61,44 @@
           ]
         }
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyStateMachine", 
+        },
+        "StateMachineName": "MyStateMachine",
         "DefinitionS3Location": {
-          "Version": 3, 
-          "Bucket": "sam-demo-bucket", 
+          "Version": 3,
+          "Bucket": "sam-demo-bucket",
           "Key": "my-state-machine.asl.json"
-        }, 
+        },
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment05bc9f394c"
-        }, 
+          "Ref": "ServerlessRestApiDeployment0e07112b2c"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment05bc9f394c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "StateMachineCWEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
           "detail": {
@@ -116,34 +106,34 @@
               "terminated"
             ]
           }
-        }, 
+        },
         "Targets": [
           {
             "RoleArn": {
               "Fn::GetAtt": [
-                "StateMachineCWEventRole", 
+                "StateMachineCWEventRole",
                 "Arn"
               ]
-            }, 
-            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            },
+            "Id": "StateMachineCWEventStepFunctionsTarget",
             "Arn": {
               "Ref": "StateMachine"
             }
           }
         ]
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -151,28 +141,28 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/startMyExecution": {
               "post": {
@@ -180,62 +170,62 @@
                   "responses": {
                     "200": {
                       "statusCode": "200"
-                    }, 
+                    },
                     "400": {
                       "statusCode": "400"
                     }
-                  }, 
+                  },
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                  }, 
-                  "httpMethod": "POST", 
+                  },
+                  "httpMethod": "POST",
                   "requestTemplates": {
                     "application/json": {
                       "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                     }
-                  }, 
+                  },
                   "credentials": {
                     "Fn::GetAtt": [
-                      "StateMachineMyApiEventRole", 
+                      "StateMachineMyApiEventRole",
                       "Arn"
                     ]
-                  }, 
+                  },
                   "type": "aws"
-                }, 
+                },
                 "responses": {
                   "200": {
                     "description": "OK"
-                  }, 
+                  },
                   "400": {
                     "description": "Bad Request"
                   }
                 }
               }
             }
-          }, 
+          },
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    }, 
+    },
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -243,70 +233,70 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        },
+        "ManagedPolicyArns": [],
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "lambda:InvokeFunction"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*",
                       {
                         "functionName": {
                           "Ref": "MyFunction"
                         }
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "StateMachineScheduleEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "events.amazonaws.com"
@@ -316,56 +306,56 @@
           ]
         }
       }
-    }, 
+    },
     "StateMachineScheduleEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "rate(1 minute)", 
+        "ScheduleExpression": "rate(1 minute)",
         "Targets": [
           {
             "RoleArn": {
               "Fn::GetAtt": [
-                "StateMachineScheduleEventRole", 
+                "StateMachineScheduleEventRole",
                 "Arn"
               ]
-            }, 
-            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            },
+            "Id": "StateMachineScheduleEventStepFunctionsTarget",
             "Arn": {
               "Ref": "StateMachine"
             }
           }
-        ], 
+        ],
         "Name": "TestSchedule"
       }
-    }, 
+    },
     "StateMachineCWEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "events.amazonaws.com"
@@ -374,6 +364,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/depends_on.json
+++ b/tests/translator/output/depends_on.json
@@ -27,16 +27,6 @@
         "MySamTable"
       ]
     },
-    "MyExplicitApiDeployment74b681ce04": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyExplicitApi"
-        },
-        "Description": "RestApi deployment id: 74b681ce04601a2cf69b6d05d53782b216cf96bb",
-        "StageName": "Stage"
-      }
-    },
     "MyExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -76,7 +66,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment74b681ce04"
+          "Ref": "MyExplicitApiDeployment98d1d7451d"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"
@@ -149,6 +139,16 @@
             }
           ]
         }
+      }
+    },
+    "MyExplicitApiDeployment98d1d7451d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyExplicitApi"
+        },
+        "Description": "RestApi deployment id: 98d1d7451d36eeb109d8152b3c842314ceec54e5",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/explicit_api.json
+++ b/tests/translator/output/explicit_api.json
@@ -1,67 +1,57 @@
 {
   "Parameters": {
     "something": {
-      "Default": "something", 
+      "Default": "something",
       "Type": "String"
-    }, 
+    },
     "MyStageName": {
-      "Default": "Production", 
+      "Default": "Production",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "webpage.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiWithInlineSwaggerStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment09cda3d97b"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeploymentd6e4241aec"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
     },
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -70,15 +60,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -88,27 +77,27 @@
           ]
         }
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "inline swagger"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -118,44 +107,54 @@
           ]
         }
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Name": "MyGetApi"
       }
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "EndpointUri": {
             "Ref": "something"
-          }, 
+          },
           "EndpointUri2": "http://example.com"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
-    }, 
-    "ApiWithInlineSwaggerDeployment09cda3d97b": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithInlineSwaggerDeploymentd6e4241aec": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 09cda3d97b008bed7bd4ebb1b5304ed622492941", 
+        },
+        "Description": "RestApi deployment id: d6e4241aecafd12a5d34fa32f427f71867e30751",
         "StageName": "Stage"
       }
     }

--- a/tests/translator/output/explicit_api_openapi_3.json
+++ b/tests/translator/output/explicit_api_openapi_3.json
@@ -1,76 +1,57 @@
 {
   "Parameters": {
     "something": {
-      "Default": "something", 
+      "Default": "something",
       "Type": "String"
-    }, 
+    },
     "MyStageName": {
-      "Default": "Production", 
+      "Default": "Production",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "webpage.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ApiWithInlineSwaggerStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment74abcb3a5b"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeploymenteaabc1f332"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
     },
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
-    "ApiWithInlineSwaggerDeployment74abcb3a5b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 74abcb3a5bbe7ad58dfc543740af3be156736130"
-      }
-    }, 
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -79,15 +60,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -97,27 +77,27 @@
           ]
         }
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
-          "this": "is", 
+          "this": "is",
           "a": "inline swagger"
         }
       }
-    }, 
+    },
     "GetHtmlFunctionGetHtmlPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -127,35 +107,54 @@
           ]
         }
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Name": "MyGetApi"
       }
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "EndpointUri": {
             "Ref": "something"
-          }, 
+          },
           "EndpointUri2": "http://example.com"
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
+      }
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithInlineSwaggerDeploymenteaabc1f332": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        },
+        "Description": "RestApi deployment id: eaabc1f3328d9cc3200d9b5c1f0afa15cd7a3343"
       }
     }
   }

--- a/tests/translator/output/explicit_api_with_invalid_events_config.json
+++ b/tests/translator/output/explicit_api_with_invalid_events_config.json
@@ -1,39 +1,39 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.restapi", 
+        },
+        "Handler": "index.restapi",
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyFunctionAddApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": "ApiWithInlineSwagger"
@@ -43,57 +43,47 @@
       }
     },
     "ApiWithInlineSwaggerProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment22d399868d"
-        }, 
+          "Ref": "ApiWithInlineSwaggerDeployment039e5eb1f1"
+        },
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ApiWithInlineSwagger": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/foo": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
-    "ApiWithInlineSwaggerDeployment22d399868d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 22d399868d5755a0d5204deae1ee870cf95a7737", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -105,13 +95,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -120,6 +110,16 @@
             }
           ]
         }
+      }
+    },
+    "ApiWithInlineSwaggerDeployment039e5eb1f1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        },
+        "Description": "RestApi deployment id: 039e5eb1f1de15b72c5917efd628d0b7a75c5fa5",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/function_with_alias_and_event_sources.json
@@ -1,72 +1,62 @@
 {
   "Parameters": {
     "MyStageName": {
-      "Default": "beta", 
+      "Default": "beta",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyAwesomeFunctionAliasLive": {
-      "Type": "AWS::Lambda::Alias", 
+      "Type": "AWS::Lambda::Alias",
       "Properties": {
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionVersion640128d35d", 
+            "MyAwesomeFunctionVersion640128d35d",
             "Version"
           ]
-        }, 
+        },
         "FunctionName": {
           "Ref": "MyAwesomeFunction"
-        }, 
+        },
         "Name": "Live"
       }
-    }, 
+    },
     "MyAwesomeFunctionNotificationTopicPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "sns.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "sns.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Ref": "Notifications"
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment79e6116109"
-        }, 
+          "Ref": "ServerlessRestApiDeployment679b7b4ee4"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "GetHtmlApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "GetHtmlApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "MyAwesomeFunctionCWEventPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "events.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionCWEvent", 
+            "MyAwesomeFunctionCWEvent",
             "Arn"
           ]
         }
@@ -89,21 +79,21 @@
       }
     },
     "MyAwesomeFunctionDDBStream": {
-      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
-        "BatchSize": 200, 
-        "EventSourceArn": "arn:aws:dynamodb:us-west-2:012345678901:table/TestTable/stream/2015-05-11T21:21:33.291", 
+        "BatchSize": 200,
+        "EventSourceArn": "arn:aws:dynamodb:us-west-2:012345678901:table/TestTable/stream/2015-05-11T21:21:33.291",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "StartingPosition": "LATEST"
       }
     },
     "MyAwesomeFunctionIoTRule": {
-      "Type": "AWS::IoT::TopicRule", 
+      "Type": "AWS::IoT::TopicRule",
       "Properties": {
         "TopicRulePayload": {
-          "AwsIotSqlVersion": "beta", 
+          "AwsIotSqlVersion": "beta",
           "Actions": [
             {
               "Lambda": {
@@ -112,34 +102,34 @@
                 }
               }
             }
-          ], 
-          "RuleDisabled": false, 
+          ],
+          "RuleDisabled": false,
           "Sql": "SELECT * FROM 'topic/test'"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionKinesisStream": {
-      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
-        "BatchSize": 100, 
-        "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream", 
+        "BatchSize": 100,
+        "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "StartingPosition": "TRIM_HORIZON"
       }
-    }, 
+    },
     "MyAwesomeFunctionImplicitApiPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -149,21 +139,21 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionIoTRulePermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "SourceAccount": {
           "Fn::Sub": "${AWS::AccountId}"
-        }, 
-        "Principal": "iot.amazonaws.com", 
+        },
+        "Principal": "iot.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:iot:${AWS::Region}:${AWS::AccountId}:rule/${RuleName}", 
+            "arn:aws:iot:${AWS::Region}:${AWS::AccountId}:rule/${RuleName}",
             {
               "RuleName": {
                 "Ref": "MyAwesomeFunctionIoTRule"
@@ -172,74 +162,64 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionNotificationTopic": {
-      "Type": "AWS::SNS::Subscription", 
+      "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Endpoint": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
-        "Protocol": "lambda", 
+        },
+        "Protocol": "lambda",
         "TopicArn": {
           "Ref": "Notifications"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionS3TriggerPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "SourceAccount": {
           "Ref": "AWS::AccountId"
-        }, 
+        },
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "Principal": "s3.amazonaws.com"
       }
-    }, 
+    },
     "GetHtmlApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Name": "MyGetApi"
       }
     },
-    "ServerlessRestApiDeployment79e6116109": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 79e6116109d76ade47a8c413291db052ed065647", 
-        "StageName": "Stage"
-      }
-    }, 
     "MyAwesomeFunctionCWLogPermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "logs.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "logs.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*", 
+            "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*",
             {
               "__LogGroupName__": "MyLogGroup"
             }
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionEBSchedule": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "rate(1 minute)", 
+        "ScheduleExpression": "rate(1 minute)",
         "Targets": [
           {
             "Id": "MyAwesomeFunctionEBScheduleLambdaTarget",
@@ -249,26 +229,26 @@
           }
         ]
       }
-    }, 
+    },
     "MyAwesomeFunctionCWLog": {
-      "Type": "AWS::Logs::SubscriptionFilter", 
+      "Type": "AWS::Logs::SubscriptionFilter",
       "Properties": {
         "DestinationArn": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
-        "FilterPattern": "My pattern", 
+        },
+        "FilterPattern": "My pattern",
         "LogGroupName": "MyLogGroup"
-      }, 
+      },
       "DependsOn": [
         "MyAwesomeFunctionCWLogPermission"
       ]
-    }, 
+    },
     "MyAwesomeFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole", 
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole",
           "arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole"
         ],
         "Tags": [
@@ -278,13 +258,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -294,32 +274,32 @@
           ]
         }
       }
-    }, 
+    },
     "MyAwesomeFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "hello.handler", 
+        "Handler": "hello.handler",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "MyAwesomeFunctionRole", 
+            "MyAwesomeFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "MyAwesomeFunctionCWEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
           "detail": {
@@ -327,10 +307,10 @@
               "terminated"
             ]
           }
-        }, 
+        },
         "Targets": [
           {
-            "Id": "MyAwesomeFunctionCWEventLambdaTarget", 
+            "Id": "MyAwesomeFunctionCWEventLambdaTarget",
             "Arn": {
               "Ref": "MyAwesomeFunctionAliasLive"
             }
@@ -359,53 +339,53 @@
       }
     },
     "MyAwesomeFunctionVersion640128d35d": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::Version", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::Version",
       "Properties": {
         "FunctionName": {
           "Ref": "MyAwesomeFunction"
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyAwesomeFunctionAliasLive}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "Notifications": {
       "Type": "AWS::SNS::Topic"
-    }, 
+    },
     "MyAwesomeFunctionEBSchedulePermission": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "events.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "events.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::GetAtt": [
             "MyAwesomeFunctionEBSchedule",
@@ -413,55 +393,55 @@
           ]
         }
       }
-    }, 
+    },
     "Images": {
-      "Type": "AWS::S3::Bucket", 
+      "Type": "AWS::S3::Bucket",
       "Properties": {
         "NotificationConfiguration": {
           "LambdaConfigurations": [
             {
               "Function": {
                 "Ref": "MyAwesomeFunctionAliasLive"
-              }, 
+              },
               "Event": "s3:ObjectCreated:*"
             }
           ]
         }
-      }, 
+      },
       "DependsOn": [
         "MyAwesomeFunctionS3TriggerPermission"
       ]
-    }, 
+    },
     "GetHtmlApiStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
-        }, 
+          "Ref": "GetHtmlApiDeployment53cc66445c"
+        },
         "RestApiId": {
           "Ref": "GetHtmlApi"
-        }, 
+        },
         "Variables": {
           "LambdaFunction": {
             "Ref": "MyAwesomeFunction"
           }
-        }, 
+        },
         "StageName": {
           "Ref": "MyStageName"
         }
       }
-    }, 
+    },
     "MyAwesomeFunctionExplicitApiPermissionStage": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyAwesomeFunctionAliasLive"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -470,6 +450,26 @@
             }
           ]
         }
+      }
+    },
+    "GetHtmlApiDeployment53cc66445c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "GetHtmlApi"
+        },
+        "Description": "RestApi deployment id: 53cc66445c0accdc5f3244004331940761c72c8b",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeployment679b7b4ee4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 679b7b4ee4aec5b30feec683b6c42d0a5e11f18b",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/function_with_request_parameters.json
+++ b/tests/translator/output/function_with_request_parameters.json
@@ -53,16 +53,6 @@
         }
       }
     },
-    "ServerlessRestApiDeployment2223b43914": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: 2223b439142974b7a3aad1381ddd39027077ce52",
-        "StageName": "Stage"
-      }
-    },
     "ApiParameterFunctionRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -118,7 +108,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment2223b43914"
+          "Ref": "ServerlessRestApiDeploymente74a01fdde"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -184,21 +174,11 @@
         }
       }
     },
-    "ApiDeploymentb45131471b": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "Api"
-        },
-        "Description": "RestApi deployment id: b45131471b437edb4cca88487357f3bfbcf59866",
-        "StageName": "Stage"
-      }
-    },
     "ApiProdStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiDeploymentb45131471b"
+          "Ref": "ApiDeploymentb7a69dbfd3"
         },
         "RestApiId": {
           "Ref": "Api"
@@ -269,6 +249,26 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    },
+    "ServerlessRestApiDeploymente74a01fdde": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: e74a01fdde807488753fe46287101c756943ec48",
+        "StageName": "Stage"
+      }
+    },
+    "ApiDeploymentb7a69dbfd3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "Api"
+        },
+        "Description": "RestApi deployment id: b7a69dbfd3a37682c75465339ecdf541caa8e7de",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/global_handle_path_level_parameter.json
+++ b/tests/translator/output/global_handle_path_level_parameter.json
@@ -128,18 +128,8 @@
         },
         "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentdb4b9da82a"
+          "Ref": "ServerlessRestApiDeployment93d0f104df"
         }
-      }
-    },
-    "ServerlessRestApiDeploymentdb4b9da82a": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: db4b9da82adc6031fcd32bf3a4954485464fc009",
-        "StageName": "Stage"
       }
     },
     "ExplicitApiSomeStageStage": {
@@ -155,7 +145,7 @@
         },
         "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9a254aa466"
+          "Ref": "ExplicitApiDeployment24b17d3335"
         }
       }
     },
@@ -199,16 +189,6 @@
             "Name": "email"
           }
         ]
-      }
-    },
-    "ExplicitApiDeployment9a254aa466": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        },
-        "Description": "RestApi deployment id: 9a254aa466c6f818951dfb6e45fde65489beb153",
-        "StageName": "Stage"
       }
     },
     "ServerlessRestApi": {
@@ -262,6 +242,26 @@
           }
         },
         "Name": "some api"
+      }
+    },
+    "ServerlessRestApiDeployment93d0f104df": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 93d0f104df96ef33407c1c6ae95e12d1b9ac609f",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeployment24b17d3335": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: 24b17d33358d1e9ca30ab2a0967848d74f40c3de",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/globals_for_api.json
+++ b/tests/translator/output/globals_for_api.json
@@ -1,30 +1,30 @@
 {
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -36,13 +36,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -53,132 +53,112 @@
         }
       }
     },
-    "ServerlessRestApiDeploymentaa32438b68": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: aa32438b68e05d3771a975585dfbc7b012672b55", 
-        "StageName": "Stage"
-      }
-    }, 
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": 2.0, 
+          },
+          "swagger": 2.0,
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
-        }, 
+        },
         "Name": "some api"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "Prod",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentaa32438b68"
+          "Ref": "ServerlessRestApiDeployment4a13bec748"
         }
       }
-    }, 
+    },
     "ExplicitApiSomeStageStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "SomeStage", 
-        "CacheClusterSize": "1.6", 
+        },
+        "StageName": "SomeStage",
+        "CacheClusterSize": "1.6",
         "Variables": {
           "SomeVar": "Value"
-        }, 
-        "CacheClusterEnabled": true, 
+        },
+        "CacheClusterEnabled": true,
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment43e01e673d"
+          "Ref": "ExplicitApiDeploymentf64bb7c4a4"
         }
       }
-    }, 
-    "ExplicitApiDeployment43e01e673d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 43e01e673d7acbd09e4c38ff78dd6ddaf2ed1d55", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -188,87 +168,107 @@
           ]
         }
       }
-    }, 
+    },
     "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+      "Type": "AWS::Cognito::UserPool",
       "Properties": {
         "UsernameAttributes": [
           "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
+        ],
+        "UserPoolName": "UserPoolName",
         "Policies": {
           "PasswordPolicy": {
             "MinimumLength": 8
           }
-        }, 
+        },
         "Schema": [
           {
-            "AttributeDataType": "String", 
-            "Required": false, 
+            "AttributeDataType": "String",
+            "Required": false,
             "Name": "email"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "security": [
                   {
                     "MyCognitoAuth": []
-                  }, 
+                  },
                   {
                     "api_key": []
                   }
-                ], 
+                ],
                 "responses": {}
               }
             }
-          }, 
-          "swagger": "2.0", 
+          },
+          "swagger": "2.0",
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header", 
-              "type": "apiKey", 
-              "name": "Authorization", 
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   {
                     "Fn::GetAtt": [
-                      "MyUserPool", 
+                      "MyUserPool",
                       "Arn"
                     ]
                   }
-                ], 
+                ],
                 "type": "cognito_user_pools"
-              }, 
+              },
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }, 
+            },
             "api_key": {
-              "type": "apiKey", 
-              "name": "x-api-key", 
+              "type": "apiKey",
+              "name": "x-api-key",
               "in": "header"
             }
           }
-        }, 
+        },
         "Name": "some api"
+      }
+    },
+    "ServerlessRestApiDeployment4a13bec748": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 4a13bec748f6d17a5fc0b19c4b29a2f0b20d60ce",
+        "StageName": "Stage"
+      }
+    },
+    "ExplicitApiDeploymentf64bb7c4a4": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: f64bb7c4a498f204e281c987b181d884fdec35b7",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/implicit_and_explicit_api_with_conditions.json
+++ b/tests/translator/output/implicit_and_explicit_api_with_conditions.json
@@ -122,7 +122,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "explicitapiDeployment9fcb053eda"
+          "Ref": "explicitapiDeployment6d637c9442"
         },
         "RestApiId": {
           "Ref": "explicitapi"
@@ -134,7 +134,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentfa2ce19a90"
+          "Ref": "ServerlessRestApiDeployment887b2aec6d"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -290,17 +290,6 @@
       },
       "Condition": "explicithello2condition"
     },
-    "ServerlessRestApiDeploymentfa2ce19a90": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: fa2ce19a90f37f90f1ece14a3dfcef1fed1f1a6a",
-        "StageName": "Stage"
-      },
-      "Condition": "ServerlessRestApiCondition"
-    },
     "explicitapi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -442,16 +431,6 @@
       },
       "Condition": "explicithello1condition"
     },
-    "explicitapiDeployment9fcb053eda": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "explicitapi"
-        },
-        "Description": "RestApi deployment id: 9fcb053edaaf92e1c6366f31270d2fb87b370240",
-        "StageName": "Stage"
-      }
-    },
     "ServerlessRestApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
@@ -571,6 +550,27 @@
         }
       },
       "Condition": "implicithello1condition"
+    },
+    "ServerlessRestApiDeployment887b2aec6d": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 887b2aec6d4dce31236432b538163caca39ef0cb",
+        "StageName": "Stage"
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "explicitapiDeployment6d637c9442": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "explicitapi"
+        },
+        "Description": "RestApi deployment id: 6d637c9442463766f49790e426cef1f8a0a787bb",
+        "StageName": "Stage"
+      }
     }
   },
   "Description": "A template to test for API condition handling with a mix of explicit and implicit api events."

--- a/tests/translator/output/implicit_api.json
+++ b/tests/translator/output/implicit_api.json
@@ -1,10 +1,10 @@
 {
   "Resources": {
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
         ],
         "Tags": [
@@ -13,15 +13,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -33,16 +32,16 @@
       }
     },
     "RestApiFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -54,16 +53,16 @@
       }
     },
     "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -73,47 +72,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment127e3fb911"
-        }, 
+          "Ref": "ServerlessRestApiDeployment52f4ee180b"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -122,15 +121,14 @@
             "Key": "lambda:createdBy"
           }
         ],
-
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -142,49 +140,39 @@
       }
     },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.restapi", 
+        },
+        "Handler": "index.restapi",
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment127e3fb911": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 127e3fb91142ab1ddc5f5446adb094442581a90d", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "RestApiFunctionGetListPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -194,82 +182,82 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/{proxy+}": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/getlist": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/complete": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "RestApiFunctionCompleteItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -278,6 +266,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment52f4ee180b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 52f4ee180b269416c553e77485c19f9daaefe939",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/implicit_api_with_auth_and_conditions_max.json
+++ b/tests/translator/output/implicit_api_with_auth_and_conditions_max.json
@@ -201,7 +201,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcbc79073ff"
+          "Ref": "ServerlessRestApiDeploymentac4e170e96"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -271,17 +271,6 @@
         }
       },
       "Condition": "FunctionCondition2"
-    },
-    "ServerlessRestApiDeploymentcbc79073ff": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: cbc79073ff900d53c3f67ea223640210914a672c",
-        "StageName": "Stage"
-      },
-      "Condition": "ServerlessRestApiCondition"
     },
     "MyFunction4Role": {
       "Type": "AWS::IAM::Role",
@@ -937,6 +926,17 @@
             }
           }
         }
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "ServerlessRestApiDeploymentac4e170e96": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: ac4e170e9629ac41477cc8f52d400b70c3273097",
+        "StageName": "Stage"
       },
       "Condition": "ServerlessRestApiCondition"
     }

--- a/tests/translator/output/implicit_api_with_many_conditions.json
+++ b/tests/translator/output/implicit_api_with_many_conditions.json
@@ -149,7 +149,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentd229cbabc1"
+          "Ref": "ServerlessRestApiDeployment3b79e27255"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -438,17 +438,6 @@
         }
       },
       "Condition": "Cond2"
-    },
-    "ServerlessRestApiDeploymentd229cbabc1": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        },
-        "Description": "RestApi deployment id: d229cbabc195ae9406a1e544dedb556864eb05b0",
-        "StageName": "Stage"
-      },
-      "Condition": "ServerlessRestApiCondition"
     },
     "helloworld3ApiEventPermissionProd": {
       "Type": "AWS::Lambda::Permission",
@@ -1405,6 +1394,17 @@
           },
           "swagger": "2.0"
         }
+      },
+      "Condition": "ServerlessRestApiCondition"
+    },
+    "ServerlessRestApiDeployment3b79e27255": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 3b79e27255461c32c7006261077cb40593ddf4c1",
+        "StageName": "Stage"
       },
       "Condition": "ServerlessRestApiCondition"
     }

--- a/tests/translator/output/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/implicit_api_with_serverless_rest_api_resource.json
@@ -1,10 +1,10 @@
 {
   "Resources": {
     "RestApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
         ],
         "Tags": [
@@ -14,13 +14,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -32,16 +32,16 @@
       }
     },
     "RestApiFunctionAddItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -53,16 +53,16 @@
       }
     },
     "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "GetHtmlFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -72,47 +72,47 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment127e3fb911"
-        }, 
+          "Ref": "ServerlessRestApiDeployment52f4ee180b"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
     },
     "GetHtmlFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.gethtml", 
+        },
+        "Handler": "index.gethtml",
         "Role": {
           "Fn::GetAtt": [
-            "GetHtmlFunctionRole", 
+            "GetHtmlFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "GetHtmlFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
           "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
         ],
         "Tags": [
@@ -122,13 +122,13 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -140,49 +140,39 @@
       }
     },
     "RestApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "todo_list.zip"
-        }, 
-        "Handler": "index.restapi", 
+        },
+        "Handler": "index.restapi",
         "Role": {
           "Fn::GetAtt": [
-            "RestApiFunctionRole", 
+            "RestApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
-    "ServerlessRestApiDeployment127e3fb911": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 127e3fb91142ab1ddc5f5446adb094442581a90d", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "RestApiFunctionGetListPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -192,82 +182,82 @@
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/add": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/{proxy+}": {
               "x-amazon-apigateway-any-method": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/getlist": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
-            }, 
+            },
             "/complete": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "RestApiFunctionCompleteItemPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "RestApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -276,6 +266,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment52f4ee180b": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 52f4ee180b269416c553e77485c19f9daaefe939",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/output/intrinsic_functions.json
+++ b/tests/translator/output/intrinsic_functions.json
@@ -2,33 +2,33 @@
   "Conditions": {
     "TrueCondition": {
       "Fn::Equals": [
-        true, 
+        true,
         true
       ]
     }
-  }, 
+  },
   "Parameters": {
     "CodeKey": {
-      "Default": "key", 
+      "Default": "key",
       "Type": "String"
-    }, 
+    },
     "CodeBucket": {
-      "Default": "sam-demo-bucket", 
+      "Default": "sam-demo-bucket",
       "Type": "String"
-    }, 
+    },
     "FunctionName": {
-      "Default": "MySuperFunctionName", 
+      "Default": "MySuperFunctionName",
       "Type": "String"
-    }, 
+    },
     "MyExplicitApiName": {
-      "Default": "SomeName", 
+      "Default": "SomeName",
       "Type": "String"
-    }, 
+    },
     "TracingConfigParam": {
-      "Default": "PassThrough", 
+      "Default": "PassThrough",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "MyExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi",
@@ -113,16 +113,6 @@
         }
       },
       "Condition": "TrueCondition"
-    },
-    "MyExplicitApiDeployment7145dd00ce": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyExplicitApi"
-        },
-        "Description": "RestApi deployment id: 7145dd00cea59b4a62b4d7855add490c587f3f62",
-        "StageName": "Stage"
-      }
     },
     "FunctionWithExplicitS3Uri": {
       "Type": "AWS::Lambda::Function",
@@ -409,7 +399,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithExplicitS3UriDeploymenta227798f00"
+          "Ref": "ApiWithExplicitS3UriDeploymentdf00ae04c1"
         },
         "RestApiId": {
           "Ref": "ApiWithExplicitS3Uri"
@@ -433,17 +423,6 @@
         },
         "StartingPosition": "LATEST"
       }
-    },
-    "ApiWithExplicitS3UriDeploymenta227798f00": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithExplicitS3Uri"
-        },
-        "Description": "RestApi deployment id: a227798f004a50b665fe47a20bb9afbf076bd85d",
-        "StageName": "Stage"
-      },
-      "Condition": "TrueCondition"
     },
     "MySqsDlqLambdaFunctionRole": {
       "Type": "AWS::IAM::Role",
@@ -499,7 +478,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment7145dd00ce"
+          "Ref": "MyExplicitApiDeploymentac5370c463"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"
@@ -524,7 +503,7 @@
     "MyFunctionMyApiPermissiondev": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
+        "Action": "lambda:InvokeFunction",
         "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "MyFunction"
@@ -541,6 +520,27 @@
           ]
         }
       }
+    },
+    "MyExplicitApiDeploymentac5370c463": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyExplicitApi"
+        },
+        "Description": "RestApi deployment id: ac5370c463a1506e2d2d574f796b90853a805218",
+        "StageName": "Stage"
+      }
+    },
+    "ApiWithExplicitS3UriDeploymentdf00ae04c1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithExplicitS3Uri"
+        },
+        "Description": "RestApi deployment id: df00ae04c10d650fc54bbd3b1444d09ff6ee0ae6",
+        "StageName": "Stage"
+      },
+      "Condition": "TrueCondition"
     }
   }
 }

--- a/tests/translator/output/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/state_machine_with_api_auth_default_scopes.json
@@ -1,725 +1,725 @@
 {
-    "Resources": {
-        "MyApiWithCognitoAuth": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/cognitowithauthnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoWithAuthNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "NONE": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultauthdefaultscopesnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesnone": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesNoneRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitoauthorizerwithdefaultscopes": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": [
-                                            "default.delete", 
-                                            "default.update"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitoauthorizercopesoverwritten": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthWithDefaultScopes": [
-                                            "overwritten.read", 
-                                            "overwritten.write"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesoverwritten": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": [
-                                            "overwritten.read", 
-                                            "overwritten.write"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/cognitodefaultscopesdefaultauthorizer": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyDefaultCognitoAuth": [
-                                            "default.write", 
-                                            "default.read"
-                                        ]
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "openapi": "3.0.1", 
-                    "components": {
-                        "securitySchemes": {
-                            "MyCognitoAuthWithDefaultScopes": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
-                                "x-amazon-apigateway-authorizer": {
-                                    "providerARNs": [
-                                        "arn:aws:2"
-                                    ], 
-                                    "type": "cognito_user_pools"
-                                }, 
-                                "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }, 
-                            "MyDefaultCognitoAuth": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
-                                "x-amazon-apigateway-authorizer": {
-                                    "providerARNs": [
-                                        "arn:aws:1"
-                                    ], 
-                                    "type": "cognito_user_pools"
-                                }, 
-                                "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }
-                        }
+  "Resources": {
+    "MyApiWithCognitoAuth": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/cognitowithauthnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                }
-            }
-        }, 
-        "MyStateMachineCognitoWithAuthNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                     }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiWithCognitoAuthProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiWithCognitoAuthDeployment57b57dfc88"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApiWithCognitoAuth"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "MyApiWithCognitoAuthDeployment57b57dfc88": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApiWithCognitoAuth"
-                }, 
-                "Description": "RestApi deployment id: 57b57dfc88b1b438a0437eadd869d77e938eedb6"
-            }
-        }, 
-        "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
+                  },
+                  "credentials": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
-                        "Arn"
+                      "MyStateMachineCognitoWithAuthNoneRole",
+                      "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "NONE": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
                 }
-            }
-        }, 
-        "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
+              }
+            },
+            "/cognitodefaultauthdefaultscopesnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole",
+                      "Arn"
                     ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
                 }
-            }
-        }, 
-        "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
+              }
+            },
+            "/cognitodefaultscopesnone": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesNoneRole",
+                      "Arn"
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitoauthorizerwithdefaultscopes": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
                     }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                     }
-                ]
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoAuthorizerWithDefaultScopesRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": [
+                      "default.delete",
+                      "default.update"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitoauthorizercopesoverwritten": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoAuthorizerScopesOverwrittenRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthWithDefaultScopes": [
+                      "overwritten.read",
+                      "overwritten.write"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitodefaultscopesoverwritten": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesWithOverwrittenRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": [
+                      "overwritten.read",
+                      "overwritten.write"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/cognitodefaultscopesdefaultauthorizer": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyDefaultCognitoAuth": [
+                      "default.write",
+                      "default.read"
+                    ]
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
             }
+          },
+          "openapi": "3.0.1",
+          "components": {
+            "securitySchemes": {
+              "MyCognitoAuthWithDefaultScopes": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    "arn:aws:2"
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
+              },
+              "MyDefaultCognitoAuth": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Authorization",
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    "arn:aws:1"
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
+              }
+            }
+          }
         }
+      }
+    },
+    "MyStateMachineCognitoWithAuthNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiWithCognitoAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithCognitoAuthDeploymentd0339f6a6f"
+        },
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiWithCognitoAuthDeploymentd0339f6a6f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        },
+        "Description": "RestApi deployment id: d0339f6a6febe05cf298904934b8af368bd689c2"
+      }
     }
+  }
 }

--- a/tests/translator/output/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/state_machine_with_api_authorizer.json
@@ -1,368 +1,368 @@
 {
-    "Resources": {
-        "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
+  "Resources": {
+    "MyApiMyLambdaTokenAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeploymentaaffc688ce"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startNoAuth": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }
-            }
-        }, 
-        "StateMachineWithLambdaTokenAuthRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiDeploymentc2779253ee": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: c2779253eecd9c0b8252440b0cf5ef8d2759b211", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeploymentc2779253ee"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeploymentaaffc688ce": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startWithLambdaToken": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaTokenAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "securityDefinitions": {
-                        "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
-                            "in": "header"
-                        }, 
-                        "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
-                                "identityValidationExpression": "mycustomauthexpression"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }
-                    }
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentd5411ae9d3"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startNoAuth": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithNoAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        }
+      }
+    },
+    "StateMachineWithLambdaTokenAuthRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment9e54799b5a"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineWithNoAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startWithLambdaToken": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaTokenAuthRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaTokenAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            },
+            "MyLambdaTokenAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
+                "identityValidationExpression": "mycustomauthexpression"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            }
+          }
+        }
+      }
+    },
+    "MyApiDeployment9e54799b5a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 9e54799b5a6cd9e973c9539f6e971451459127e2",
+        "StageName": "Stage"
+      }
+    },
+    "ServerlessRestApiDeploymentd5411ae9d3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: d5411ae9d3cfb9e3457f9f276ef3d7ae53e1b07d",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/state_machine_with_api_authorizer_maximum.json
@@ -1,682 +1,682 @@
 {
-    "Resources": {
-        "MyApiDeploymentde088eafc3": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: de088eafc3dd099f3b79506a6e0542dadb9fcd23", 
-                "StageName": "Stage"
+  "Resources": {
+    "MyApiMyLambdaRequestAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
             }
-        }, 
-        "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachineWithLambdaRequestAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "StateMachineWithDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "NONE": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/users": {
-                            "put": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithDefaultAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyCognitoAuthMultipleUserPools": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "patch": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }, 
-                            "delete": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineWithLambdaRequestAuthorizerRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "security": [
-                                    {
-                                        "MyLambdaRequestAuth": []
-                                    }, 
-                                    {
-                                        "api_key": []
-                                    }
-                                ], 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "securityDefinitions": {
-                        "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Authorization", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "MyCognitoAuthMultipleUserPools": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader2", 
-                            "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression2", 
-                                "providerARNs": [
-                                    "arn:aws:2", 
-                                    "arn:aws:3"
-                                ], 
-                                "type": "cognito_user_pools"
-                            }, 
-                            "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
-                        "MyLambdaRequestAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Unused", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "request", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "MyCognitoAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression", 
-                                "providerARNs": [
-                                    "arn:aws:1"
-                                ], 
-                                "type": "cognito_user_pools"
-                            }, 
-                            "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
-                        "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
-                            "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
-                                "authorizerUri": {
-                                    "Fn::Sub": [
-                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
-                                        {
-                                            "__FunctionArn__": "arn:aws"
-                                        }
-                                    ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
-                                "identityValidationExpression": "mycustomauthexpression"
-                            }, 
-                            "x-amazon-apigateway-authtype": "custom"
-                        }, 
-                        "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
-                            "in": "header"
-                        }
-                    }
-                }
-            }
-        }, 
-        "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "StateMachineWithLambdaTokenAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
-            "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-                        {
-                            "__ApiId__": {
-                                "Ref": "MyApi"
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeploymentde088eafc3"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachineWithLambdaRequestAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachineWithDefaultAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithNoAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "NONE": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/users": {
+              "put": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithDefaultAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyCognitoAuthMultipleUserPools": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "patch": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaTokenAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaTokenAuthNoneFunctionInvokeRole": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              },
+              "delete": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineWithLambdaRequestAuthorizerRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "security": [
+                  {
+                    "MyLambdaRequestAuth": []
+                  },
+                  {
+                    "api_key": []
+                  }
+                ],
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "MyLambdaTokenAuthNoneFunctionInvokeRole": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 0,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                }
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "MyCognitoAuthMultipleUserPools": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader2",
+              "x-amazon-apigateway-authorizer": {
+                "identityValidationExpression": "myauthvalidationexpression2",
+                "providerARNs": [
+                  "arn:aws:2",
+                  "arn:aws:3"
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyLambdaRequestAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Unused",
+              "x-amazon-apigateway-authorizer": {
+                "type": "request",
+                "authorizerResultTtlInSeconds": 0,
+                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "MyCognitoAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyAuthorizationHeader",
+              "x-amazon-apigateway-authorizer": {
+                "identityValidationExpression": "myauthvalidationexpression",
+                "providerARNs": [
+                  "arn:aws:1"
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyLambdaTokenAuth": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "MyCustomAuthHeader",
+              "x-amazon-apigateway-authorizer": {
+                "type": "token",
+                "authorizerResultTtlInSeconds": 20,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": "arn:aws"
+                    }
+                  ]
+                },
+                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
+                "identityValidationExpression": "mycustomauthexpression"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            },
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        }
+      }
+    },
+    "MyApiMyLambdaTokenAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachineWithLambdaTokenAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": "arn:aws",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment785599cba1"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "StateMachineWithNoAuthorizerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyApiDeployment785599cba1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 785599cba1da6e723591bb7d55e430a4767bbd62",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/state_machine_with_api_resource_policy.json
@@ -1,474 +1,474 @@
 {
-    "Resources": {
-        "MyStateMachineGetHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "MyStateMachineGetHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "ExplicitApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/one": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachineGetHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/three": {
-                            "put": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachinePutHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }, 
-                        "/two": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "MyStateMachinePostHtmlRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
-                        "Statement": [
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Allow", 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "NotIpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "IpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Allow", 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "NotIpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }, 
-                            {
-                                "Action": "execute-api:Invoke", 
-                                "Resource": [
-                                    {
-                                        "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
-                                            {
-                                                "__Stage__": null
-                                            }
-                                        ]
-                                    }
-                                ], 
-                                "Effect": "Deny", 
-                                "Condition": {
-                                    "IpAddress": {
-                                        "aws:SourceIp": [
-                                            "1.2.3.4"
-                                        ]
-                                    }
-                                }, 
-                                "Principal": "*"
-                            }
-                        ]
-                    }
-                }
-            }
-        }, 
-        "ExplicitApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ExplicitApiDeployment17065a95ba"
-                }, 
-                "RestApiId": {
-                    "Ref": "ExplicitApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "MyStateMachinePutHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "MyStateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ExplicitApiDeployment17065a95ba": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ExplicitApi"
-                }, 
-                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2", 
-                "StageName": "Stage"
-            }
-        }, 
-        "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "MyStateMachinePostHtmlRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "MyStateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
+          ]
         }
+      }
+    },
+    "ExplicitApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachineGetHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/three": {
+              "put": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachinePutHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            },
+            "/two": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "MyStateMachinePostHtmlRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Allow",
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "NotIpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/GET/one",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "IpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Allow",
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "NotIpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              },
+              {
+                "Action": "execute-api:Invoke",
+                "Resource": [
+                  {
+                    "Fn::Sub": [
+                      "execute-api:/${__Stage__}/POST/two",
+                      {
+                        "__Stage__": null
+                      }
+                    ]
+                  }
+                ],
+                "Effect": "Deny",
+                "Condition": {
+                  "IpAddress": {
+                    "aws:SourceIp": [
+                      "1.2.3.4"
+                    ]
+                  }
+                },
+                "Principal": "*"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeploymente0026ec516"
+        },
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyStateMachinePutHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "MyStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyStateMachinePostHtmlRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ExplicitApiDeploymente0026ec516": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: e0026ec516d4da624aa0d0e56caf9ccf79e409b2",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/state_machine_with_condition_and_events.json
+++ b/tests/translator/output/state_machine_with_condition_and_events.json
@@ -1,297 +1,297 @@
 {
-    "Conditions": {
-        "TestCondition": {
-            "Fn::Equals": [
-                "test", 
-                "test"
-            ]
-        }
-    }, 
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole", 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionS3Location": {
-                    "Version": 3, 
-                    "Bucket": "sam-demo-bucket", 
-                    "Key": "my-state-machine.asl.json"
-                }, 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineScheduleEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "events.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeploymentaeae651245"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineScheduleEvent": {
-            "Type": "AWS::Events::Rule", 
-            "Properties": {
-                "ScheduleExpression": "rate(1 minute)", 
-                "Targets": [
-                    {
-                        "RoleArn": {
-                            "Fn::GetAtt": [
-                                "StateMachineScheduleEventRole", 
-                                "Arn"
-                            ]
-                        }, 
-                        "Id": "StateMachineScheduleEventStepFunctionsTarget", 
-                        "Arn": {
-                            "Ref": "StateMachine"
-                        }
-                    }
-                ], 
-                "Name": "TestSchedule"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineCWEvent": {
-            "Type": "AWS::Events::Rule", 
-            "Properties": {
-                "EventPattern": {
-                    "detail": {
-                        "state": [
-                            "terminated"
-                        ]
-                    }
-                }, 
-                "Targets": [
-                    {
-                        "RoleArn": {
-                            "Fn::GetAtt": [
-                                "StateMachineCWEventRole", 
-                                "Arn"
-                            ]
-                        }, 
-                        "Id": "StateMachineCWEventStepFunctionsTarget", 
-                        "Arn": {
-                            "Ref": "StateMachine"
-                        }
-                    }
-                ]
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "Fn::If": [
-                                "TestCondition", 
-                                {
-                                    "post": {
-                                        "Fn::If": [
-                                            "TestCondition", 
-                                            {
-                                                "x-amazon-apigateway-integration": {
-                                                    "responses": {
-                                                        "200": {
-                                                            "statusCode": "200"
-                                                        }, 
-                                                        "400": {
-                                                            "statusCode": "400"
-                                                        }
-                                                    }, 
-                                                    "uri": {
-                                                        "Fn::If": [
-                                                            "TestCondition", 
-                                                            {
-                                                                "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                                            }, 
-                                                            {
-                                                                "Ref": "AWS::NoValue"
-                                                            }
-                                                        ]
-                                                    }, 
-                                                    "httpMethod": "POST", 
-                                                    "requestTemplates": {
-                                                        "application/json": {
-                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                                        }
-                                                    }, 
-                                                    "credentials": {
-                                                        "Fn::GetAtt": [
-                                                            "StateMachineMyApiEventRole", 
-                                                            "Arn"
-                                                        ]
-                                                    }, 
-                                                    "type": "aws"
-                                                }, 
-                                                "responses": {
-                                                    "200": {
-                                                        "description": "OK"
-                                                    }, 
-                                                    "400": {
-                                                        "description": "Bad Request"
-                                                    }
-                                                }
-                                            }, 
-                                            {
-                                                "Ref": "AWS::NoValue"
-                                            }
-                                        ]
-                                    }
-                                }, 
-                                {
-                                    "Ref": "AWS::NoValue"
-                                }
-                            ]
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "ServerlessRestApiDeploymentaeae651245": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aeae651245fe7d417a17f2bea50b255f2727e2b8", 
-                "StageName": "Stage"
-            }, 
-            "Condition": "TestCondition"
-        }, 
-        "StateMachineCWEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "events.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }, 
-            "Condition": "TestCondition"
-        }
+  "Conditions": {
+    "TestCondition": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
     }
+  },
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
+        "StateMachineName": "MyStateMachine",
+        "DefinitionS3Location": {
+          "Version": 3,
+          "Bucket": "sam-demo-bucket",
+          "Key": "my-state-machine.asl.json"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineScheduleEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentf22928ca9f"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineScheduleEvent": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)",
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineScheduleEventRole",
+                "Arn"
+              ]
+            },
+            "Id": "StateMachineScheduleEventStepFunctionsTarget",
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ],
+        "Name": "TestSchedule"
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineCWEvent": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        },
+        "Targets": [
+          {
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineCWEventRole",
+                "Arn"
+              ]
+            },
+            "Id": "StateMachineCWEventStepFunctionsTarget",
+            "Arn": {
+              "Ref": "StateMachine"
+            }
+          }
+        ]
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "Fn::If": [
+                "TestCondition",
+                {
+                  "post": {
+                    "Fn::If": [
+                      "TestCondition",
+                      {
+                        "x-amazon-apigateway-integration": {
+                          "responses": {
+                            "200": {
+                              "statusCode": "200"
+                            },
+                            "400": {
+                              "statusCode": "400"
+                            }
+                          },
+                          "uri": {
+                            "Fn::If": [
+                              "TestCondition",
+                              {
+                                "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                              },
+                              {
+                                "Ref": "AWS::NoValue"
+                              }
+                            ]
+                          },
+                          "httpMethod": "POST",
+                          "requestTemplates": {
+                            "application/json": {
+                              "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                            }
+                          },
+                          "credentials": {
+                            "Fn::GetAtt": [
+                              "StateMachineMyApiEventRole",
+                              "Arn"
+                            ]
+                          },
+                          "type": "aws"
+                        },
+                        "responses": {
+                          "200": {
+                            "description": "OK"
+                          },
+                          "400": {
+                            "description": "Bad Request"
+                          }
+                        }
+                      },
+                      {
+                        "Ref": "AWS::NoValue"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "Ref": "AWS::NoValue"
+                }
+              ]
+            }
+          },
+          "swagger": "2.0"
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "StateMachineCWEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "TestCondition"
+    },
+    "ServerlessRestApiDeploymentf22928ca9f": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: f22928ca9fa163df139e3c1f896167ecefffa178",
+        "StageName": "Stage"
+      },
+      "Condition": "TestCondition"
+    }
+  }
 }

--- a/tests/translator/output/state_machine_with_explicit_api.json
+++ b/tests/translator/output/state_machine_with_explicit_api.json
@@ -1,202 +1,202 @@
 {
-    "Resources": {
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+  "Resources": {
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment0e07112b2c"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "MyApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-                "StageName": "Stage"
-            }
-        }, 
-        "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "MyApiDeployment05bc9f394c"
-                }, 
-                "RestApiId": {
-                    "Ref": "MyApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        }, 
-        "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }
-            }
+          ]
         }
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        }
+      }
+    },
+    "MyApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/state_machine_with_implicit_api.json
+++ b/tests/translator/output/state_machine_with_implicit_api.json
@@ -1,202 +1,202 @@
 {
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeployment05bc9f394c"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0"
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment0e07112b2c"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        }
+      }
+    },
+    "ServerlessRestApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/state_machine_with_implicit_api_globals.json
@@ -1,224 +1,224 @@
 {
-    "Resources": {
-        "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": "states:StartExecution", 
-                                    "Resource": {
-                                        "Ref": "StateMachine"
-                                    }, 
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "apigateway.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
+  "Resources": {
+    "StateMachineMyApiEventRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Policies": [
+          {
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  },
+                  "Effect": "Allow"
                 }
+              ]
             }
-        }, 
-        "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
-            "Properties": {
-                "RoleArn": {
-                    "Fn::GetAtt": [
-                        "StateMachineRole", 
-                        "Arn"
-                    ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
                 ]
+              }
             }
-        }, 
-        "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
-            "Properties": {
-                "DeploymentId": {
-                    "Ref": "ServerlessRestApiDeployment1f01b589d4"
-                }, 
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "StageName": "Prod"
-            }
-        }, 
-        "ServerlessRestApiDeployment1f01b589d4": {
-            "Type": "AWS::ApiGateway::Deployment", 
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a", 
-                "StageName": "Stage"
-            }
-        }, 
-        "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
-                            "Principal": {
-                                "Service": [
-                                    "states.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                }, 
-                "ManagedPolicyArns": [], 
-                "Policies": [
-                    {
-                        "PolicyName": "StateMachineRolePolicy0", 
-                        "PolicyDocument": {
-                            "Version": "2012-10-17", 
-                            "Statement": [
-                                {
-                                    "Action": "*", 
-                                    "Resource": "*", 
-                                    "Effect": "Deny"
-                                }
-                            ]
-                        }
-                    }
-                ], 
-                "Tags": [
-                    {
-                        "Value": "SAM", 
-                        "Key": "stateMachine:createdBy"
-                    }
-                ]
-            }
-        }, 
-        "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
-            "Properties": {
-                "Body": {
-                    "info": {
-                        "version": "1.0", 
-                        "title": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }, 
-                    "paths": {
-                        "/startMyExecution": {
-                            "post": {
-                                "x-amazon-apigateway-integration": {
-                                    "responses": {
-                                        "200": {
-                                            "statusCode": "200"
-                                        }, 
-                                        "400": {
-                                            "statusCode": "400"
-                                        }
-                                    }, 
-                                    "uri": {
-                                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
-                                    "requestTemplates": {
-                                        "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
-                                        }
-                                    }, 
-                                    "credentials": {
-                                        "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
-                                            "Arn"
-                                        ]
-                                    }, 
-                                    "type": "aws"
-                                }, 
-                                "responses": {
-                                    "200": {
-                                        "description": "OK"
-                                    }, 
-                                    "400": {
-                                        "description": "Bad Request"
-                                    }
-                                }
-                            }
-                        }
-                    }, 
-                    "swagger": "2.0", 
-                    "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
-                        "Statement": {
-                            "Action": "execute-api:Invoke", 
-                            "Resource": [
-                                {
-                                    "Fn::Sub": [
-                                        "execute-api:/${__Stage__}/POST/startMyExecution", 
-                                        {
-                                            "__Stage__": "Prod"
-                                        }
-                                    ]
-                                }
-                            ], 
-                            "Effect": "Deny", 
-                            "Principal": {
-                                "AWS": [
-                                    "12345"
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
+          ]
         }
+      }
+    },
+    "StateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "MyStateMachine",
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "StateMachineType": "STANDARD",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentc81fbad89e"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "StateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "StateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Resource": "*",
+                  "Effect": "Deny"
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "stateMachine:createdBy"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                    }
+                  },
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "StateMachineMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "type": "aws"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17",
+            "Statement": {
+              "Action": "execute-api:Invoke",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "execute-api:/${__Stage__}/POST/startMyExecution",
+                    {
+                      "__Stage__": "Prod"
+                    }
+                  ]
+                }
+              ],
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": [
+                  "12345"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "ServerlessRestApiDeploymentc81fbad89e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: c81fbad89effca825bf52acf474877e98e597381",
+        "StageName": "Stage"
+      }
     }
+  }
 }

--- a/tests/translator/output/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/state_machine_with_permissions_boundary.json
@@ -1,57 +1,57 @@
 {
   "Resources": {
     "MyFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
+        },
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
-        ], 
-        "ReservedConcurrentExecutions": 100, 
-        "Handler": "hello.handler", 
+        ],
+        "ReservedConcurrentExecutions": 100,
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "python2.7"
       }
-    }, 
+    },
     "StateMachineMyApiEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "apigateway.amazonaws.com"
@@ -61,54 +61,44 @@
           ]
         }
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyStateMachine", 
+        },
+        "StateMachineName": "MyStateMachine",
         "DefinitionS3Location": {
-          "Version": 3, 
-          "Bucket": "sam-demo-bucket", 
+          "Version": 3,
+          "Bucket": "sam-demo-bucket",
           "Key": "my-state-machine.asl.json"
-        }, 
+        },
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment05bc9f394c"
-        }, 
+          "Ref": "ServerlessRestApiDeployment0e07112b2c"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeployment05bc9f394c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "StateMachineCWEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
           "detail": {
@@ -116,34 +106,34 @@
               "terminated"
             ]
           }
-        }, 
+        },
         "Targets": [
           {
             "RoleArn": {
               "Fn::GetAtt": [
-                "StateMachineCWEventRole", 
+                "StateMachineCWEventRole",
                 "Arn"
               ]
-            }, 
-            "Id": "StateMachineCWEventStepFunctionsTarget", 
+            },
+            "Id": "StateMachineCWEventStepFunctionsTarget",
             "Arn": {
               "Ref": "StateMachine"
             }
           }
         ]
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -151,28 +141,28 @@
               }
             }
           ]
-        }, 
+        },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/startMyExecution": {
               "post": {
@@ -180,54 +170,54 @@
                   "responses": {
                     "200": {
                       "statusCode": "200"
-                    }, 
+                    },
                     "400": {
                       "statusCode": "400"
                     }
-                  }, 
+                  },
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                  }, 
-                  "httpMethod": "POST", 
+                  },
+                  "httpMethod": "POST",
                   "requestTemplates": {
                     "application/json": {
                       "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                     }
-                  }, 
+                  },
                   "credentials": {
                     "Fn::GetAtt": [
-                      "StateMachineMyApiEventRole", 
+                      "StateMachineMyApiEventRole",
                       "Arn"
                     ]
-                  }, 
+                  },
                   "type": "aws"
-                }, 
+                },
                 "responses": {
                   "200": {
                     "description": "OK"
-                  }, 
+                  },
                   "400": {
                     "description": "Bad Request"
                   }
                 }
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         }
       }
-    }, 
+    },
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -235,70 +225,70 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        },
+        "ManagedPolicyArns": [],
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "lambda:InvokeFunction"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*",
                       {
                         "functionName": {
                           "Ref": "MyFunction"
                         }
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "StateMachineScheduleEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineScheduleEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "events.amazonaws.com"
@@ -308,56 +298,56 @@
           ]
         }
       }
-    }, 
+    },
     "StateMachineScheduleEvent": {
-      "Type": "AWS::Events::Rule", 
+      "Type": "AWS::Events::Rule",
       "Properties": {
-        "ScheduleExpression": "rate(1 minute)", 
+        "ScheduleExpression": "rate(1 minute)",
         "Targets": [
           {
             "RoleArn": {
               "Fn::GetAtt": [
-                "StateMachineScheduleEventRole", 
+                "StateMachineScheduleEventRole",
                 "Arn"
               ]
-            }, 
-            "Id": "StateMachineScheduleEventStepFunctionsTarget", 
+            },
+            "Id": "StateMachineScheduleEventStepFunctionsTarget",
             "Arn": {
               "Ref": "StateMachine"
             }
           }
-        ], 
+        ],
         "Name": "TestSchedule"
       }
-    }, 
+    },
     "StateMachineCWEventRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
+        "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",
         "Policies": [
           {
-            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy", 
+            "PolicyName": "StateMachineCWEventRoleStartExecutionPolicy",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "states:StartExecution", 
+                  "Action": "states:StartExecution",
                   "Resource": {
                     "Ref": "StateMachine"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "events.amazonaws.com"
@@ -366,6 +356,16 @@
             }
           ]
         }
+      }
+    },
+    "ServerlessRestApiDeployment0e07112b2c": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "Description": "RestApi deployment id: 0e07112b2ca2a92bf2c02c9cf9e93554ea04bc8c",
+        "StageName": "Stage"
       }
     }
   }

--- a/tests/translator/test_api_resource.py
+++ b/tests/translator/test_api_resource.py
@@ -118,13 +118,14 @@ class TestApiGatewayDeploymentResource(TestCase):
         generator_mock.get_hash.return_value = full_hash
 
         swagger = {"a": "b"}
+        hash_input = {"swagger": swagger}
         deployment = ApiGatewayDeployment(logical_id=prefix)
         deployment.make_auto_deployable(stage, swagger=swagger)
 
         self.assertEqual(deployment.logical_id, id_val)
         self.assertEqual(deployment.Description, "RestApi deployment id: {}".format(full_hash))
 
-        LogicalIdGeneratorMock.assert_called_once_with(prefix, str(swagger))
+        LogicalIdGeneratorMock.assert_called_once_with(prefix, hash_input)
         generator_mock.gen.assert_called_once_with()
         generator_mock.get_hash.assert_called_once_with(length=40)  # getting full SHA
         stage.update_deployment_ref.assert_called_once_with(id_val)

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -353,11 +353,6 @@ class TestTranslatorEndToEnd(TestCase):
 
         print(json.dumps(output_fragment, indent=2))
 
-        # Only update the deployment Logical Id hash in Py3.
-        if sys.version_info.major >= 3:
-            self._update_logical_id_hash(expected)
-            self._update_logical_id_hash(output_fragment)
-
         assert deep_sort_lists(output_fragment) == deep_sort_lists(expected)
 
     @parameterized.expand(
@@ -436,11 +431,6 @@ class TestTranslatorEndToEnd(TestCase):
 
         print(json.dumps(output_fragment, indent=2))
 
-        # Only update the deployment Logical Id hash in Py3.
-        if sys.version_info.major >= 3:
-            self._update_logical_id_hash(expected)
-            self._update_logical_id_hash(output_fragment)
-
         assert deep_sort_lists(output_fragment) == deep_sort_lists(expected)
 
     @parameterized.expand(
@@ -495,10 +485,6 @@ class TestTranslatorEndToEnd(TestCase):
             output_fragment = transform(manifest, parameter_values, mock_policy_loader)
         print(json.dumps(output_fragment, indent=2))
 
-        # Only update the deployment Logical Id hash in Py3.
-        if sys.version_info.major >= 3:
-            self._update_logical_id_hash(expected)
-            self._update_logical_id_hash(output_fragment)
         assert deep_sort_lists(output_fragment) == deep_sort_lists(expected)
 
     def _update_logical_id_hash(self, resources):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In current implementation, due to use of `str(swagger)` and `json.dumps(domain)`, the hash output depends on Python's default iteration behaviour and can result in inconsistency even if swagger/domain did not change. `function_names` in the `redeploy_restapi_parameters` param is subjected to inconsistency due to serialization of `dict` object.

This PR implements consistent logical ID for generated `AWS::ApiGateway::Deployment` resource. 

*Description of how you validated changes:*
* Added new tests to ensure `_make_hash_input(...)` returns a `dict` object
* Updated all test template outputs, which contain generated `AWS::ApiGateway::Deployment`, to use consistent logical ID
* In `test_translator.py`, remove branches that modify Deployment logical IDs if python version >= 3
* Run `make pr` in Python3 and `make pr2.7` in Python2.7, and make sure tests passed in both Python versions.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
