### PR TITLE
fix the request parameter parsing, the value can contain dots

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -1134,7 +1134,10 @@ class SwaggerEditor(object):
 
                 parameter_name = request_parameter["Name"]
                 location_name = parameter_name.replace("method.request.", "")
-                location, name = location_name.split(".")
+
+                parameter_name_parts = location_name.split(".")
+                location = parameter_name_parts[0]
+                name = ".".join(parameter_name_parts[1:])
 
                 if location == "querystring":
                     location = "query"

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -1135,9 +1135,7 @@ class SwaggerEditor(object):
                 parameter_name = request_parameter["Name"]
                 location_name = parameter_name.replace("method.request.", "")
 
-                parameter_name_parts = location_name.split(".")
-                location = parameter_name_parts[0]
-                name = ".".join(parameter_name_parts[1:])
+                location, name = location_name.split(".", 1)
 
                 if location == "querystring":
                     location = "query"

--- a/tests/translator/input/function_with_request_parameters.yaml
+++ b/tests/translator/input/function_with_request_parameters.yaml
@@ -38,3 +38,4 @@ Resources:
             RequestParameters:
               - method.request.querystring.type
               - method.request.path.id
+              - method.request.querystring.full.type

--- a/tests/translator/output/aws-cn/function_with_request_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_request_parameters.json
@@ -53,13 +53,13 @@
         }
       }
     },
-    "ServerlessRestApiDeploymentc2741b5220": {
+    "ServerlessRestApiDeployment32042a0513": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
-        "Description": "RestApi deployment id: c2741b5220c940a753e3d1e18da6763aaba1c19b",
+        "Description": "RestApi deployment id: 32042a0513cd1c4e5c14794b306c4de10ca5c4af",
         "StageName": "Stage"
       }
     },
@@ -118,7 +118,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc2741b5220"
+          "Ref": "ServerlessRestApiDeployment32042a0513"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-cn/function_with_request_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_request_parameters.json
@@ -247,6 +247,12 @@
                     "type": "string",
                     "name": "id",
                     "in": "path"
+                  },
+                  {
+                    "required": false,
+                    "type": "string",
+                    "name": "full.type",
+                    "in": "query"
                   }
                 ]
               }

--- a/tests/translator/output/aws-us-gov/function_with_request_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_request_parameters.json
@@ -53,13 +53,13 @@
         }
       }
     },
-    "ServerlessRestApiDeployment7c706bcd56": {
+    "ServerlessRestApiDeploymentbe3a929cf9": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
-        "Description": "RestApi deployment id: 7c706bcd56e685afb5882e0219515c9413bcd13b",
+        "Description": "RestApi deployment id: be3a929cf90555789f2865fc4a96eb9a11ff7a81",
         "StageName": "Stage"
       }
     },
@@ -128,7 +128,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment7c706bcd56"
+          "Ref": "ServerlessRestApiDeploymentbe3a929cf9"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-us-gov/function_with_request_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_request_parameters.json
@@ -247,6 +247,12 @@
                     "type": "string",
                     "name": "id",
                     "in": "path"
+                  },
+                  {
+                    "required": false,
+                    "type": "string",
+                    "name": "full.type",
+                    "in": "query"
                   }
                 ]
               }

--- a/tests/translator/output/function_with_request_parameters.json
+++ b/tests/translator/output/function_with_request_parameters.json
@@ -239,6 +239,12 @@
                     "type": "string",
                     "name": "id",
                     "in": "path"
+                  },
+                  {
+                    "required": false,
+                    "type": "string",
+                    "name": "full.type",
+                    "in": "query"
                   }
                 ]
               }

--- a/tests/translator/output/function_with_request_parameters.json
+++ b/tests/translator/output/function_with_request_parameters.json
@@ -53,13 +53,13 @@
         }
       }
     },
-    "ServerlessRestApiDeployment2223b43914": {
+    "ServerlessRestApiDeployment104b236830": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
-        "Description": "RestApi deployment id: 2223b439142974b7a3aad1381ddd39027077ce52",
+        "Description": "RestApi deployment id: 104b236830d26d2515909073d13fa9c58ad6db49",
         "StageName": "Stage"
       }
     },
@@ -118,7 +118,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment2223b43914"
+          "Ref": "ServerlessRestApiDeployment104b236830"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"


### PR DESCRIPTION
*Issue #, if available:*
As per [this documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-api.html#sam-function-api-requestparameters), Request Parameters names can contain dots.

fix the request parameter parsing, the value can contain dots
*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [X] Write/update tests
- [X] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
