### PR TITLE
fix: Crash when using an invalid method in open api

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -531,6 +531,17 @@ class SwaggerEditor(object):
             if add_default_auth_to_preflight or normalized_method_name != "options":
                 normalized_method_name = self._normalize_method_name(method_name)
                 # It is possible that the method could have two definitions in a Fn::If block.
+
+                # check for valid methods
+                if normalized_method_name.upper() not in self._ALL_HTTP_METHODS:
+                    raise InvalidDocumentException(
+                        [
+                            InvalidTemplateException(
+                                "Path '{}' contains method '{}' which is not a supported method {}".format(path, method_name, self._ALL_HTTP_METHODS)
+                            )
+                        ]
+                    )
+
                 for method_definition in self.get_method_contents(self.get_path(path)[normalized_method_name]):
 
                     # If no integration given, then we don't need to process this definition (could be AWS::NoValue)

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -537,7 +537,9 @@ class SwaggerEditor(object):
                     raise InvalidDocumentException(
                         [
                             InvalidTemplateException(
-                                "Path '{}' contains method '{}' which is not a supported method {}".format(path, method_name, self._ALL_HTTP_METHODS)
+                                "Path '{}' contains method '{}' which is not a supported method {}".format(
+                                    path, method_name, self._ALL_HTTP_METHODS
+                                )
                             )
                         ]
                     )

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -1457,6 +1457,7 @@ class TestSwaggerEditor_add_authorization_scopes(TestCase):
         self.editor.add_auth_to_method("/cognito", "get", auth, self.api)
         self.assertEqual([{"NONE": []}], self.editor.swagger["paths"]["/cognito"]["get"]["security"])
 
+
 class TestSwaggerEditor_set_path_default_authorizer(TestCase):
     def setUp(self):
         self.api = api = {
@@ -1488,4 +1489,6 @@ class TestSwaggerEditor_set_path_default_authorizer(TestCase):
 
     def test_should_fail_when_path_methods_are_invalid(self):
         with self.assertRaises(InvalidDocumentException):
-            self.editor.set_path_default_authorizer("/cognito", "MyCognitoAuth", {"MyOtherCognitoAuth": {}, "MyCognitoAuth": {}})
+            self.editor.set_path_default_authorizer(
+                "/cognito", "MyCognitoAuth", {"MyOtherCognitoAuth": {}, "MyCognitoAuth": {}}
+            )

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -1456,3 +1456,36 @@ class TestSwaggerEditor_add_authorization_scopes(TestCase):
 
         self.editor.add_auth_to_method("/cognito", "get", auth, self.api)
         self.assertEqual([{"NONE": []}], self.editor.swagger["paths"]["/cognito"]["get"]["security"])
+
+class TestSwaggerEditor_set_path_default_authorizer(TestCase):
+    def setUp(self):
+        self.api = api = {
+            "Auth": {
+                "Authorizers": {"MyOtherCognitoAuth": {}, "MyCognitoAuth": {}},
+                "DefaultAuthorizer": "MyCognitoAuth",
+            }
+        }
+        self.editor = SwaggerEditor(
+            {
+                "swagger": "2.0",
+                "paths": {
+                    "/cognito": {
+                        "nonMethod": {
+                            "x-amazon-apigateway-integration": {
+                                "httpMethod": "POST",
+                                "type": "aws_proxy",
+                                "uri": {
+                                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFn.Arn}/invocations"
+                                },
+                            },
+                            "security": [],
+                            "responses": {},
+                        }
+                    }
+                },
+            }
+        )
+
+    def test_should_fail_when_path_methods_are_invalid(self):
+        with self.assertRaises(InvalidDocumentException):
+            self.editor.set_path_default_authorizer("/cognito", "MyCognitoAuth", {"MyOtherCognitoAuth": {}, "MyCognitoAuth": {}})

--- a/tests/translator/input/error_api_with_invalid_path_object.yaml
+++ b/tests/translator/input/error_api_with_invalid_path_object.yaml
@@ -1,15 +1,13 @@
 Globals:
   Api:
     Name: "some api"
-    CacheClusterEnabled: True
-    CacheClusterSize: "1.6"
+    Variables:
+      SomeVar: Value
     Auth:
       DefaultAuthorizer: MyCognitoAuth
       Authorizers:
         MyCognitoAuth:
           UserPoolArn: !GetAtt MyUserPool.Arn
-    Variables:
-      SomeVar: Value
 
 Resources:
   ImplicitApiFunction:
@@ -18,12 +16,6 @@ Resources:
       CodeUri: s3://sam-demo-bucket/member_portal.zip
       Handler: index.gethtml
       Runtime: nodejs12.x
-      Events:
-        GetHtml:
-          Type: Api
-          Properties:
-            Path: /
-            Method: get
 
   ExplicitApi:
     Type: AWS::Serverless::Api
@@ -31,20 +23,9 @@ Resources:
       StageName: SomeStage
       DefinitionBody:
         swagger: 2.0
-        info:
-          version: '1.0'
-          title: !Ref AWS::StackName
         paths:
-          "/":
-            parameters:
-              - name: domain
-                in: path
-                description: Application domain
-                type: string
-                required: true
-            options:
-              - InvalidMethodDefinition
-            get:
+          "/a":
+            SomeInvalidKey:
               x-amazon-apigateway-integration:
                 httpMethod: POST
                 type: aws_proxy

--- a/tests/translator/output/error_api_with_invalid_path_object.json
+++ b/tests/translator/output/error_api_with_invalid_path_object.json
@@ -1,3 +1,3 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Path '/command' contains method 'Auth' which is not a supported method ['OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH']"
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Path '/a' contains method 'SomeInvalidKey' which is not a supported method ['OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH']"
 }

--- a/tests/translator/output/error_api_with_invalid_path_object.json
+++ b/tests/translator/output/error_api_with_invalid_path_object.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Path '/command' contains method 'Auth' which is not a supported method ['OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH']"
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -413,7 +413,6 @@ class TestTranslatorEndToEnd(TestCase):
             ],  # Run all the above tests against each of the list of partitions to test against
         )
     )
-    @pytest.mark.slow
     @patch(
         "samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call",
         mock_sar_service_call,


### PR DESCRIPTION
When customers use auth and define an invalid method in the open api
definition, SAM would return a 'server error'. This was actually
due to SAM attempting to get the method from the path. If the method
was not a supported method and non-lowercase, SAM would attempt to fetch
the lower case method and crash with a KeyError. This PR addresses that
by checking for the valid methods supported.

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
