### PR TITLE
feat: Add HttpApi Event as new event type for AWS::Serverless::StateMachine

### DIFF
--- a/integration/helpers/file_resources.py
+++ b/integration/helpers/file_resources.py
@@ -4,6 +4,7 @@ FILE_TO_S3_URI_MAP = {
     "swagger1.json": {"type": "s3", "uri": ""},
     "swagger2.json": {"type": "s3", "uri": ""},
     "template.yaml": {"type": "http", "uri": ""},
+    "statemachine.json": {"type": "s3", "uri": ""},
 }
 
 CODE_KEY_TO_FILE_MAP = {
@@ -11,4 +12,5 @@ CODE_KEY_TO_FILE_MAP = {
     "contenturi": "layer1.zip",
     "definitionuri": "swagger1.json",
     "templateurl": "template.yaml",
+    "statemachineurl": "statemachine.json",
 }

--- a/integration/resources/code/statemachine.json
+++ b/integration/resources/code/statemachine.json
@@ -1,0 +1,16 @@
+{
+    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+    "StartAt": "Hello",
+    "States": {
+      "Hello": {
+        "Type": "Pass",
+        "Result": "Hello",
+        "Next": "World"
+      },
+      "World": {
+        "Type": "Pass",
+        "Result": "World",
+        "End": true
+      }
+    }
+  }

--- a/integration/resources/expected/single/basic_state_machine_with_http_api.json
+++ b/integration/resources/expected/single/basic_state_machine_with_http_api.json
@@ -1,0 +1,9 @@
+[
+    { "LogicalResourceId":"APIGatewayDeploymentdevStage", "ResourceType":"AWS::ApiGatewayV2::Stage"},
+    { "LogicalResourceId":"APIGatewayDeployment", "ResourceType":"AWS::ApiGatewayV2::Api" },
+    { "LogicalResourceId":"APIGatewayDeploymentMyStateMachineRole", "ResourceType":"AWS::IAM::Role" },
+    { "LogicalResourceId":"MyStateMachineRole", "ResourceType":"AWS::IAM::Role" },
+    { "LogicalResourceId":"MyStateMachine", "ResourceType":"AWS::StepFunctions::StateMachine" },
+    { "LogicalResourceId":"TestFunctionRole", "ResourceType":"AWS::IAM::Role" },
+    { "LogicalResourceId":"TestFunction", "ResourceType":"AWS::Lambda::Function" }
+] 

--- a/integration/resources/templates/single/basic_state_machine_with_http_api.yaml
+++ b/integration/resources/templates/single/basic_state_machine_with_http_api.yaml
@@ -1,0 +1,52 @@
+Resources:
+  TestFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: "exports.handler = async(event, context) => { console.log('te1st'); };"
+      Handler: app.handler
+      Runtime: nodejs12.x
+      MemorySize: 128
+
+  APIGatewayDeployment:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: 'dev'
+    DefinitionBody:
+        info:
+          title:
+            Ref: AWS::StackName
+          version: "1.0"
+        openapi: 3.0.1
+
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: ${statemachineurl}
+      Events:
+        NormalPost:
+          Type: HttpApi
+          Properties:
+            Path: /normal
+            Method: post
+            ApiId: 
+              Ref: APIGatewayDeployment  
+        StopPost:
+          Type: HttpApi
+          Properties:
+            Path: /stop
+            Method: post
+            Action: stop
+            ApiId: 
+              Ref: APIGatewayDeployment  
+        SyncPost:
+          Type: HttpApi
+          Properties:
+            Path: /sync
+            Method: post
+            Action: startSync
+            ApiId: 
+              Ref: APIGatewayDeployment          
+      Policies: 
+        - LambdaInvokePolicy:
+            FunctionName: 
+              Ref: TestFunction

--- a/integration/single/test_basic_state_machine.py
+++ b/integration/single/test_basic_state_machine.py
@@ -25,6 +25,12 @@ class TestBasicLayerVersion(BaseTest):
         self._verify_tag_presence(tags, "TagOne", "ValueOne")
         self._verify_tag_presence(tags, "TagTwo", "ValueTwo")
 
+    def test_basic_state_machine_with_http_api(self):
+        """
+        Creates a State Machine with tags
+        """
+        self.create_and_verify_stack("basic_state_machine_with_http_api")
+
     def _verify_tag_presence(self, tags, key, value):
         """
         Verifies the presence of a tag and its value

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -1129,13 +1129,8 @@ class HttpApi(PushEventSource):
             condition = function.resource_attributes[CONDITION]
 
         editor.add_lambda_integration(self.Path, self.Method, uri, self.Auth, api.get("Auth"), condition=condition)
-        if self.Auth:
-            method_authorizer = self.Auth.get("Authorizer")
-            if not method_authorizer:
-                api_auth = api.get("Auth", {})
-                if api_auth.get("DefaultAuthorizer"):
-                    self.Auth["Authorizer"] = api_auth.get("DefaultAuthorizer")
-            editor.add_auth_to_integration(api, self.Path, self.Method, self.Auth, self.relative_id)
+        if self.Auth: # ?? is this a BUG in case there is a defaultAthorizer the intergration needs to be added right?
+            editor.add_auth_to_integration(api=api, path=self.Path, method=self.Method, auth=self.Auth, relative_id=self.relative_id)
         if self.TimeoutInMillis:
             editor.add_timeout_to_method(api=api, path=self.Path, method_name=self.Method, timeout=self.TimeoutInMillis)
         path_parameters = re.findall("{(.*?)}", self.Path)

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -1129,8 +1129,10 @@ class HttpApi(PushEventSource):
             condition = function.resource_attributes[CONDITION]
 
         editor.add_lambda_integration(self.Path, self.Method, uri, self.Auth, api.get("Auth"), condition=condition)
-        if self.Auth: # ?? is this a BUG in case there is a defaultAthorizer the intergration needs to be added right?
-            editor.add_auth_to_integration(api=api, path=self.Path, method=self.Method, auth=self.Auth, relative_id=self.relative_id)
+        if self.Auth:  # ?? is this a BUG in case there is a defaultAthorizer the intergration needs to be added right?
+            editor.add_auth_to_integration(
+                api=api, path=self.Path, method=self.Method, auth=self.Auth, relative_id=self.relative_id
+            )
         if self.TimeoutInMillis:
             editor.add_timeout_to_method(api=api, path=self.Path, method_name=self.Method, timeout=self.TimeoutInMillis)
         path_parameters = re.findall("{(.*?)}", self.Path)

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -532,7 +532,9 @@ class HttpApi(EventSource):
         role = self._construct_full_role(resource, permissions_boundary, kwargs["api_id"] + resource.logical_id)
         resources.append(role)
 
-        self._add_swagger_integration(explicit_api, resource, role, intrinsics_resolver, explicit_api.get("__MANAGE_SWAGGER"))
+        self._add_swagger_integration(
+            explicit_api, resource, role, intrinsics_resolver, explicit_api.get("__MANAGE_SWAGGER")
+        )
 
         return resources
 

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -487,6 +487,8 @@ class HttpApi(EventSource):
         "Stage": PropertyType(False, is_str()),
         "Auth": PropertyType(False, is_type(dict)),
         "Action": PropertyType(False, is_str()),
+        "Parameters": PropertyType(False, is_type(dict)), # Name, Cause, Error, TraceHeader, Input
+        #"Responses": PropertyType(False, is_type(dict)), # 200: target method source
     }
 
     def resources_to_link(self, resources):
@@ -559,10 +561,15 @@ class HttpApi(EventSource):
             )
 
         if resource.StateMachineType == "EXPRESS" and self.Action == "stop":
-            # Cannot add the integration, if it is already present
             raise InvalidEventException(
                 self.relative_id,
                 'Action "stop" cannot be used on StateMachines of type EXPRESS',
+            )
+
+        if resource.StateMachineType == "STANDARD" and self.Action == "startSync":
+            raise InvalidEventException(
+                self.relative_id,
+                'Action "startSync" cannot be used on StateMachines of type STANDARD',
             )
 
         condition = None
@@ -574,6 +581,7 @@ class HttpApi(EventSource):
             self.Method,
             resource_arn,  # was integration_uri
             self.Action,
+            self.Parameters,
             role.get_runtime_attr("arn"),
             request_templates=None,
             condition=condition,

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -488,6 +488,7 @@ class HttpApi(EventSource):
         "Action": PropertyType(False, is_str()),
         "Parameters": PropertyType(False, is_type(dict)),  # Name, Cause, Error, TraceHeader, Input
         # "Responses": PropertyType(False, is_type(dict)), # 200: target method source
+        "TimeoutInMillis": PropertyType(False, is_type(int)),
     }
 
     def resources_to_link(self, resources):
@@ -592,5 +593,6 @@ class HttpApi(EventSource):
         editor.add_auth_to_integration(
             api=api, path=self.Path, method=self.Method, auth=self.Auth, relative_id=self.relative_id
         )
-
+        if self.TimeoutInMillis:
+            editor.add_timeout_to_method(api=api, path=self.Path, method_name=self.Method, timeout=self.TimeoutInMillis)
         api["DefinitionBody"] = editor.openapi

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -595,6 +595,8 @@ class HttpApi(EventSource):
                 api_auth = api.get("Auth", {})
                 if api_auth.get("DefaultAuthorizer"):
                     self.Auth["Authorizer"] = api_auth.get("DefaultAuthorizer")
-            editor.add_auth_to_integration(api=api, path=self.Path, method=self.Method, auth=self.Auth, relative_id=self.relative_id)
+            editor.add_auth_to_integration(
+                api=api, path=self.Path, method=self.Method, auth=self.Auth, relative_id=self.relative_id
+            )
 
         api["DefinitionBody"] = editor.openapi

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -227,6 +227,85 @@ class OpenApiEditor(object):
         if condition:
             path_dict[method] = make_conditional(condition, path_dict[method])
 
+    def _get_integration_subtype(self, action):
+        if action is None:
+            return "StepFunctions-StartExecution"
+        if action == "start":
+            return "StepFunctions-StartExecution"
+        if action == "stop":
+            return "StepFunctions-StopExecution"
+        if action == "startSync":
+            return "StepFunctions-StartSyncExecution"
+        raise ValueError("Action should be start, stop or startSync")
+
+    def add_state_machine_integration(
+        self,
+        path,
+        method,
+        integration_uri,
+        action,
+        credentials,
+        request_templates=None,  # this param is ignored (only used in Swagger)
+        condition=None,
+    ):
+        """
+        Adds aws APIGW integration to the given path+method.
+
+        :param string path: Path name
+        :param string method: HTTP Method
+        :param string integration_uri: URI for the integration
+        :param string credentials: Credentials for the integration
+        :param dict request_templates: A map of templates that are applied on the request payload.
+        :param bool condition: Condition for the integration
+        """
+
+        method = self._normalize_method_name(method)
+        if self.has_integration(path, method):
+            raise ValueError("Integration already exists on Path={}, Method={}".format(path, method))
+
+        integration_subtype = self._get_integration_subtype(action)
+
+        self.add_path(path, method)
+
+        # Wrap the integration_uri in a Condition if one exists on that state machine
+        # This is necessary so CFN doesn't try to resolve the integration reference.
+        if condition:
+            integration_uri = make_conditional(condition, integration_uri)
+
+        path_dict = self.get_path(path)
+
+        # Responses
+        default_method_responses = {
+            "default": {"description": "Default response for Method={} Path={}".format(method, path)}
+        }
+
+        param = "StateMachineArn"
+        if action == "stop":
+            param = "ExecutionArn"
+            integration_uri = "$request.body.ExecutionArn"
+
+        path_dict[method][self._X_APIGW_INTEGRATION] = {
+            "type": "aws_proxy",
+            "requestParameters": {
+                param: integration_uri,
+                # Region
+                # Name
+                # Input
+            },
+            "payloadFormatVersion": "1.0",
+            "credentials": credentials,
+            "integrationSubtype": integration_subtype,
+            "connectionType": "INTERNET",
+            # timeoutInMillis
+        }
+
+        # If 'responses' key is *not* present, add it with an empty dict as value
+        path_dict[method].setdefault("responses", default_method_responses)
+
+        # If a condition is present, wrap all method contents up into the condition
+        if condition:
+            path_dict[method] = make_conditional(condition, path_dict[method])
+
     def make_path_conditional(self, path, condition):
         """
         Wrap entire API path definition in a CloudFormation if condition.

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -244,6 +244,8 @@ class OpenApiEditor(object):
         method,
         integration_uri,
         action,
+        parameters,
+        #responseParameters
         credentials,
         request_templates=None,  # this param is ignored (only used in Swagger)
         condition=None,
@@ -284,14 +286,18 @@ class OpenApiEditor(object):
             param = "ExecutionArn"
             integration_uri = "$request.body.ExecutionArn"
 
+        request_parameters = parameters
+        if request_parameters is None:
+            request_parameters = {}
+        
+        request_parameters[param] = integration_uri
+
         path_dict[method][self._X_APIGW_INTEGRATION] = {
             "type": "aws_proxy",
-            "requestParameters": {
-                param: integration_uri,
-                # Region
-                # Name
-                # Input
-            },
+            #responseParameters:
+            #    200:
+            #    - overwrite:header.test_test: "$response.header.test_test"            
+            "requestParameters": request_parameters,
             "payloadFormatVersion": "1.0",
             "credentials": credentials,
             "integrationSubtype": integration_subtype,

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -438,42 +438,21 @@ class OpenApiEditor(object):
                     existing_security = method_definition.get("security", [])
                     if existing_security:
                         return
-                    authorizer_list = []
-                    if authorizers:
-                        authorizer_list.extend(authorizers.keys())
                     security_dict = dict()
                     security_dict[default_authorizer] = self._get_authorization_scopes(
                         api_authorizers, default_authorizer
                     )
-                    authorizer_security = [security_dict]
+                    security = [security_dict]
 
-                    security = authorizer_security
-
-                    if security:
-                        method_definition["security"] = security
-
-    def add_auth_to_method(self, path, method_name, auth, api):
-        """
-        Adds auth settings for this path/method. Auth settings currently consist of Authorizers
-        but this method will eventually include setting other auth settings such as Resource Policy, etc.
-        This is used to configure the security for individual functions.
-
-        :param string path: Path name
-        :param string method_name: Method name
-        :param dict auth: Auth configuration such as Authorizers
-        :param dict api: Reference to the related Api's properties as defined in the template.
-        """
-        method_authorizer = auth and auth.get("Authorizer")
-        authorization_scopes = auth and auth.get("AuthorizationScopes", [])
-        api_auth = api and api.get("Auth")
-        authorizers = api_auth and api_auth.get("Authorizers")
-        if method_authorizer:
-            self._set_method_authorizer(path, method_name, method_authorizer, authorizers, authorization_scopes)
+                    method_definition["security"] = security
 
     def add_auth_to_integration(self, api, path, method, auth, relative_id):
         """Adds authorization to the lambda integration
         :param api: api object
-        :param editor: OpenApiEditor object that contains the OpenApi definition
+        :param string path: Path name
+        :param string method_name: Method name
+        :param dict auth: Auth configuration such as Authorizers
+        :relative_id: Relative id of the event source for which the authorisation is added
         """
         api_auth = api.get("Auth", {})
 
@@ -681,11 +660,6 @@ class OpenApiEditor(object):
         if self.info.get("description"):
             return
         self.info["description"] = description
-
-    def has_api_gateway_cors(self):
-        if self._doc.get(self._X_APIGW_CORS):
-            return True
-        return False
 
     @property
     def openapi(self):

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -236,13 +236,7 @@ class OpenApiEditor(object):
             return "StepFunctions-StopExecution"
         if action == "startSync":
             return "StepFunctions-StartSyncExecution"
-        raise InvalidDocumentException(
-            [
-                InvalidTemplateException(
-                    "Action should be start, stop or startSync."
-                )
-            ]            
-        )
+        raise InvalidDocumentException([InvalidTemplateException("Action should be start, stop or startSync.")])
 
     def add_state_machine_integration(
         self,
@@ -488,7 +482,7 @@ class OpenApiEditor(object):
                 "'Auth' section requires either "
                 "an explicit 'Authorizer' set or a 'DefaultAuthorizer' "
                 "configured on the HttpApi.",
-            )        
+            )
 
         api_auth = api.get("Auth", {})
         api_authorizers = api_auth and api_auth.get("Authorizers")

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -212,6 +212,7 @@ class SwaggerEditor(object):
         path,
         method,
         integration_uri,
+        action,  # ignored, added for symmetry with openapi
         credentials,
         request_templates=None,
         condition=None,

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -282,25 +282,6 @@ class TestOpenApiEditor_add_lambda_integration(TestCase):
         self.assertEqual(expected, actual)
 
 
-class TestOpenApiEditor_add_state_machine_integration(TestCase):
-    def setUp(self):
-
-        self.original_openapi = {
-            "openapi": "3.0.1",
-            "paths": {
-                "/foo": {"post": {"a": [1, 2, "b"], "responses": {"something": "is already here"}}},
-                "/bar": {"get": {_X_INTEGRATION: {"a": "b"}}},
-            },
-        }
-
-        self.editor = OpenApiEditor(self.original_openapi)
-
-    def test_must_raise_on_existing_integration(self):
-
-        with self.assertRaises(ValueError):
-            self.editor.add_state_machine_integration("/bar", "get", "integrationUri", "start", None, "credentials")
-
-
 class TestOpenApiEditor_iter_on_path(TestCase):
     def setUp(self):
 

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -301,12 +301,10 @@ class TestOpenApiEditor_add_state_machine_integration(TestCase):
         integration_uri = "something"
         credentials = "creds"
         expected = {
-            "responses": { "default": { "description": "Default response for Method={} Path={}".format(method,path) } },
+            "responses": {"default": {"description": "Default response for Method={} Path={}".format(method, path)}},
             _X_INTEGRATION: {
                 "type": "aws_proxy",
-                "requestParameters": {
-                    "StateMachineArn": integration_uri
-                },                
+                "requestParameters": {"StateMachineArn": integration_uri},
                 "payloadFormatVersion": "1.0",
                 "credentials": credentials,
                 "integrationSubtype": "StepFunctions-StartExecution",
@@ -330,7 +328,9 @@ class TestOpenApiEditor_add_state_machine_integration(TestCase):
             "Fn::If": [
                 "condition",
                 {
-                    "responses": { "default": { "description": "Default response for Method={} Path={}".format(method, path) } },
+                    "responses": {
+                        "default": {"description": "Default response for Method={} Path={}".format(method, path)}
+                    },
                     _X_INTEGRATION: {
                         "type": "aws_proxy",
                         "requestParameters": {
@@ -346,7 +346,9 @@ class TestOpenApiEditor_add_state_machine_integration(TestCase):
             ]
         }
 
-        self.editor.add_state_machine_integration(path, method, integration_uri, None, None, credentials, condition=condition)
+        self.editor.add_state_machine_integration(
+            path, method, integration_uri, None, None, credentials, condition=condition
+        )
 
         self.assertTrue(self.editor.has_path(path, method))
         actual = self.editor.openapi["paths"][path][method]
@@ -365,9 +367,7 @@ class TestOpenApiEditor_add_state_machine_integration(TestCase):
             # New values must be added
             _X_INTEGRATION: {
                 "type": "aws_proxy",
-                "requestParameters": {
-                    "StateMachineArn": integration_uri
-                },
+                "requestParameters": {"StateMachineArn": integration_uri},
                 "payloadFormatVersion": "1.0",
                 "credentials": credentials,
                 "integrationSubtype": "StepFunctions-StartExecution",

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -300,6 +300,7 @@ class TestOpenApiEditor_add_state_machine_integration(TestCase):
         with self.assertRaises(ValueError):
             self.editor.add_state_machine_integration("/bar", "get", "integrationUri", "start", None, "credentials")
 
+
 class TestOpenApiEditor_iter_on_path(TestCase):
     def setUp(self):
 

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -557,9 +557,36 @@ class TestOpenApiEditor_add_auth(TestCase):
         self.assertEqual(noscopes, [])
 
     def test_add_auth_to_integration(self):
+        rel_id = "123"
+        path = "/test"
+        method = "post"
+        authorizer = {}
+        with self.assertRaises(InvalidEventException) as raises_assert:
+            self.editor.add_auth_to_integration({}, path, method, authorizer, rel_id)
 
-        with self.assertRaises(InvalidEventException):
-            self.editor.add_auth_to_integration({}, "/test", "post", {}, "123")
+        ex = raises_assert.exception
+        self.assertEqual(
+            ex.message,
+            "Event with id [{}] is invalid. Unable to set Authorizer [{}] on API method [{}] for path [{}] because the related API does not define any Authorizers.".format(
+                rel_id, authorizer, method, path
+            ),
+        )
+
+    def test_add_auth_to_integration_empty(self):
+        rel_id = "123"
+        path = "/test"
+        method = "post"
+        authorizer = {"Authorizer": None}
+        with self.assertRaises(InvalidEventException) as raises_assert:
+            self.editor.add_auth_to_integration({"test": "test"}, path, method, authorizer, rel_id)
+
+        ex = raises_assert.exception
+        self.assertEqual(
+            ex.message,
+            "Event with id [{}] is invalid. 'Auth' section requires either an explicit 'Authorizer' set or a 'DefaultAuthorizer' configured on the HttpApi.".format(
+                rel_id
+            ),
+        )
 
 
 class TestOpenApiEditor_add_cors(TestCase):

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -282,6 +282,24 @@ class TestOpenApiEditor_add_lambda_integration(TestCase):
         self.assertEqual(expected, actual)
 
 
+class TestOpenApiEditor_add_state_machine_integration(TestCase):
+    def setUp(self):
+
+        self.original_openapi = {
+            "openapi": "3.0.1",
+            "paths": {
+                "/foo": {"post": {"a": [1, 2, "b"], "responses": {"something": "is already here"}}},
+                "/bar": {"get": {_X_INTEGRATION: {"a": "b"}}},
+            },
+        }
+
+        self.editor = OpenApiEditor(self.original_openapi)
+
+    def test_must_raise_on_existing_integration(self):
+
+        with self.assertRaises(ValueError):
+            self.editor.add_state_machine_integration("/bar", "get", "integrationUri", "start", None, "credentials")
+
 class TestOpenApiEditor_iter_on_path(TestCase):
     def setUp(self):
 

--- a/tests/translator/input/error_state_machine_with_http_api_duplicate_path.yaml
+++ b/tests/translator/input/error_state_machine_with_http_api_duplicate_path.yaml
@@ -1,0 +1,23 @@
+Resources:
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: s3://bucket/key
+      DefinitionSubstitutions:
+        MyFunction: !GetAtt MyFunction.Arn
+      Events:
+        PathOne:
+          Type: HttpApi
+          Properties:
+            Path: /inbound
+            Method: post
+            Action: start
+        PathTwo:
+          Type: HttpApi
+          Properties:
+            Path: /inbound
+            Method: post
+            Action: start         
+      Policies: 
+        - LambdaInvokePolicy:
+            FunctionName: TestFunctionName

--- a/tests/translator/input/error_state_machine_with_http_api_express_stop.yaml
+++ b/tests/translator/input/error_state_machine_with_http_api_express_stop.yaml
@@ -1,0 +1,18 @@
+Resources:
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Type: EXPRESS
+      DefinitionUri: s3://bucket/key
+      DefinitionSubstitutions:
+        MyFunction: !GetAtt MyFunction.Arn
+      Events:
+        HttpAPIGateway:
+          Type: HttpApi
+          Properties:
+            Path: /inbound
+            Method: post
+            Action: stop
+      Policies: 
+        - LambdaInvokePolicy:
+            FunctionName: TestFunctionName

--- a/tests/translator/input/error_state_machine_with_http_api_invalid_action.yaml
+++ b/tests/translator/input/error_state_machine_with_http_api_invalid_action.yaml
@@ -1,0 +1,17 @@
+Resources:
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: s3://bucket/key
+      DefinitionSubstitutions:
+        MyFunction: !GetAtt MyFunction.Arn
+      Events:
+        HttpAPIGateway:
+          Type: HttpApi
+          Properties:
+            Path: /inbound
+            Method: post
+            Action: bogusAction
+      Policies: 
+        - LambdaInvokePolicy:
+            FunctionName: TestFunctionName

--- a/tests/translator/input/error_state_machine_with_http_api_standard_startsync.yaml
+++ b/tests/translator/input/error_state_machine_with_http_api_standard_startsync.yaml
@@ -1,0 +1,17 @@
+Resources:
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: s3://bucket/key
+      DefinitionSubstitutions:
+        MyFunction: !GetAtt MyFunction.Arn
+      Events:
+        HttpAPIGateway:
+          Type: HttpApi
+          Properties:
+            Path: /inbound
+            Method: post
+            Action: startSync
+      Policies: 
+        - LambdaInvokePolicy:
+            FunctionName: TestFunctionName

--- a/tests/translator/input/state_machine_with_http_api.yaml
+++ b/tests/translator/input/state_machine_with_http_api.yaml
@@ -1,0 +1,27 @@
+Resources:
+  APIGatewayDeployment:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: 'dev'
+    DefinitionBody:
+        info:
+          title: !Ref AWS::StackName
+          version: "1.0"
+        openapi: 3.0.1
+
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: s3://bucket/key
+      DefinitionSubstitutions:
+        MyFunction: !GetAtt MyFunction.Arn
+      Events:
+        HttpAPIGateway:
+          Type: HttpApi
+          Properties:
+            Path: /inbound
+            Method: post
+            ApiId: !Ref APIGatewayDeployment
+      Policies: 
+        - LambdaInvokePolicy:
+            FunctionName: !Ref MyFunction

--- a/tests/translator/input/state_machine_with_http_api.yaml
+++ b/tests/translator/input/state_machine_with_http_api.yaml
@@ -1,27 +1,52 @@
 Resources:
-  APIGatewayDeployment:
-    Type: AWS::Serverless::HttpApi
-    Properties:
-      StageName: 'dev'
-    DefinitionBody:
-        info:
-          title: !Ref AWS::StackName
-          version: "1.0"
-        openapi: 3.0.1
-
-  MyStateMachine:
+  MyStandardStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
       DefinitionUri: s3://bucket/key
       DefinitionSubstitutions:
         MyFunction: !GetAtt MyFunction.Arn
       Events:
-        HttpAPIGateway:
+        ApiStart:
           Type: HttpApi
           Properties:
-            Path: /inbound
+            Path: /start
             Method: post
-            ApiId: !Ref APIGatewayDeployment
+        ApiStop:
+          Type: HttpApi
+          Properties:
+            Path: /stop
+            Action: stop
+            Method: post
+        ApiStartExpl:
+          Type: HttpApi
+          Properties:
+            Path: /startExpl
+            Method: post
+            Action: start
       Policies: 
         - LambdaInvokePolicy:
             FunctionName: !Ref MyFunction
+
+  MyExpressStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Type: EXPRESS
+      DefinitionUri: s3://bucket/key
+      DefinitionSubstitutions:
+        MyFunction: !GetAtt MyFunction.Arn
+      Events:
+        ApiExprStart:
+          Type: HttpApi
+          Properties:
+            Path: /exprstart
+            Method: post
+        ApiExprStartSync:
+          Type: HttpApi
+          Properties:
+            Path: /exprsync
+            Action: startSync
+            Method: post
+      PermissionsBoundary: arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary
+      Policies: 
+        - LambdaInvokePolicy:
+            FunctionName: !Ref MyFunction            

--- a/tests/translator/input/state_machine_with_http_api_authorizer_maximum.yaml
+++ b/tests/translator/input/state_machine_with_http_api_authorizer_maximum.yaml
@@ -1,0 +1,74 @@
+Resources:
+  MyApi:
+    Type: "AWS::Serverless::HttpApi"
+    Properties:
+      StageName: Prod
+      Auth:
+        Authorizers:
+          LambdaAuth:
+            FunctionArn: !GetAtt MyAuthFn.Arn
+            AuthorizerPayloadFormatVersion: 1.0
+          OAuthAuth:
+            AuthorizationScopes:
+              - scope4
+            JwtConfiguration:
+              issuer: "https://www.example.com/v1/connect/oidc"
+              audience:
+                - MyApi
+            IdentitySource: "$request.querystring.param"
+        DefaultAuthorizer: LambdaAuth
+
+  StateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: MyStateMachine
+      Type: STANDARD
+      Definition:
+        Comment: A Hello World example of the Amazon States Language using Pass states
+        StartAt: Hello
+        States:
+          Hello:
+            Type: Pass
+            Result: Hello
+            Next: World
+          World:
+            Type: Pass
+            Result: World
+            End: true
+      Policies:
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Deny
+              Action: "*"
+              Resource: "*"
+      Events:
+        WithNoAuthorizer:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+            Path: /
+            Method: get
+            Auth:
+              Authorizer: NONE
+        WithLambdaAuthorizer:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+            Path: /users
+            Method: post
+            Auth:
+              Authorizer: LambdaAuth
+        WithOAuthAuthorizer:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+            Path: /users
+            Method: get
+            Auth:
+              Authorizer: OAuthAuth
+        WithDefaultAuthorizer:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+            Path: /users
+            Method: put

--- a/tests/translator/output/aws-cn/state_machine_with_http_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_http_api.json
@@ -1,0 +1,206 @@
+{
+    "Resources": {
+      "APIGatewayDeploymentMyStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "APIGatewayDeploymentMyStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "MyStateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "MyStateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "MyStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "APIGatewayDeployment": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/inbound": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "APIGatewayDeploymentMyStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/inbound"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }, 
+      "APIGatewayDeploymentdevStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "APIGatewayDeployment"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "dev", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "MyStateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "lambda:InvokeFunction"
+                    ], 
+                    "Resource": {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                        {
+                          "functionName": {
+                            "Ref": "MyFunction"
+                          }
+                        }
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-cn/state_machine_with_http_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_http_api.json
@@ -1,11 +1,12 @@
 {
     "Resources": {
-      "APIGatewayDeploymentMyStateMachineRole": {
+      "ServerlessHttpApiMyExpressStateMachineRole": {
         "Type": "AWS::IAM::Role", 
         "Properties": {
+          "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
           "Policies": [
             {
-              "PolicyName": "APIGatewayDeploymentMyStateMachineRoleStartExecutionPolicy", 
+              "PolicyName": "ServerlessHttpApiMyExpressStateMachineRoleStartExecutionPolicy", 
               "PolicyDocument": {
                 "Statement": [
                   {
@@ -14,7 +15,7 @@
                       "states:StartSyncExecution"
                     ], 
                     "Resource": {
-                      "Ref": "MyStateMachine"
+                      "Ref": "MyExpressStateMachine"
                     }, 
                     "Effect": "Allow"
                   }, 
@@ -27,7 +28,7 @@
                           {
                             "__Name__": {
                               "Fn::GetAtt": [
-                                "MyStateMachine", 
+                                "MyExpressStateMachine", 
                                 "Name"
                               ]
                             }
@@ -59,97 +60,7 @@
           }
         }
       }, 
-      "MyStateMachine": {
-        "Type": "AWS::StepFunctions::StateMachine", 
-        "Properties": {
-          "DefinitionSubstitutions": {
-            "MyFunction": {
-              "Fn::GetAtt": [
-                "MyFunction", 
-                "Arn"
-              ]
-            }
-          }, 
-          "RoleArn": {
-            "Fn::GetAtt": [
-              "MyStateMachineRole", 
-              "Arn"
-            ]
-          }, 
-          "DefinitionS3Location": {
-            "Bucket": "bucket", 
-            "Key": "key"
-          }, 
-          "Tags": [
-            {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
-            }
-          ]
-        }
-      }, 
-      "APIGatewayDeployment": {
-        "Type": "AWS::ApiGatewayV2::Api", 
-        "Properties": {
-          "Body": {
-            "info": {
-              "version": "1.0", 
-              "title": {
-                "Ref": "AWS::StackName"
-              }
-            }, 
-            "paths": {
-              "/inbound": {
-                "post": {
-                  "x-amazon-apigateway-integration": {
-                    "requestParameters": {
-                      "StateMachineArn": {
-                        "Ref": "MyStateMachine"
-                      }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
-                    "credentials": {
-                      "Fn::GetAtt": [
-                        "APIGatewayDeploymentMyStateMachineRole", 
-                        "Arn"
-                      ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "responses": {
-                    "default": {
-                      "description": "Default response for Method=post Path=/inbound"
-                    }
-                  }
-                }
-              }
-            }, 
-            "openapi": "3.0.1", 
-            "tags": [
-              {
-                "name": "httpapi:createdBy", 
-                "x-amazon-apigateway-tag-value": "SAM"
-              }
-            ]
-          }
-        }
-      }, 
-      "APIGatewayDeploymentdevStage": {
-        "Type": "AWS::ApiGatewayV2::Stage", 
-        "Properties": {
-          "ApiId": {
-            "Ref": "APIGatewayDeployment"
-          }, 
-          "AutoDeploy": true, 
-          "StageName": "dev", 
-          "Tags": {
-            "httpapi:createdBy": "SAM"
-          }
-        }
-      }, 
-      "MyStateMachineRole": {
+      "MyExpressStateMachineRole": {
         "Type": "AWS::IAM::Role", 
         "Properties": {
           "AssumeRolePolicyDocument": {
@@ -169,9 +80,10 @@
             ]
           }, 
           "ManagedPolicyArns": [], 
+          "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
           "Policies": [
             {
-              "PolicyName": "MyStateMachineRolePolicy0", 
+              "PolicyName": "MyExpressStateMachineRolePolicy0", 
               "PolicyDocument": {
                 "Statement": [
                   {
@@ -194,6 +106,340 @@
               }
             }
           ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyStandardStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "MyStandardStateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "lambda:InvokeFunction"
+                    ], 
+                    "Resource": {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                        {
+                          "functionName": {
+                            "Ref": "MyFunction"
+                          }
+                        }
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "ServerlessHttpApi": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/startExpl": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStandardStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/startExpl"
+                    }
+                  }
+                }
+              }, 
+              "/exprstart": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyExpressStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyExpressStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/exprstart"
+                    }
+                  }
+                }
+              }, 
+              "/stop": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "ExecutionArn": "$request.body.ExecutionArn"
+                    }, 
+                    "integrationSubtype": "StepFunctions-StopExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/stop"
+                    }
+                  }
+                }
+              }, 
+              "/start": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStandardStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/start"
+                    }
+                  }
+                }
+              }, 
+              "/exprsync": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyExpressStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartSyncExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyExpressStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/exprsync"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }, 
+      "ServerlessHttpApiApiGatewayDefaultStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "ServerlessHttpApi"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "$default", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyStandardStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyStandardStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "ServerlessHttpApiMyStandardStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "ServerlessHttpApiMyStandardStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "MyStandardStateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "MyStandardStateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "MyExpressStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyExpressStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "StateMachineType": "EXPRESS", 
           "Tags": [
             {
               "Value": "SAM", 

--- a/tests/translator/output/aws-cn/state_machine_with_http_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-cn/state_machine_with_http_api_authorizer_maximum.json
@@ -1,16 +1,58 @@
 {
     "Resources": {
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine",
+        "Properties": {
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n",
+              [
+                "{",
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+                "    \"StartAt\": \"Hello\",",
+                "    \"States\": {",
+                "        \"Hello\": {",
+                "            \"Next\": \"World\",",
+                "            \"Result\": \"Hello\",",
+                "            \"Type\": \"Pass\"",
+                "        },",
+                "        \"World\": {",
+                "            \"End\": true,",
+                "            \"Result\": \"World\",",
+                "            \"Type\": \"Pass\"",
+                "        }",
+                "    }",
+                "}"
+              ]
+            ]
+          },
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole",
+              "Arn"
+            ]
+          },
+          "StateMachineName": "MyStateMachine",
+          "StateMachineType": "STANDARD",
+          "Tags": [
+            {
+              "Key": "stateMachine:createdBy",
+              "Value": "SAM"
+            }
+          ]
+        }
+      },
       "StateMachineRole": {
-        "Type": "AWS::IAM::Role", 
+        "Type": "AWS::IAM::Role",
         "Properties": {
           "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
                 "Action": [
                   "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "Service": [
                     "states.amazonaws.com"
@@ -18,93 +60,42 @@
                 }
               }
             ]
-          }, 
-          "ManagedPolicyArns": [], 
+          },
+          "ManagedPolicyArns": [],
           "Policies": [
             {
-              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyName": "StateMachineRolePolicy0",
               "PolicyDocument": {
-                "Version": "2012-10-17", 
+                "Version": "2012-10-17",
                 "Statement": [
                   {
-                    "Action": "*", 
-                    "Resource": "*", 
-                    "Effect": "Deny"
+                    "Effect": "Deny",
+                    "Action": "*",
+                    "Resource": "*"
                   }
                 ]
               }
             }
-          ], 
+          ],
           "Tags": [
             {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
+              "Key": "stateMachine:createdBy",
+              "Value": "SAM"
             }
           ]
         }
