### PR TITLE
fix: Change yaml.load to yaml_parse as a best practice

### DIFF
--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -293,7 +293,7 @@ class BaseTest(TestCase):
         for key, _ in self.code_key_to_file.items():
             # We must double the {} to escape them so they will survive a round of unescape
             data = data.replace("${{{}}}".format(key), self.get_code_key_s3_uri(key))
-        yaml_doc = yaml.load(data, Loader=yaml.FullLoader)
+        yaml_doc = yaml.safe_load(data)
 
         dump_yaml(updated_template_path, yaml_doc)
 

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -4,6 +4,7 @@ import os
 from integration.helpers.client_provider import ClientProvider
 from integration.helpers.resource import generate_suffix, create_bucket, verify_stack_resources
 from integration.helpers.yaml_utils import dump_yaml, load_yaml
+from samtranslator.yaml_helper import yaml_parse
 
 try:
     from pathlib import Path
@@ -293,7 +294,7 @@ class BaseTest(TestCase):
         for key, _ in self.code_key_to_file.items():
             # We must double the {} to escape them so they will survive a round of unescape
             data = data.replace("${{{}}}".format(key), self.get_code_key_s3_uri(key))
-        yaml_doc = yaml.safe_load(data)
+        yaml_doc = yaml_parse(data)
 
         dump_yaml(updated_template_path, yaml_doc)
 

--- a/integration/helpers/yaml_utils.py
+++ b/integration/helpers/yaml_utils.py
@@ -1,5 +1,7 @@
 import yaml
 
+from samtranslator.yaml_helper import yaml_parse
+
 
 def load_yaml(file_path):
     """
@@ -17,7 +19,7 @@ def load_yaml(file_path):
     """
     with open(file_path) as f:
         data = f.read()
-    return yaml.safe_load(data)
+    return yaml_parse(data)
 
 
 def dump_yaml(file_path, yaml_doc):

--- a/integration/helpers/yaml_utils.py
+++ b/integration/helpers/yaml_utils.py
@@ -17,7 +17,7 @@ def load_yaml(file_path):
     """
     with open(file_path) as f:
         data = f.read()
-    return yaml.load(data, Loader=yaml.FullLoader)
+    return yaml.safe_load(data)
 
 
 def dump_yaml(file_path, yaml_doc):


### PR DESCRIPTION
change yaml.load to yaml.safe_load for the security best practice

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
