### PR TITLE
Update state machine generator to use Definition object instead of DefinitionString

### DIFF
--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -124,7 +124,7 @@ class StateMachineGenerator(object):
                     self.state_machine.DefinitionSubstitutions.update(substitutions)
                 else:
                     self.state_machine.DefinitionSubstitutions = substitutions
-            self.state_machine.DefinitionString = self._build_definition_string(processed_definition)
+            self.state_machine.Definition = processed_definition
         elif self.definition_uri:
             self.state_machine.DefinitionS3Location = self._construct_definition_uri()
         else:
@@ -187,22 +187,6 @@ class StateMachineGenerator(object):
         if "Version" in s3_pointer:
             definition_s3["Version"] = s3_pointer["Version"]
         return definition_s3
-
-    def _build_definition_string(self, definition_dict):
-        """
-        Builds a CloudFormation definition string from a definition dictionary. The definition string constructed is
-        a Fn::Join intrinsic function to make it readable.
-
-        :param definition_dict: State machine definition as a dictionary
-
-        :returns: the state machine definition.
-        :rtype: dict
-        """
-        # Indenting and then splitting the JSON-encoded string for readability of the state machine definition in the CloudFormation translated resource.
-        # Separators are passed explicitly to maintain trailing whitespace consistency across Py2 and Py3
-        definition_lines = json.dumps(definition_dict, sort_keys=True, indent=4, separators=(",", ": ")).split("\n")
-        definition_string = fnJoin("\n", definition_lines)
-        return definition_string
 
     def _construct_role(self):
         """

--- a/tests/translator/output/aws-cn/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_auth_default_scopes.json
@@ -1,15 +1,15 @@
 {
     "Resources": {
         "MyApiWithCognitoAuth": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/cognitowithauthnone": {
                             "get": {
@@ -17,381 +17,381 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoWithAuthNoneRole", 
+                                            "MyStateMachineCognitoWithAuthNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "NONE": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultauthdefaultscopesnone": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole", 
+                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesnone": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesNoneRole", 
+                                            "MyStateMachineCognitoDefaultScopesNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitoauthorizerwithdefaultscopes": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole", 
+                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": [
-                                            "default.delete", 
+                                            "default.delete",
                                             "default.update"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitoauthorizercopesoverwritten": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole", 
+                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": [
-                                            "overwritten.read", 
+                                            "overwritten.read",
                                             "overwritten.write"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesoverwritten": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole", 
+                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": [
-                                            "overwritten.read", 
+                                            "overwritten.read",
                                             "overwritten.write"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesdefaultauthorizer": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole", 
+                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": [
-                                            "default.write", 
+                                            "default.write",
                                             "default.read"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "openapi": "3.0.1", 
+                    },
+                    "openapi": "3.0.1",
                     "components": {
                         "securitySchemes": {
                             "MyCognitoAuthWithDefaultScopes": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
+                                "in": "header",
+                                "type": "apiKey",
+                                "name": "Authorization",
                                 "x-amazon-apigateway-authorizer": {
                                     "providerARNs": [
                                         "arn:aws:2"
-                                    ], 
+                                    ],
                                     "type": "cognito_user_pools"
-                                }, 
+                                },
                                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }, 
+                            },
                             "MyDefaultCognitoAuth": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
+                                "in": "header",
+                                "type": "apiKey",
+                                "name": "Authorization",
                                 "x-amazon-apigateway-authorizer": {
                                     "providerARNs": [
                                         "arn:aws:1"
-                                    ], 
+                                    ],
                                     "type": "cognito_user_pools"
-                                }, 
+                                },
                                 "x-amazon-apigateway-authtype": "cognito_user_pools"
                             }
                         }
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoWithAuthNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -401,34 +401,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -438,34 +438,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -475,34 +475,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -512,55 +512,55 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiWithCognitoAuthProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiWithCognitoAuthDeployment57b57dfc88"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApiWithCognitoAuth"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "MyApiWithCognitoAuthDeployment57b57dfc88": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApiWithCognitoAuth"
-                }, 
+                },
                 "Description": "RestApi deployment id: 57b57dfc88b1b438a0437eadd869d77e938eedb6"
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -570,75 +570,68 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
+                        "MyStateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -648,34 +641,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -685,18 +678,18 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -704,26 +697,26 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
+                        "PolicyName": "MyStateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]

--- a/tests/translator/output/aws-cn/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_authorizer.json
@@ -1,69 +1,62 @@
 {
     "Resources": {
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeploymentaaffc688ce"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startNoAuth": {
                             "post": {
@@ -71,78 +64,78 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
+                                            "StateMachineWithNoAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }
             }
-        }, 
+        },
         "StateMachineWithLambdaTokenAuthRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -152,16 +145,16 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -170,17 +163,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startWithLambdaToken": {
                             "post": {
@@ -188,97 +181,97 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthRole", 
+                                            "StateMachineWithLambdaTokenAuthRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaTokenAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "securityDefinitions": {
                         "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
+                            "type": "apiKey",
+                            "name": "x-api-key",
                             "in": "header"
-                        }, 
+                        },
                         "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyCustomAuthHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 20,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                                },
+                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                                 "identityValidationExpression": "mycustomauthexpression"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
                         }
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -286,80 +279,80 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeployment2d6a709a2a"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeploymentaaffc688ce": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb", 
+                },
+                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -369,14 +362,14 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiDeployment2d6a709a2a": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 2d6a709a2a2b67ee19ca14fe4594114921c537d0", 
+                },
+                "Description": "RestApi deployment id: 2d6a709a2a2b67ee19ca14fe4594114921c537d0",
                 "StageName": "Stage"
             }
         }

--- a/tests/translator/output/aws-cn/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_authorizer_maximum.json
@@ -1,14 +1,14 @@
 {
     "Resources": {
         "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -17,34 +17,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineWithLambdaRequestAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -54,76 +54,69 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "StateMachineWithDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -133,17 +126,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/": {
                             "get": {
@@ -151,338 +144,338 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
+                                            "StateMachineWithNoAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "NONE": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/users": {
                             "put": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithDefaultAuthorizerRole", 
+                                            "StateMachineWithDefaultAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "post": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole", 
+                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthMultipleUserPools": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "patch": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthorizerRole", 
+                                            "StateMachineWithLambdaTokenAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "delete": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaRequestAuthorizerRole", 
+                                            "StateMachineWithLambdaRequestAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaRequestAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "securityDefinitions": {
                         "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Authorization", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "Authorization",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 0, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 0,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
                                 }
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "MyCognitoAuthMultipleUserPools": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader2", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyAuthorizationHeader2",
                             "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression2", 
+                                "identityValidationExpression": "myauthvalidationexpression2",
                                 "providerARNs": [
-                                    "arn:aws:2", 
+                                    "arn:aws:2",
                                     "arn:aws:3"
-                                ], 
+                                ],
                                 "type": "cognito_user_pools"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
+                        },
                         "MyLambdaRequestAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Unused", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "Unused",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "request", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                                "type": "request",
+                                "authorizerResultTtlInSeconds": 0,
+                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
+                                },
                                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "MyCognitoAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyAuthorizationHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression", 
+                                "identityValidationExpression": "myauthvalidationexpression",
                                 "providerARNs": [
                                     "arn:aws:1"
-                                ], 
+                                ],
                                 "type": "cognito_user_pools"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
+                        },
                         "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyCustomAuthHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 20,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                                },
+                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                                 "identityValidationExpression": "mycustomauthexpression"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
+                            "type": "apiKey",
+                            "name": "x-api-key",
                             "in": "header"
                         }
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }
             }
-        }, 
+        },
         "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -491,18 +484,18 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -510,58 +503,58 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "StateMachineWithLambdaTokenAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -571,16 +564,16 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -589,56 +582,56 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiDeployment704a2ea820": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 704a2ea8202a6b11b22e31524b5e5dfa2b528378", 
+                },
+                "Description": "RestApi deployment id: 704a2ea8202a6b11b22e31524b5e5dfa2b528378",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeployment704a2ea820"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -648,34 +641,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"

--- a/tests/translator/output/aws-cn/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_resource_policy.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "MyStateMachineGetHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,17 +36,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "ExplicitApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/one": {
                             "get": {
@@ -54,289 +54,289 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineGetHtmlRole", 
+                                            "MyStateMachineGetHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/three": {
                             "put": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachinePutHtmlRole", 
+                                            "MyStateMachinePutHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/two": {
                             "post": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachinePostHtmlRole", 
+                                            "MyStateMachinePostHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
+                        "Version": "2012-10-17",
                         "Statement": [
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Allow", 
+                                ],
+                                "Effect": "Allow",
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "NotIpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "IpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Allow", 
+                                ],
+                                "Effect": "Allow",
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "NotIpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "IpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
                             }
                         ]
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }
             }
-        }, 
+        },
         "ExplicitApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ExplicitApiDeployment17065a95ba"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ExplicitApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "MyStateMachinePutHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -346,69 +346,62 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
+                        "MyStateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ExplicitApiDeployment17065a95ba": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ExplicitApi"
-                }, 
-                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2", 
+                },
+                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -416,58 +409,58 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
+                        "PolicyName": "MyStateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyStateMachinePostHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"

--- a/tests/translator/output/aws-cn/state_machine_with_definition_substitutions.json
+++ b/tests/translator/output/aws-cn/state_machine_with_definition_substitutions.json
@@ -120,28 +120,21 @@
             "Arn"
           ]
         },
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"${my_state_var_1}\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"${my_state_var_2}\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "${my_state_var_1}"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "${my_state_var_2}"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/aws-cn/state_machine_with_explicit_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_explicit_api.json
@@ -1,16 +1,16 @@
 {
     "Resources": {
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -18,122 +18,115 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+                },
+                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeployment05bc9f394c"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -143,17 +136,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,46 +154,46 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }

--- a/tests/translator/output/aws-cn/state_machine_with_implicit_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_implicit_api.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,82 +36,75 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeployment05bc9f394c"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+                },
+                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -119,41 +112,41 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,46 +154,46 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }

--- a/tests/translator/output/aws-cn/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/aws-cn/state_machine_with_implicit_api_globals.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,82 +36,75 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeployment1f01b589d4"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeployment1f01b589d4": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a", 
+                },
+                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -119,41 +112,41 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,55 +154,55 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
+                        "Version": "2012-10-17",
                         "Statement": {
-                            "Action": "execute-api:Invoke", 
+                            "Action": "execute-api:Invoke",
                             "Resource": [
                                 {
                                     "Fn::Sub": [
-                                        "execute-api:/${__Stage__}/POST/startMyExecution", 
+                                        "execute-api:/${__Stage__}/POST/startMyExecution",
                                         {
                                             "__Stage__": "Prod"
                                         }
                                     ]
                                 }
-                            ], 
-                            "Effect": "Deny", 
+                            ],
+                            "Effect": "Deny",
                             "Principal": {
                                 "AWS": [
                                     "12345"
@@ -217,12 +210,12 @@
                             }
                         }
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }

--- a/tests/translator/output/aws-cn/state_machine_with_inline_definition.json
+++ b/tests/translator/output/aws-cn/state_machine_with_inline_definition.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -18,68 +18,61 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
+        },
+        "ManagedPolicyArns": [],
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
-              "Version": "2012-10-17", 
+              "Version": "2012-10-17",
               "Statement": [
                 {
-                  "Action": "*", 
-                  "Resource": "*", 
+                  "Action": "*",
+                  "Resource": "*",
                   "Effect": "Deny"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyBasicStateMachine", 
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n", 
-            [
-              "{", 
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-              "    \"StartAt\": \"Hello\",", 
-              "    \"States\": {", 
-              "        \"Hello\": {", 
-              "            \"Next\": \"World\",", 
-              "            \"Result\": \"Hello\",", 
-              "            \"Type\": \"Pass\"", 
-              "        },", 
-              "        \"World\": {", 
-              "            \"End\": true,", 
-              "            \"Result\": \"World\",", 
-              "            \"Type\": \"Pass\"", 
-              "        }", 
-              "    }", 
-              "}"
-            ]
-          ]
-        }, 
-        "StateMachineType": "STANDARD", 
+        },
+        "StateMachineName": "MyBasicStateMachine",
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Result": "World",
+              "Type": "Pass"
+            }
+          }
+        },
+        "StateMachineType": "STANDARD",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]

--- a/tests/translator/output/aws-cn/state_machine_with_inline_definition_intrinsics.json
+++ b/tests/translator/output/aws-cn/state_machine_with_inline_definition_intrinsics.json
@@ -105,28 +105,21 @@
     "StateMachine": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/aws-cn/state_machine_with_inline_policies.json
+++ b/tests/translator/output/aws-cn/state_machine_with_inline_policies.json
@@ -105,28 +105,21 @@
     "StateMachine": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/aws-cn/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/aws-cn/state_machine_with_sam_policy_templates.json
@@ -35,30 +35,23 @@
           }
         },
         "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"An example ASL file for nested workflows\",",
-              "    \"StartAt\": \"NestedStateOne\",",
-              "    \"States\": {",
-              "        \"NestedStateOne\": {",
-              "            \"Next\": \"NestedStateTwo\",",
-              "            \"Result\": {",
-              "                \"Value\": \"MyValue\"",
-              "            },",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"NestedStateTwo\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "An example ASL file for nested workflows",
+          "StartAt": "NestedStateOne",
+          "States": {
+            "NestedStateOne": {
+              "Next": "NestedStateTwo",
+              "Result": {
+                "Value": "MyValue"
+              },
+              "Type": "Pass"
+            },
+            "NestedStateTwo": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "StateMachineType": "STANDARD",
         "Tags": [
@@ -121,115 +114,108 @@
             "Arn"
           ]
         },
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"An example ASL file with parallel states\",",
-              "    \"StartAt\": \"StateOne\",",
-              "    \"States\": {",
-              "        \"StateOne\": {",
-              "            \"Next\": \"StateTwo\",",
-              "            \"Result\": {",
-              "                \"Value\": \"MyValue\"",
-              "            },",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"StateTwo\": {",
-              "            \"Branches\": [",
-              "                {",
-              "                    \"StartAt\": \"BranchOne_StateOne\",",
-              "                    \"States\": {",
-              "                        \"BranchOne_StateFour\": {",
-              "                            \"Choices\": [",
-              "                                {",
-              "                                    \"Next\": \"ValueIsZero\",",
-              "                                    \"NumericEquals\": 0,",
-              "                                    \"Variable\": \"$.value\"",
-              "                                },",
-              "                                {",
-              "                                    \"Next\": \"ValueIsOne\",",
-              "                                    \"NumericEquals\": 1,",
-              "                                    \"Variable\": \"$.value\"",
-              "                                }",
-              "                            ],",
-              "                            \"Type\": \"Choice\"",
-              "                        },",
-              "                        \"BranchOne_StateOne\": {",
-              "                            \"Next\": \"BranchOne_StateTwo\",",
-              "                            \"Resource\": \"${definition_substitution_1}\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchOne_StateThree\": {",
-              "                            \"Next\": \"BranchOne_StateFour\",",
-              "                            \"Parameters\": {",
-              "                                \"FunctionName\": \"${definition_substitution_2}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::lambda:invoke\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchOne_StateTwo\": {",
-              "                            \"Next\": \"BranchOne_StateThree\",",
-              "                            \"Parameters\": {",
-              "                                \"MessageBody.$\": \"$.input.message\",",
-              "                                \"QueueUrl\": \"${definition_substitution_3}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::sqs:sendMessage.waitForTaskToken\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"ValueIsOne\": {",
-              "                            \"Type\": \"Succeed\"",
-              "                        },",
-              "                        \"ValueIsZero\": {",
-              "                            \"Type\": \"Fail\"",
-              "                        }",
-              "                    }",
-              "                },",
-              "                {",
-              "                    \"StartAt\": \"BranchTwo_StateOne\",",
-              "                    \"States\": {",
-              "                        \"BranchTwo_StateOne\": {",
-              "                            \"Next\": \"BranchTwo_StateTwo\",",
-              "                            \"Parameters\": {",
-              "                                \"Input\": {",
-              "                                    \"KeyA\": \"ValueA\",",
-              "                                    \"KeyC\": \"ValueC\"",
-              "                                },",
-              "                                \"StateMachineArn\": \"${definition_substitution_4}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::states:startExecution.sync\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchTwo_StateThree\": {",
-              "                            \"Type\": \"Succeed\"",
-              "                        },",
-              "                        \"BranchTwo_StateTwo\": {",
-              "                            \"Next\": \"BranchTwo_StateThree\",",
-              "                            \"Parameters\": {",
-              "                                \"Item\": {",
-              "                                    \"Body\": {",
-              "                                        \"S.$\": \"$.MessageDetails.Body\"",
-              "                                    },",
-              "                                    \"MessageId\": {",
-              "                                        \"S.$\": \"$.MessageDetails.MessageId\"",
-              "                                    }",
-              "                                },",
-              "                                \"TableName\": \"${definition_substitution_5}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::dynamodb:putItem\",",
-              "                            \"Type\": \"Task\"",
-              "                        }",
-              "                    }",
-              "                }",
-              "            ],",
-              "            \"End\": true,",
-              "            \"Type\": \"Parallel\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "An example ASL file with parallel states",
+          "StartAt": "StateOne",
+          "States": {
+            "StateOne": {
+              "Next": "StateTwo",
+              "Result": {
+                "Value": "MyValue"
+              },
+              "Type": "Pass"
+            },
+            "StateTwo": {
+              "Branches": [
+                {
+                  "StartAt": "BranchOne_StateOne",
+                  "States": {
+                    "BranchOne_StateFour": {
+                      "Choices": [
+                        {
+                          "Next": "ValueIsZero",
+                          "NumericEquals": 0,
+                          "Variable": "$.value"
+                        },
+                        {
+                          "Next": "ValueIsOne",
+                          "NumericEquals": 1,
+                          "Variable": "$.value"
+                        }
+                      ],
+                      "Type": "Choice"
+                    },
+                    "BranchOne_StateOne": {
+                      "Next": "BranchOne_StateTwo",
+                      "Resource": "${definition_substitution_1}",
+                      "Type": "Task"
+                    },
+                    "BranchOne_StateThree": {
+                      "Next": "BranchOne_StateFour",
+                      "Parameters": {
+                        "FunctionName": "${definition_substitution_2}"
+                      },
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Type": "Task"
+                    },
+                    "BranchOne_StateTwo": {
+                      "Next": "BranchOne_StateThree",
+                      "Parameters": {
+                        "MessageBody.$": "$.input.message",
+                        "QueueUrl": "${definition_substitution_3}"
+                      },
+                      "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+                      "Type": "Task"
+                    },
+                    "ValueIsOne": {
+                      "Type": "Succeed"
+                    },
+                    "ValueIsZero": {
+                      "Type": "Fail"
+                    }
+                  }
+                },
+                {
+                  "StartAt": "BranchTwo_StateOne",
+                  "States": {
+                    "BranchTwo_StateOne": {
+                      "Next": "BranchTwo_StateTwo",
+                      "Parameters": {
+                        "Input": {
+                          "KeyA": "ValueA",
+                          "KeyC": "ValueC"
+                        },
+                        "StateMachineArn": "${definition_substitution_4}"
+                      },
+                      "Resource": "arn:aws:states:::states:startExecution.sync",
+                      "Type": "Task"
+                    },
+                    "BranchTwo_StateThree": {
+                      "Type": "Succeed"
+                    },
+                    "BranchTwo_StateTwo": {
+                      "Next": "BranchTwo_StateThree",
+                      "Parameters": {
+                        "Item": {
+                          "Body": {
+                            "S.$": "$.MessageDetails.Body"
+                          },
+                          "MessageId": {
+                            "S.$": "$.MessageDetails.MessageId"
+                          }
+                        },
+                        "TableName": "${definition_substitution_5}"
+                      },
+                      "Resource": "arn:aws:states:::dynamodb:putItem",
+                      "Type": "Task"
+                    }
+                  }
+                }
+              ],
+              "End": true,
+              "Type": "Parallel"
+            }
+          }
         },
         "StateMachineType": "STANDARD",
         "Tags": [

--- a/tests/translator/output/aws-cn/state_machine_with_tags.json
+++ b/tests/translator/output/aws-cn/state_machine_with_tags.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -18,84 +18,77 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
+        },
+        "ManagedPolicyArns": [],
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
-              "Version": "2012-10-17", 
+              "Version": "2012-10-17",
               "Statement": [
                 {
-                  "Action": "*", 
-                  "Resource": "*", 
+                  "Action": "*",
+                  "Resource": "*",
                   "Effect": "Deny"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
-          }, 
+          },
           {
-            "Value": "ValueTwo", 
+            "Value": "ValueTwo",
             "Key": "TagTwo"
-          }, 
+          },
           {
-            "Value": "ValueOne", 
+            "Value": "ValueOne",
             "Key": "TagOne"
           }
         ]
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyStateMachineWithTags", 
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n", 
-            [
-              "{", 
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-              "    \"StartAt\": \"Hello\",", 
-              "    \"States\": {", 
-              "        \"Hello\": {", 
-              "            \"Next\": \"World\",", 
-              "            \"Result\": \"Hello\",", 
-              "            \"Type\": \"Pass\"", 
-              "        },", 
-              "        \"World\": {", 
-              "            \"End\": true,", 
-              "            \"Result\": \"World\",", 
-              "            \"Type\": \"Pass\"", 
-              "        }", 
-              "    }", 
-              "}"
-            ]
-          ]
-        }, 
-        "StateMachineType": "STANDARD", 
+        },
+        "StateMachineName": "MyStateMachineWithTags",
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Result": "World",
+              "Type": "Pass"
+            }
+          }
+        },
+        "StateMachineType": "STANDARD",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
-          }, 
+          },
           {
-            "Value": "ValueTwo", 
+            "Value": "ValueTwo",
             "Key": "TagTwo"
-          }, 
+          },
           {
-            "Value": "ValueOne", 
+            "Value": "ValueOne",
             "Key": "TagOne"
           }
         ]

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_auth_default_scopes.json
@@ -1,15 +1,15 @@
 {
     "Resources": {
         "MyApiWithCognitoAuth": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/cognitowithauthnone": {
                             "get": {
@@ -17,381 +17,381 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoWithAuthNoneRole", 
+                                            "MyStateMachineCognitoWithAuthNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "NONE": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultauthdefaultscopesnone": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole", 
+                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesnone": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesNoneRole", 
+                                            "MyStateMachineCognitoDefaultScopesNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitoauthorizerwithdefaultscopes": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole", 
+                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": [
-                                            "default.delete", 
+                                            "default.delete",
                                             "default.update"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitoauthorizercopesoverwritten": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole", 
+                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": [
-                                            "overwritten.read", 
+                                            "overwritten.read",
                                             "overwritten.write"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesoverwritten": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole", 
+                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": [
-                                            "overwritten.read", 
+                                            "overwritten.read",
                                             "overwritten.write"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesdefaultauthorizer": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole", 
+                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": [
-                                            "default.write", 
+                                            "default.write",
                                             "default.read"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "openapi": "3.0.1", 
+                    },
+                    "openapi": "3.0.1",
                     "components": {
                         "securitySchemes": {
                             "MyCognitoAuthWithDefaultScopes": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
+                                "in": "header",
+                                "type": "apiKey",
+                                "name": "Authorization",
                                 "x-amazon-apigateway-authorizer": {
                                     "providerARNs": [
                                         "arn:aws:2"
-                                    ], 
+                                    ],
                                     "type": "cognito_user_pools"
-                                }, 
+                                },
                                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }, 
+                            },
                             "MyDefaultCognitoAuth": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
+                                "in": "header",
+                                "type": "apiKey",
+                                "name": "Authorization",
                                 "x-amazon-apigateway-authorizer": {
                                     "providerARNs": [
                                         "arn:aws:1"
-                                    ], 
+                                    ],
                                     "type": "cognito_user_pools"
-                                }, 
+                                },
                                 "x-amazon-apigateway-authtype": "cognito_user_pools"
                             }
                         }
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoWithAuthNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -401,34 +401,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -438,34 +438,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -475,34 +475,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -512,55 +512,55 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiWithCognitoAuthProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiWithCognitoAuthDeployment57b57dfc88"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApiWithCognitoAuth"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "MyApiWithCognitoAuthDeployment57b57dfc88": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApiWithCognitoAuth"
-                }, 
+                },
                 "Description": "RestApi deployment id: 57b57dfc88b1b438a0437eadd869d77e938eedb6"
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -570,75 +570,68 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
+                        "MyStateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -648,34 +641,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -685,18 +678,18 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -704,26 +697,26 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
+                        "PolicyName": "MyStateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer.json
@@ -1,69 +1,62 @@
 {
     "Resources": {
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeploymentaaffc688ce"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startNoAuth": {
                             "post": {
@@ -71,78 +64,78 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
+                                            "StateMachineWithNoAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }
             }
-        }, 
+        },
         "StateMachineWithLambdaTokenAuthRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -152,16 +145,16 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -170,18 +163,18 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -189,90 +182,90 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyApiDeployment3c26186470": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 3c2618647036e31ff3ebf6ae8d4602ba63997fd7", 
+                },
+                "Description": "RestApi deployment id: 3c2618647036e31ff3ebf6ae8d4602ba63997fd7",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeployment3c26186470"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeploymentaaffc688ce": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb", 
+                },
+                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -282,17 +275,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startWithLambdaToken": {
                             "post": {
@@ -300,81 +293,81 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthRole", 
+                                            "StateMachineWithLambdaTokenAuthRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaTokenAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "securityDefinitions": {
                         "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
+                            "type": "apiKey",
+                            "name": "x-api-key",
                             "in": "header"
-                        }, 
+                        },
                         "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyCustomAuthHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 20,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                                },
+                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                                 "identityValidationExpression": "mycustomauthexpression"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
                         }
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer_maximum.json
@@ -1,14 +1,14 @@
 {
     "Resources": {
         "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -17,34 +17,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineWithLambdaRequestAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -54,86 +54,79 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyApiDeployment2120b73f3e": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 2120b73f3e7efc28dc4baca314ee3b30d8d8c783", 
+                },
+                "Description": "RestApi deployment id: 2120b73f3e7efc28dc4baca314ee3b30d8d8c783",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineWithDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -143,16 +136,16 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -161,18 +154,18 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -180,58 +173,58 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "StateMachineWithLambdaTokenAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -241,16 +234,16 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -259,46 +252,46 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeployment2120b73f3e"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -308,34 +301,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -345,17 +338,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/": {
                             "get": {
@@ -363,324 +356,324 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
+                                            "StateMachineWithNoAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "NONE": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/users": {
                             "put": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithDefaultAuthorizerRole", 
+                                            "StateMachineWithDefaultAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "post": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole", 
+                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthMultipleUserPools": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "patch": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthorizerRole", 
+                                            "StateMachineWithLambdaTokenAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "delete": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaRequestAuthorizerRole", 
+                                            "StateMachineWithLambdaRequestAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaRequestAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "securityDefinitions": {
                         "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Authorization", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "Authorization",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 0, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 0,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
                                 }
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "MyCognitoAuthMultipleUserPools": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader2", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyAuthorizationHeader2",
                             "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression2", 
+                                "identityValidationExpression": "myauthvalidationexpression2",
                                 "providerARNs": [
-                                    "arn:aws:2", 
+                                    "arn:aws:2",
                                     "arn:aws:3"
-                                ], 
+                                ],
                                 "type": "cognito_user_pools"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
+                        },
                         "MyLambdaRequestAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Unused", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "Unused",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "request", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                                "type": "request",
+                                "authorizerResultTtlInSeconds": 0,
+                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
+                                },
                                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "MyCognitoAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyAuthorizationHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression", 
+                                "identityValidationExpression": "myauthvalidationexpression",
                                 "providerARNs": [
                                     "arn:aws:1"
-                                ], 
+                                ],
                                 "type": "cognito_user_pools"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
+                        },
                         "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyCustomAuthHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 20,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                                },
+                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                                 "identityValidationExpression": "mycustomauthexpression"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
+                            "type": "apiKey",
+                            "name": "x-api-key",
                             "in": "header"
                         }
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_resource_policy.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "MyStateMachineGetHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,17 +36,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "ExplicitApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/one": {
                             "get": {
@@ -54,289 +54,289 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineGetHtmlRole", 
+                                            "MyStateMachineGetHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/three": {
                             "put": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachinePutHtmlRole", 
+                                            "MyStateMachinePutHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/two": {
                             "post": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachinePostHtmlRole", 
+                                            "MyStateMachinePostHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
+                        "Version": "2012-10-17",
                         "Statement": [
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Allow", 
+                                ],
+                                "Effect": "Allow",
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "NotIpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "IpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Allow", 
+                                ],
+                                "Effect": "Allow",
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "NotIpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "IpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
                             }
                         ]
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }
             }
-        }, 
+        },
         "ExplicitApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ExplicitApiDeployment17065a95ba"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ExplicitApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "MyStateMachinePutHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -346,69 +346,62 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
+                        "MyStateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ExplicitApiDeployment17065a95ba": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ExplicitApi"
-                }, 
-                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2", 
+                },
+                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -416,58 +409,58 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
+                        "PolicyName": "MyStateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyStateMachinePostHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"

--- a/tests/translator/output/aws-us-gov/state_machine_with_definition_substitutions.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_definition_substitutions.json
@@ -120,28 +120,21 @@
             "Arn"
           ]
         },
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"${my_state_var_1}\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"${my_state_var_2}\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "${my_state_var_1}"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "${my_state_var_2}"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/state_machine_with_explicit_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_explicit_api.json
@@ -1,16 +1,16 @@
 {
     "Resources": {
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -18,122 +18,115 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+                },
+                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeployment05bc9f394c"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -143,17 +136,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,46 +154,46 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_implicit_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_implicit_api.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,82 +36,75 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeployment05bc9f394c"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+                },
+                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -119,41 +112,41 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,46 +154,46 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_implicit_api_globals.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,82 +36,75 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeployment1f01b589d4"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeployment1f01b589d4": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a", 
+                },
+                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -119,41 +112,41 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,55 +154,55 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
+                        "Version": "2012-10-17",
                         "Statement": {
-                            "Action": "execute-api:Invoke", 
+                            "Action": "execute-api:Invoke",
                             "Resource": [
                                 {
                                     "Fn::Sub": [
-                                        "execute-api:/${__Stage__}/POST/startMyExecution", 
+                                        "execute-api:/${__Stage__}/POST/startMyExecution",
                                         {
                                             "__Stage__": "Prod"
                                         }
                                     ]
                                 }
-                            ], 
-                            "Effect": "Deny", 
+                            ],
+                            "Effect": "Deny",
                             "Principal": {
                                 "AWS": [
                                     "12345"
@@ -217,12 +210,12 @@
                             }
                         }
                     }
-                }, 
+                },
                 "EndpointConfiguration": {
                     "Types": [
                         "REGIONAL"
                     ]
-                }, 
+                },
                 "Parameters": {
                     "endpointConfigurationTypes": "REGIONAL"
                 }

--- a/tests/translator/output/aws-us-gov/state_machine_with_inline_definition.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_inline_definition.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -18,68 +18,61 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
+        },
+        "ManagedPolicyArns": [],
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
-              "Version": "2012-10-17", 
+              "Version": "2012-10-17",
               "Statement": [
                 {
-                  "Action": "*", 
-                  "Resource": "*", 
+                  "Action": "*",
+                  "Resource": "*",
                   "Effect": "Deny"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyBasicStateMachine", 
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n", 
-            [
-              "{", 
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-              "    \"StartAt\": \"Hello\",", 
-              "    \"States\": {", 
-              "        \"Hello\": {", 
-              "            \"Next\": \"World\",", 
-              "            \"Result\": \"Hello\",", 
-              "            \"Type\": \"Pass\"", 
-              "        },", 
-              "        \"World\": {", 
-              "            \"End\": true,", 
-              "            \"Result\": \"World\",", 
-              "            \"Type\": \"Pass\"", 
-              "        }", 
-              "    }", 
-              "}"
-            ]
-          ]
-        }, 
-        "StateMachineType": "STANDARD", 
+        },
+        "StateMachineName": "MyBasicStateMachine",
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Result": "World",
+              "Type": "Pass"
+            }
+          }
+        },
+        "StateMachineType": "STANDARD",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]

--- a/tests/translator/output/aws-us-gov/state_machine_with_inline_definition_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_inline_definition_intrinsics.json
@@ -105,28 +105,21 @@
     "StateMachine": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/state_machine_with_inline_policies.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_inline_policies.json
@@ -105,28 +105,21 @@
     "StateMachine": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_sam_policy_templates.json
@@ -35,30 +35,23 @@
           }
         },
         "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"An example ASL file for nested workflows\",",
-              "    \"StartAt\": \"NestedStateOne\",",
-              "    \"States\": {",
-              "        \"NestedStateOne\": {",
-              "            \"Next\": \"NestedStateTwo\",",
-              "            \"Result\": {",
-              "                \"Value\": \"MyValue\"",
-              "            },",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"NestedStateTwo\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "An example ASL file for nested workflows",
+          "StartAt": "NestedStateOne",
+          "States": {
+            "NestedStateOne": {
+              "Next": "NestedStateTwo",
+              "Result": {
+                "Value": "MyValue"
+              },
+              "Type": "Pass"
+            },
+            "NestedStateTwo": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "StateMachineType": "STANDARD",
         "Tags": [
@@ -121,115 +114,108 @@
             "Arn"
           ]
         },
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"An example ASL file with parallel states\",",
-              "    \"StartAt\": \"StateOne\",",
-              "    \"States\": {",
-              "        \"StateOne\": {",
-              "            \"Next\": \"StateTwo\",",
-              "            \"Result\": {",
-              "                \"Value\": \"MyValue\"",
-              "            },",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"StateTwo\": {",
-              "            \"Branches\": [",
-              "                {",
-              "                    \"StartAt\": \"BranchOne_StateOne\",",
-              "                    \"States\": {",
-              "                        \"BranchOne_StateFour\": {",
-              "                            \"Choices\": [",
-              "                                {",
-              "                                    \"Next\": \"ValueIsZero\",",
-              "                                    \"NumericEquals\": 0,",
-              "                                    \"Variable\": \"$.value\"",
-              "                                },",
-              "                                {",
-              "                                    \"Next\": \"ValueIsOne\",",
-              "                                    \"NumericEquals\": 1,",
-              "                                    \"Variable\": \"$.value\"",
-              "                                }",
-              "                            ],",
-              "                            \"Type\": \"Choice\"",
-              "                        },",
-              "                        \"BranchOne_StateOne\": {",
-              "                            \"Next\": \"BranchOne_StateTwo\",",
-              "                            \"Resource\": \"${definition_substitution_1}\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchOne_StateThree\": {",
-              "                            \"Next\": \"BranchOne_StateFour\",",
-              "                            \"Parameters\": {",
-              "                                \"FunctionName\": \"${definition_substitution_2}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::lambda:invoke\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchOne_StateTwo\": {",
-              "                            \"Next\": \"BranchOne_StateThree\",",
-              "                            \"Parameters\": {",
-              "                                \"MessageBody.$\": \"$.input.message\",",
-              "                                \"QueueUrl\": \"${definition_substitution_3}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::sqs:sendMessage.waitForTaskToken\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"ValueIsOne\": {",
-              "                            \"Type\": \"Succeed\"",
-              "                        },",
-              "                        \"ValueIsZero\": {",
-              "                            \"Type\": \"Fail\"",
-              "                        }",
-              "                    }",
-              "                },",
-              "                {",
-              "                    \"StartAt\": \"BranchTwo_StateOne\",",
-              "                    \"States\": {",
-              "                        \"BranchTwo_StateOne\": {",
-              "                            \"Next\": \"BranchTwo_StateTwo\",",
-              "                            \"Parameters\": {",
-              "                                \"Input\": {",
-              "                                    \"KeyA\": \"ValueA\",",
-              "                                    \"KeyC\": \"ValueC\"",
-              "                                },",
-              "                                \"StateMachineArn\": \"${definition_substitution_4}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::states:startExecution.sync\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchTwo_StateThree\": {",
-              "                            \"Type\": \"Succeed\"",
-              "                        },",
-              "                        \"BranchTwo_StateTwo\": {",
-              "                            \"Next\": \"BranchTwo_StateThree\",",
-              "                            \"Parameters\": {",
-              "                                \"Item\": {",
-              "                                    \"Body\": {",
-              "                                        \"S.$\": \"$.MessageDetails.Body\"",
-              "                                    },",
-              "                                    \"MessageId\": {",
-              "                                        \"S.$\": \"$.MessageDetails.MessageId\"",
-              "                                    }",
-              "                                },",
-              "                                \"TableName\": \"${definition_substitution_5}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::dynamodb:putItem\",",
-              "                            \"Type\": \"Task\"",
-              "                        }",
-              "                    }",
-              "                }",
-              "            ],",
-              "            \"End\": true,",
-              "            \"Type\": \"Parallel\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "An example ASL file with parallel states",
+          "StartAt": "StateOne",
+          "States": {
+            "StateOne": {
+              "Next": "StateTwo",
+              "Result": {
+                "Value": "MyValue"
+              },
+              "Type": "Pass"
+            },
+            "StateTwo": {
+              "Branches": [
+                {
+                  "StartAt": "BranchOne_StateOne",
+                  "States": {
+                    "BranchOne_StateFour": {
+                      "Choices": [
+                        {
+                          "Next": "ValueIsZero",
+                          "NumericEquals": 0,
+                          "Variable": "$.value"
+                        },
+                        {
+                          "Next": "ValueIsOne",
+                          "NumericEquals": 1,
+                          "Variable": "$.value"
+                        }
+                      ],
+                      "Type": "Choice"
+                    },
+                    "BranchOne_StateOne": {
+                      "Next": "BranchOne_StateTwo",
+                      "Resource": "${definition_substitution_1}",
+                      "Type": "Task"
+                    },
+                    "BranchOne_StateThree": {
+                      "Next": "BranchOne_StateFour",
+                      "Parameters": {
+                        "FunctionName": "${definition_substitution_2}"
+                      },
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Type": "Task"
+                    },
+                    "BranchOne_StateTwo": {
+                      "Next": "BranchOne_StateThree",
+                      "Parameters": {
+                        "MessageBody.$": "$.input.message",
+                        "QueueUrl": "${definition_substitution_3}"
+                      },
+                      "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+                      "Type": "Task"
+                    },
+                    "ValueIsOne": {
+                      "Type": "Succeed"
+                    },
+                    "ValueIsZero": {
+                      "Type": "Fail"
+                    }
+                  }
+                },
+                {
+                  "StartAt": "BranchTwo_StateOne",
+                  "States": {
+                    "BranchTwo_StateOne": {
+                      "Next": "BranchTwo_StateTwo",
+                      "Parameters": {
+                        "Input": {
+                          "KeyA": "ValueA",
+                          "KeyC": "ValueC"
+                        },
+                        "StateMachineArn": "${definition_substitution_4}"
+                      },
+                      "Resource": "arn:aws:states:::states:startExecution.sync",
+                      "Type": "Task"
+                    },
+                    "BranchTwo_StateThree": {
+                      "Type": "Succeed"
+                    },
+                    "BranchTwo_StateTwo": {
+                      "Next": "BranchTwo_StateThree",
+                      "Parameters": {
+                        "Item": {
+                          "Body": {
+                            "S.$": "$.MessageDetails.Body"
+                          },
+                          "MessageId": {
+                            "S.$": "$.MessageDetails.MessageId"
+                          }
+                        },
+                        "TableName": "${definition_substitution_5}"
+                      },
+                      "Resource": "arn:aws:states:::dynamodb:putItem",
+                      "Type": "Task"
+                    }
+                  }
+                }
+              ],
+              "End": true,
+              "Type": "Parallel"
+            }
+          }
         },
         "StateMachineType": "STANDARD",
         "Tags": [

--- a/tests/translator/output/aws-us-gov/state_machine_with_tags.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_tags.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -18,84 +18,77 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
+        },
+        "ManagedPolicyArns": [],
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
-              "Version": "2012-10-17", 
+              "Version": "2012-10-17",
               "Statement": [
                 {
-                  "Action": "*", 
-                  "Resource": "*", 
+                  "Action": "*",
+                  "Resource": "*",
                   "Effect": "Deny"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
-          }, 
+          },
           {
-            "Value": "ValueTwo", 
+            "Value": "ValueTwo",
             "Key": "TagTwo"
-          }, 
+          },
           {
-            "Value": "ValueOne", 
+            "Value": "ValueOne",
             "Key": "TagOne"
           }
         ]
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyStateMachineWithTags", 
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n", 
-            [
-              "{", 
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-              "    \"StartAt\": \"Hello\",", 
-              "    \"States\": {", 
-              "        \"Hello\": {", 
-              "            \"Next\": \"World\",", 
-              "            \"Result\": \"Hello\",", 
-              "            \"Type\": \"Pass\"", 
-              "        },", 
-              "        \"World\": {", 
-              "            \"End\": true,", 
-              "            \"Result\": \"World\",", 
-              "            \"Type\": \"Pass\"", 
-              "        }", 
-              "    }", 
-              "}"
-            ]
-          ]
-        }, 
-        "StateMachineType": "STANDARD", 
+        },
+        "StateMachineName": "MyStateMachineWithTags",
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Result": "World",
+              "Type": "Pass"
+            }
+          }
+        },
+        "StateMachineType": "STANDARD",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
-          }, 
+          },
           {
-            "Value": "ValueTwo", 
+            "Value": "ValueTwo",
             "Key": "TagTwo"
-          }, 
+          },
           {
-            "Value": "ValueOne", 
+            "Value": "ValueOne",
             "Key": "TagOne"
           }
         ]

--- a/tests/translator/output/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/state_machine_with_api_auth_default_scopes.json
@@ -1,15 +1,15 @@
 {
     "Resources": {
         "MyApiWithCognitoAuth": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/cognitowithauthnone": {
                             "get": {
@@ -17,373 +17,373 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoWithAuthNoneRole", 
+                                            "MyStateMachineCognitoWithAuthNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "NONE": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultauthdefaultscopesnone": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole", 
+                                            "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesnone": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesNoneRole", 
+                                            "MyStateMachineCognitoDefaultScopesNoneRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitoauthorizerwithdefaultscopes": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole", 
+                                            "MyStateMachineCognitoAuthorizerWithDefaultScopesRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": [
-                                            "default.delete", 
+                                            "default.delete",
                                             "default.update"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitoauthorizercopesoverwritten": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole", 
+                                            "MyStateMachineCognitoAuthorizerScopesOverwrittenRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthWithDefaultScopes": [
-                                            "overwritten.read", 
+                                            "overwritten.read",
                                             "overwritten.write"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesoverwritten": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole", 
+                                            "MyStateMachineCognitoDefaultScopesWithOverwrittenRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": [
-                                            "overwritten.read", 
+                                            "overwritten.read",
                                             "overwritten.write"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/cognitodefaultscopesdefaultauthorizer": {
                             "get": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole", 
+                                            "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyDefaultCognitoAuth": [
-                                            "default.write", 
+                                            "default.write",
                                             "default.read"
                                         ]
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "openapi": "3.0.1", 
+                    },
+                    "openapi": "3.0.1",
                     "components": {
                         "securitySchemes": {
                             "MyCognitoAuthWithDefaultScopes": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
+                                "in": "header",
+                                "type": "apiKey",
+                                "name": "Authorization",
                                 "x-amazon-apigateway-authorizer": {
                                     "providerARNs": [
                                         "arn:aws:2"
-                                    ], 
+                                    ],
                                     "type": "cognito_user_pools"
-                                }, 
+                                },
                                 "x-amazon-apigateway-authtype": "cognito_user_pools"
-                            }, 
+                            },
                             "MyDefaultCognitoAuth": {
-                                "in": "header", 
-                                "type": "apiKey", 
-                                "name": "Authorization", 
+                                "in": "header",
+                                "type": "apiKey",
+                                "name": "Authorization",
                                 "x-amazon-apigateway-authorizer": {
                                     "providerARNs": [
                                         "arn:aws:1"
-                                    ], 
+                                    ],
                                     "type": "cognito_user_pools"
-                                }, 
+                                },
                                 "x-amazon-apigateway-authtype": "cognito_user_pools"
                             }
                         }
                     }
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoWithAuthNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoWithAuthNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -393,34 +393,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -430,34 +430,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultAuthDefaultScopesNoneRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -467,34 +467,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesWithOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesWithOverwrittenRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -504,55 +504,55 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiWithCognitoAuthProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiWithCognitoAuthDeployment57b57dfc88"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApiWithCognitoAuth"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "MyApiWithCognitoAuthDeployment57b57dfc88": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApiWithCognitoAuth"
-                }, 
+                },
                 "Description": "RestApi deployment id: 57b57dfc88b1b438a0437eadd869d77e938eedb6"
             }
-        }, 
+        },
         "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoDefaultScopesDefaultAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -562,75 +562,68 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
+                        "MyStateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyStateMachineCognitoAuthorizerWithDefaultScopesRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoAuthorizerWithDefaultScopesRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -640,34 +633,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineCognitoAuthorizerScopesOverwrittenRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineCognitoAuthorizerScopesOverwrittenRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -677,18 +670,18 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -696,26 +689,26 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
+                        "PolicyName": "MyStateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]

--- a/tests/translator/output/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/state_machine_with_api_authorizer.json
@@ -1,14 +1,14 @@
 {
     "Resources": {
         "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -17,71 +17,64 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeploymentaaffc688ce"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startNoAuth": {
                             "post": {
@@ -89,70 +82,70 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
+                                            "StateMachineWithNoAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
                 }
             }
-        }, 
+        },
         "StateMachineWithLambdaTokenAuthRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaTokenAuthRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -162,28 +155,28 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiDeploymentc2779253ee": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: c2779253eecd9c0b8252440b0cf5ef8d2759b211", 
+                },
+                "Description": "RestApi deployment id: c2779253eecd9c0b8252440b0cf5ef8d2759b211",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -191,80 +184,80 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeploymentc2779253ee"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeploymentaaffc688ce": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb", 
+                },
+                "Description": "RestApi deployment id: aaffc688ce6d1b26ccd7a90641e103263f6240bb",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -274,17 +267,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startWithLambdaToken": {
                             "post": {
@@ -292,72 +285,72 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthRole", 
+                                            "StateMachineWithLambdaTokenAuthRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaTokenAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "securityDefinitions": {
                         "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
+                            "type": "apiKey",
+                            "name": "x-api-key",
                             "in": "header"
-                        }, 
+                        },
                         "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyCustomAuthHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 20,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                                },
+                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                                 "identityValidationExpression": "mycustomauthexpression"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
                         }
                     }

--- a/tests/translator/output/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/state_machine_with_api_authorizer_maximum.json
@@ -1,24 +1,24 @@
 {
     "Resources": {
         "MyApiDeploymentde088eafc3": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: de088eafc3dd099f3b79506a6e0542dadb9fcd23", 
+                },
+                "Description": "RestApi deployment id: de088eafc3dd099f3b79506a6e0542dadb9fcd23",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyApiMyLambdaRequestAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -27,34 +27,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineWithLambdaRequestAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaRequestAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -64,76 +64,69 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "StateMachineWithDefaultAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithDefaultAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -143,17 +136,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/": {
                             "get": {
@@ -161,330 +154,330 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithNoAuthorizerRole", 
+                                            "StateMachineWithNoAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "NONE": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/users": {
                             "put": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithDefaultAuthorizerRole", 
+                                            "StateMachineWithDefaultAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "post": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole", 
+                                            "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyCognitoAuthMultipleUserPools": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "patch": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaTokenAuthorizerRole", 
+                                            "StateMachineWithLambdaTokenAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaTokenAuthNoneFunctionInvokeRole": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
-                            }, 
+                            },
                             "delete": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineWithLambdaRequestAuthorizerRole", 
+                                            "StateMachineWithLambdaRequestAuthorizerRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "security": [
                                     {
                                         "MyLambdaRequestAuth": []
-                                    }, 
+                                    },
                                     {
                                         "api_key": []
                                     }
-                                ], 
+                                ],
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "securityDefinitions": {
                         "MyLambdaTokenAuthNoneFunctionInvokeRole": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Authorization", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "Authorization",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 0, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 0,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
                                 }
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "MyCognitoAuthMultipleUserPools": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader2", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyAuthorizationHeader2",
                             "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression2", 
+                                "identityValidationExpression": "myauthvalidationexpression2",
                                 "providerARNs": [
-                                    "arn:aws:2", 
+                                    "arn:aws:2",
                                     "arn:aws:3"
-                                ], 
+                                ],
                                 "type": "cognito_user_pools"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
+                        },
                         "MyLambdaRequestAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "Unused", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "Unused",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "request", 
-                                "authorizerResultTtlInSeconds": 0, 
-                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4", 
+                                "type": "request",
+                                "authorizerResultTtlInSeconds": 0,
+                                "identitySource": "method.request.header.Authorization1, method.request.querystring.Authorization2, stageVariables.Authorization3, context.Authorization4",
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
+                                },
                                 "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "MyCognitoAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyAuthorizationHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyAuthorizationHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "identityValidationExpression": "myauthvalidationexpression", 
+                                "identityValidationExpression": "myauthvalidationexpression",
                                 "providerARNs": [
                                     "arn:aws:1"
-                                ], 
+                                ],
                                 "type": "cognito_user_pools"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "cognito_user_pools"
-                        }, 
+                        },
                         "MyLambdaTokenAuth": {
-                            "in": "header", 
-                            "type": "apiKey", 
-                            "name": "MyCustomAuthHeader", 
+                            "in": "header",
+                            "type": "apiKey",
+                            "name": "MyCustomAuthHeader",
                             "x-amazon-apigateway-authorizer": {
-                                "type": "token", 
-                                "authorizerResultTtlInSeconds": 20, 
+                                "type": "token",
+                                "authorizerResultTtlInSeconds": 20,
                                 "authorizerUri": {
                                     "Fn::Sub": [
-                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations", 
+                                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
                                         {
                                             "__FunctionArn__": "arn:aws"
                                         }
                                     ]
-                                }, 
-                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access", 
+                                },
+                                "authorizerCredentials": "arn:aws:iam::123456789012:role/S3Access",
                                 "identityValidationExpression": "mycustomauthexpression"
-                            }, 
+                            },
                             "x-amazon-apigateway-authtype": "custom"
-                        }, 
+                        },
                         "api_key": {
-                            "type": "apiKey", 
-                            "name": "x-api-key", 
+                            "type": "apiKey",
+                            "name": "x-api-key",
                             "in": "header"
                         }
                     }
                 }
             }
-        }, 
+        },
         "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -493,18 +486,18 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -512,58 +505,58 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "StateMachineWithLambdaTokenAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithLambdaTokenAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -573,16 +566,16 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiMyLambdaTokenAuthNoneFunctionInvokeRoleAuthorizerPermission": {
-            "Type": "AWS::Lambda::Permission", 
+            "Type": "AWS::Lambda::Permission",
             "Properties": {
-                "Action": "lambda:InvokeFunction", 
-                "Principal": "apigateway.amazonaws.com", 
-                "FunctionName": "arn:aws", 
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com",
+                "FunctionName": "arn:aws",
                 "SourceArn": {
                     "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
                         {
                             "__ApiId__": {
                                 "Ref": "MyApi"
@@ -591,46 +584,46 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeploymentde088eafc3"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "StateMachineWithCognitoMultipleUserPoolsAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithCognitoMultipleUserPoolsAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -640,34 +633,34 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachineWithNoAuthorizerRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineWithNoAuthorizerRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"

--- a/tests/translator/output/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/state_machine_with_api_resource_policy.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "MyStateMachineGetHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachineGetHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,17 +36,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "ExplicitApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/one": {
                             "get": {
@@ -54,281 +54,281 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachineGetHtmlRole", 
+                                            "MyStateMachineGetHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/three": {
                             "put": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachinePutHtmlRole", 
+                                            "MyStateMachinePutHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
-                        }, 
+                        },
                         "/two": {
                             "post": {
                                 "x-amazon-apigateway-integration": {
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "MyStateMachinePostHtmlRole", 
+                                            "MyStateMachinePostHtmlRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
+                        "Version": "2012-10-17",
                         "Statement": [
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Allow", 
+                                ],
+                                "Effect": "Allow",
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "NotIpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/GET/one", 
+                                            "execute-api:/${__Stage__}/GET/one",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "IpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Allow", 
+                                ],
+                                "Effect": "Allow",
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "NotIpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
-                            }, 
+                            },
                             {
-                                "Action": "execute-api:Invoke", 
+                                "Action": "execute-api:Invoke",
                                 "Resource": [
                                     {
                                         "Fn::Sub": [
-                                            "execute-api:/${__Stage__}/POST/two", 
+                                            "execute-api:/${__Stage__}/POST/two",
                                             {
                                                 "__Stage__": null
                                             }
                                         ]
                                     }
-                                ], 
-                                "Effect": "Deny", 
+                                ],
+                                "Effect": "Deny",
                                 "Condition": {
                                     "IpAddress": {
                                         "aws:SourceIp": [
                                             "1.2.3.4"
                                         ]
                                     }
-                                }, 
+                                },
                                 "Principal": "*"
                             }
                         ]
                     }
                 }
             }
-        }, 
+        },
         "ExplicitApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ExplicitApiDeployment17065a95ba"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ExplicitApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "MyStateMachinePutHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachinePutHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -338,69 +338,62 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyStateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "MyStateMachineRole", 
+                        "MyStateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ExplicitApiDeployment17065a95ba": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ExplicitApi"
-                }, 
-                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2", 
+                },
+                "Description": "RestApi deployment id: 17065a95bac1ac0e3dc22fef2ff7aa228539b1d2",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyStateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -408,58 +401,58 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachineRolePolicy0", 
+                        "PolicyName": "MyStateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyStateMachinePostHtmlRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy", 
+                        "PolicyName": "MyStateMachinePostHtmlRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "MyStateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"

--- a/tests/translator/output/state_machine_with_definition_substitutions.json
+++ b/tests/translator/output/state_machine_with_definition_substitutions.json
@@ -120,28 +120,21 @@
             "Arn"
           ]
         },
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"${my_state_var_1}\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"${my_state_var_2}\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "${my_state_var_1}"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "${my_state_var_2}"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/state_machine_with_explicit_api.json
+++ b/tests/translator/output/state_machine_with_explicit_api.json
@@ -1,16 +1,16 @@
 {
     "Resources": {
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -18,122 +18,115 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "MyApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+                },
+                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "MyApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "MyApiDeployment05bc9f394c"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "MyApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -143,17 +136,17 @@
                     ]
                 }
             }
-        }, 
+        },
         "MyApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,39 +154,39 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
                 }
             }

--- a/tests/translator/output/state_machine_with_implicit_api.json
+++ b/tests/translator/output/state_machine_with_implicit_api.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,82 +36,75 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeployment05bc9f394c"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeployment05bc9f394c": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e", 
+                },
+                "Description": "RestApi deployment id: 05bc9f394c3ca5d24b8d6dc69d133762afd1298e",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -119,41 +112,41 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,39 +154,39 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "swagger": "2.0"
                 }
             }

--- a/tests/translator/output/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/state_machine_with_implicit_api_globals.json
@@ -1,32 +1,32 @@
 {
     "Resources": {
         "StateMachineMyApiEventRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy", 
+                        "PolicyName": "StateMachineMyApiEventRoleStartExecutionPolicy",
                         "PolicyDocument": {
                             "Statement": [
                                 {
-                                    "Action": "states:StartExecution", 
+                                    "Action": "states:StartExecution",
                                     "Resource": {
                                         "Ref": "StateMachine"
-                                    }, 
+                                    },
                                     "Effect": "Allow"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "apigateway.amazonaws.com"
@@ -36,82 +36,75 @@
                     ]
                 }
             }
-        }, 
+        },
         "StateMachine": {
-            "Type": "AWS::StepFunctions::StateMachine", 
+            "Type": "AWS::StepFunctions::StateMachine",
             "Properties": {
                 "RoleArn": {
                     "Fn::GetAtt": [
-                        "StateMachineRole", 
+                        "StateMachineRole",
                         "Arn"
                     ]
-                }, 
-                "StateMachineName": "MyStateMachine", 
-                "DefinitionString": {
-                    "Fn::Join": [
-                        "\n", 
-                        [
-                            "{", 
-                            "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-                            "    \"StartAt\": \"Hello\",", 
-                            "    \"States\": {", 
-                            "        \"Hello\": {", 
-                            "            \"Next\": \"World\",", 
-                            "            \"Result\": \"Hello\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        },", 
-                            "        \"World\": {", 
-                            "            \"End\": true,", 
-                            "            \"Result\": \"World\",", 
-                            "            \"Type\": \"Pass\"", 
-                            "        }", 
-                            "    }", 
-                            "}"
-                        ]
-                    ]
-                }, 
-                "StateMachineType": "STANDARD", 
+                },
+                "StateMachineName": "MyStateMachine",
+                "Definition": {
+                    "Comment": "A Hello World example of the Amazon States Language using Pass states",
+                    "StartAt": "Hello",
+                    "States": {
+                        "Hello": {
+                            "Next": "World",
+                            "Result": "Hello",
+                            "Type": "Pass"
+                        },
+                        "World": {
+                            "End": true,
+                            "Result": "World",
+                            "Type": "Pass"
+                        }
+                    }
+                },
+                "StateMachineType": "STANDARD",
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApiProdStage": {
-            "Type": "AWS::ApiGateway::Stage", 
+            "Type": "AWS::ApiGateway::Stage",
             "Properties": {
                 "DeploymentId": {
                     "Ref": "ServerlessRestApiDeployment1f01b589d4"
-                }, 
+                },
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
+                },
                 "StageName": "Prod"
             }
-        }, 
+        },
         "ServerlessRestApiDeployment1f01b589d4": {
-            "Type": "AWS::ApiGateway::Deployment", 
+            "Type": "AWS::ApiGateway::Deployment",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ServerlessRestApi"
-                }, 
-                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a", 
+                },
+                "Description": "RestApi deployment id: 1f01b589d4e226c84a3e14ca738b5d060e7b611a",
                 "StageName": "Stage"
             }
-        }, 
+        },
         "StateMachineRole": {
-            "Type": "AWS::IAM::Role", 
+            "Type": "AWS::IAM::Role",
             "Properties": {
                 "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17", 
+                    "Version": "2012-10-17",
                     "Statement": [
                         {
                             "Action": [
                                 "sts:AssumeRole"
-                            ], 
-                            "Effect": "Allow", 
+                            ],
+                            "Effect": "Allow",
                             "Principal": {
                                 "Service": [
                                     "states.amazonaws.com"
@@ -119,41 +112,41 @@
                             }
                         }
                     ]
-                }, 
-                "ManagedPolicyArns": [], 
+                },
+                "ManagedPolicyArns": [],
                 "Policies": [
                     {
-                        "PolicyName": "StateMachineRolePolicy0", 
+                        "PolicyName": "StateMachineRolePolicy0",
                         "PolicyDocument": {
-                            "Version": "2012-10-17", 
+                            "Version": "2012-10-17",
                             "Statement": [
                                 {
-                                    "Action": "*", 
-                                    "Resource": "*", 
+                                    "Action": "*",
+                                    "Resource": "*",
                                     "Effect": "Deny"
                                 }
                             ]
                         }
                     }
-                ], 
+                ],
                 "Tags": [
                     {
-                        "Value": "SAM", 
+                        "Value": "SAM",
                         "Key": "stateMachine:createdBy"
                     }
                 ]
             }
-        }, 
+        },
         "ServerlessRestApi": {
-            "Type": "AWS::ApiGateway::RestApi", 
+            "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
                 "Body": {
                     "info": {
-                        "version": "1.0", 
+                        "version": "1.0",
                         "title": {
                             "Ref": "AWS::StackName"
                         }
-                    }, 
+                    },
                     "paths": {
                         "/startMyExecution": {
                             "post": {
@@ -161,55 +154,55 @@
                                     "responses": {
                                         "200": {
                                             "statusCode": "200"
-                                        }, 
+                                        },
                                         "400": {
                                             "statusCode": "400"
                                         }
-                                    }, 
+                                    },
                                     "uri": {
                                         "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
-                                    }, 
-                                    "httpMethod": "POST", 
+                                    },
+                                    "httpMethod": "POST",
                                     "requestTemplates": {
                                         "application/json": {
                                             "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
-                                    }, 
+                                    },
                                     "credentials": {
                                         "Fn::GetAtt": [
-                                            "StateMachineMyApiEventRole", 
+                                            "StateMachineMyApiEventRole",
                                             "Arn"
                                         ]
-                                    }, 
+                                    },
                                     "type": "aws"
-                                }, 
+                                },
                                 "responses": {
                                     "200": {
                                         "description": "OK"
-                                    }, 
+                                    },
                                     "400": {
                                         "description": "Bad Request"
                                     }
                                 }
                             }
                         }
-                    }, 
-                    "swagger": "2.0", 
+                    },
+                    "swagger": "2.0",
                     "x-amazon-apigateway-policy": {
-                        "Version": "2012-10-17", 
+                        "Version": "2012-10-17",
                         "Statement": {
-                            "Action": "execute-api:Invoke", 
+                            "Action": "execute-api:Invoke",
                             "Resource": [
                                 {
                                     "Fn::Sub": [
-                                        "execute-api:/${__Stage__}/POST/startMyExecution", 
+                                        "execute-api:/${__Stage__}/POST/startMyExecution",
                                         {
                                             "__Stage__": "Prod"
                                         }
                                     ]
                                 }
-                            ], 
-                            "Effect": "Deny", 
+                            ],
+                            "Effect": "Deny",
                             "Principal": {
                                 "AWS": [
                                     "12345"

--- a/tests/translator/output/state_machine_with_inline_definition.json
+++ b/tests/translator/output/state_machine_with_inline_definition.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -18,68 +18,61 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
+        },
+        "ManagedPolicyArns": [],
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
-              "Version": "2012-10-17", 
+              "Version": "2012-10-17",
               "Statement": [
                 {
-                  "Action": "*", 
-                  "Resource": "*", 
+                  "Action": "*",
+                  "Resource": "*",
                   "Effect": "Deny"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyBasicStateMachine", 
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n", 
-            [
-              "{", 
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-              "    \"StartAt\": \"Hello\",", 
-              "    \"States\": {", 
-              "        \"Hello\": {", 
-              "            \"Next\": \"World\",", 
-              "            \"Result\": \"Hello\",", 
-              "            \"Type\": \"Pass\"", 
-              "        },", 
-              "        \"World\": {", 
-              "            \"End\": true,", 
-              "            \"Result\": \"World\",", 
-              "            \"Type\": \"Pass\"", 
-              "        }", 
-              "    }", 
-              "}"
-            ]
-          ]
-        }, 
-        "StateMachineType": "STANDARD", 
+        },
+        "StateMachineName": "MyBasicStateMachine",
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Result": "World",
+              "Type": "Pass"
+            }
+          }
+        },
+        "StateMachineType": "STANDARD",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
           }
         ]

--- a/tests/translator/output/state_machine_with_inline_definition_intrinsics.json
+++ b/tests/translator/output/state_machine_with_inline_definition_intrinsics.json
@@ -105,28 +105,21 @@
     "StateMachine": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/state_machine_with_inline_policies.json
+++ b/tests/translator/output/state_machine_with_inline_policies.json
@@ -105,28 +105,21 @@
     "StateMachine": {
       "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "Tags": [
           {

--- a/tests/translator/output/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/state_machine_with_sam_policy_templates.json
@@ -35,30 +35,23 @@
           }
         },
         "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"An example ASL file for nested workflows\",",
-              "    \"StartAt\": \"NestedStateOne\",",
-              "    \"States\": {",
-              "        \"NestedStateOne\": {",
-              "            \"Next\": \"NestedStateTwo\",",
-              "            \"Result\": {",
-              "                \"Value\": \"MyValue\"",
-              "            },",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"NestedStateTwo\": {",
-              "            \"End\": true,",
-              "            \"Resource\": \"${definition_substitution_1}\",",
-              "            \"Type\": \"Task\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "An example ASL file for nested workflows",
+          "StartAt": "NestedStateOne",
+          "States": {
+            "NestedStateOne": {
+              "Next": "NestedStateTwo",
+              "Result": {
+                "Value": "MyValue"
+              },
+              "Type": "Pass"
+            },
+            "NestedStateTwo": {
+              "End": true,
+              "Resource": "${definition_substitution_1}",
+              "Type": "Task"
+            }
+          }
         },
         "StateMachineType": "STANDARD",
         "Tags": [
@@ -121,115 +114,108 @@
             "Arn"
           ]
         },
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"An example ASL file with parallel states\",",
-              "    \"StartAt\": \"StateOne\",",
-              "    \"States\": {",
-              "        \"StateOne\": {",
-              "            \"Next\": \"StateTwo\",",
-              "            \"Result\": {",
-              "                \"Value\": \"MyValue\"",
-              "            },",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"StateTwo\": {",
-              "            \"Branches\": [",
-              "                {",
-              "                    \"StartAt\": \"BranchOne_StateOne\",",
-              "                    \"States\": {",
-              "                        \"BranchOne_StateFour\": {",
-              "                            \"Choices\": [",
-              "                                {",
-              "                                    \"Next\": \"ValueIsZero\",",
-              "                                    \"NumericEquals\": 0,",
-              "                                    \"Variable\": \"$.value\"",
-              "                                },",
-              "                                {",
-              "                                    \"Next\": \"ValueIsOne\",",
-              "                                    \"NumericEquals\": 1,",
-              "                                    \"Variable\": \"$.value\"",
-              "                                }",
-              "                            ],",
-              "                            \"Type\": \"Choice\"",
-              "                        },",
-              "                        \"BranchOne_StateOne\": {",
-              "                            \"Next\": \"BranchOne_StateTwo\",",
-              "                            \"Resource\": \"${definition_substitution_1}\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchOne_StateThree\": {",
-              "                            \"Next\": \"BranchOne_StateFour\",",
-              "                            \"Parameters\": {",
-              "                                \"FunctionName\": \"${definition_substitution_2}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::lambda:invoke\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchOne_StateTwo\": {",
-              "                            \"Next\": \"BranchOne_StateThree\",",
-              "                            \"Parameters\": {",
-              "                                \"MessageBody.$\": \"$.input.message\",",
-              "                                \"QueueUrl\": \"${definition_substitution_3}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::sqs:sendMessage.waitForTaskToken\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"ValueIsOne\": {",
-              "                            \"Type\": \"Succeed\"",
-              "                        },",
-              "                        \"ValueIsZero\": {",
-              "                            \"Type\": \"Fail\"",
-              "                        }",
-              "                    }",
-              "                },",
-              "                {",
-              "                    \"StartAt\": \"BranchTwo_StateOne\",",
-              "                    \"States\": {",
-              "                        \"BranchTwo_StateOne\": {",
-              "                            \"Next\": \"BranchTwo_StateTwo\",",
-              "                            \"Parameters\": {",
-              "                                \"Input\": {",
-              "                                    \"KeyA\": \"ValueA\",",
-              "                                    \"KeyC\": \"ValueC\"",
-              "                                },",
-              "                                \"StateMachineArn\": \"${definition_substitution_4}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::states:startExecution.sync\",",
-              "                            \"Type\": \"Task\"",
-              "                        },",
-              "                        \"BranchTwo_StateThree\": {",
-              "                            \"Type\": \"Succeed\"",
-              "                        },",
-              "                        \"BranchTwo_StateTwo\": {",
-              "                            \"Next\": \"BranchTwo_StateThree\",",
-              "                            \"Parameters\": {",
-              "                                \"Item\": {",
-              "                                    \"Body\": {",
-              "                                        \"S.$\": \"$.MessageDetails.Body\"",
-              "                                    },",
-              "                                    \"MessageId\": {",
-              "                                        \"S.$\": \"$.MessageDetails.MessageId\"",
-              "                                    }",
-              "                                },",
-              "                                \"TableName\": \"${definition_substitution_5}\"",
-              "                            },",
-              "                            \"Resource\": \"arn:aws:states:::dynamodb:putItem\",",
-              "                            \"Type\": \"Task\"",
-              "                        }",
-              "                    }",
-              "                }",
-              "            ],",
-              "            \"End\": true,",
-              "            \"Type\": \"Parallel\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "Definition": {
+          "Comment": "An example ASL file with parallel states",
+          "StartAt": "StateOne",
+          "States": {
+            "StateOne": {
+              "Next": "StateTwo",
+              "Result": {
+                "Value": "MyValue"
+              },
+              "Type": "Pass"
+            },
+            "StateTwo": {
+              "Branches": [
+                {
+                  "StartAt": "BranchOne_StateOne",
+                  "States": {
+                    "BranchOne_StateFour": {
+                      "Choices": [
+                        {
+                          "Next": "ValueIsZero",
+                          "NumericEquals": 0,
+                          "Variable": "$.value"
+                        },
+                        {
+                          "Next": "ValueIsOne",
+                          "NumericEquals": 1,
+                          "Variable": "$.value"
+                        }
+                      ],
+                      "Type": "Choice"
+                    },
+                    "BranchOne_StateOne": {
+                      "Next": "BranchOne_StateTwo",
+                      "Resource": "${definition_substitution_1}",
+                      "Type": "Task"
+                    },
+                    "BranchOne_StateThree": {
+                      "Next": "BranchOne_StateFour",
+                      "Parameters": {
+                        "FunctionName": "${definition_substitution_2}"
+                      },
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Type": "Task"
+                    },
+                    "BranchOne_StateTwo": {
+                      "Next": "BranchOne_StateThree",
+                      "Parameters": {
+                        "MessageBody.$": "$.input.message",
+                        "QueueUrl": "${definition_substitution_3}"
+                      },
+                      "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+                      "Type": "Task"
+                    },
+                    "ValueIsOne": {
+                      "Type": "Succeed"
+                    },
+                    "ValueIsZero": {
+                      "Type": "Fail"
+                    }
+                  }
+                },
+                {
+                  "StartAt": "BranchTwo_StateOne",
+                  "States": {
+                    "BranchTwo_StateOne": {
+                      "Next": "BranchTwo_StateTwo",
+                      "Parameters": {
+                        "Input": {
+                          "KeyA": "ValueA",
+                          "KeyC": "ValueC"
+                        },
+                        "StateMachineArn": "${definition_substitution_4}"
+                      },
+                      "Resource": "arn:aws:states:::states:startExecution.sync",
+                      "Type": "Task"
+                    },
+                    "BranchTwo_StateThree": {
+                      "Type": "Succeed"
+                    },
+                    "BranchTwo_StateTwo": {
+                      "Next": "BranchTwo_StateThree",
+                      "Parameters": {
+                        "Item": {
+                          "Body": {
+                            "S.$": "$.MessageDetails.Body"
+                          },
+                          "MessageId": {
+                            "S.$": "$.MessageDetails.MessageId"
+                          }
+                        },
+                        "TableName": "${definition_substitution_5}"
+                      },
+                      "Resource": "arn:aws:states:::dynamodb:putItem",
+                      "Type": "Task"
+                    }
+                  }
+                }
+              ],
+              "End": true,
+              "Type": "Parallel"
+            }
+          }
         },
         "StateMachineType": "STANDARD",
         "Tags": [

--- a/tests/translator/output/state_machine_with_tags.json
+++ b/tests/translator/output/state_machine_with_tags.json
@@ -1,16 +1,16 @@
 {
   "Resources": {
     "StateMachineRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "states.amazonaws.com"
@@ -18,84 +18,77 @@
               }
             }
           ]
-        }, 
-        "ManagedPolicyArns": [], 
+        },
+        "ManagedPolicyArns": [],
         "Policies": [
           {
-            "PolicyName": "StateMachineRolePolicy0", 
+            "PolicyName": "StateMachineRolePolicy0",
             "PolicyDocument": {
-              "Version": "2012-10-17", 
+              "Version": "2012-10-17",
               "Statement": [
                 {
-                  "Action": "*", 
-                  "Resource": "*", 
+                  "Action": "*",
+                  "Resource": "*",
                   "Effect": "Deny"
                 }
               ]
             }
           }
-        ], 
+        ],
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
-          }, 
+          },
           {
-            "Value": "ValueTwo", 
+            "Value": "ValueTwo",
             "Key": "TagTwo"
-          }, 
+          },
           {
-            "Value": "ValueOne", 
+            "Value": "ValueOne",
             "Key": "TagOne"
           }
         ]
       }
-    }, 
+    },
     "StateMachine": {
-      "Type": "AWS::StepFunctions::StateMachine", 
+      "Type": "AWS::StepFunctions::StateMachine",
       "Properties": {
         "RoleArn": {
           "Fn::GetAtt": [
-            "StateMachineRole", 
+            "StateMachineRole",
             "Arn"
           ]
-        }, 
-        "StateMachineName": "MyStateMachineWithTags", 
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n", 
-            [
-              "{", 
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",", 
-              "    \"StartAt\": \"Hello\",", 
-              "    \"States\": {", 
-              "        \"Hello\": {", 
-              "            \"Next\": \"World\",", 
-              "            \"Result\": \"Hello\",", 
-              "            \"Type\": \"Pass\"", 
-              "        },", 
-              "        \"World\": {", 
-              "            \"End\": true,", 
-              "            \"Result\": \"World\",", 
-              "            \"Type\": \"Pass\"", 
-              "        }", 
-              "    }", 
-              "}"
-            ]
-          ]
-        }, 
-        "StateMachineType": "STANDARD", 
+        },
+        "StateMachineName": "MyStateMachineWithTags",
+        "Definition": {
+          "Comment": "A Hello World example of the Amazon States Language using Pass states",
+          "StartAt": "Hello",
+          "States": {
+            "Hello": {
+              "Next": "World",
+              "Result": "Hello",
+              "Type": "Pass"
+            },
+            "World": {
+              "End": true,
+              "Result": "World",
+              "Type": "Pass"
+            }
+          }
+        },
+        "StateMachineType": "STANDARD",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "stateMachine:createdBy"
-          }, 
+          },
           {
-            "Value": "ValueTwo", 
+            "Value": "ValueTwo",
             "Key": "TagTwo"
-          }, 
+          },
           {
-            "Value": "ValueOne", 
+            "Value": "ValueOne",
             "Key": "TagOne"
           }
         ]


### PR DESCRIPTION
*Description of changes:*
Step Functions recently released a new CloudFormation property called Definition, which allows users to specify their state machine definitions in object format. Since SAM already supported users providing their state machine definitions as an object, we would convert that object to a DefinitionString and use that in the generated CloudFormation template. With this update to the state machine resource schema, we no longer need to do this conversion in SAM, and can simply pass the Definition object directly to the CFN template.

A request for documentation updates has been made to note that SAM Definition property is now passed directly to CFN Definition property.

*Description of how you validated changes:*

- Update to unit test suite for State Machine resource. 
- Manual testing of generated CloudFormation template 


*Checklist:*

- [X] Write/update tests
- [X] `make pr` passes
- [X] Update documentation
- [X] Verify transformed template deploys and application functions as expected

*Examples?*
No changes are needed for the state machine examples. 

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
