### PR TITLE
Percentage-based Enablement for Feature Toggle

### DIFF
--- a/samtranslator/feature_toggle/dialup.py
+++ b/samtranslator/feature_toggle/dialup.py
@@ -17,13 +17,13 @@ class BaseDialup(object):
         return self.__class__.__name__
 
 
-class NeverEnabledDialup(BaseDialup):
+class DisabledDialup(BaseDialup):
     """
     A dialup that is never enabled
     """
 
     def __init__(self, region_config, **kwargs):
-        super(NeverEnabledDialup, self).__init__(region_config)
+        super(DisabledDialup, self).__init__(region_config)
 
     def is_enabled(self):
         return False

--- a/samtranslator/feature_toggle/dialup.py
+++ b/samtranslator/feature_toggle/dialup.py
@@ -1,0 +1,65 @@
+import hashlib
+
+
+class BaseDialup(object):
+    def __init__(self, region_config, **kwargs):
+        self.region_config = region_config
+
+    def is_enabled(self):
+        raise NotImplementedError
+
+    def __str__(self):
+        return self.__class__.__name__
+
+
+class NeverEnabledDialup(BaseDialup):
+    """
+    A dialup that is never enabled
+    """
+
+    def __init__(self, region_config, **kwargs):
+        super(NeverEnabledDialup, self).__init__(region_config)
+
+    def is_enabled(self):
+        return False
+
+
+class ToggleDialup(BaseDialup):
+    """
+    A simple toggle Dialup
+    Example of region_config: { "type": "toggle", "enabled": True }
+    """
+
+    def __init__(self, region_config, **kwargs):
+        super(ToggleDialup, self).__init__(region_config)
+        self.region_config = region_config
+
+    def is_enabled(self):
+        return self.region_config.get("enabled", False)
+
+
+class SimpleAccountPercentileDialup(BaseDialup):
+    """
+    Simple account percentile dialup, enabling X% of
+    Example of region_config: { "type": "account-percentile", "enabled-%": 20 }
+    """
+
+    def __init__(self, region_config, account_id, feature_name, **kwargs):
+        super(SimpleAccountPercentileDialup, self).__init__(region_config)
+        self.account_id = account_id
+        self.feature_name = feature_name
+
+    def _get_account_percentile(self):
+        """
+        Get account percentile based on sha256 hash of account ID and feature_name
+
+        :returns: integer n, where 0 <= n < 100
+        """
+        m = hashlib.sha256()
+        m.update(self.account_id.encode())
+        m.update(self.feature_name.encode())
+        return int(m.hexdigest(), 16) % 100
+
+    def is_enabled(self):
+        target_percentile = self.region_config.get("enabled-%", 0)
+        return self._get_account_percentile() < target_percentile

--- a/samtranslator/feature_toggle/dialup.py
+++ b/samtranslator/feature_toggle/dialup.py
@@ -2,10 +2,15 @@ import hashlib
 
 
 class BaseDialup(object):
+    """BaseDialup class to provide an interface for all dialup classes"""
+
     def __init__(self, region_config, **kwargs):
         self.region_config = region_config
 
     def is_enabled(self):
+        """
+        Returns a bool on whether this dialup is enabled or not
+        """
         raise NotImplementedError
 
     def __str__(self):
@@ -61,5 +66,9 @@ class SimpleAccountPercentileDialup(BaseDialup):
         return int(m.hexdigest(), 16) % 100
 
     def is_enabled(self):
+        """
+        Enable when account_percentile falls within target_percentile
+        Meaning only (target_percentile)% of accounts will be enabled
+        """
         target_percentile = self.region_config.get("enabled-%", 0)
         return self._get_account_percentile() < target_percentile

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -38,7 +38,9 @@ class FeatureToggle:
         region = self.region
         account_id = self.account_id
         if not stage or not region or not account_id:
