### PR TITLE
fix: Don't attempt to refetch a swagger method object by its name as we already have it

### DIFF
--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -352,7 +352,7 @@ class OpenApiEditor(object):
                             )
                         ]
                     )
-                for method_definition in self.get_method_contents(self.get_path(path)[normalized_method_name]):
+                for method_definition in self.get_method_contents(method):
                     # If no integration given, then we don't need to process this definition (could be AWS::NoValue)
                     if not self.method_definition_has_integration(method_definition):
                         continue

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -620,14 +620,13 @@ class SwaggerEditor(object):
         :param string path: Path name
         """
 
-        for method_name, _ in self.get_path(path).items():
+        for method_name, method in self.get_path(path).items():
             # Excluding parameters section
             if method_name == "parameters":
                 continue
 
-            normalized_method_name = self._normalize_method_name(method_name)
             # It is possible that the method could have two definitions in a Fn::If block.
-            for method_definition in self.get_method_contents(self.get_path(path)[normalized_method_name]):
+            for method_definition in self.get_method_contents(method):
 
                 # If no integration given, then we don't need to process this definition (could be AWS::NoValue)
                 if not self.method_definition_has_integration(method_definition):

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -531,7 +531,7 @@ class SwaggerEditor(object):
             if add_default_auth_to_preflight or normalized_method_name != "options":
                 normalized_method_name = self._normalize_method_name(method_name)
                 # It is possible that the method could have two definitions in a Fn::If block.
-                for method_definition in self.get_method_contents(self.get_path(path)[normalized_method_name]):
+                for method_definition in self.get_method_contents(method):
 
                     # If no integration given, then we don't need to process this definition (could be AWS::NoValue)
                     if not isinstance(method_definition, dict):

--- a/tests/translator/input/api_with_any_method_in_swagger.yaml
+++ b/tests/translator/input/api_with_any_method_in_swagger.yaml
@@ -1,0 +1,44 @@
+Resources:
+  HttpApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/todo_list.zip
+      Handler: index.restapi
+      Runtime: python3.7
+      Events:
+        SimpleCase:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+        BasePath:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+            Path: /
+            Method: get
+
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName:
+        Ref: Stage
+      Auth:
+        DefaultAuthorizer: "LambdaAuthorizer"
+        Authorizers:
+          LambdaAuthorizer:
+            FunctionPayloadType: "REQUEST"
+            Identity:
+              Headers:
+                  - "Authorization"
+      DefinitionBody:
+        openapi: '3.0'
+        info:
+          title: !Sub ${AWS::StackName}-Api
+        paths:
+          /:
+            any:
+              x-amazon-apigateway-integration:
+                httpMethod: ANY
+                type: http_proxy
+                uri: https://www.alphavantage.co/
+                payloadFormatVersion: '1.0'

--- a/tests/translator/output/api_with_any_method_in_swagger.json
+++ b/tests/translator/output/api_with_any_method_in_swagger.json
@@ -1,0 +1,189 @@
+{
+  "Resources": {
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Fn::Sub": "${AWS::StackName}-Api"
+            }
+          },
+          "paths": {
+            "$default": {
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"
+                  },
+                  "payloadFormatVersion": "2.0"
+                },
+                "isDefaultRoute": true,
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ],
+                "responses": {}
+              }
+            },
+            "/": {
+              "any": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "ANY",
+                  "type": "http_proxy",
+                  "uri": "https://www.alphavantage.co/",
+                  "payloadFormatVersion": "1.0"
+                },
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ]
+              },
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"
+                  },
+                  "payloadFormatVersion": "2.0"
+                },
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ],
+                "responses": {}
+              }
+            }
+          },
+          "openapi": "3.0",
+          "components": {
+            "securitySchemes": {
+              "LambdaAuthorizer": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
+                "x-amazon-apigateway-authorizer": {
+                  "type": "request",
+                  "identitySource": "method.request.header.Authorization",
+                  "authorizerUri": {
+                    "Fn::Sub": [
+                      "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                      {
+                        "__FunctionArn__": null
+                      }
+                    ]
+                  }
+                },
+                "x-amazon-apigateway-authtype": "custom"
+              }
+            }
+          }
+        }
+      }
+    },
+    "HttpApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.restapi",
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "HttpApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "HttpApiFunctionSimpleCasePermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HttpApiFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HttpApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment69a80e7382"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": {
+          "Ref": "Stage"
+        }
+      }
+    },
+    "MyApiDeployment69a80e7382": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 69a80e738222706cff079ab8d7f348c0d89eddab",
+        "StageName": "Stage"
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_any_method_in_swagger.json
+++ b/tests/translator/output/aws-cn/api_with_any_method_in_swagger.json
@@ -1,0 +1,197 @@
+{
+  "Resources": {
+    "MyApiStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment37c803d096"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": {
+          "Ref": "Stage"
+        }
+      }
+    },
+    "HttpApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiDeployment37c803d096": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 37c803d09628334a047966047f087abf49267a2c",
+        "StageName": "Stage"
+      }
+    },
+    "HttpApiFunctionSimpleCasePermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HttpApiFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HttpApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.restapi",
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "HttpApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Fn::Sub": "${AWS::StackName}-Api"
+            }
+          },
+          "paths": {
+            "$default": {
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"
+                  },
+                  "payloadFormatVersion": "2.0"
+                },
+                "isDefaultRoute": true,
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ],
+                "responses": {}
+              }
+            },
+            "/": {
+              "any": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "ANY",
+                  "type": "http_proxy",
+                  "uri": "https://www.alphavantage.co/",
+                  "payloadFormatVersion": "1.0"
+                },
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ]
+              },
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"
+                  },
+                  "payloadFormatVersion": "2.0"
+                },
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ],
+                "responses": {}
+              }
+            }
+          },
+          "openapi": "3.0",
+          "components": {
+            "securitySchemes": {
+              "LambdaAuthorizer": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
+                "x-amazon-apigateway-authorizer": {
+                  "type": "request",
+                  "identitySource": "method.request.header.Authorization",
+                  "authorizerUri": {
+                    "Fn::Sub": [
+                      "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                      {
+                        "__FunctionArn__": null
+                      }
+                    ]
+                  }
+                },
+                "x-amazon-apigateway-authtype": "custom"
+              }
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_with_any_method_in_swagger.json
+++ b/tests/translator/output/aws-us-gov/api_with_any_method_in_swagger.json
@@ -1,0 +1,197 @@
+{
+  "Resources": {
+    "MyApiStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment0ebc8893a3"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": {
+          "Ref": "Stage"
+        }
+      }
+    },
+    "HttpApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.restapi",
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "HttpApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "HttpApiFunctionSimpleCasePermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HttpApiFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HttpApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "MyApiDeployment0ebc8893a3": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Description": "RestApi deployment id: 0ebc8893a30055fb944d26720dc8ffddacc6d27d",
+        "StageName": "Stage"
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Fn::Sub": "${AWS::StackName}-Api"
+            }
+          },
+          "paths": {
+            "$default": {
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"
+                  },
+                  "payloadFormatVersion": "2.0"
+                },
+                "isDefaultRoute": true,
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ],
+                "responses": {}
+              }
+            },
+            "/": {
+              "any": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "ANY",
+                  "type": "http_proxy",
+                  "uri": "https://www.alphavantage.co/",
+                  "payloadFormatVersion": "1.0"
+                },
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ]
+              },
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"
+                  },
+                  "payloadFormatVersion": "2.0"
+                },
+                "security": [
+                  {
+                    "LambdaAuthorizer": []
+                  }
+                ],
+                "responses": {}
+              }
+            }
+          },
+          "openapi": "3.0",
+          "components": {
+            "securitySchemes": {
+              "LambdaAuthorizer": {
+                "in": "header",
+                "type": "apiKey",
+                "name": "Unused",
+                "x-amazon-apigateway-authorizer": {
+                  "type": "request",
+                  "identitySource": "method.request.header.Authorization",
+                  "authorizerUri": {
+                    "Fn::Sub": [
+                      "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                      {
+                        "__FunctionArn__": null
+                      }
+                    ]
+                  }
+                },
+                "x-amazon-apigateway-authtype": "custom"
+              }
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -316,6 +316,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "api_with_gateway_responses_string_status_code",
                 "api_cache",
                 "api_with_access_log_setting",
+                "api_with_any_method_in_swagger",
                 "api_with_canary_setting",
                 "api_with_xray_tracing",
                 "api_request_model",


### PR DESCRIPTION

*Issue #, if available:*
N/A

*Description of changes:*
[here](https://github.com/aws/serverless-application-model/blob/develop/samtranslator/swagger/swagger.py#L628) the method_name, which is a [key](https://github.com/aws/serverless-application-model/blob/develop/samtranslator/swagger/swagger.py#L623) in the path hash, is normalized (may be modified) then get [fetched](https://github.com/aws/serverless-application-model/blob/develop/samtranslator/swagger/swagger.py#L630) again from the same hash which will result in KeyError if the normalization modified the key

*Description of how you validated changes:*
Not normalizing the key. It looks like the logic was just a copy/paste from another place where the normalization was needed. but here it is not needed at all.

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
