### PR TITLE
Publish fails for Schedule with RetryPolicy

### DIFF
--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -791,15 +791,43 @@
         "Schedule": {
           "type": "string"
         },
-	"Name": {
-	  "type": "string"
-	},
-	"Description": {
-	  "type": "string"
-	},
-	"Enabled": {
-	  "type": "boolean"
-	}
+        "Name": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Enabled": {
+          "type": "boolean"
+        },
+        "DeadLetterConfig": {
+            "additionalProperties": false,
+            "properties": {
+              "Arn": {
+                "type": "string"
+              },
+              "Type": {
+                "type": "string"
+              },
+              "QueueLogicalId": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+        },        
+        "RetryPolicy": {
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "MaximumEventAgeInSeconds": {
+              "type": "number"
+            },
+            "MaximumRetryAttempts": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        }
       },
       "required": [
         "Schedule"

--- a/tests/translator/input/function_with_schedule_retry_policy.yaml
+++ b/tests/translator/input/function_with_schedule_retry_policy.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Author: user1
+    Description: hello world
+    HomePageUrl: https://github.com/user1/my-app-project
+    Labels:
+    - tests
+    LicenseUrl: s3://sam-integ-bucket-bfewbgodigmw/128ecf542a35ac5270a87dc740918404
+    Name: my-app
+    ReadmeUrl: s3://sam-integ-bucket-bfewbgodigmw/3905d7917f2b3429490b01cfb60d8f5b
+    SemanticVersion: '0.0.1'
+    SourceCodeUrl: https://github.com/user1/my-app-project
+    SpdxLicenseId: Apache-2.0
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-integ-bucket-bfewbgodigmw/code.zip
+      Events:
+        MinutelyTrigger:
+          Type: Schedule
+          Properties:
+            Description: Minutely trigger for the CloudWatch adapter
+            DeadLetterConfig:
+              Type: SQS
+              QueueLogicalId: MyDLQ
+            Enabled: true
+            RetryPolicy:
+              MaximumEventAgeInSeconds: 60
+              MaximumRetryAttempts: 0
+            Schedule: rate(1 minute)
+      Handler: index.handler
+      MemorySize: 128
+      Policies:
+      - AWSLambdaRole
+      - AmazonS3ReadOnlyAccess
+      Runtime: nodejs12.x

--- a/tests/translator/validator/test_validator.py
+++ b/tests/translator/validator/test_validator.py
@@ -75,6 +75,7 @@ INPUT_FOLDER = os.path.join(BASE_PATH, os.pardir, "input")
         "function_concurrency",
         "simple_table_with_extra_tags",
         "explicit_api_with_invalid_events_config",
+        "function_with_schedule_retry_policy",
     ],
 )
 def test_validate_template_success(testcase):


### PR DESCRIPTION
schema.json DeadLetterConfig and RetryPolicy added to ScheduleEvent

*Issue https://github.com/aws/aws-sam-cli/issues/2645, if available:*

*Description of changes:*
- validator test added issue that shows the error described in the issue
- in schema.json DeadLetterConfig and RetryPolicy added to ScheduleEvent

*Description of how you validated changes:*
- first reproduced error (occurs with sam publish!)
- verified that set RetryPolicy was on the target

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