-            LOG.warning("One or more of stage, region and account_id is not properly set. Feature not enabled.")
+            LOG.warning(
+                "One or more of stage, region and account_id is not set. Feature '{}' not enabled.".format(feature_name)
+            )
             return False
 
         stage_config = self.feature_config.get(feature_name, {}).get(stage, {})

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -30,50 +30,10 @@ class FeatureToggle:
 
         :param feature_name: name of feature
         """
-        if self.account_id is None:
-            LOG.warning("Account ID is missing. Feature not enabled.")
-            return False
-        return self.is_enabled_for_account_in_region(feature_name, self.stage, self.account_id, self.region)
+        stage = self.stage
+        region = self.region
+        account_id = self.account_id
 
-    def is_enabled_for_stage_in_region(self, feature_name, stage, region="default"):
-        """
-        To check if feature is available for a particular stage or not.
-        :param feature_name: name of feature
-        :param stage: stage where SAM is running
-        :param region: region in which SAM is running
-        :return:
-        """
-        if feature_name not in self.feature_config:
-            LOG.warning("Feature '{}' not available in Feature Toggle Config.".format(feature_name))
-            return False
-        stage_config = self.feature_config.get(feature_name, {}).get(stage, {})
-        if not stage_config:
-            LOG.info("Stage '{}' not enabled for Feature '{}'.".format(stage, feature_name))
-            return False
-        region_config = stage_config.get(region, {}) if region in stage_config else stage_config.get("default", {})
-        if "enabled-%" in region_config:
-            LOG.warning(
-                """
-            Percentage-based enablement is configured for Feature '{}' in Stage '{}' in Region '{}'. 
-            Please use is_enabled_for_account_in_region() instead. Feature not enabled.
-            """.format(
-                    feature_name, stage, region
-                )
-            )
-            return False
-        is_enabled = region_config.get("enabled", False)
-        LOG.info("Feature '{}' is enabled: '{}'".format(feature_name, is_enabled))
-        return is_enabled
-
-    def is_enabled_for_account_in_region(self, feature_name, stage, account_id, region="default"):
-        """
-        To check if feature is available for a particular account or not.
-        :param feature_name: name of feature
-        :param stage: stage where SAM is running
-        :param account_id: account_id who is executing SAM template
-        :param region: region in which SAM is running
-        :return:
-        """
         if feature_name not in self.feature_config:
             LOG.warning("Feature '{}' not available in Feature Toggle Config.".format(feature_name))
             return False

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -7,7 +7,7 @@ import hashlib
 
 from botocore.config import Config
 from samtranslator.feature_toggle.dialup import (
-    NeverEnabledDialup,
+    DisabledDialup,
     ToggleDialup,
     SimpleAccountPercentileDialup,
 )
@@ -39,7 +39,7 @@ class FeatureToggle:
         """
         get the right dialup instance
         if no dialup type is provided or the specified dialup is not supported,
-        an instance of NeverEnabledDialup will be returned
+        an instance of DisabledDialup will be returned
 
         :param region_config: region config
         :param feature_name: feature_name
@@ -51,7 +51,7 @@ class FeatureToggle:
                 region_config, account_id=self.account_id, feature_name=feature_name
             )
         LOG.warning("Dialup type '{}' is None or is not supported.".format(dialup_type))
-        return NeverEnabledDialup(region_config)
+        return DisabledDialup(region_config)
 
     def is_enabled(self, feature_name):
         """

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -83,18 +83,17 @@ class FeatureToggle:
             return False
 
         if account_id in stage_config:
-            account_config = stage_config.get(account_id)
-            region_config = (
-                account_config.get(region, {}) if region in account_config else account_config.get("default", {})
-            )
+            account_config = stage_config[account_id]
+            region_config = account_config[region] if region in account_config else account_config.get("default", {})
         else:
-            region_config = stage_config.get(region, {}) if region in stage_config else stage_config.get("default", {})
+            region_config = stage_config[region] if region in stage_config else stage_config.get("default", {})
 
         if "enabled-%" in region_config:
             # Percentage-based enablement
+            # Assumption: account_id is uniformly distributed
             # account_id is calculated into one of 100 partitions (0-99)
             # if partition < enabled_percent, we consider the feature is enabled for this given account_id
-            enabled_percent = region_config.get("enabled-%")
+            enabled_percent = region_config["enabled-%"]
             partition = int(account_id) % 100
             is_enabled = partition < enabled_percent
         else:

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -18,7 +18,7 @@ class FeatureToggle:
     SAM is executing or not.
     """
 
-    def __init__(self, config_provider, stage="beta", account_id=None, region="default"):
+    def __init__(self, config_provider, stage, account_id, region):
         self.feature_config = config_provider.config
         self.stage = stage
         self.account_id = account_id
