### PR TITLE
fix: Increase PageSize of ListPolicies Paginator

### DIFF
--- a/samtranslator/translator/managed_policy_translator.py
+++ b/samtranslator/translator/managed_policy_translator.py
@@ -7,15 +7,19 @@ class ManagedPolicyLoader(object):
     def __init__(self, iam_client):
         self._iam_client = iam_client
         self._policy_map = None
+        self.max_items = 1000
 
     def load(self):
         if self._policy_map is None:
             LOG.info("Loading policies from IAM...")
+
             paginator = self._iam_client.get_paginator("list_policies")
             # Setting the scope to AWS limits the returned values to only AWS Managed Policies and will
             # not returned policies owned by any specific account.
             # http://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicies.html#API_ListPolicies_RequestParameters
-            page_iterator = paginator.paginate(Scope="AWS")
+            # Note(jfuss): boto3 PaginationConfig MaxItems does not control the number of items returned from the API
+            # call. This is actually controlled by PageSize.
+            page_iterator = paginator.paginate(Scope="AWS", PaginationConfig={"PageSize": self.max_items})
             name_to_arn_map = {}
 
             for page in page_iterator:

--- a/tests/translator/test_managed_policies_translator.py
+++ b/tests/translator/test_managed_policies_translator.py
@@ -32,4 +32,4 @@ def test_load():
     assert actual == expected
 
     iam.get_paginator.assert_called_once_with("list_policies")
-    paginator.paginate.assert_called_once_with(Scope="AWS")
+    paginator.paginate.assert_called_once_with(Scope="AWS", PaginationConfig={"PageSize": 1000})


### PR DESCRIPTION
SAM runs within a Lambda function and loads IAM Managed Policies once per
Lambda. Previous to this, SAM would call IAM 9 times which could cause
throttling by IAM. With this change, we update the MaxItems from the
default of 100 to the max (1000). In local testing, this has shown
a 0.6 second reduction in the latency in calling IAM.

*Issue #, if available:*
n/a

*Description of changes:*
See above

*Description of how you validated changes:*
I tested the updated Policy loader in a python interpreter validating the pagination works as expected.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
