### PR TITLE
chore: don't install integration tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,9 @@ setup(
     url="https://github.com/awslabs/serverless-application-model",
     license="Apache License 2.0",
     # Exclude all but the code folders
-    packages=find_packages(exclude=("tests", "tests.*", "docs", "examples", "versions")),
+    packages=find_packages(
+        exclude=("tests", "tests.*", "integration", "integration.*", "docs", "examples", "versions")
+    ),
     install_requires=read_requirements("base.txt"),
     include_package_data=True,
     extras_require={"dev": read_requirements("dev.txt")},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Unit tests are excluded from installation. I assume the convention also applies to integration tests.

*Description of how you validated changes:*

Running `python setup.py install` without this patch creates `~/.local/lib/python3.9/site-packages/integration`. That folder is no longer installed after this patch.

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

N/A - only the build script is changed

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
