### PR TITLE
Add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,19 @@
 
 # AWS Serverless Application Model (AWS SAM)
 
-![Apache-2.0](https://img.shields.io/github/license/awslabs/serverless-application-model.svg)
-![SAM_CLI release](https://img.shields.io/github/release/awslabs/aws-sam-cli.svg?label=CLI%20Version)
+![Apache-2.0](https://img.shields.io/github/license/aws/serverless-application-model.svg)
+![SAM_CLI release](https://img.shields.io/github/release/aws/aws-sam-cli.svg?label=CLI%20Version)
+[![codecov](https://codecov.io/gh/aws/serverless-application-model/branch/master/graphs/badge.svg?style=flat)](https://codecov.io/gh/aws/serverless-application-model)
 
-The AWS Serverless Application Model (SAM) is an open-source framework for building serverless applications. 
-It provides shorthand syntax to express functions, APIs, databases, and event source mappings. 
+The AWS Serverless Application Model (SAM) is an open-source framework for building serverless applications.
+It provides shorthand syntax to express functions, APIs, databases, and event source mappings.
 With just a few lines of configuration, you can define the application you want and model it.
 
 [![Getting Started with AWS SAM](./docs/get-started-youtube.png)](https://www.youtube.com/watch?v=1dzihtC5LJ0)
 
 ## Get Started
 
-To get started with building SAM-based applications, use the SAM CLI. SAM CLI provides a Lambda-like execution 
+To get started with building SAM-based applications, use the SAM CLI. SAM CLI provides a Lambda-like execution
 environment that lets you locally build, test, debug, and deploy applications defined by SAM templates.
 
 * [Install SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
@@ -35,14 +36,14 @@ environment that lets you locally build, test, debug, and deploy applications de
 ## Why SAM
 
 + **Single\-deployment configuration**\. SAM makes it easy to organize related components and resources, and operate on a single stack\. You can use SAM to share configuration \(such as memory and timeouts\) between resources, and deploy all related resources together as a single, versioned entity\.
-   
+
 + **Local debugging and testing**\. Use SAM CLI to locally build, test, and debug SAM applications on a Lambda-like execution environment. It tightens the development loop by helping you find & troubleshoot issues locally that you might otherwise identify only after deploying to the cloud.
 
 + **Deep integration with development tools**. You can use SAM with a suite of tools you love and use.
     + IDEs: [PyCharm](https://aws.amazon.com/pycharm/), [IntelliJ](https://aws.amazon.com/intellij/), [Visual Studio Code](https://aws.amazon.com/visualstudiocode/), [Visual Studio](https://aws.amazon.com/visualstudio/), [AWS Cloud9](https://aws.amazon.com/cloud9/)
     + Build: [CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/)
     + Deploy: [CodeDeploy](https://docs.aws.amazon.com/codedeploy/latest/userguide/), [Jenkins](https://wiki.jenkins.io/display/JENKINS/AWS+SAM+Plugin)
-    + Continuous Delivery Pipelines: [CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/) 
+    + Continuous Delivery Pipelines: [CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/)
     + Discover Serverless Apps & Patterns: [AWS Serverless Application Repository](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/)
 
 + **Built\-in best practices**\. You can use SAM to define and deploy your infrastructure as configuration. This makes it possible for you to use and enforce best practices through code reviews. Also, with a few lines of configuration, you can enable safe deployments through CodeDeploy, and can enable tracing using AWS X\-Ray\.
@@ -51,40 +52,40 @@ environment that lets you locally build, test, debug, and deploy applications de
 
 ## What is this Github repository? 💻
 
-This GitHub repository contains the SAM Specification, the Python code that translates SAM templates into AWS CloudFormation stacks and lots of examples applications. 
+This GitHub repository contains the SAM Specification, the Python code that translates SAM templates into AWS CloudFormation stacks and lots of examples applications.
 In the words of SAM developers:
 
-> SAM Translator is the Python code that deploys SAM templates via AWS CloudFormation. Source code is high quality (95% unit test coverage), 
-with tons of tests to ensure your changes don't break compatibility. Change the code, run the tests, and if they pass, you should be good to go! 
+> SAM Translator is the Python code that deploys SAM templates via AWS CloudFormation. Source code is high quality (95% unit test coverage),
+with tons of tests to ensure your changes don't break compatibility. Change the code, run the tests, and if they pass, you should be good to go!
 Clone it and run `make pr`!
 
 ## Contribute to SAM
 
-We love our contributors ❤️ We have over 100 contributors who have built various parts of the product. 
+We love our contributors ❤️ We have over 100 contributors who have built various parts of the product.
 Read this [testimonial from @ndobryanskyy](https://www.lohika.com/aws-sam-my-exciting-first-open-source-experience/) to learn
-more about what it was like contributing to SAM. 
+more about what it was like contributing to SAM.
 
-Depending on your interest and skill, you can help build the different parts of the SAM project; 
+Depending on your interest and skill, you can help build the different parts of the SAM project;
 
 **Enhance the SAM Specification**
 
 Make pull requests, report bugs, and share ideas to improve the full SAM template specification.
-Source code is located on Github at [awslabs/serverless-application-model](https://github.com/awslabs/serverless-application-model). 
+Source code is located on Github at [awslabs/serverless-application-model](https://github.com/awslabs/serverless-application-model).
 Read the [SAM Specification Contributing Guide](https://github.com/awslabs/serverless-application-model/blob/master/CONTRIBUTING.md)
 to get started.
-    
+
 **Strengthen SAM CLI**
 
 Add new commands or enhance existing ones, report bugs, or request new features for the SAM CLI.
-Source code is located on Github at [awslabs/aws-sam-cli](https://github.com/awslabs/aws-sam-cli). Read the [SAM CLI Contributing Guide](https://github.com/awslabs/aws-sam-cli/blob/develop/CONTRIBUTING.md) to 
-get started. 
+Source code is located on Github at [awslabs/aws-sam-cli](https://github.com/awslabs/aws-sam-cli). Read the [SAM CLI Contributing Guide](https://github.com/awslabs/aws-sam-cli/blob/develop/CONTRIBUTING.md) to
+get started.
 
 **Update SAM Developer Guide**
 
 [SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/index.html) provides comprehensive getting started guide and reference documentation.
 Source code is located on Github at [awsdocs/aws-sam-developer-guide](https://github.com/awsdocs/aws-sam-developer-guide).
 Read the [SAM Documentation Contribution Guide](https://github.com/awsdocs/aws-sam-developer-guide/blob/master/CONTRIBUTING.md) to get
-started. 
+started.
 
 ### Join the SAM Community on Slack
 [Join the SAM developers channel (#samdev)](https://join.slack.com/t/awsdevelopers/shared_invite/zt-idww18e8-Z1kXhI7GNuDewkweCF3YjA) on Slack to collaborate with fellow community members and the AWS SAM team.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds the Codecov badge to the README.
Also removed some trailing whitespace.
Also updated other badges to use the `aws` organization

*Description of how you validated changes:*
I clicked on the badges.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
