### PR TITLE
Documentation: fix incorrect header

### DIFF
--- a/docs/internals/generated_resources.rst
+++ b/docs/internals/generated_resources.rst
@@ -129,7 +129,7 @@ AWS::Lambda::Permission            MyFunction\ **ThumbnailApi**\ Permission\ **P
   NOTE: ``ServerlessRestApi*`` resources are generated one per stack.
 
 HTTP API
-^^^
+^^^^
 This is called an "Implicit HTTP API". There can be many functions in the template that define these APIs. Behind the 
 scenes, SAM will collect all implicit HTTP APIs from all Functions in the template, generate an OpenApi doc, and create an 
 implicit ``AWS::Serverless::HttpApi`` using this OpenApi. This API defaults to a StageName called "$default" that cannot be


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixed the incorrectly formatted header for HTTP API section. Previously, the section wasn't corrected recognized and not rendered in the table of contents too

*Description of how you validated changes:* generated preview

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
