### PR TITLE
Add CustomTargetId property to EventBridgeRule

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -233,6 +233,22 @@ class EventBridgeRule(CloudWatchEvent):
     """EventBridge Rule event source for SAM Functions."""
 
     resource_type = "EventBridgeRule"
+    property_types = {
+        "EventBusName": PropertyType(False, is_str()),
+        "Pattern": PropertyType(False, is_type(dict)),
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),
+        "RetryPolicy": PropertyType(False, is_type(dict)),
+        "Input": PropertyType(False, is_str()),
+        "InputPath": PropertyType(False, is_str()),
+        "Target": PropertyType(False, is_type(dict)),
+        "TargetId": PropertyType(False, is_str()),
+    }
+
+    def _construct_target(self, function, dead_letter_queue_arn=None):
+        target = super()._construct_target(function, dead_letter_queue_arn)
+        if self.TargetId is not None:
+            target["Id"] = self.TargetId
+        return target
 
 
 class S3(PushEventSource):

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -360,6 +360,9 @@
     "AWS::Serverless::Function.EventBridgeRule": {
       "additionalProperties": false,
       "properties": {
+        "EventBusName": {
+          "type": "string"
+        },
         "TargetId": {
           "type": "string"
         },

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -360,6 +360,9 @@
     "AWS::Serverless::Function.EventBridgeRule": {
       "additionalProperties": false,
       "properties": {
+        "TargetId": {
+          "type": "string"
+        },
         "Input": {
           "type": "string"
         },

--- a/tests/translator/input/eventbridgerule.yaml
+++ b/tests/translator/input/eventbridgerule.yaml
@@ -20,6 +20,7 @@ Resources:
         OnTerminate:
           Type: EventBridgeRule
           Properties:
+            TargetId: CustomTargetId
             EventBusName: ExternalEventBridge
             Pattern:
               detail:

--- a/tests/translator/output/aws-cn/eventbridgerule.json
+++ b/tests/translator/output/aws-cn/eventbridgerule.json
@@ -99,7 +99,7 @@
         "EventBusName": "ExternalEventBridge",
         "Targets": [
           {
-            "Id": "TriggeredFunctionOnTerminateLambdaTarget", 
+            "Id": "CustomTargetId",
             "Arn": {
               "Fn::GetAtt": [
                 "TriggeredFunction", 

--- a/tests/translator/output/aws-us-gov/eventbridgerule.json
+++ b/tests/translator/output/aws-us-gov/eventbridgerule.json
@@ -99,7 +99,7 @@
         "EventBusName": "ExternalEventBridge",
         "Targets": [
           {
-            "Id": "TriggeredFunctionOnTerminateLambdaTarget", 
+            "Id": "CustomTargetId",
             "Arn": {
               "Fn::GetAtt": [
                 "TriggeredFunction", 

--- a/tests/translator/output/eventbridgerule.json
+++ b/tests/translator/output/eventbridgerule.json
@@ -99,7 +99,7 @@
         "EventBusName": "ExternalEventBridge",
         "Targets": [
           {
-            "Id": "TriggeredFunctionOnTerminateLambdaTarget", 
+            "Id": "CustomTargetId",
             "Arn": {
               "Fn::GetAtt": [
                 "TriggeredFunction", 


### PR DESCRIPTION
*Issue #, if available: https://github.com/aws/serverless-application-model/issues/1920

*Description of changes: According to [docs](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-eventbridgerule.html#sam-function-eventbridgerule-targetid), EventBridgeRule should have a `TargetId` property, but the code doesn't have it.

*Description of how you validated changes: `make test`

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
