### PR TITLE
fix: add UpdateReplacePolicy to supported resource attributes.

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -43,7 +43,8 @@ class Resource(object):
     property_types = None
     _keywords = ["logical_id", "relative_id", "depends_on", "resource_attributes"]
 
-    _supported_resource_attributes = ["DeletionPolicy", "UpdatePolicy", "Condition"]
+    # Add UpdateReplacePolicy per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html
+    _supported_resource_attributes = ["Condition", "DeletionPolicy", "UpdatePolicy", "UpdateReplacePolicy"]
 
     # Runtime attributes that can be qureied resource. They are CloudFormation attributes like ARN, Name etc that
     # will be resolvable at runtime. This map will be implemented by sub-classes to express list of attributes they

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -139,6 +139,7 @@ class TestResourceAttributes(TestCase):
             "Type": "foo",
             "Properties": {},
             "UpdatePolicy": "update",
+            "UpdateReplacePolicy": "Retain",
             "DeletionPolicy": [1, 2, 3],
         }
 
@@ -148,6 +149,7 @@ class TestResourceAttributes(TestCase):
         r = self.MyResource.from_dict("id", resource_dict=all_supported_attributes)
         self.assertEqual(r.get_resource_attribute("DeletionPolicy"), [1, 2, 3])
         self.assertEqual(r.get_resource_attribute("UpdatePolicy"), "update")
+        self.assertEqual(r.get_resource_attribute("UpdateReplacePolicy"), "Retain")
 
 
 class TestResourceRuntimeAttributes(TestCase):


### PR DESCRIPTION
- Cloudformation added native support for UpdateReplacePolicy on Jan 2019.

*Issue #, if available:* 

https://github.com/aws/serverless-application-model/issues/1807

*Description of changes:*

* Addition to supported resource attributes within SAM models.

*Description of how you validated changes:*

* Unit tested and validated transformation of template with UpdateReplacePolicy defined.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
