### PR TITLE
fix: Correct grammar in the waiting for changeset message

### DIFF
--- a/integration/helpers/deployer/deployer.py
+++ b/integration/helpers/deployer/deployer.py
@@ -284,7 +284,7 @@ class Deployer:
         :param stack_name:   Stack name
         :return: Latest status of the create-change-set operation
         """
-        sys.stdout.write("\nWaiting for changeset to be created..\n")
+        sys.stdout.write("\nWaiting for changeset to be created...\n")
         sys.stdout.flush()
 
         # Wait for changeset to be created


### PR DESCRIPTION
*Description of changes:*

There is no such punctuation as `..`. There is a period (`.`). There is an ellipsis (`…` or `…`).

This corrects the grammar in the line to use punctuation which exists.
