### PR TITLE
fix(policy-templates): Correct AMIDescribePolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -478,9 +478,7 @@
             "Action": [
               "ec2:DescribeImages"
             ],
-            "Resource": {
-              "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/*"
-            }
+            "Resource": "*"
           }
         ]
       }

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -336,9 +336,7 @@
                   "Action": [
                     "ec2:DescribeImages"
                   ], 
-                  "Resource": {
-                    "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/*"
-                  }, 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -336,9 +336,7 @@
                   "Action": [
                     "ec2:DescribeImages"
                   ], 
-                  "Resource": {
-                    "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/*"
-                  }, 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -336,9 +336,7 @@
                   "Action": [
                     "ec2:DescribeImages"
                   ], 
-                  "Resource": {
-                    "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/*"
-                  }, 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]


### PR DESCRIPTION
The action underlying this policy does not take a particular resource.

*Issue #, if available:*

Resolves #1944

*Description of changes:*

Removes templated ARN from `AMIDescribePolicy`, replacing it with a static `*`.

*Description of how you validated changes:*

Aside from the translator tests, created a Lambda Function using these permissions and successfully performed the action.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] ~Update documentation~ _The documentation appears not to be in the repo – wherever that is will have to be updated. Maybe it's generated?_
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
