### PR TITLE
feat: Support adding events to existing functions (take 2)

### DIFF
--- a/integration/helpers/file_resources.py
+++ b/integration/helpers/file_resources.py
@@ -4,6 +4,7 @@ FILE_TO_S3_URI_MAP = {
     "swagger1.json": {"type": "s3", "uri": ""},
     "swagger2.json": {"type": "s3", "uri": ""},
     "template.yaml": {"type": "http", "uri": ""},
+    "stack.yaml": {"type": "http", "uri": ""},
 }
 
 CODE_KEY_TO_FILE_MAP = {
@@ -11,4 +12,5 @@ CODE_KEY_TO_FILE_MAP = {
     "contenturi": "layer1.zip",
     "definitionuri": "swagger1.json",
     "templateurl": "template.yaml",
+    "stackurl": "stack.yaml",
 }

--- a/integration/resources/code/stack.yaml
+++ b/integration/resources/code/stack.yaml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+   API for integrating  quickly and easily
+Resources:
+  TestFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: "exports.handler = async(event, context) => { console.log('te1st'); };"
+      Handler: app.handler
+      Runtime: nodejs12.x
+      MemorySize: 128
+Outputs:
+  FunctionName:
+    Value: !Ref TestFunction

--- a/integration/resources/expected/single/basic_application_sar_with_event.json
+++ b/integration/resources/expected/single/basic_application_sar_with_event.json
@@ -1,0 +1,5 @@
+[
+    { "LogicalResourceId":"Images", "ResourceType":"AWS::S3::Bucket" },
+    { "LogicalResourceId":"NestedApp", "ResourceType":"AWS::CloudFormation::Stack" },
+    { "LogicalResourceId":"NestedAppAPILambdaPermission", "ResourceType":"AWS::Lambda::Permission" }
+]

--- a/integration/resources/expected/single/basic_stack_with_event.json
+++ b/integration/resources/expected/single/basic_stack_with_event.json
@@ -1,0 +1,5 @@
+[
+    { "LogicalResourceId":"Images", "ResourceType":"AWS::S3::Bucket" },
+    { "LogicalResourceId":"NestedStack", "ResourceType":"AWS::CloudFormation::Stack" },
+    { "LogicalResourceId":"ThumbnailFunctionImageBucketPermission", "ResourceType":"AWS::Lambda::Permission" }
+]

--- a/integration/resources/templates/single/basic_application_sar_with_event.yaml
+++ b/integration/resources/templates/single/basic_application_sar_with_event.yaml
@@ -1,0 +1,17 @@
+Resources:
+  NestedApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: 'arn:aws:serverlessrepo:us-east-1:380013960170:applications/test-app-for-testing'
+        SemanticVersion: 1.0.1
+      Events:
+        APILambda:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*    
+
+  Images:
+    Type: AWS::S3::Bucket

--- a/integration/resources/templates/single/basic_stack_with_event.yaml
+++ b/integration/resources/templates/single/basic_stack_with_event.yaml
@@ -1,0 +1,23 @@
+Resources: 
+  NestedStack: 
+    Type: AWS::CloudFormation::Stack
+    Properties: 
+      TemplateURL: ${stackurl}
+
+  ThumbnailFunction:
+    Type: AWS::Serverless::FunctionReference
+    Properties:
+      FunctionName:
+        Fn::GetAtt:
+          - NestedStack
+          - Outputs.FunctionName
+      Events:
+        ImageBucket:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*    
+                  
+  Images:
+    Type: AWS::S3::Bucket       

--- a/integration/single/test_basic_application.py
+++ b/integration/single/test_basic_application.py
@@ -43,3 +43,35 @@ class TestBasicApplication(BaseTest):
 
         self.assertEqual(len(functions), 1)
         self.assertEqual(functions[0]["LogicalResourceId"], expected_function_name)
+
+    def test_basic_application_sar_with_event(self):
+        """
+        Creates an application with a lambda function with intrinsics
+        """
+        self.create_and_verify_stack("basic_application_sar_with_event")
+
+        nested_stack_resource = self.get_stack_nested_stack_resources()
+        functions = self.get_stack_resources("AWS::Lambda::Function", nested_stack_resource)
+
+        bucket_id = self.get_physical_id_by_logical_id("Images")
+        config = self.client_provider.s3_client.get_bucket_notification_configuration(
+            Bucket=bucket_id
+        )
+        
+        self.assertRegexpMatches(config['LambdaFunctionConfigurations'][0]['LambdaFunctionArn'], functions[0]['PhysicalResourceId'])
+
+    def test_basic_stack_with_event(self):
+        """
+        Creates an application with a lambda function with intrinsics
+        """
+        self.create_and_verify_stack("basic_stack_with_event")
+
+        nested_stack_resource = self.get_stack_nested_stack_resources()
+        functions = self.get_stack_resources("AWS::Lambda::Function", nested_stack_resource)
+
+        bucket_id = self.get_physical_id_by_logical_id("Images")
+        config = self.client_provider.s3_client.get_bucket_notification_configuration(
+            Bucket=bucket_id
+        )
+        
+        self.assertRegexpMatches(config['LambdaFunctionConfigurations'][0]['LambdaFunctionArn'], functions[0]['PhysicalResourceId'])

--- a/integration/single/test_basic_application.py
+++ b/integration/single/test_basic_application.py
@@ -54,11 +54,11 @@ class TestBasicApplication(BaseTest):
         functions = self.get_stack_resources("AWS::Lambda::Function", nested_stack_resource)
 
         bucket_id = self.get_physical_id_by_logical_id("Images")
-        config = self.client_provider.s3_client.get_bucket_notification_configuration(
-            Bucket=bucket_id
+        config = self.client_provider.s3_client.get_bucket_notification_configuration(Bucket=bucket_id)
+
+        self.assertRegexpMatches(
+            config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"], functions[0]["PhysicalResourceId"]
         )
-        
-        self.assertRegexpMatches(config['LambdaFunctionConfigurations'][0]['LambdaFunctionArn'], functions[0]['PhysicalResourceId'])
 
     def test_basic_stack_with_event(self):
         """
@@ -70,8 +70,8 @@ class TestBasicApplication(BaseTest):
         functions = self.get_stack_resources("AWS::Lambda::Function", nested_stack_resource)
 
         bucket_id = self.get_physical_id_by_logical_id("Images")
-        config = self.client_provider.s3_client.get_bucket_notification_configuration(
-            Bucket=bucket_id
+        config = self.client_provider.s3_client.get_bucket_notification_configuration(Bucket=bucket_id)
+
+        self.assertRegexpMatches(
+            config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"], functions[0]["PhysicalResourceId"]
         )
-        
-        self.assertRegexpMatches(config['LambdaFunctionConfigurations'][0]['LambdaFunctionArn'], functions[0]['PhysicalResourceId'])

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -44,7 +44,7 @@ from samtranslator.model.intrinsics import (
     make_and_condition,
     fnSub,
     fnJoin,
-    fnGetAtt
+    fnGetAtt,
 )
 from samtranslator.model.sqs import SQSQueue
 from samtranslator.model.sns import SNSTopic
@@ -853,7 +853,7 @@ class SamFunctionReference(SamEventsResource):
         intrinsics_resolver = kwargs["intrinsics_resolver"]
         try:
             resources += self._generate_event_resources(
-                self, 
+                self,
                 None,
                 kwargs["event_resources"],
                 intrinsics_resolver,
@@ -1164,11 +1164,12 @@ class SamApplication(SamEventsResource):
 
         try:
             resources += self._generate_event_resources(
-                nested_stack, 
+                nested_stack,
                 None,
-                kwargs['event_resources'],
+                kwargs["event_resources"],
                 intrinsics_resolver,
-                function_resolver=lambda self, logical_id: self._create_helper(logical_id))
+                function_resolver=lambda self, logical_id: self._create_helper(logical_id),
+            )
         except InvalidEventException as e:
             raise InvalidResourceException(self.logical_id, e.message)
 

--- a/tests/translator/input/application_with_event.yaml
+++ b/tests/translator/input/application_with_event.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  NestedApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: 'arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world'
+        SemanticVersion: 1.0.1
+      Events:
+        ThumbnailFunction:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*    
+
+  Images:
+    Type: AWS::S3::Bucket

--- a/tests/translator/input/functionreference_s3.yaml
+++ b/tests/translator/input/functionreference_s3.yaml
@@ -1,0 +1,15 @@
+Resources:
+  ThumbnailFunction:
+    Type: AWS::Serverless::FunctionReference
+    Properties:
+      FunctionName: ThumbnailFunction    
+      Events:
+        ImageBucket:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*    
+                  
+  Images:
+    Type: AWS::S3::Bucket

--- a/tests/translator/input/stack_functionreference_s3.yaml
+++ b/tests/translator/input/stack_functionreference_s3.yaml
@@ -1,0 +1,23 @@
+Resources: 
+  NestedStack: 
+    Type: AWS::CloudFormation::Stack
+    Properties: 
+      TemplateURL: "https://s3.amazonaws.com/cloudformation-templates-us-east-2/EC2ChooseAMI.template"
+      Parameters: 
+        InstanceType: "t1.micro"
+        KeyName: "mykey"
+
+  ThumbnailFunction:
+    Type: AWS::Serverless::FunctionReference
+    Properties:
+      FunctionName: !GetAtt NestedStack.Outputs.ThumbnailFunction  
+      Events:
+        ImageBucket:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*    
+                  
+  Images:
+    Type: AWS::S3::Bucket        

--- a/tests/translator/output/application_with_event.json
+++ b/tests/translator/output/application_with_event.json
@@ -1,0 +1,72 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "NestedAppThumbnailFunctionPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      {
+                        "Fn::GetAtt": [
+                          "NestedApp",
+                          "Outputs.ThumbnailFunction"
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "NestedApp": {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {
+          "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+          "Tags": [
+            {
+              "Key": "lambda:createdBy",
+              "Value": "SAM"
+            },
+            {
+              "Key": "serverlessrepo:applicationId",
+              "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
+            },
+            {
+              "Key": "serverlessrepo:semanticVersion",
+              "Value": "1.0.1"
+            }
+          ]
+        }
+      },
+      "NestedAppThumbnailFunctionPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:InvokeFunction",
+          "FunctionName": {
+            "Fn::GetAtt": [
+              "NestedApp",
+              "Outputs.ThumbnailFunction"
+            ]
+          },
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-cn/application_with_event.json
+++ b/tests/translator/output/aws-cn/application_with_event.json
@@ -1,0 +1,72 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "NestedAppThumbnailFunctionPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      {
+                        "Fn::GetAtt": [
+                          "NestedApp",
+                          "Outputs.ThumbnailFunction"
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "NestedApp": {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {
+          "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+          "Tags": [
+            {
+              "Key": "lambda:createdBy",
+              "Value": "SAM"
+            },
+            {
+              "Key": "serverlessrepo:applicationId",
+              "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
+            },
+            {
+              "Key": "serverlessrepo:semanticVersion",
+              "Value": "1.0.1"
+            }
+          ]
+        }
+      },
+      "NestedAppThumbnailFunctionPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:InvokeFunction",
+          "FunctionName": {
+            "Fn::GetAtt": [
+              "NestedApp",
+              "Outputs.ThumbnailFunction"
+            ]
+          },
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-cn/functionreference_s3.json
+++ b/tests/translator/output/aws-cn/functionreference_s3.json
@@ -1,0 +1,41 @@
+{
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "ThumbnailFunctionImageBucketPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      "ThumbnailFunction"
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "ThumbnailFunctionImageBucketPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:InvokeFunction",
+          "FunctionName": "ThumbnailFunction",
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/application_with_event.json
+++ b/tests/translator/output/aws-us-gov/application_with_event.json
@@ -1,0 +1,72 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "NestedAppThumbnailFunctionPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      {
+                        "Fn::GetAtt": [
+                          "NestedApp",
+                          "Outputs.ThumbnailFunction"
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "NestedApp": {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {
+          "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+          "Tags": [
+            {
+              "Key": "lambda:createdBy",
+              "Value": "SAM"
+            },
+            {
+              "Key": "serverlessrepo:applicationId",
+              "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
+            },
+            {
+              "Key": "serverlessrepo:semanticVersion",
+              "Value": "1.0.1"
+            }
+          ]
+        }
+      },
+      "NestedAppThumbnailFunctionPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:InvokeFunction",
+          "FunctionName": {
+            "Fn::GetAtt": [
+              "NestedApp",
+              "Outputs.ThumbnailFunction"
+            ]
+          },
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/functionreference_s3.json
+++ b/tests/translator/output/aws-us-gov/functionreference_s3.json
@@ -1,0 +1,41 @@
+{
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "ThumbnailFunctionImageBucketPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      "ThumbnailFunction"
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "ThumbnailFunctionImageBucketPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:InvokeFunction",
+          "FunctionName": "ThumbnailFunction",
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/functionreference_s3.json
+++ b/tests/translator/output/functionreference_s3.json
@@ -1,0 +1,41 @@
+{
+    "Resources": {
+      "Images": {
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+          "ThumbnailFunctionImageBucketPermission"
+        ],
+        "Properties": {
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Function": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:"
+                      },
+                      "ThumbnailFunction"
+                    ]
+                  ]
+                },
+                "Event": "s3:ObjectCreated:*"
+              }
+            ]
+          }
+        }
+      },
+      "ThumbnailFunctionImageBucketPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "Action": "lambda:InvokeFunction",
+          "FunctionName": "ThumbnailFunction",
+          "Principal": "s3.amazonaws.com",
+          "SourceAccount": {
+            "Ref": "AWS::AccountId"
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -313,6 +313,8 @@ class TestTranslatorEndToEnd(TestCase):
                 "state_machine_with_xray",
                 "function_with_file_system_config",
                 "state_machine_with_permissions_boundary",
+                "functionreference_s3",
+                "application_with_event"
             ],
             [
                 ("aws", "ap-southeast-1"),

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -314,7 +314,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "function_with_file_system_config",
                 "state_machine_with_permissions_boundary",
                 "functionreference_s3",
-                "application_with_event"
+                "application_with_event",
             ],
             [
                 ("aws", "ap-southeast-1"),


### PR DESCRIPTION
*Issue #866:*
Support adding events to existing functions

*Description of changes:*
- class SamEventsResource(SamResourceMacro) to share events handling with SamFunction, SamApplication and SamFunctionReference
- class SamFunction now inherits from SamEventsResource 
- class SamStackFunctionReference(SamResourceMacro) helper function reference for sar
- class SamFunctionReference(SamEventsResource) introduced for use as new sam resource that supports events
- class SamApplication now inherits from SamEventsResource so events can be used on it

*Description of how you validated changes:*
Added two translator tests and two integration tests

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