@@ -30,13 +30,17 @@ class FeatureToggle:
 
         :param feature_name: name of feature
         """
-        stage = self.stage
-        region = self.region
-        account_id = self.account_id
-
         if feature_name not in self.feature_config:
             LOG.warning("Feature '{}' not available in Feature Toggle Config.".format(feature_name))
             return False
+
+        stage = self.stage
+        region = self.region
+        account_id = self.account_id
+        if not stage or not region or not account_id:
+            LOG.warning("One or more of stage, region and account_id is not properly set. Feature not enabled.")
+            return False
+
         stage_config = self.feature_config.get(feature_name, {}).get(stage, {})
         if not stage_config:
             LOG.info("Stage '{}' not enabled for Feature '{}'.".format(stage, feature_name))

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -55,14 +55,7 @@ class FeatureToggle:
         else:
             region_config = stage_config[region] if region in stage_config else stage_config.get("default", {})
 
-        if "enabled-%" in region_config:
-            # Percentage-based enablement
-            # if target_percentile = 10 => account_percentile < 10 means the account is the selected 10%
-            target_percentile = region_config["enabled-%"]
-            account_percentile = self._get_account_percentile(feature_name)
-            is_enabled = account_percentile < target_percentile
-        else:
-            is_enabled = region_config.get("enabled", False)
+        is_enabled = self._is_feature_enabled_for_region_config(feature_name, region_config)
 
         LOG.info("Feature '{}' is enabled: '{}'".format(feature_name, is_enabled))
         return is_enabled
@@ -78,6 +71,25 @@ class FeatureToggle:
         m.update(self.account_id.encode())
         m.update(feature_name.encode())
         return int(m.hexdigest(), 16) % 100
+
+    def _is_feature_enabled_for_region_config(self, feature_name, region_config):
+        """
+        returns if a feature is enabled for a given config
+
+        :params feature_name: name of feature
+        :params region_config: region config obtained from stage_config or account_config
+        :returns: bool is_enabled
+        """
+        if "enabled-%" in region_config:
+            # Percentage-based enablement
+            # if target_percentile = 10 => account_percentile < 10 means the account is the selected 10%
+            target_percentile = region_config["enabled-%"]
+            account_percentile = self._get_account_percentile(feature_name)
+            is_enabled = account_percentile < target_percentile
+        else:
+            is_enabled = region_config.get("enabled", False)
+
+        return is_enabled
 
 
 class FeatureToggleConfigProvider:

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -91,7 +91,11 @@ class Translator:
         :returns: a copy of the template with SAM resources replaced with the corresponding CloudFormation, which may \
                 be dumped into a valid CloudFormation JSON or YAML template
         """
-        self.feature_toggle = feature_toggle if feature_toggle else FeatureToggle(FeatureToggleDefaultConfigProvider())
+        self.feature_toggle = (
+            feature_toggle
+            if feature_toggle
+            else FeatureToggle(FeatureToggleDefaultConfigProvider(), stage=None, account_id=None, region=None)
+        )
         self.function_names = dict()
         self.redeploy_restapi_parameters = dict()
         sam_parameter_values = SamParameterValues(parameter_values)

