### PR TITLE
fix: Fail when Intrinsics are in SourceVPC list instead of IntrinsicsSourceVPC

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -877,6 +877,8 @@ class SwaggerEditor(object):
         ip_range_blacklist = resource_policy.get("IpRangeBlacklist")
         source_vpc_whitelist = resource_policy.get("SourceVpcWhitelist")
         source_vpc_blacklist = resource_policy.get("SourceVpcBlacklist")
+
+        # Intrinsic's supported in these properties
         source_vpc_intrinsic_whitelist = resource_policy.get("IntrinsicVpcWhitelist")
         source_vpce_intrinsic_whitelist = resource_policy.get("IntrinsicVpceWhitelist")
         source_vpc_intrinsic_blacklist = resource_policy.get("IntrinsicVpcBlacklist")
@@ -898,31 +900,32 @@ class SwaggerEditor(object):
             resource_list = self._get_method_path_uri_list(path, api_id, stage)
             self._add_ip_resource_policy_for_method(ip_range_blacklist, "IpAddress", resource_list)
 
-        if (
-            (source_vpc_blacklist is not None)
-            or (source_vpc_intrinsic_blacklist is not None)
-            or (source_vpce_intrinsic_blacklist is not None)
-        ):
-            blacklist_dict = {
-                "StringEndpointList": source_vpc_blacklist,
-                "IntrinsicVpcList": source_vpc_intrinsic_blacklist,
-                "IntrinsicVpceList": source_vpce_intrinsic_blacklist,
-            }
-            resource_list = self._get_method_path_uri_list(path, api_id, stage)
-            self._add_vpc_resource_policy_for_method(blacklist_dict, "StringEquals", resource_list)
+        # if (
+        #     (source_vpc_blacklist is not None)
+        #     or (source_vpc_intrinsic_blacklist is not None)
+        #     or (source_vpce_intrinsic_blacklist is not None)
+        # ):
+        if source_vpc_blacklist is not None and not all(isinstance(x, string_types) for x in source_vpc_blacklist):
+            raise InvalidDocumentException([InvalidTemplateException("SourceVpcBlacklist must be a list of strings. Use IntrinsicVpcBlacklist instead for values that use Intrinsic Functions")])
 
-        if (
-            (source_vpc_whitelist is not None)
-            or (source_vpc_intrinsic_whitelist is not None)
-            or (source_vpce_intrinsic_whitelist is not None)
-        ):
-            whitelist_dict = {
-                "StringEndpointList": source_vpc_whitelist,
-                "IntrinsicVpcList": source_vpc_intrinsic_whitelist,
-                "IntrinsicVpceList": source_vpce_intrinsic_whitelist,
-            }
-            resource_list = self._get_method_path_uri_list(path, api_id, stage)
-            self._add_vpc_resource_policy_for_method(whitelist_dict, "StringNotEquals", resource_list)
+        blacklist_dict = {
+            "StringEndpointList": source_vpc_blacklist,
+            "IntrinsicVpcList": source_vpc_intrinsic_blacklist,
+            "IntrinsicVpceList": source_vpce_intrinsic_blacklist,
+        }
+        resource_list = self._get_method_path_uri_list(path, api_id, stage)
+        self._add_vpc_resource_policy_for_method(blacklist_dict, "StringEquals", resource_list)
+
+        if source_vpc_whitelist is not None and not all(isinstance(x, string_types) for x in source_vpc_whitelist):
+            raise InvalidDocumentException([InvalidTemplateException("SourceVpcWhitelist must be a list of strings. Use IntrinsicVpcWhitelist instead for values that use Intrinsic Functions")])
+
+        whitelist_dict = {
+            "StringEndpointList": source_vpc_whitelist,
+            "IntrinsicVpcList": source_vpc_intrinsic_whitelist,
+            "IntrinsicVpceList": source_vpce_intrinsic_whitelist,
+        }
+        resource_list = self._get_method_path_uri_list(path, api_id, stage)
+        self._add_vpc_resource_policy_for_method(whitelist_dict, "StringNotEquals", resource_list)
 
         self._doc[self._X_APIGW_POLICY] = self.resource_policy
 

--- a/tests/translator/input/error_api_invalid_source_vpc_blacklist.yaml
+++ b/tests/translator/input/error_api_invalid_source_vpc_blacklist.yaml
@@ -1,0 +1,31 @@
+Globals:
+  Api:
+    Auth:
+      ResourcePolicy:
+        SourceVpcBlacklist: [{"Ref":"SomeParameter"}]
+
+Parameters:
+  SomeParameter:
+    Type: String
+    Default: param
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |
+        exports.handler = async (event) => {
+          const response = {
+            statusCode: 200,
+            body: JSON.stringify('Hello from Lambda!'),
+          };
+          return response;
+        };
+      Handler: index.handler
+      Runtime: nodejs12.x
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Method: Put
+            Path: /get

--- a/tests/translator/input/error_api_invalid_source_vpc_whitelist.yaml
+++ b/tests/translator/input/error_api_invalid_source_vpc_whitelist.yaml
@@ -1,0 +1,31 @@
+Globals:
+  Api:
+    Auth:
+      ResourcePolicy:
+        SourceVpcWhitelist: [{"Ref":"SomeParameter"}]
+
+Parameters:
+  SomeParameter:
+    Type: String
+    Default: param
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |
+        exports.handler = async (event) => {
+          const response = {
+            statusCode: 200,
+            body: JSON.stringify('Hello from Lambda!'),
+          };
+          return response;
+        };
+      Handler: index.handler
+      Runtime: nodejs12.x
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            Method: Put
+            Path: /get

--- a/tests/translator/output/error_api_invalid_source_vpc_blacklist.json
+++ b/tests/translator/output/error_api_invalid_source_vpc_blacklist.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. SourceVpcBlacklist must be a list of strings. Use IntrinsicVpcBlacklist instead for values that use Intrinsic Functions"
+}

--- a/tests/translator/output/error_api_invalid_source_vpc_whitelist.json
+++ b/tests/translator/output/error_api_invalid_source_vpc_whitelist.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. SourceVpcWhitelist must be a list of strings. Use IntrinsicVpcWhitelist instead for values that use Intrinsic Functions"
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When SAM is running and an Intrinsic is the value of SourceVPC* under the API Auth, SAM translation will fail. This is due to the code expecting SourceVPC* being a list of strings and operating on it with a regex, which eventually fails because you can't do a regex on a dictionary. SAM introduced a property called IntrinsicsSourceVPC to support this use-case but never guarded against them passed into SourceVPC.

This PR also removes unneeded if statements. We were doing a collection of `or` statements which means the functions we called within that block needed to handle `None`'s aways, so simplified the code paths to remove the unneeded checks.

*Description of how you validated changes:*
* Ran tests locally
* Validated that before these changes, the templates tests added failed. 

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