-      }, 
-      "MyApiProdStage": {
-        "Type": "AWS::ApiGatewayV2::Stage", 
-        "Properties": {
-          "ApiId": {
-            "Ref": "MyApi"
-          }, 
-          "AutoDeploy": true, 
-          "StageName": "Prod", 
-          "Tags": {
-            "httpapi:createdBy": "SAM"
-          }
-        }
-      }, 
+      },
       "MyApiStateMachineRole": {
-        "Type": "AWS::IAM::Role", 
+        "Type": "AWS::IAM::Role",
         "Properties": {
-          "Policies": [
-            {
-              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy", 
-              "PolicyDocument": {
-                "Statement": [
-                  {
-                    "Action": [
-                      "states:StartExecution", 
-                      "states:StartSyncExecution"
-                    ], 
-                    "Resource": {
-                      "Ref": "StateMachine"
-                    }, 
-                    "Effect": "Allow"
-                  }, 
-                  {
-                    "Action": "states:StopExecution", 
-                    "Resource": [
-                      {
-                        "Fn::Sub": [
-                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
-                          {
-                            "__Name__": {
-                              "Fn::GetAtt": [
-                                "StateMachine", 
-                                "Name"
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    ], 
-                    "Effect": "Allow"
-                  }
-                ]
-              }
-            }
-          ], 
           "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
                 "Action": [
                   "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "Service": [
                     "apigateway.amazonaws.com"
@@ -112,232 +103,241 @@
                 }
               }
             ]
-          }
-        }
-      }, 
-      "StateMachine": {
-        "Type": "AWS::StepFunctions::StateMachine", 
-        "Properties": {
-          "RoleArn": {
-            "Fn::GetAtt": [
-              "StateMachineRole", 
-              "Arn"
-            ]
-          }, 
-          "StateMachineName": "MyStateMachine", 
-          "DefinitionString": {
-            "Fn::Join": [
-              "\n", 
-              [
-                "{", 
-                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                "    \"StartAt\": \"Hello\",", 
-                "    \"States\": {", 
-                "        \"Hello\": {", 
-                "            \"Next\": \"World\",", 
-                "            \"Result\": \"Hello\",", 
-                "            \"Type\": \"Pass\"", 
-                "        },", 
-                "        \"World\": {", 
-                "            \"End\": true,", 
-                "            \"Result\": \"World\",", 
-                "            \"Type\": \"Pass\"", 
-                "        }", 
-                "    }", 
-                "}"
-              ]
-            ]
-          }, 
-          "StateMachineType": "STANDARD", 
-          "Tags": [
+          },
+          "Policies": [
             {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
+              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy",
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution",
+                      "states:StartSyncExecution"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": {
+                      "Ref": "StateMachine"
+                    }
+                  },
+                  {
+                    "Action": "states:StopExecution",
+                    "Effect": "Allow",
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*",
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "StateMachine",
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           ]
         }
-      }, 
+      },
       "MyApi": {
-        "Type": "AWS::ApiGatewayV2::Api", 
+        "Type": "AWS::ApiGatewayV2::Api",
         "Properties": {
           "Body": {
+            "openapi": "3.0.1",
             "info": {
-              "version": "1.0", 
+              "version": "1.0",
               "title": {
                 "Ref": "AWS::StackName"
               }
-            }, 
+            },
             "paths": {
               "/": {
                 "get": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "security": [
-                    {
-                      "NONE": []
-                    }
-                  ], 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
                       "description": "Default response for Method=get Path=/"
                     }
-                  }
-                }
-              }, 
-              "/users": {
-                "put": {
-                  "x-amazon-apigateway-integration": {
-                    "requestParameters": {
-                      "StateMachineArn": {
-                        "Ref": "StateMachine"
-                      }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
-                    "credentials": {
-                      "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
-                        "Arn"
-                      ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
+                  },
                   "security": [
                     {
-                      "LambdaAuth": []
+                      "NONE": []
                     }
-                  ], 
-                  "responses": {
-                    "default": {
-                      "description": "Default response for Method=put Path=/users"
-                    }
-                  }
-                }, 
+                  ]
+                }
+              },
+              "/users": {
                 "post": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "security": [
-                    {
-                      "LambdaAuth": []
-                    }
-                  ], 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
                       "description": "Default response for Method=post Path=/users"
                     }
-                  }
-                }, 
+                  },
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ]
+                },
                 "get": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/users"
