### PR TITLE
fix: Added SAR Support Check

### DIFF
--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -12,6 +12,7 @@ from samtranslator.public.sdk.resource import SamResourceType
 from samtranslator.public.sdk.template import SamTemplate
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.intrinsics.actions import FindInMapAction
+from samtranslator.region_configuration import RegionConfiguration
 
 LOG = logging.getLogger(__name__)
 
@@ -104,6 +105,10 @@ class ServerlessAppPlugin(BasePlugin):
 
             if key not in self._applications:
                 try:
+                    if not RegionConfiguration().is_sar_supported():
+                        raise InvalidResourceException(
+                            logical_id, "Serverless Application Repository is not available in this region."
+                        )
                     # Lazy initialization of the client- create it when it is needed
                     if not self._sar_client:
                         self._sar_client = boto3.client("serverlessrepo")

--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -105,7 +105,7 @@ class ServerlessAppPlugin(BasePlugin):
 
             if key not in self._applications:
                 try:
-                    if not RegionConfiguration().is_sar_supported():
+                    if not RegionConfiguration.is_sar_supported():
                         raise InvalidResourceException(
                             logical_id, "Serverless Application Repository is not available in this region."
                         )

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -1,3 +1,5 @@
+import boto3
+
 from .translator.arn_generator import ArnGenerator
 
 
@@ -21,4 +23,10 @@ class RegionConfiguration(object):
             "aws-iso",
             "aws-iso-b",
             "aws-cn",
+        ]
+
+    @classmethod
+    def is_sar_supported(cls):
+        return boto3.Session().region_name not in [
+            "af-south-1",
         ]

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -27,6 +27,12 @@ class RegionConfiguration(object):
 
     @classmethod
     def is_sar_supported(cls):
+        """
+        SAR is not supported in af-south-1 at the moment.
+        https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
+
+        :return: True, if SAR is supported in current region.
+        """
         return boto3.Session().region_name not in [
             "af-south-1",
         ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SAR does not provide service in af-south-1. SAM translator will throw a 5xx error instead of a 4xx.

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
