### PR TITLE
Add StepFunctionsReadOnlyPolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1729,6 +1729,34 @@
         ]
       }
     },
+    "StepFunctionsListExecutionPolicy": {
+      "Description": "Gives permission to list state machine executions of a Step Functions",
+      "Parameters": {
+        "StateMachineName": {
+          "Description":"The name of the state machine to list its executions."
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "states:ListExecutions"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
+                {
+                  "stateMachineName": {
+                    "Ref": "StateMachineName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     "CodeCommitCrudPolicy": {
       "Description": "Gives permissions to create/read/update/delete objects within a specific codecommit repository",
       "Parameters": {

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1729,8 +1729,8 @@
         ]
       }
     },
-    "StepFunctionsListExecutionPolicy": {
-      "Description": "Gives permission to list state machine executions of a Step Functions",
+    "StepFunctionsReadOnlyPolicy": {
+      "Description": "Gives readonly permission to a Step Functions",
       "Parameters": {
         "StateMachineName": {
           "Description":"The name of the state machine to list its executions."
@@ -1741,7 +1741,14 @@
           {
             "Effect": "Allow",
             "Action": [
-              "states:ListExecutions"
+                "states:ListStateMachines",
+                "states:ListActivities",
+                "states:DescribeStateMachine",
+                "states:DescribeStateMachineForExecution",
+                "states:ListExecutions",
+                "states:DescribeExecution",
+                "states:GetExecutionHistory",
+                "states:DescribeActivity"
             ],
             "Resource": {
               "Fn::Sub": [


### PR DESCRIPTION
This policy will allow Lambda functions to list executions of a Step function

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