+                    }
+                  },
                   "security": [
                     {
                       "OAuthAuth": [
                         "scope4"
                       ]
                     }
-                  ], 
+                  ]
+                },
+                "put": {
+                  "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    },
+                    "payloadFormatVersion": "1.0",
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole",
+                        "Arn"
+                      ]
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
-                      "description": "Default response for Method=get Path=/users"
+                      "description": "Default response for Method=put Path=/users"
                     }
-                  }
+                  },
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ]
                 }
               }
-            }, 
-            "openapi": "3.0.1", 
+            },
             "components": {
               "securitySchemes": {
-                "OAuthAuth": {
-                  "type": "oauth2", 
-                  "x-amazon-apigateway-authorizer": {
-                    "identitySource": "$request.querystring.param", 
-                    "type": "jwt", 
-                    "jwtConfiguration": {
-                      "audience": [
-                        "MyApi"
-                      ], 
-                      "issuer": "https://www.example.com/v1/connect/oidc"
-                    }
-                  }
-                }, 
                 "LambdaAuth": {
-                  "type": "apiKey", 
-                  "name": "Unused", 
+                  "type": "apiKey",
+                  "name": "Unused",
+                  "in": "header",
                   "x-amazon-apigateway-authorizer": {
-                    "type": "request", 
+                    "type": "request",
                     "authorizerUri": {
                       "Fn::Sub": [
-                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                         {
                           "__FunctionArn__": {
                             "Fn::GetAtt": [
-                              "MyAuthFn", 
+                              "MyAuthFn",
                               "Arn"
                             ]
                           }
                         }
                       ]
-                    }, 
+                    },
                     "authorizerPayloadFormatVersion": 1.0
-                  }, 
-                  "in": "header"
+                  }
+                },
+                "OAuthAuth": {
+                  "type": "oauth2",
+                  "x-amazon-apigateway-authorizer": {
+                    "jwtConfiguration": {
+                      "issuer": "https://www.example.com/v1/connect/oidc",
+                      "audience": [
+                        "MyApi"
+                      ]
+                    },
+                    "identitySource": "$request.querystring.param",
+                    "type": "jwt"
+                  }
                 }
               }
