### PR TITLE
Added StepFunctionSyncExecutionPolicy to support StartSyncExecution for SFN express workflows.

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1729,34 +1729,6 @@
         ]
       }
     },
-	"StepFunctionsSyncExecutionPolicy": {
-      "Description": "Gives permission to start a synchronous Step Functions state machine execution. Only supported for Express workflows.",
-      "Parameters": {
-        "StateMachineName": {
-          "Description":"The name of the state machine to execute."
-        }
-      },
-      "Definition": {
-        "Statement": [
-          {
-            "Effect": "Allow",
-            "Action": [
-              "states:StartSyncExecution"
-            ],
-            "Resource": {
-              "Fn::Sub": [
-                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
-                {
-                  "stateMachineName": {
-                    "Ref": "StateMachineName"
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
     "CodeCommitCrudPolicy": {
       "Description": "Gives permissions to create/read/update/delete objects within a specific codecommit repository",
       "Parameters": {
@@ -2381,6 +2353,34 @@
                 {
                   "HostedZoneId": {
                     "Ref": "HostedZoneId"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "StepFunctionsSyncExecutionPolicy": {
+      "Description": "Gives permission to start a synchronous Step Functions state machine execution. Only supported for Express workflows.",
+      "Parameters": {
+        "StateMachineName": {
+          "Description":"The name of the state machine to execute."
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "states:StartSyncExecution"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
+                {
+                  "stateMachineName": {
+                    "Ref": "StateMachineName"
                   }
                 }
               ]

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1729,6 +1729,34 @@
         ]
       }
     },
+	"StepFunctionsSyncExecutionPolicy": {
+      "Description": "Gives permission to start a synchronous Step Functions state machine execution. Only supported for Express workflows.",
+      "Parameters": {
+        "StateMachineName": {
+          "Description":"The name of the state machine to execute."
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "states:StartSyncExecution"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
+                {
+                  "stateMachineName": {
+                    "Ref": "StateMachineName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     "CodeCommitCrudPolicy": {
       "Description": "Gives permissions to create/read/update/delete objects within a specific codecommit repository",
       "Parameters": {

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -148,6 +148,9 @@ Resources:
         - StepFunctionsExecutionPolicy:
             StateMachineName: name
 
+        - StepFunctionsSyncExecutionPolicy:
+            StateMachineName: name
+
         - CodeCommitCrudPolicy:
             RepositoryName: name
 

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -148,9 +148,6 @@ Resources:
         - StepFunctionsExecutionPolicy:
             StateMachineName: name
 
-        - StepFunctionsSyncExecutionPolicy:
-            StateMachineName: name
-
         - CodeCommitCrudPolicy:
             RepositoryName: name
 
@@ -177,3 +174,6 @@ Resources:
 
         - Route53ChangeResourceRecordSetsPolicy:
             HostedZoneId: test
+
+        - StepFunctionsSyncExecutionPolicy:
+            StateMachineName: name

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1610,6 +1610,27 @@
                 }
               ]
             }
+          }, 
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "states:StartSyncExecution"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}", 
+                      {
+                        "stateMachineName": "name"
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1610,6 +1610,27 @@
                 }
               ]
             }
+          }, 
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "states:StartSyncExecution"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}", 
+                      {
+                        "stateMachineName": "name"
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1610,6 +1610,27 @@
                 }
               ]
             }
+          }, 
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "states:StartSyncExecution"
+                  ], 
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}", 
+                      {
+                        "stateMachineName": "name"
+                      }
+                    ]
+                  }, 
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added "StepFunctionsSyncExecutionPolicy" policy to add support for synchronous execution of SFN express workflows.

*Description of how you validated changes:*
The policy is based on existing one for the StepFunction. The only difference is Action StartSyncExecution. I triple checked file formats.

*Checklist:*

- [x] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*
```yaml
  StartSyncSFNExpressFunction:
    Type: AWS::Serverless::Function
    Properties:
      FunctionName: StartSyncSFNExpressFunctionName
      CodeUri: ../Lambdas/StartSyncSFNExpressFunction
      Handler: StartSyncSFNExpressFunction.StartExecution
      Runtime: python3.8
      Policies:
        - StepFunctionsSyncExecutionPolicy:
            StateMachineName: !GetAtt TestStepFunction.Name
```

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