--- a/tests/feature_toggle/input/feature_toggle_config.json
+++ b/tests/feature_toggle/input/feature_toggle_config.json
@@ -3,6 +3,7 @@
     "feature-1": {
         "beta": {
             "us-west-2": {"enabled": true},
+            "us-east-1": {"enabled-%": 10},
             "default": {"enabled": false},
             "123456789123": {"us-west-2": {"enabled": true}, "default": {"enabled": false}}
         },

--- a/tests/feature_toggle/input/feature_toggle_config.json
+++ b/tests/feature_toggle/input/feature_toggle_config.json
@@ -2,14 +2,20 @@
     "__note__": "This is a dummy config for local testing. Any change here need to be migrated to SAM service.",
     "feature-1": {
         "beta": {
-            "us-west-2": {"enabled": true},
-            "us-east-1": {"enabled-%": 10},
-            "default": {"enabled": false},
-            "123456789123": {"us-west-2": {"enabled": true}, "default": {"enabled": false}}
+            "us-west-2": {"type": "toggle", "enabled": true},
+            "us-east-1": {"type": "account-percentile", "enabled-%": 10},
+            "default": {"type": "toggle", "enabled": false},
+            "123456789123": {
+                "us-west-2": {"type": "toggle", "enabled": true},
+                "default": {"type": "toggle", "enabled": false}
+            }
         },
         "gamma": {
-            "default": {"enabled": false},
-            "123456789123": {"us-east-1": {"enabled": false}, "default": {"enabled": false}}
+            "default": {"type": "toggle", "enabled": false},
+            "123456789123": {
+                "us-east-1": {"type": "toggle", "enabled": false},
+                "default": {"type": "toggle", "enabled": false}
+            }
         },
         "prod": {"default": {"enabled": false}}
     }

--- a/tests/feature_toggle/test_dialup.py
+++ b/tests/feature_toggle/test_dialup.py
@@ -1,0 +1,65 @@
+from unittest import TestCase
+
+from parameterized import parameterized, param
+from samtranslator.feature_toggle.dialup import *
+
+
+class TestBaseDialup(TestCase):
+    def test___str__(self):
+        region_config = {}
+        dialup = BaseDialup(region_config)
+        self.assertEqual(str(dialup), "BaseDialup")
+
+
+class TestNeverEnabledDialup(TestCase):
+    def test_is_enabled(self):
+        region_config = {}
+        dialup = NeverEnabledDialup(region_config)
+        self.assertFalse(dialup.is_enabled())
+
+
+class TestToggleDialUp(TestCase):
+    @parameterized.expand(
+        [
+            param({"type": "toggle", "enabled": True}, True),
+            param({"type": "toggle", "enabled": False}, False),
+            param({"type": "toggle"}, False),  # missing "enabled" key
+        ]
+    )
+    def test_is_enabled(self, region_config, expected):
+        dialup = ToggleDialup(region_config)
+        self.assertEqual(dialup.is_enabled(), expected)
+
+
+class TestSimpleAccountPercentileDialup(TestCase):
+    @parameterized.expand(
+        [
+            param({"type": "account-percentile", "enabled-%": 10}, "feature-1", "123456789100", True),
+            param({"type": "account-percentile", "enabled-%": 10}, "feautre-1", "123456789123", False),
+            param({"type": "account-percentile", "enabled": True}, "feature-1", "123456789100", False),
+        ]
+    )
+    def test_is_enabled(self, region_config, feature_name, account_id, expected):
+        dialup = SimpleAccountPercentileDialup(
+            region_config=region_config,
+            account_id=account_id,
+            feature_name=feature_name,
+        )
+        self.assertEqual(dialup.is_enabled(), expected)
+
+    @parameterized.expand(
+        [
+            param("feature-1", "123456789123"),
+            param("feature-2", "000000000000"),
+            param("feature-3", "432187654321"),
+            param("feature-4", "111222333444"),
+        ]
+    )
+    def test__get_account_percentile(self, account_id, feature_name):
+        region_config = {"type": "account-percentile", "enabled-%": 10}
+        dialup = SimpleAccountPercentileDialup(
+            region_config=region_config,
+            account_id=account_id,
+            feature_name=feature_name,
+        )
+        self.assertTrue(0 <= dialup._get_account_percentile() < 100)

--- a/tests/feature_toggle/test_dialup.py
+++ b/tests/feature_toggle/test_dialup.py
@@ -11,10 +11,10 @@ class TestBaseDialup(TestCase):
         self.assertEqual(str(dialup), "BaseDialup")
 
 
-class TestNeverEnabledDialup(TestCase):
+class TestDisabledDialup(TestCase):
     def test_is_enabled(self):
         region_config = {}
-        dialup = NeverEnabledDialup(region_config)
+        dialup = DisabledDialup(region_config)
         self.assertFalse(dialup.is_enabled())
 
 

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -16,22 +16,6 @@ sys.path.insert(0, my_path + "/..")
 class TestFeatureToggle(TestCase):
     @parameterized.expand(
         [
-            param("feature-1", "beta", "default", False),
-            param("feature-1", "beta", "us-west-2", True),
-            param("feature-2", "beta", "us-west-2", False),  # because feature is missing
-            param("feature-1", "beta", "us-east-1", False),  # because percentage-based enablement is configured
-            param("feature-1", "alpha", "us-east-1", False),  # non-exist stage
-        ]
-    )
-    def test_feature_toggle_with_local_provider_for_stage(self, feature_name, stage, region, expected):
-        feature_toggle = FeatureToggle(
-            FeatureToggleLocalConfigProvider(os.path.join(my_path, "input", "feature_toggle_config.json"))
-        )
-        self.assertEqual(feature_toggle.is_enabled_for_stage_in_region(feature_name, stage, region), expected)
-        self.assertFalse(feature_toggle.is_enabled(feature_name))
-
-    @parameterized.expand(
-        [
             param("feature-1", "beta", "default", "123456789123", False),
             param("feature-1", "beta", "us-west-2", "123456789123", True),
             param("feature-2", "beta", "us-west-2", "123456789123", False),  # because feature is missing
@@ -47,9 +31,6 @@ class TestFeatureToggle(TestCase):
             stage=stage,
             region=region,
             account_id=account_id,
-        )
-        self.assertEqual(
-            feature_toggle.is_enabled_for_account_in_region(feature_name, stage, account_id, region), expected
         )
         self.assertEqual(feature_toggle.is_enabled(feature_name), expected)
 
@@ -79,24 +60,6 @@ class TestFeatureToggleAppConfig(TestCase):
 
     @parameterized.expand(
         [
-            param("feature-1", "beta", "default", False),
-            param("feature-1", "beta", "us-west-2", True),
-            param("feature-2", "beta", "us-west-2", False),  # because feature is missing
-            param("feature-1", "beta", "us-east-1", False),  # because percentage-based enablement is configured
-            param("feature-1", "alpha", "us-east-1", False),  # non-exist stage
-        ]
-    )
-    @patch("samtranslator.feature_toggle.feature_toggle.boto3")
-    def test_feature_toggle_for_stage(self, feature_name, stage, region, expected, boto3_mock):
-        boto3_mock.client.return_value = self.app_config_mock
-        feature_toggle_config_provider = FeatureToggleAppConfigConfigProvider(
-            "test_app_id", "test_env_id", "test_conf_id"
-        )
-        feature_toggle = FeatureToggle(feature_toggle_config_provider)
-        self.assertEqual(feature_toggle.is_enabled_for_stage_in_region(feature_name, stage, region), expected)
-
-    @parameterized.expand(
-        [
             param("feature-1", "beta", "default", "123456789123", False),
             param("feature-1", "beta", "us-west-2", "123456789123", True),
             param("feature-2", "beta", "us-west-2", "123456789123", False),  # because feature is missing
@@ -114,9 +77,6 @@ class TestFeatureToggleAppConfig(TestCase):
         )
         feature_toggle = FeatureToggle(
             feature_toggle_config_provider, stage=stage, region=region, account_id=account_id
-        )
-        self.assertEqual(
-            feature_toggle.is_enabled_for_account_in_region(feature_name, stage, account_id, region), expected
         )
         self.assertEqual(feature_toggle.is_enabled(feature_name), expected)
 

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -23,6 +23,11 @@ class TestFeatureToggle(TestCase):
             param("feature-1", "beta", "us-east-1", "123456789109", True),
             param("feature-1", "beta", "us-east-1", "123456789123", False),  # account_id is not within defined %
             param("feature-1", "alpha", "us-east-1", "123456789123", False),  # non-exist stage
+            # any None for stage, region and account_id should return False
+            param("feature-1", None, None, None, False),
+            param("feature-1", "beta", None, None, False),
+            param("feature-1", "beta", "us-west-2", None, False),
+            param("feature-1", "beta", None, "123456789123", False),
         ]
     )
     def test_feature_toggle_with_local_provider(self, feature_name, stage, region, account_id, expected):
@@ -67,6 +72,11 @@ class TestFeatureToggleAppConfig(TestCase):
             param("feature-1", "beta", "us-east-1", "123456789109", True),
             param("feature-1", "beta", "us-east-1", "123456789123", False),  # account_id is not within defined %
             param("feature-1", "alpha", "us-east-1", "123456789123", False),  # non-exist stage
+            # any None for stage, region and account_id returns False
+            param("feature-1", None, None, None, False),
+            param("feature-1", "beta", None, None, False),
+            param("feature-1", "beta", "us-west-2", None, False),
+            param("feature-1", "beta", None, "123456789123", False),
         ]
     )
     @patch("samtranslator.feature_toggle.feature_toggle.boto3")

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -20,9 +20,9 @@ class TestFeatureToggle(TestCase):
             param("feature-1", "beta", "us-west-2", "123456789123", True),
             param("feature-2", "beta", "us-west-2", "123456789123", False),  # because feature is missing
             param("feature-1", "beta", "ap-south-1", "123456789124", False),  # because default is used