-            }, 
+            },
             "tags": [
               {
-                "name": "httpapi:createdBy", 
+                "name": "httpapi:createdBy",
                 "x-amazon-apigateway-tag-value": "SAM"
               }
             ]
           }
+        }
+      },
+      "MyApiProdStage": {
+        "Type": "AWS::ApiGatewayV2::Stage",
+        "Properties": {
+          "ApiId": {
+            "Ref": "MyApi"
+          },
+          "StageName": "Prod",
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          },
+          "AutoDeploy": true
         }
       }
     }

--- a/tests/translator/output/aws-cn/state_machine_with_http_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-cn/state_machine_with_http_api_authorizer_maximum.json
@@ -1,0 +1,344 @@
+{
+    "Resources": {
+      "StateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Version": "2012-10-17", 
+                "Statement": [
+                  {
+                    "Action": "*", 
+                    "Resource": "*", 
+                    "Effect": "Deny"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyApiProdStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "MyApi"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "Prod", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyApiStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "StateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "StateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "StateMachineName": "MyStateMachine", 
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n", 
+              [
+                "{", 
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
+                "    \"StartAt\": \"Hello\",", 
+                "    \"States\": {", 
+                "        \"Hello\": {", 
+                "            \"Next\": \"World\",", 
+                "            \"Result\": \"Hello\",", 
+                "            \"Type\": \"Pass\"", 
+                "        },", 
+                "        \"World\": {", 
+                "            \"End\": true,", 
+                "            \"Result\": \"World\",", 
+                "            \"Type\": \"Pass\"", 
+                "        }", 
+                "    }", 
+                "}"
+              ]
+            ]
+          }, 
+          "StateMachineType": "STANDARD", 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyApi": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/": {
+                "get": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "NONE": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/"
+                    }
+                  }
+                }
+              }, 
+              "/users": {
+                "put": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=put Path=/users"
+                    }
+                  }
+                }, 
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/users"
+                    }
+                  }
+                }, 
+                "get": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "OAuthAuth": [
+                        "scope4"
+                      ]
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/users"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "components": {
+              "securitySchemes": {
+                "OAuthAuth": {
+                  "type": "oauth2", 
+                  "x-amazon-apigateway-authorizer": {
+                    "identitySource": "$request.querystring.param", 
+                    "type": "jwt", 
+                    "jwtConfiguration": {
+                      "audience": [
+                        "MyApi"
+                      ], 
+                      "issuer": "https://www.example.com/v1/connect/oidc"
+                    }
+                  }
+                }, 
+                "LambdaAuth": {
+                  "type": "apiKey", 
+                  "name": "Unused", 
+                  "x-amazon-apigateway-authorizer": {
+                    "type": "request", 
+                    "authorizerUri": {
+                      "Fn::Sub": [
+                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                        {
+                          "__FunctionArn__": {
+                            "Fn::GetAtt": [
+                              "MyAuthFn", 
+                              "Arn"
+                            ]
+                          }
+                        }
+                      ]
+                    }, 
+                    "authorizerPayloadFormatVersion": 1.0
+                  }, 
+                  "in": "header"
+                }
+              }
+            }, 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/state_machine_with_http_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_http_api.json
@@ -1,0 +1,206 @@
+{
+    "Resources": {
+      "APIGatewayDeploymentMyStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "APIGatewayDeploymentMyStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "MyStateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "MyStateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "MyStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "APIGatewayDeployment": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/inbound": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "APIGatewayDeploymentMyStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/inbound"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }, 
+      "APIGatewayDeploymentdevStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "APIGatewayDeployment"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "dev", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "MyStateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "lambda:InvokeFunction"
+                    ], 
+                    "Resource": {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                        {
+                          "functionName": {
+                            "Ref": "MyFunction"
+                          }
+                        }
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/state_machine_with_http_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_http_api.json
@@ -1,11 +1,12 @@
 {
     "Resources": {
-      "APIGatewayDeploymentMyStateMachineRole": {
+      "ServerlessHttpApiMyExpressStateMachineRole": {
         "Type": "AWS::IAM::Role", 
         "Properties": {
+          "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
           "Policies": [
             {
-              "PolicyName": "APIGatewayDeploymentMyStateMachineRoleStartExecutionPolicy", 
+              "PolicyName": "ServerlessHttpApiMyExpressStateMachineRoleStartExecutionPolicy", 
               "PolicyDocument": {
                 "Statement": [
                   {
@@ -14,7 +15,7 @@
                       "states:StartSyncExecution"
                     ], 
                     "Resource": {
-                      "Ref": "MyStateMachine"
+                      "Ref": "MyExpressStateMachine"
                     }, 
                     "Effect": "Allow"
                   }, 
@@ -27,7 +28,7 @@
                           {
                             "__Name__": {
                               "Fn::GetAtt": [
-                                "MyStateMachine", 
+                                "MyExpressStateMachine", 
                                 "Name"
                               ]
                             }
@@ -59,97 +60,7 @@
           }
         }
       }, 
-      "MyStateMachine": {
-        "Type": "AWS::StepFunctions::StateMachine", 
-        "Properties": {
-          "DefinitionSubstitutions": {
-            "MyFunction": {
-              "Fn::GetAtt": [
-                "MyFunction", 
-                "Arn"
-              ]
-            }
-          }, 
-          "RoleArn": {
-            "Fn::GetAtt": [
-              "MyStateMachineRole", 
-              "Arn"
-            ]
-          }, 
-          "DefinitionS3Location": {
-            "Bucket": "bucket", 
-            "Key": "key"
-          }, 
-          "Tags": [
-            {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
-            }
-          ]
-        }
-      }, 
-      "APIGatewayDeployment": {
-        "Type": "AWS::ApiGatewayV2::Api", 
-        "Properties": {
-          "Body": {
-            "info": {
-              "version": "1.0", 
-              "title": {
-                "Ref": "AWS::StackName"
-              }
-            }, 
-            "paths": {
-              "/inbound": {
-                "post": {
-                  "x-amazon-apigateway-integration": {
-                    "requestParameters": {
-                      "StateMachineArn": {
-                        "Ref": "MyStateMachine"
-                      }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
-                    "credentials": {
-                      "Fn::GetAtt": [
-                        "APIGatewayDeploymentMyStateMachineRole", 
-                        "Arn"
-                      ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "responses": {
-                    "default": {
-                      "description": "Default response for Method=post Path=/inbound"
-                    }
-                  }
-                }
-              }
-            }, 
-            "openapi": "3.0.1", 
-            "tags": [
-              {
-                "name": "httpapi:createdBy", 
-                "x-amazon-apigateway-tag-value": "SAM"
-              }
-            ]
-          }
-        }
-      }, 
-      "APIGatewayDeploymentdevStage": {
-        "Type": "AWS::ApiGatewayV2::Stage", 
-        "Properties": {
-          "ApiId": {
-            "Ref": "APIGatewayDeployment"
-          }, 
-          "AutoDeploy": true, 
-          "StageName": "dev", 
-          "Tags": {
-            "httpapi:createdBy": "SAM"
-          }
-        }
-      }, 
-      "MyStateMachineRole": {
+      "MyExpressStateMachineRole": {
         "Type": "AWS::IAM::Role", 
         "Properties": {
           "AssumeRolePolicyDocument": {
@@ -169,9 +80,10 @@
             ]
           }, 
           "ManagedPolicyArns": [], 
+          "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
           "Policies": [
             {
-              "PolicyName": "MyStateMachineRolePolicy0", 
+              "PolicyName": "MyExpressStateMachineRolePolicy0", 
               "PolicyDocument": {
                 "Statement": [
                   {
@@ -194,6 +106,340 @@
               }
             }
           ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyStandardStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "MyStandardStateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "lambda:InvokeFunction"
+                    ], 
+                    "Resource": {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                        {
+                          "functionName": {
+                            "Ref": "MyFunction"
+                          }
+                        }
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "ServerlessHttpApi": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/startExpl": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStandardStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/startExpl"
+                    }
+                  }
+                }
+              }, 
+              "/exprstart": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyExpressStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyExpressStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/exprstart"
+                    }
+                  }
+                }
+              }, 
+              "/stop": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "ExecutionArn": "$request.body.ExecutionArn"
+                    }, 
+                    "integrationSubtype": "StepFunctions-StopExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/stop"
+                    }
+                  }
+                }
+              }, 
+              "/start": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStandardStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/start"
+                    }
+                  }
+                }
+              }, 
+              "/exprsync": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyExpressStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartSyncExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyExpressStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/exprsync"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }, 
+      "ServerlessHttpApiApiGatewayDefaultStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "ServerlessHttpApi"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "$default", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyStandardStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyStandardStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "ServerlessHttpApiMyStandardStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "ServerlessHttpApiMyStandardStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "MyStandardStateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "MyStandardStateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "MyExpressStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyExpressStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "StateMachineType": "EXPRESS", 
           "Tags": [
             {
               "Value": "SAM", 

--- a/tests/translator/output/aws-us-gov/state_machine_with_http_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_http_api_authorizer_maximum.json
@@ -1,16 +1,58 @@
 {
     "Resources": {
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine",
+        "Properties": {
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n",
+              [
+                "{",
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+                "    \"StartAt\": \"Hello\",",
+                "    \"States\": {",
+                "        \"Hello\": {",
+                "            \"Next\": \"World\",",
+                "            \"Result\": \"Hello\",",
+                "            \"Type\": \"Pass\"",
+                "        },",
+                "        \"World\": {",
+                "            \"End\": true,",
+                "            \"Result\": \"World\",",
+                "            \"Type\": \"Pass\"",
+                "        }",
+                "    }",
+                "}"
+              ]
+            ]
+          },
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole",
+              "Arn"
+            ]
+          },
+          "StateMachineName": "MyStateMachine",
+          "StateMachineType": "STANDARD",
+          "Tags": [
+            {
+              "Key": "stateMachine:createdBy",
+              "Value": "SAM"
+            }
+          ]
+        }
+      },
       "StateMachineRole": {
-        "Type": "AWS::IAM::Role", 
+        "Type": "AWS::IAM::Role",
         "Properties": {
           "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
                 "Action": [
                   "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "Service": [
                     "states.amazonaws.com"
@@ -18,93 +60,42 @@
                 }
               }
             ]
