### PR TITLE
feature(kms): Allow Functions to Decrypt Environment Variables

### DIFF
--- a/docs/internals/generated_resources.rst
+++ b/docs/internals/generated_resources.rst
@@ -86,6 +86,31 @@ AWS::IAM::Role                     CodeDeployServiceRole
 
   NOTE: ``AWS::IAM::Role`` resources are only generated if no Role parameter is supplied for DeploymentPreference
 
+
+With KmsKeyArn Property
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Example:
+
+.. code:: yaml
+
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      ...
+      KmsKeyArn: !GetAtt MyKmsKey.Arn
+      ...
+
+
+Additional generated resources:
+
+================================== ================================
+CloudFormation Resource Type       Logical ID 
+================================== ================================
+AWS::IAM::Poilicy                  MyFunction\ **DecryptEnvironmentVariablesPolicy**
+================================== ================================
+
+
 With Events
 ~~~~~~~~~~~
 

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -24,7 +24,7 @@ from samtranslator.model.cloudformation import NestedStack
 from samtranslator.model.dynamodb import DynamoDBTable
 from samtranslator.model.exceptions import InvalidEventException, InvalidResourceException
 from samtranslator.model.resource_policies import ResourcePolicies, PolicyTypes
-from samtranslator.model.iam import IAMRole, IAMRolePolicies
+from samtranslator.model.iam import IAMRole, IAMPolicy, IAMRolePolicies, IAMPolicies
 from samtranslator.model.lambda_ import (
     LambdaFunction,
     LambdaVersion,
@@ -182,6 +182,10 @@ class SamFunction(SamResourceMacro):
             execution_role = self._construct_role(managed_policy_map, event_invoke_policies)
             lambda_function.Role = execution_role.get_runtime_attr("arn")
             resources.append(execution_role)
+
+        if self.KmsKeyArn:
+            env_vars_policy = self._construct_environment_variables_decrypt_policy(lambda_function)
+            resources.append(env_vars_policy)
 
         try:
             resources += self._generate_event_resources(
@@ -492,6 +496,18 @@ class SamFunction(SamResourceMacro):
             tags=self._construct_tag_list(self.Tags),
         )
         return execution_role
+
+    def _construct_environment_variables_decrypt_policy(self, lambda_function):
+        """Constructs a Lambda policy for reading encrypted environment variables
+        based on this SAM function's KmsKeyArn property.
+
+        :returns: the generated IAM Policy
+        :rtype: model.iam.IAMPolicy
+        """
+        policy = IAMPolicies.lambda_decrypt_environment_variables_policy(
+            self.logical_id, lambda_function.KmsKeyArn, lambda_function.get_runtime_attr("arn"), lambda_function.Role
+        )
+        return policy
 
     def _validate_package_type(self, lambda_function):
         """

--- a/tests/translator/output/aws-cn/function_with_kmskeyarn.json
+++ b/tests/translator/output/aws-cn/function_with_kmskeyarn.json
@@ -1,60 +1,23 @@
 {
   "Resources": {
-    "FunctionWithKeyArnRole": {
-      "Type": "AWS::IAM::Role",
+    "myKey": {
+      "Type": "AWS::KMS::Key",
       "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "AssumeRolePolicyDocument": {
+        "Description": "A sample key",
+        "KeyPolicy": {
           "Version": "2012-10-17",
+          "Id": "key-default-1",
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Sid": "Allow administration of the key",
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "FunctionWithReferenceToKeyArnRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
+                "AWS": "arn:aws:iam::123456789012:user/Alice"
+              },
               "Action": [
-                "sts:AssumeRole"
+                "kms:Create*"
               ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
+              "Resource": "*"
             }
           ]
         }
@@ -67,13 +30,6 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "KmsKeyArn": "thisIsaKey",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -81,30 +37,81 @@
             "Arn"
           ]
         },
-        "Runtime": "python2.7"
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "KmsKeyArn": "thisIsaKey"
       }
     },
-    "myKey": {
-      "Type": "AWS::KMS::Key",
+    "FunctionWithKeyArnRole": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "KeyPolicy": {
+        "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
-          "Id": "key-default-1",
           "Statement": [
             {
               "Action": [
-                "kms:Create*"
+                "sts:AssumeRole"
               ],
-              "Sid": "Allow administration of the key",
-              "Resource": "*",
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::123456789012:user/Alice"
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]
         },
-        "Description": "A sample key"
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionWithKeyArnDecryptEnvironmentVariablesPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": "thisIsaKey",
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": "lambda.amazonaws.com"
+                },
+                "ForAnyValue:ArnEquals": {
+                  "kms:EncryptionContext:aws:lambda:FunctionArn": {
+                    "Fn::GetAtt": [
+                      "FunctionWithKeyArn",
+                      "Arn"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "PolicyName": "DecryptEnvironmentVariablesPolicy",
+        "Roles": [
+          {
+            "Fn::GetAtt": [
+              "FunctionWithKeyArnRole",
+              "Arn"
+            ]
+          }
+        ]
       }
     },
     "FunctionWithReferenceToKeyArn": {
@@ -114,15 +121,6 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "KmsKeyArn": {
-          "Ref": "myKey"
-        },
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -130,7 +128,85 @@
             "Arn"
           ]
         },
-        "Runtime": "python2.7"
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "KmsKeyArn": {
+          "Ref": "myKey"
+        }
+      }
+    },
+    "FunctionWithReferenceToKeyArnRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionWithReferenceToKeyArnDecryptEnvironmentVariablesPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "myKey"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": "lambda.amazonaws.com"
+                },
+                "ForAnyValue:ArnEquals": {
+                  "kms:EncryptionContext:aws:lambda:FunctionArn": {
+                    "Fn::GetAtt": [
+                      "FunctionWithReferenceToKeyArn",
+                      "Arn"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "PolicyName": "DecryptEnvironmentVariablesPolicy",
+        "Roles": [
+          {
+            "Fn::GetAtt": [
+              "FunctionWithReferenceToKeyArnRole",
+              "Arn"
+            ]
+          }
+        ]
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/function_with_kmskeyarn.json
+++ b/tests/translator/output/aws-us-gov/function_with_kmskeyarn.json
@@ -1,60 +1,23 @@
 {
   "Resources": {
-    "FunctionWithKeyArnRole": {
-      "Type": "AWS::IAM::Role",
+    "myKey": {
+      "Type": "AWS::KMS::Key",
       "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "AssumeRolePolicyDocument": {
+        "Description": "A sample key",
+        "KeyPolicy": {
           "Version": "2012-10-17",
+          "Id": "key-default-1",
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Sid": "Allow administration of the key",
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "FunctionWithReferenceToKeyArnRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
+                "AWS": "arn:aws:iam::123456789012:user/Alice"
+              },
               "Action": [
-                "sts:AssumeRole"
+                "kms:Create*"
               ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
+              "Resource": "*"
             }
           ]
         }
@@ -67,13 +30,6 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "KmsKeyArn": "thisIsaKey",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -81,30 +37,81 @@
             "Arn"
           ]
         },
-        "Runtime": "python2.7"
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "KmsKeyArn": "thisIsaKey"
       }
     },
-    "myKey": {
-      "Type": "AWS::KMS::Key",
+    "FunctionWithKeyArnRole": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "KeyPolicy": {
+        "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
-          "Id": "key-default-1",
           "Statement": [
             {
               "Action": [
-                "kms:Create*"
+                "sts:AssumeRole"
               ],
-              "Sid": "Allow administration of the key",
-              "Resource": "*",
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::123456789012:user/Alice"
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]
         },
-        "Description": "A sample key"
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionWithKeyArnDecryptEnvironmentVariablesPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": "thisIsaKey",
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": "lambda.amazonaws.com"
+                },
+                "ForAnyValue:ArnEquals": {
+                  "kms:EncryptionContext:aws:lambda:FunctionArn": {
+                    "Fn::GetAtt": [
+                      "FunctionWithKeyArn",
+                      "Arn"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "PolicyName": "DecryptEnvironmentVariablesPolicy",
+        "Roles": [
+          {
+            "Fn::GetAtt": [
+              "FunctionWithKeyArnRole",
+              "Arn"
+            ]
+          }
+        ]
       }
     },
     "FunctionWithReferenceToKeyArn": {
@@ -114,15 +121,6 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "KmsKeyArn": {
-          "Ref": "myKey"
-        },
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -130,7 +128,85 @@
             "Arn"
           ]
         },
-        "Runtime": "python2.7"
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "KmsKeyArn": {
+          "Ref": "myKey"
+        }
+      }
+    },
+    "FunctionWithReferenceToKeyArnRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionWithReferenceToKeyArnDecryptEnvironmentVariablesPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "myKey"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": "lambda.amazonaws.com"
+                },
+                "ForAnyValue:ArnEquals": {
+                  "kms:EncryptionContext:aws:lambda:FunctionArn": {
+                    "Fn::GetAtt": [
+                      "FunctionWithReferenceToKeyArn",
+                      "Arn"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "PolicyName": "DecryptEnvironmentVariablesPolicy",
+        "Roles": [
+          {
+            "Fn::GetAtt": [
+              "FunctionWithReferenceToKeyArnRole",
+              "Arn"
+            ]
+          }
+        ]
       }
     }
   }

--- a/tests/translator/output/function_with_kmskeyarn.json
+++ b/tests/translator/output/function_with_kmskeyarn.json
@@ -1,60 +1,23 @@
 {
   "Resources": {
-    "FunctionWithKeyArnRole": {
-      "Type": "AWS::IAM::Role",
+    "myKey": {
+      "Type": "AWS::KMS::Key",
       "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "AssumeRolePolicyDocument": {
+        "Description": "A sample key",
+        "KeyPolicy": {
           "Version": "2012-10-17",
+          "Id": "key-default-1",
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Sid": "Allow administration of the key",
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "FunctionWithReferenceToKeyArnRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
+                "AWS": "arn:aws:iam::123456789012:user/Alice"
+              },
               "Action": [
-                "sts:AssumeRole"
+                "kms:Create*"
               ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
+              "Resource": "*"
             }
           ]
         }
@@ -67,13 +30,6 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "KmsKeyArn": "thisIsaKey",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -81,30 +37,81 @@
             "Arn"
           ]
         },
-        "Runtime": "python2.7"
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "KmsKeyArn": "thisIsaKey"
       }
     },
-    "myKey": {
-      "Type": "AWS::KMS::Key",
+    "FunctionWithKeyArnRole": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "KeyPolicy": {
+        "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
-          "Id": "key-default-1",
           "Statement": [
             {
               "Action": [
-                "kms:Create*"
+                "sts:AssumeRole"
               ],
-              "Sid": "Allow administration of the key",
-              "Resource": "*",
               "Effect": "Allow",
               "Principal": {
-                "AWS": "arn:aws:iam::123456789012:user/Alice"
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]
         },
-        "Description": "A sample key"
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionWithKeyArnDecryptEnvironmentVariablesPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": "thisIsaKey",
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": "lambda.amazonaws.com"
+                },
+                "ForAnyValue:ArnEquals": {
+                  "kms:EncryptionContext:aws:lambda:FunctionArn": {
+                    "Fn::GetAtt": [
+                      "FunctionWithKeyArn",
+                      "Arn"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "PolicyName": "DecryptEnvironmentVariablesPolicy",
+        "Roles": [
+          {
+            "Fn::GetAtt": [
+              "FunctionWithKeyArnRole",
+              "Arn"
+            ]
+          }
+        ]
       }
     },
     "FunctionWithReferenceToKeyArn": {
@@ -114,15 +121,6 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ],
-        "KmsKeyArn": {
-          "Ref": "myKey"
-        },
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -130,7 +128,85 @@
             "Arn"
           ]
         },
-        "Runtime": "python2.7"
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "KmsKeyArn": {
+          "Ref": "myKey"
+        }
+      }
+    },
+    "FunctionWithReferenceToKeyArnRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionWithReferenceToKeyArnDecryptEnvironmentVariablesPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "myKey"
+              },
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": "lambda.amazonaws.com"
+                },
+                "ForAnyValue:ArnEquals": {
+                  "kms:EncryptionContext:aws:lambda:FunctionArn": {
+                    "Fn::GetAtt": [
+                      "FunctionWithReferenceToKeyArn",
+                      "Arn"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "PolicyName": "DecryptEnvironmentVariablesPolicy",
+        "Roles": [
+          {
+            "Fn::GetAtt": [
+              "FunctionWithReferenceToKeyArnRole",
+              "Arn"
+            ]
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
...If They Have Been Encrypted

When a Function specifies that its environment variables should be
encrypted by supplying a value for `KmsKeyArn`, a corresponding
Policy will be generated for that Function's execution Role which
allows it to decrypt the environment variables with that key.
Permissions are restricted so that it should be able to do nothing
else with the key.

*Issue #, if available:*

#1989 

*Description of changes:*

Checks for presence of `KmsKeyArn` and creates a corresponding `AWS::IAM::Policy` for `kms:Decrypt` on that value with restrictive `Conditions`.

*Description of how you validated changes:*

Ran all unit tests and compared generated policy to manually written one from other, earlier projects.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