-            param("feature-1", "beta", "us-east-1", "123456789109", True),
-            param("feature-1", "beta", "us-east-1", "123456789123", False),  # account_id is not within defined %
             param("feature-1", "alpha", "us-east-1", "123456789123", False),  # non-exist stage
+            param("feature-1", "beta", "us-east-1", "123456789100", True),
+            param("feature-1", "beta", "us-east-1", "123456789123", False),
             # any None for stage, region and account_id should return False
             param("feature-1", None, None, None, False),
             param("feature-1", "beta", None, None, False),
@@ -38,6 +38,23 @@ class TestFeatureToggle(TestCase):
             account_id=account_id,
         )
         self.assertEqual(feature_toggle.is_enabled(feature_name), expected)
+
+    @parameterized.expand(
+        [
+            param("123456789123", "feature-1"),
+            param("000000000000", "feature-2"),
+            param("432187654321", "feature-3"),
+            param("111222333444", "feature-4"),
+        ]
+    )
+    def test__get_account_percentile(self, account_id, feature_name):
+        feature_toggle = FeatureToggle(
+            FeatureToggleLocalConfigProvider(os.path.join(my_path, "input", "feature_toggle_config.json")),
+            stage=None,
+            region=None,
+            account_id=account_id,
+        )
+        self.assertTrue(0 <= feature_toggle._get_account_percentile(feature_name) < 100)
 
 
 class TestFeatureToggleAppConfig(TestCase):