-          }, 
-          "ManagedPolicyArns": [], 
+          },
+          "ManagedPolicyArns": [],
           "Policies": [
             {
-              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyName": "StateMachineRolePolicy0",
               "PolicyDocument": {
-                "Version": "2012-10-17", 
+                "Version": "2012-10-17",
                 "Statement": [
                   {
-                    "Action": "*", 
-                    "Resource": "*", 
-                    "Effect": "Deny"
+                    "Effect": "Deny",
+                    "Action": "*",
+                    "Resource": "*"
                   }
                 ]
               }
             }
-          ], 
+          ],
           "Tags": [
             {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
+              "Key": "stateMachine:createdBy",
+              "Value": "SAM"
             }
           ]
         }
-      }, 
-      "MyApiProdStage": {
-        "Type": "AWS::ApiGatewayV2::Stage", 
-        "Properties": {
-          "ApiId": {
-            "Ref": "MyApi"
-          }, 
-          "AutoDeploy": true, 
-          "StageName": "Prod", 
-          "Tags": {
-            "httpapi:createdBy": "SAM"
-          }
-        }
-      }, 
+      },
       "MyApiStateMachineRole": {
-        "Type": "AWS::IAM::Role", 
+        "Type": "AWS::IAM::Role",
         "Properties": {
-          "Policies": [
-            {
-              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy", 
-              "PolicyDocument": {
-                "Statement": [
-                  {
-                    "Action": [
-                      "states:StartExecution", 
-                      "states:StartSyncExecution"
-                    ], 
-                    "Resource": {
-                      "Ref": "StateMachine"
-                    }, 
-                    "Effect": "Allow"
-                  }, 
-                  {
-                    "Action": "states:StopExecution", 
-                    "Resource": [
-                      {
-                        "Fn::Sub": [
-                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
-                          {
-                            "__Name__": {
-                              "Fn::GetAtt": [
-                                "StateMachine", 
-                                "Name"
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    ], 
-                    "Effect": "Allow"
-                  }
-                ]
-              }
-            }
-          ], 
           "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
                 "Action": [
                   "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "Service": [
                     "apigateway.amazonaws.com"
@@ -112,232 +103,241 @@
                 }
               }
             ]
-          }
-        }
-      }, 
-      "StateMachine": {
-        "Type": "AWS::StepFunctions::StateMachine", 
-        "Properties": {
-          "RoleArn": {
-            "Fn::GetAtt": [
-              "StateMachineRole", 
-              "Arn"
-            ]
-          }, 
-          "StateMachineName": "MyStateMachine", 
-          "DefinitionString": {
-            "Fn::Join": [
-              "\n", 
-              [
-                "{", 
-                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                "    \"StartAt\": \"Hello\",", 
-                "    \"States\": {", 
-                "        \"Hello\": {", 
-                "            \"Next\": \"World\",", 
-                "            \"Result\": \"Hello\",", 
-                "            \"Type\": \"Pass\"", 
-                "        },", 
-                "        \"World\": {", 
-                "            \"End\": true,", 
-                "            \"Result\": \"World\",", 
-                "            \"Type\": \"Pass\"", 
-                "        }", 
-                "    }", 
-                "}"
-              ]
-            ]
-          }, 
-          "StateMachineType": "STANDARD", 
-          "Tags": [
+          },
+          "Policies": [
             {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
+              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy",
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution",
+                      "states:StartSyncExecution"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": {
+                      "Ref": "StateMachine"
+                    }
+                  },
+                  {
+                    "Action": "states:StopExecution",
+                    "Effect": "Allow",
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*",
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "StateMachine",
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           ]
         }
-      }, 
+      },
       "MyApi": {
-        "Type": "AWS::ApiGatewayV2::Api", 
+        "Type": "AWS::ApiGatewayV2::Api",
         "Properties": {
           "Body": {
+            "openapi": "3.0.1",
             "info": {
-              "version": "1.0", 
+              "version": "1.0",
               "title": {
                 "Ref": "AWS::StackName"
               }
-            }, 
+            },
             "paths": {
               "/": {
                 "get": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "security": [
-                    {
-                      "NONE": []
-                    }
-                  ], 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
                       "description": "Default response for Method=get Path=/"
                     }
-                  }
-                }
-              }, 
-              "/users": {
-                "put": {
-                  "x-amazon-apigateway-integration": {
-                    "requestParameters": {
-                      "StateMachineArn": {
-                        "Ref": "StateMachine"
-                      }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
-                    "credentials": {
-                      "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
-                        "Arn"
-                      ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
+                  },
                   "security": [
                     {
-                      "LambdaAuth": []
+                      "NONE": []
                     }
-                  ], 
-                  "responses": {
-                    "default": {
-                      "description": "Default response for Method=put Path=/users"
-                    }
-                  }
-                }, 
+                  ]
+                }
+              },
+              "/users": {
                 "post": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "security": [
-                    {
-                      "LambdaAuth": []
-                    }
-                  ], 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
                       "description": "Default response for Method=post Path=/users"
                     }
-                  }
-                }, 
+                  },
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ]
+                },
                 "get": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/users"
