### PR TITLE
Fix lambda version reference in docs

### DIFF
--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -139,7 +139,7 @@ resource:
         - Name: FunctionName
           Value: !Ref MyLambdaFunction
         - Name: ExecutedVersion
-          Value: !GetAtt MyLambdaFunction.Version.Version
+          Value: !Ref MyLambdaFunction.Version.Version
       EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda


### PR DESCRIPTION
*Issue #, if available:* nil

*Description of changes:*
safe_lambda_deployments.rst uses GetAtt to retrieve the Lambda
function version. GetAtt can only retrieve the ARN for the Lambda.

Ref is the correct intrinsic function.

*Description of how you validated changes:*
Deployed to personal account. Failed with 
```yaml
Value: !GetAtt MyLambdaFunction.Version.Version
```
Passed with
```yaml
Value: !Ref MyLambdaFunction.Version.Version
```

*Checklist:*

- [ n/a] Write/update tests
- [ n/a] `make pr` passes
- [ x] Update documentation
- [n/a ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