@@ -69,9 +86,9 @@ class TestFeatureToggleAppConfig(TestCase):
             param("feature-1", "beta", "us-west-2", "123456789123", True),
             param("feature-2", "beta", "us-west-2", "123456789123", False),  # because feature is missing
             param("feature-1", "beta", "ap-south-1", "123456789124", False),  # because default is used
-            param("feature-1", "beta", "us-east-1", "123456789109", True),
-            param("feature-1", "beta", "us-east-1", "123456789123", False),  # account_id is not within defined %
             param("feature-1", "alpha", "us-east-1", "123456789123", False),  # non-exist stage
+            param("feature-1", "beta", "us-east-1", "123456789100", True),
+            param("feature-1", "beta", "us-east-1", "123456789123", False),
             # any None for stage, region and account_id returns False
             param("feature-1", None, None, None, False),
             param("feature-1", "beta", None, None, False),

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -8,7 +8,7 @@ from samtranslator.feature_toggle.feature_toggle import (
     FeatureToggleLocalConfigProvider,
     FeatureToggleAppConfigConfigProvider,
 )
-from samtranslator.feature_toggle.dialup import ToggleDialup, SimpleAccountPercentileDialup, NeverEnabledDialup
+from samtranslator.feature_toggle.dialup import ToggleDialup, SimpleAccountPercentileDialup, DisabledDialup
 
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, my_path + "/..")
@@ -44,7 +44,7 @@ class TestFeatureToggle(TestCase):
         [
             param("toggle", ToggleDialup),
             param("account-percentile", SimpleAccountPercentileDialup),
-            param("something-else", NeverEnabledDialup),
+            param("something-else", DisabledDialup),
         ]
     )
     def test__get_dialup(self, dialup_type, expected_class):

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -70,7 +70,9 @@ class TestFeatureToggleAppConfig(TestCase):
         ]
     )
     @patch("samtranslator.feature_toggle.feature_toggle.boto3")
-    def test_feature_toggle_with_appconfig_provider(self, feature_name, stage, region, account_id, expected, boto3_mock):
+    def test_feature_toggle_with_appconfig_provider(
+        self, feature_name, stage, region, account_id, expected, boto3_mock
+    ):
         boto3_mock.client.return_value = self.app_config_mock
         feature_toggle_config_provider = FeatureToggleAppConfigConfigProvider(
             "test_app_id", "test_env_id", "test_conf_id"

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -56,6 +56,27 @@ class TestFeatureToggle(TestCase):
         )
         self.assertTrue(0 <= feature_toggle._get_account_percentile(feature_name) < 100)
 