+                    }
+                  },
                   "security": [
                     {
                       "OAuthAuth": [
                         "scope4"
                       ]
                     }
-                  ], 
+                  ]
+                },
+                "put": {
+                  "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    },
+                    "payloadFormatVersion": "1.0",
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole",
+                        "Arn"
+                      ]
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
-                      "description": "Default response for Method=get Path=/users"
+                      "description": "Default response for Method=put Path=/users"
                     }
-                  }
+                  },
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ]
                 }
               }
-            }, 
-            "openapi": "3.0.1", 
+            },
             "components": {
               "securitySchemes": {
-                "OAuthAuth": {
-                  "type": "oauth2", 
-                  "x-amazon-apigateway-authorizer": {
-                    "identitySource": "$request.querystring.param", 
-                    "type": "jwt", 
-                    "jwtConfiguration": {
-                      "audience": [
-                        "MyApi"
-                      ], 
-                      "issuer": "https://www.example.com/v1/connect/oidc"
-                    }
-                  }
-                }, 
                 "LambdaAuth": {
-                  "type": "apiKey", 
-                  "name": "Unused", 
+                  "type": "apiKey",
+                  "name": "Unused",
+                  "in": "header",
                   "x-amazon-apigateway-authorizer": {
-                    "type": "request", 
+                    "type": "request",
                     "authorizerUri": {
                       "Fn::Sub": [
-                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                         {
                           "__FunctionArn__": {
                             "Fn::GetAtt": [
-                              "MyAuthFn", 
+                              "MyAuthFn",
                               "Arn"
                             ]
                           }
                         }
                       ]
-                    }, 
+                    },
                     "authorizerPayloadFormatVersion": 1.0
-                  }, 
-                  "in": "header"
+                  }
+                },
+                "OAuthAuth": {
+                  "type": "oauth2",
+                  "x-amazon-apigateway-authorizer": {
+                    "jwtConfiguration": {
+                      "issuer": "https://www.example.com/v1/connect/oidc",
+                      "audience": [
+                        "MyApi"
+                      ]
+                    },
+                    "identitySource": "$request.querystring.param",
+                    "type": "jwt"
+                  }
                 }
               }
-            }, 
+            },
             "tags": [
               {
-                "name": "httpapi:createdBy", 
+                "name": "httpapi:createdBy",
                 "x-amazon-apigateway-tag-value": "SAM"
               }
             ]
           }
+        }
+      },
+      "MyApiProdStage": {
+        "Type": "AWS::ApiGatewayV2::Stage",
+        "Properties": {
+          "ApiId": {
+            "Ref": "MyApi"
+          },
+          "StageName": "Prod",
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          },
+          "AutoDeploy": true
         }
       }
     }

--- a/tests/translator/output/aws-us-gov/state_machine_with_http_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_http_api_authorizer_maximum.json
@@ -1,0 +1,344 @@
+{
+    "Resources": {
+      "StateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Version": "2012-10-17", 
+                "Statement": [
+                  {
+                    "Action": "*", 
+                    "Resource": "*", 
+                    "Effect": "Deny"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyApiProdStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "MyApi"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "Prod", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyApiStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "StateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "StateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "StateMachineName": "MyStateMachine", 
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n", 
+              [
+                "{", 
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
+                "    \"StartAt\": \"Hello\",", 
+                "    \"States\": {", 
+                "        \"Hello\": {", 
+                "            \"Next\": \"World\",", 
+                "            \"Result\": \"Hello\",", 
+                "            \"Type\": \"Pass\"", 
+                "        },", 
+                "        \"World\": {", 
+                "            \"End\": true,", 
+                "            \"Result\": \"World\",", 
+                "            \"Type\": \"Pass\"", 
+                "        }", 
+                "    }", 
+                "}"
+              ]
+            ]
+          }, 
+          "StateMachineType": "STANDARD", 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyApi": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/": {
+                "get": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "NONE": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/"
+                    }
+                  }
+                }
+              }, 
+              "/users": {
+                "put": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=put Path=/users"
+                    }
+                  }
+                }, 
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/users"
+                    }
+                  }
+                }, 
+                "get": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "OAuthAuth": [
+                        "scope4"
+                      ]
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/users"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "components": {
+              "securitySchemes": {
+                "OAuthAuth": {
+                  "type": "oauth2", 
+                  "x-amazon-apigateway-authorizer": {
+                    "identitySource": "$request.querystring.param", 
+                    "type": "jwt", 
+                    "jwtConfiguration": {
+                      "audience": [
+                        "MyApi"
+                      ], 
+                      "issuer": "https://www.example.com/v1/connect/oidc"
+                    }
+                  }
+                }, 
+                "LambdaAuth": {
+                  "type": "apiKey", 
+                  "name": "Unused", 
+                  "x-amazon-apigateway-authorizer": {
+                    "type": "request", 
+                    "authorizerUri": {
+                      "Fn::Sub": [
+                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                        {
+                          "__FunctionArn__": {
+                            "Fn::GetAtt": [
+                              "MyAuthFn", 
+                              "Arn"
+                            ]
+                          }
+                        }
+                      ]
+                    }, 
+                    "authorizerPayloadFormatVersion": 1.0
+                  }, 
+                  "in": "header"
+                }
+              }
+            }, 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/error_state_machine_with_http_api_duplicate_path.json
+++ b/tests/translator/output/error_state_machine_with_http_api_duplicate_path.json
@@ -1,0 +1,3 @@
+{
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Event with id [PathTwo] is invalid. API method \"post\" defined multiple times for path \"/inbound\"."
+}

--- a/tests/translator/output/error_state_machine_with_http_api_express_stop.json
+++ b/tests/translator/output/error_state_machine_with_http_api_express_stop.json
@@ -1,0 +1,3 @@
+{
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Event with id [HttpAPIGateway] is invalid. Action \"stop\" cannot be used on StateMachines of type EXPRESS"
+}

--- a/tests/translator/output/error_state_machine_with_http_api_invalid_action.json
+++ b/tests/translator/output/error_state_machine_with_http_api_invalid_action.json
@@ -1,0 +1,8 @@
+{
+    "errors": [
+        {
+            "errorMessage": "Action should be start, stop or startSync"
+        }
+    ],
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Action should be start, stop or startSync."
+}

--- a/tests/translator/output/error_state_machine_with_http_api_standard_startsync.json
+++ b/tests/translator/output/error_state_machine_with_http_api_standard_startsync.json
@@ -1,0 +1,3 @@
+{
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Event with id [HttpAPIGateway] is invalid. Action \"startSync\" cannot be used on StateMachines of type STANDARD"
+}

--- a/tests/translator/output/state_machine_with_http_api.json
+++ b/tests/translator/output/state_machine_with_http_api.json
@@ -1,0 +1,206 @@
+{
+    "Resources": {
+      "APIGatewayDeploymentMyStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "APIGatewayDeploymentMyStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "MyStateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "MyStateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "MyStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "APIGatewayDeployment": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/inbound": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "APIGatewayDeploymentMyStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/inbound"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }, 
+      "APIGatewayDeploymentdevStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "APIGatewayDeployment"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "dev", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "MyStateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "lambda:InvokeFunction"
+                    ], 
+                    "Resource": {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                        {
+                          "functionName": {
+                            "Ref": "MyFunction"
+                          }
+                        }
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/output/state_machine_with_http_api.json
+++ b/tests/translator/output/state_machine_with_http_api.json
@@ -1,11 +1,12 @@
 {
     "Resources": {
-      "APIGatewayDeploymentMyStateMachineRole": {
+      "ServerlessHttpApiMyExpressStateMachineRole": {
         "Type": "AWS::IAM::Role", 
         "Properties": {
+          "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
           "Policies": [
             {
-              "PolicyName": "APIGatewayDeploymentMyStateMachineRoleStartExecutionPolicy", 
+              "PolicyName": "ServerlessHttpApiMyExpressStateMachineRoleStartExecutionPolicy", 
               "PolicyDocument": {
                 "Statement": [
                   {
@@ -14,7 +15,7 @@
                       "states:StartSyncExecution"
                     ], 
                     "Resource": {
-                      "Ref": "MyStateMachine"
+                      "Ref": "MyExpressStateMachine"
                     }, 
                     "Effect": "Allow"
                   }, 
@@ -27,7 +28,7 @@
                           {
                             "__Name__": {
                               "Fn::GetAtt": [
-                                "MyStateMachine", 
+                                "MyExpressStateMachine", 
                                 "Name"
                               ]
                             }
@@ -59,97 +60,7 @@
           }
         }
       }, 
-      "MyStateMachine": {
-        "Type": "AWS::StepFunctions::StateMachine", 
-        "Properties": {
-          "DefinitionSubstitutions": {
-            "MyFunction": {
-              "Fn::GetAtt": [
-                "MyFunction", 
-                "Arn"
-              ]
-            }
-          }, 
-          "RoleArn": {
-            "Fn::GetAtt": [
-              "MyStateMachineRole", 
-              "Arn"
-            ]
-          }, 
-          "DefinitionS3Location": {
-            "Bucket": "bucket", 
-            "Key": "key"
-          }, 
-          "Tags": [
-            {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
-            }
-          ]
-        }
-      }, 
-      "APIGatewayDeployment": {
-        "Type": "AWS::ApiGatewayV2::Api", 
-        "Properties": {
-          "Body": {
-            "info": {
-              "version": "1.0", 
-              "title": {
-                "Ref": "AWS::StackName"
-              }
-            }, 
-            "paths": {
-              "/inbound": {
-                "post": {
-                  "x-amazon-apigateway-integration": {
-                    "requestParameters": {
-                      "StateMachineArn": {
-                        "Ref": "MyStateMachine"
-                      }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
-                    "credentials": {
-                      "Fn::GetAtt": [
-                        "APIGatewayDeploymentMyStateMachineRole", 
-                        "Arn"
-                      ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "responses": {
-                    "default": {
-                      "description": "Default response for Method=post Path=/inbound"
-                    }
-                  }
-                }
-              }
-            }, 
-            "openapi": "3.0.1", 
-            "tags": [
-              {
-                "name": "httpapi:createdBy", 
-                "x-amazon-apigateway-tag-value": "SAM"
-              }
-            ]
-          }
-        }
-      }, 
-      "APIGatewayDeploymentdevStage": {
-        "Type": "AWS::ApiGatewayV2::Stage", 
-        "Properties": {
-          "ApiId": {
-            "Ref": "APIGatewayDeployment"
-          }, 
-          "AutoDeploy": true, 
-          "StageName": "dev", 
-          "Tags": {
-            "httpapi:createdBy": "SAM"
-          }
-        }
-      }, 
-      "MyStateMachineRole": {
+      "MyExpressStateMachineRole": {
         "Type": "AWS::IAM::Role", 
         "Properties": {
           "AssumeRolePolicyDocument": {
@@ -169,9 +80,10 @@
             ]
           }, 
           "ManagedPolicyArns": [], 
+          "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
           "Policies": [
             {
-              "PolicyName": "MyStateMachineRolePolicy0", 
+              "PolicyName": "MyExpressStateMachineRolePolicy0", 
               "PolicyDocument": {
                 "Statement": [
                   {
@@ -194,6 +106,340 @@
               }
             }
           ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyStandardStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "MyStandardStateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "lambda:InvokeFunction"
+                    ], 
+                    "Resource": {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                        {
+                          "functionName": {
+                            "Ref": "MyFunction"
+                          }
+                        }
+                      ]
+                    }, 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "ServerlessHttpApi": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/startExpl": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStandardStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/startExpl"
+                    }
+                  }
+                }
+              }, 
+              "/exprstart": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyExpressStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyExpressStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/exprstart"
+                    }
+                  }
+                }
+              }, 
+              "/stop": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "ExecutionArn": "$request.body.ExecutionArn"
+                    }, 
+                    "integrationSubtype": "StepFunctions-StopExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/stop"
+                    }
+                  }
+                }
+              }, 
+              "/start": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyStandardStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyStandardStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/start"
+                    }
+                  }
+                }
+              }, 
+              "/exprsync": {
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "MyExpressStateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartSyncExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "ServerlessHttpApiMyExpressStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/exprsync"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }, 
+      "ServerlessHttpApiApiGatewayDefaultStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "ServerlessHttpApi"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "$default", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyStandardStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyStandardStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "ServerlessHttpApiMyStandardStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "ServerlessHttpApiMyStandardStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "MyStandardStateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "MyStandardStateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "MyExpressStateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "DefinitionSubstitutions": {
+            "MyFunction": {
+              "Fn::GetAtt": [
+                "MyFunction", 
+                "Arn"
+              ]
+            }
+          }, 
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "MyExpressStateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "DefinitionS3Location": {
+            "Bucket": "bucket", 
+            "Key": "key"
+          }, 
+          "StateMachineType": "EXPRESS", 
           "Tags": [
             {
               "Value": "SAM", 

--- a/tests/translator/output/state_machine_with_http_api_authorizer_maximum.json
+++ b/tests/translator/output/state_machine_with_http_api_authorizer_maximum.json
@@ -1,0 +1,344 @@
+{
+    "Resources": {
+      "StateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "states.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }, 
+          "ManagedPolicyArns": [], 
+          "Policies": [
+            {
+              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyDocument": {
+                "Version": "2012-10-17", 
+                "Statement": [
+                  {
+                    "Action": "*", 
+                    "Resource": "*", 
+                    "Effect": "Deny"
+                  }
+                ]
+              }
+            }
+          ], 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyApiProdStage": {
+        "Type": "AWS::ApiGatewayV2::Stage", 
+        "Properties": {
+          "ApiId": {
+            "Ref": "MyApi"
+          }, 
+          "AutoDeploy": true, 
+          "StageName": "Prod", 
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          }
+        }
+      }, 
+      "MyApiStateMachineRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "Policies": [
+            {
+              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy", 
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution", 
+                      "states:StartSyncExecution"
+                    ], 
+                    "Resource": {
+                      "Ref": "StateMachine"
+                    }, 
+                    "Effect": "Allow"
+                  }, 
+                  {
+                    "Action": "states:StopExecution", 
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "StateMachine", 
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ], 
+                    "Effect": "Allow"
+                  }
+                ]
+              }
+            }
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "apigateway.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine", 
+        "Properties": {
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole", 
+              "Arn"
+            ]
+          }, 
+          "StateMachineName": "MyStateMachine", 
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n", 
+              [
+                "{", 
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
+                "    \"StartAt\": \"Hello\",", 
+                "    \"States\": {", 
+                "        \"Hello\": {", 
+                "            \"Next\": \"World\",", 
+                "            \"Result\": \"Hello\",", 
+                "            \"Type\": \"Pass\"", 
+                "        },", 
+                "        \"World\": {", 
+                "            \"End\": true,", 
+                "            \"Result\": \"World\",", 
+                "            \"Type\": \"Pass\"", 
+                "        }", 
+                "    }", 
+                "}"
+              ]
+            ]
+          }, 
+          "StateMachineType": "STANDARD", 
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "stateMachine:createdBy"
+            }
+          ]
+        }
+      }, 
+      "MyApi": {
+        "Type": "AWS::ApiGatewayV2::Api", 
+        "Properties": {
+          "Body": {
+            "info": {
+              "version": "1.0", 
+              "title": {
+                "Ref": "AWS::StackName"
+              }
+            }, 
+            "paths": {
+              "/": {
+                "get": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "NONE": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/"
+                    }
+                  }
+                }
+              }, 
+              "/users": {
+                "put": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=put Path=/users"
+                    }
+                  }
+                }, 
+                "post": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=post Path=/users"
+                    }
+                  }
+                }, 
+                "get": {
+                  "x-amazon-apigateway-integration": {
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    }, 
+                    "integrationSubtype": "StepFunctions-StartExecution", 
+                    "connectionType": "INTERNET", 
+                    "payloadFormatVersion": "1.0", 
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole", 
+                        "Arn"
+                      ]
+                    }, 
+                    "type": "aws_proxy"
+                  }, 
+                  "security": [
+                    {
+                      "OAuthAuth": [
+                        "scope4"
+                      ]
+                    }
+                  ], 
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/users"
+                    }
+                  }
+                }
+              }
+            }, 
+            "openapi": "3.0.1", 
+            "components": {
+              "securitySchemes": {
+                "OAuthAuth": {
+                  "type": "oauth2", 
+                  "x-amazon-apigateway-authorizer": {
+                    "identitySource": "$request.querystring.param", 
+                    "type": "jwt", 
+                    "jwtConfiguration": {
+                      "audience": [
+                        "MyApi"
+                      ], 
+                      "issuer": "https://www.example.com/v1/connect/oidc"
+                    }
+                  }
+                }, 
+                "LambdaAuth": {
+                  "type": "apiKey", 
+                  "name": "Unused", 
+                  "x-amazon-apigateway-authorizer": {
+                    "type": "request", 
+                    "authorizerUri": {
+                      "Fn::Sub": [
+                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                        {
+                          "__FunctionArn__": {
+                            "Fn::GetAtt": [
+                              "MyAuthFn", 
+                              "Arn"
+                            ]
+                          }
+                        }
+                      ]
+                    }, 
+                    "authorizerPayloadFormatVersion": 1.0
+                  }, 
+                  "in": "header"
+                }
+              }
+            }, 
+            "tags": [
+              {
+                "name": "httpapi:createdBy", 
+                "x-amazon-apigateway-tag-value": "SAM"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }

--- a/tests/translator/output/state_machine_with_http_api_authorizer_maximum.json
+++ b/tests/translator/output/state_machine_with_http_api_authorizer_maximum.json
@@ -1,16 +1,58 @@
 {
     "Resources": {
+      "StateMachine": {
+        "Type": "AWS::StepFunctions::StateMachine",
+        "Properties": {
+          "DefinitionString": {
+            "Fn::Join": [
+              "\n",
+              [
+                "{",
+                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+                "    \"StartAt\": \"Hello\",",
+                "    \"States\": {",
+                "        \"Hello\": {",
+                "            \"Next\": \"World\",",
+                "            \"Result\": \"Hello\",",
+                "            \"Type\": \"Pass\"",
+                "        },",
+                "        \"World\": {",
+                "            \"End\": true,",
+                "            \"Result\": \"World\",",
+                "            \"Type\": \"Pass\"",
+                "        }",
+                "    }",
+                "}"
+              ]
+            ]
+          },
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "StateMachineRole",
+              "Arn"
+            ]
+          },
+          "StateMachineName": "MyStateMachine",
+          "StateMachineType": "STANDARD",
+          "Tags": [
+            {
+              "Key": "stateMachine:createdBy",
+              "Value": "SAM"
+            }
+          ]
+        }
+      },
       "StateMachineRole": {
-        "Type": "AWS::IAM::Role", 
+        "Type": "AWS::IAM::Role",
         "Properties": {
           "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
                 "Action": [
                   "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "Service": [
                     "states.amazonaws.com"
@@ -18,93 +60,42 @@
                 }
               }
             ]
-          }, 
-          "ManagedPolicyArns": [], 
+          },
+          "ManagedPolicyArns": [],
           "Policies": [
             {
-              "PolicyName": "StateMachineRolePolicy0", 
+              "PolicyName": "StateMachineRolePolicy0",
               "PolicyDocument": {
-                "Version": "2012-10-17", 
+                "Version": "2012-10-17",
                 "Statement": [
                   {
-                    "Action": "*", 
-                    "Resource": "*", 
-                    "Effect": "Deny"
+                    "Effect": "Deny",
+                    "Action": "*",
+                    "Resource": "*"
                   }
                 ]
               }
             }
-          ], 
+          ],
           "Tags": [
             {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
+              "Key": "stateMachine:createdBy",
+              "Value": "SAM"
             }
           ]
         }