+    @parameterized.expand(
+        [
+            param({"enabled": True}, 0, True),
+            param({"enabled-%": 10}, 0, True),
+            param({"enabled": False}, 0, False),
+            param({"enabled-%": 10}, 20, False),
+        ]
+    )
+    @patch.object(FeatureToggle, "_get_account_percentile")
+    def test__is_feature_enabled_for_region_config(
+        self, region_config, account_percentile, expected, get_account_percentile_mock
+    ):
+        feature_toggle = FeatureToggle(
+            FeatureToggleLocalConfigProvider(os.path.join(my_path, "input", "feature_toggle_config.json")),
+            stage=None,
+            region=None,
+            account_id="123456789",
+        )
+        get_account_percentile_mock.return_value = account_percentile
+        self.assertEqual(feature_toggle._is_feature_enabled_for_region_config("feature", region_config), expected)
+
 
 class TestFeatureToggleAppConfig(TestCase):
     def setUp(self):

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -25,7 +25,7 @@ class TestFeatureToggle(TestCase):
             param("feature-1", "alpha", "us-east-1", "123456789123", False),  # non-exist stage
         ]
     )
-    def test_feature_toggle_with_local_provider_for_account_id(self, feature_name, stage, region, account_id, expected):
+    def test_feature_toggle_with_local_provider(self, feature_name, stage, region, account_id, expected):
         feature_toggle = FeatureToggle(
             FeatureToggleLocalConfigProvider(os.path.join(my_path, "input", "feature_toggle_config.json")),
             stage=stage,
@@ -70,7 +70,7 @@ class TestFeatureToggleAppConfig(TestCase):
         ]
     )
     @patch("samtranslator.feature_toggle.feature_toggle.boto3")
-    def test_feature_toggle_for_account_id(self, feature_name, stage, region, account_id, expected, boto3_mock):
+    def test_feature_toggle_with_appconfig_provider(self, feature_name, stage, region, account_id, expected, boto3_mock):
         boto3_mock.client.return_value = self.app_config_mock
         feature_toggle_config_provider = FeatureToggleAppConfigConfigProvider(
             "test_app_id", "test_env_id", "test_conf_id"

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -28,6 +28,7 @@ class TestFeatureToggle(TestCase):
             FeatureToggleLocalConfigProvider(os.path.join(my_path, "input", "feature_toggle_config.json"))
         )
         self.assertEqual(feature_toggle.is_enabled_for_stage_in_region(feature_name, stage, region), expected)
+        self.assertFalse(feature_toggle.is_enabled(feature_name))
 
     @parameterized.expand(
         [
@@ -42,11 +43,15 @@ class TestFeatureToggle(TestCase):
     )
     def test_feature_toggle_with_local_provider_for_account_id(self, feature_name, stage, region, account_id, expected):
         feature_toggle = FeatureToggle(
-            FeatureToggleLocalConfigProvider(os.path.join(my_path, "input", "feature_toggle_config.json"))
+            FeatureToggleLocalConfigProvider(os.path.join(my_path, "input", "feature_toggle_config.json")),
+            stage=stage,
+            region=region,
+            account_id=account_id,
         )
         self.assertEqual(
             feature_toggle.is_enabled_for_account_in_region(feature_name, stage, account_id, region), expected
         )
+        self.assertEqual(feature_toggle.is_enabled(feature_name), expected)
 
 
 class TestFeatureToggleAppConfig(TestCase):
@@ -107,10 +112,13 @@ class TestFeatureToggleAppConfig(TestCase):
         feature_toggle_config_provider = FeatureToggleAppConfigConfigProvider(
             "test_app_id", "test_env_id", "test_conf_id"
         )
-        feature_toggle = FeatureToggle(feature_toggle_config_provider)
+        feature_toggle = FeatureToggle(
+            feature_toggle_config_provider, stage=stage, region=region, account_id=account_id
+        )
         self.assertEqual(
             feature_toggle.is_enabled_for_account_in_region(feature_name, stage, account_id, region), expected
         )
+        self.assertEqual(feature_toggle.is_enabled(feature_name), expected)
 
 
 class TestFeatureToggleAppConfigConfigProvider(TestCase):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add support for Percentage-based Enablement for Feature Toggle.
When `enabled-%` is set (instead of `enabled`) under a region config, `is_enabled_for_account_in_region(...)` will determine whether the given `account_id` falls in the percentage range for feature enablement.

*Description of how you validated changes:*
Added more tests

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