-      }, 
-      "MyApiProdStage": {
-        "Type": "AWS::ApiGatewayV2::Stage", 
-        "Properties": {
-          "ApiId": {
-            "Ref": "MyApi"
-          }, 
-          "AutoDeploy": true, 
-          "StageName": "Prod", 
-          "Tags": {
-            "httpapi:createdBy": "SAM"
-          }
-        }
-      }, 
+      },
       "MyApiStateMachineRole": {
-        "Type": "AWS::IAM::Role", 
+        "Type": "AWS::IAM::Role",
         "Properties": {
-          "Policies": [
-            {
-              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy", 
-              "PolicyDocument": {
-                "Statement": [
-                  {
-                    "Action": [
-                      "states:StartExecution", 
-                      "states:StartSyncExecution"
-                    ], 
-                    "Resource": {
-                      "Ref": "StateMachine"
-                    }, 
-                    "Effect": "Allow"
-                  }, 
-                  {
-                    "Action": "states:StopExecution", 
-                    "Resource": [
-                      {
-                        "Fn::Sub": [
-                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*", 
-                          {
-                            "__Name__": {
-                              "Fn::GetAtt": [
-                                "StateMachine", 
-                                "Name"
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    ], 
-                    "Effect": "Allow"
-                  }
-                ]
-              }
-            }
-          ], 
           "AssumeRolePolicyDocument": {
-            "Version": "2012-10-17", 
+            "Version": "2012-10-17",
             "Statement": [
               {
                 "Action": [
                   "sts:AssumeRole"
-                ], 
-                "Effect": "Allow", 
+                ],
+                "Effect": "Allow",
                 "Principal": {
                   "Service": [
                     "apigateway.amazonaws.com"
@@ -112,232 +103,241 @@
                 }
               }
             ]
-          }
-        }
-      }, 
-      "StateMachine": {
-        "Type": "AWS::StepFunctions::StateMachine", 
-        "Properties": {
-          "RoleArn": {
-            "Fn::GetAtt": [
-              "StateMachineRole", 
-              "Arn"
-            ]
-          }, 
-          "StateMachineName": "MyStateMachine", 
-          "DefinitionString": {
-            "Fn::Join": [
-              "\n", 
-              [
-                "{", 
-                "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                "    \"StartAt\": \"Hello\",", 
-                "    \"States\": {", 
-                "        \"Hello\": {", 
-                "            \"Next\": \"World\",", 
-                "            \"Result\": \"Hello\",", 
-                "            \"Type\": \"Pass\"", 
-                "        },", 
-                "        \"World\": {", 
-                "            \"End\": true,", 
-                "            \"Result\": \"World\",", 
-                "            \"Type\": \"Pass\"", 
-                "        }", 
-                "    }", 
-                "}"
-              ]
-            ]
-          }, 
-          "StateMachineType": "STANDARD", 
-          "Tags": [
+          },
+          "Policies": [
             {
-              "Value": "SAM", 
-              "Key": "stateMachine:createdBy"
+              "PolicyName": "MyApiStateMachineRoleStartExecutionPolicy",
+              "PolicyDocument": {
+                "Statement": [
+                  {
+                    "Action": [
+                      "states:StartExecution",
+                      "states:StartSyncExecution"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": {
+                      "Ref": "StateMachine"
+                    }
+                  },
+                  {
+                    "Action": "states:StopExecution",
+                    "Effect": "Allow",
+                    "Resource": [
+                      {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${__Name__}:*",
+                          {
+                            "__Name__": {
+                              "Fn::GetAtt": [
+                                "StateMachine",
+                                "Name"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           ]
         }
-      }, 
+      },
       "MyApi": {
-        "Type": "AWS::ApiGatewayV2::Api", 
+        "Type": "AWS::ApiGatewayV2::Api",
         "Properties": {
           "Body": {
+            "openapi": "3.0.1",
             "info": {
-              "version": "1.0", 
+              "version": "1.0",
               "title": {
                 "Ref": "AWS::StackName"
               }
-            }, 
+            },
             "paths": {
               "/": {
                 "get": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "security": [
-                    {
-                      "NONE": []
-                    }
-                  ], 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
                       "description": "Default response for Method=get Path=/"
                     }
-                  }
-                }
-              }, 
-              "/users": {
-                "put": {
-                  "x-amazon-apigateway-integration": {
-                    "requestParameters": {
-                      "StateMachineArn": {
-                        "Ref": "StateMachine"
-                      }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
-                    "credentials": {
-                      "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
-                        "Arn"
-                      ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
+                  },
                   "security": [
                     {
-                      "LambdaAuth": []
+                      "NONE": []
                     }
-                  ], 
-                  "responses": {
-                    "default": {
-                      "description": "Default response for Method=put Path=/users"
-                    }
-                  }
-                }, 
+                  ]
+                }
+              },
+              "/users": {
                 "post": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
-                  "security": [
-                    {
-                      "LambdaAuth": []
-                    }
-                  ], 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
                       "description": "Default response for Method=post Path=/users"
                     }
-                  }
-                }, 
+                  },
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ]
+                },
                 "get": {
                   "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
                     "requestParameters": {
                       "StateMachineArn": {
                         "Ref": "StateMachine"
                       }
-                    }, 
-                    "integrationSubtype": "StepFunctions-StartExecution", 
-                    "connectionType": "INTERNET", 
-                    "payloadFormatVersion": "1.0", 
+                    },
+                    "payloadFormatVersion": "1.0",
                     "credentials": {
                       "Fn::GetAtt": [
-                        "MyApiStateMachineRole", 
+                        "MyApiStateMachineRole",
                         "Arn"
                       ]
-                    }, 
-                    "type": "aws_proxy"
-                  }, 
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
+                  "responses": {
+                    "default": {
+                      "description": "Default response for Method=get Path=/users"
+                    }
+                  },
                   "security": [
                     {
                       "OAuthAuth": [
                         "scope4"
                       ]
                     }
-                  ], 
+                  ]
+                },
+                "put": {
+                  "x-amazon-apigateway-integration": {
+                    "type": "aws_proxy",
+                    "requestParameters": {
+                      "StateMachineArn": {
+                        "Ref": "StateMachine"
+                      }
+                    },
+                    "payloadFormatVersion": "1.0",
+                    "credentials": {
+                      "Fn::GetAtt": [
+                        "MyApiStateMachineRole",
+                        "Arn"
+                      ]
+                    },
+                    "integrationSubtype": "StepFunctions-StartExecution",
+                    "connectionType": "INTERNET"
+                  },
                   "responses": {
                     "default": {
-                      "description": "Default response for Method=get Path=/users"
+                      "description": "Default response for Method=put Path=/users"
                     }
-                  }
+                  },
+                  "security": [
+                    {
+                      "LambdaAuth": []
+                    }
+                  ]
                 }
               }
-            }, 
-            "openapi": "3.0.1", 
+            },
             "components": {
               "securitySchemes": {
-                "OAuthAuth": {
-                  "type": "oauth2", 
-                  "x-amazon-apigateway-authorizer": {
-                    "identitySource": "$request.querystring.param", 
-                    "type": "jwt", 
-                    "jwtConfiguration": {
-                      "audience": [
-                        "MyApi"
-                      ], 
-                      "issuer": "https://www.example.com/v1/connect/oidc"
-                    }
-                  }
-                }, 
                 "LambdaAuth": {
-                  "type": "apiKey", 
-                  "name": "Unused", 
+                  "type": "apiKey",
+                  "name": "Unused",
+                  "in": "header",
                   "x-amazon-apigateway-authorizer": {
-                    "type": "request", 
+                    "type": "request",
                     "authorizerUri": {
                       "Fn::Sub": [
-                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                         {
                           "__FunctionArn__": {
                             "Fn::GetAtt": [
-                              "MyAuthFn", 
+                              "MyAuthFn",
                               "Arn"
                             ]
                           }
                         }
                       ]
-                    }, 
+                    },
                     "authorizerPayloadFormatVersion": 1.0
-                  }, 
-                  "in": "header"
+                  }
+                },
+                "OAuthAuth": {
+                  "type": "oauth2",
+                  "x-amazon-apigateway-authorizer": {
+                    "jwtConfiguration": {
+                      "issuer": "https://www.example.com/v1/connect/oidc",
+                      "audience": [
+                        "MyApi"
+                      ]
+                    },
+                    "identitySource": "$request.querystring.param",
+                    "type": "jwt"
+                  }
                 }
               }
-            }, 
+            },
             "tags": [
               {
-                "name": "httpapi:createdBy", 
+                "name": "httpapi:createdBy",
                 "x-amazon-apigateway-tag-value": "SAM"
               }
             ]
           }
+        }
+      },
+      "MyApiProdStage": {
+        "Type": "AWS::ApiGatewayV2::Stage",
+        "Properties": {
+          "ApiId": {
+            "Ref": "MyApi"
+          },
+          "StageName": "Prod",
+          "Tags": {
+            "httpapi:createdBy": "SAM"
+          },
+          "AutoDeploy": true
         }
       }
     }

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -314,6 +314,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "function_with_file_system_config",
                 "state_machine_with_permissions_boundary",
                 "state_machine_with_http_api",
+                "state_machine_with_http_api_authorizer_maximum",
             ],
             [
                 ("aws", "ap-southeast-1"),

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -692,6 +692,10 @@ class TestTranslatorEndToEnd(TestCase):
         "error_invalid_method_definition",
         "error_mappings_is_null",
         "error_swagger_security_not_dict",
+        "error_state_machine_with_http_api_express_stop",
+        "error_state_machine_with_http_api_standard_startsync",
+        "error_state_machine_with_http_api_invalid_action",
+        "error_state_machine_with_http_api_duplicate_path",
     ],
 )
 @patch("boto3.session.Session.region_name", "ap-southeast-1")

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -313,6 +313,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "state_machine_with_xray",
                 "function_with_file_system_config",
                 "state_machine_with_permissions_boundary",
+                "state_machine_with_http_api",
             ],
             [
                 ("aws", "ap-southeast-1"),


### PR DESCRIPTION
*Issue #1851*

*Description of changes:*
- integration test
- unit test(s)
- added a full role to also support stop and startSync
- added action property to event source (can be start, stop, startSync)
- error added when you try to add stop to EXPRESS state machine
- error added when you try to add startSync to STANDARD state machine
- refactored adding auth to HttpApi from `eventsources/push.py` and `stepfunctions/events.py`
- added TimeoutMillis support

*Description of how you validated changes:*
- used the integration test to verify deployed httpapi
- visually verified that all the integrations were added properly
- exported openapi yaml and checked all is there
- tested if the API responded correctly using Postman

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

See integration test that was added

*TODO*
- [x] test with various auth options
- [x] Error, Cause, Input, Name,  TraceHeader parameters for action
- [x] discuss role naming/scope
- [x] discuss Action property
- [x] discuss possibility of cross region integration api (eu-west-1) -> statemachine (us-east-1)
- [x] timeOutMilles is missing
- [x] fix code coverage (get open_api.py) green
- [ ] discuss output parameters

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
