### PR TITLE
fix: state machine input escaping

### DIFF
--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -439,7 +439,7 @@ class Api(EventSource):
                         # escapeJavaScript escapes single quotes, which is unnecessary and invalid
                         # in JSON, so have to unescape afterwards.
                         # See https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-template-reference
-                        "input": r'''$util.escapeJavaScript($input.json('$')).replaceAll("\\'","'")''',
+                        "input": r"""$util.escapeJavaScript($input.json('$')).replaceAll("\'","'")""",
                         "stateMachineArn": "${" + resource.logical_id + "}",
                     }
                 )

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -436,7 +436,10 @@ class Api(EventSource):
             "application/json": fnSub(
                 json.dumps(
                     {
-                        "input": "$util.escapeJavaScript($input.json('$'))",
+                        # escapeJavaScript escapes single quotes, which is unnecessary and invalid
+                        # in JSON, so have to unescape afterwards.
+                        # See https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-template-reference
+                        "input": r'''$util.escapeJavaScript($input.json('$')).replaceAll("\\'","'")''',
                         "stateMachineArn": "${" + resource.logical_id + "}",
                     }
                 )

--- a/tests/model/stepfunctions/test_api_event.py
+++ b/tests/model/stepfunctions/test_api_event.py
@@ -1,3 +1,5 @@
+import json
+
 from mock import Mock
 from unittest import TestCase
 
@@ -86,7 +88,9 @@ class ApiEventSource(TestCase):
             request_template,
             {
                 "application/json": {
-                    "Fn::Sub": '{"input": "$util.escapeJavaScript($input.json(\'$\'))", "stateMachineArn": "${MockStateMachine}"}'
+                    "Fn::Sub": r"""{"input": "$util.escapeJavaScript($input.json('$')).replaceAll(\"\\'\",\"'\")", "stateMachineArn": "${MockStateMachine}"}"""
                 }
             },
         )
+        request = json.loads(request_template["application/json"]["Fn::Sub"])
+        self.assertEqual(request["input"], r"""$util.escapeJavaScript($input.json('$')).replaceAll("\'","'")""")

--- a/tests/translator/output/aws-cn/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_auth_default_scopes.json
@@ -28,7 +28,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -71,7 +71,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -114,7 +114,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -157,7 +157,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -203,7 +203,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -249,7 +249,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -295,7 +295,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-cn/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_authorizer.json
@@ -82,7 +82,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -199,7 +199,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-cn/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_authorizer_maximum.json
@@ -162,7 +162,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -208,7 +208,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -252,7 +252,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -296,7 +296,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -340,7 +340,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-cn/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_resource_policy.json
@@ -65,7 +65,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -103,7 +103,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -141,7 +141,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-cn/state_machine_with_condition_and_events.json
+++ b/tests/translator/output/aws-cn/state_machine_with_condition_and_events.json
@@ -207,7 +207,7 @@
                                                     "httpMethod": "POST", 
                                                     "requestTemplates": {
                                                         "application/json": {
-                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                                         }
                                                     }, 
                                                     "credentials": {

--- a/tests/translator/output/aws-cn/state_machine_with_explicit_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_explicit_api.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-cn/state_machine_with_implicit_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_implicit_api.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-cn/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/aws-cn/state_machine_with_implicit_api_globals.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-cn/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/aws-cn/state_machine_with_permissions_boundary.json
@@ -191,7 +191,7 @@
                   "httpMethod": "POST", 
                   "requestTemplates": {
                     "application/json": {
-                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                     }
                   }, 
                   "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_auth_default_scopes.json
@@ -28,7 +28,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -71,7 +71,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -114,7 +114,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -157,7 +157,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -203,7 +203,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -249,7 +249,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -295,7 +295,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer.json
@@ -82,7 +82,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -311,7 +311,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_authorizer_maximum.json
@@ -374,7 +374,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -420,7 +420,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -464,7 +464,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -508,7 +508,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -552,7 +552,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_resource_policy.json
@@ -65,7 +65,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -103,7 +103,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -141,7 +141,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_condition_and_events.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_condition_and_events.json
@@ -207,7 +207,7 @@
                                                     "httpMethod": "POST", 
                                                     "requestTemplates": {
                                                         "application/json": {
-                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                                         }
                                                     }, 
                                                     "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_explicit_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_explicit_api.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_implicit_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_implicit_api.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_implicit_api_globals.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_permissions_boundary.json
@@ -191,7 +191,7 @@
                   "httpMethod": "POST", 
                   "requestTemplates": {
                     "application/json": {
-                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                     }
                   }, 
                   "credentials": {

--- a/tests/translator/output/state_machine_with_api_auth_default_scopes.json
+++ b/tests/translator/output/state_machine_with_api_auth_default_scopes.json
@@ -28,7 +28,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -71,7 +71,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -114,7 +114,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -157,7 +157,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -203,7 +203,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -249,7 +249,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -295,7 +295,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/state_machine_with_api_authorizer.json
+++ b/tests/translator/output/state_machine_with_api_authorizer.json
@@ -100,7 +100,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -303,7 +303,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/state_machine_with_api_authorizer_maximum.json
+++ b/tests/translator/output/state_machine_with_api_authorizer_maximum.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -218,7 +218,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -262,7 +262,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -306,7 +306,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -350,7 +350,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/state_machine_with_api_resource_policy.json
+++ b/tests/translator/output/state_machine_with_api_resource_policy.json
@@ -65,7 +65,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -103,7 +103,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {
@@ -141,7 +141,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${MyStateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${MyStateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/state_machine_with_condition_and_events.json
+++ b/tests/translator/output/state_machine_with_condition_and_events.json
@@ -207,7 +207,7 @@
                                                     "httpMethod": "POST", 
                                                     "requestTemplates": {
                                                         "application/json": {
-                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                                         }
                                                     }, 
                                                     "credentials": {

--- a/tests/translator/output/state_machine_with_explicit_api.json
+++ b/tests/translator/output/state_machine_with_explicit_api.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/state_machine_with_implicit_api.json
+++ b/tests/translator/output/state_machine_with_implicit_api.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/state_machine_with_implicit_api_globals.json
+++ b/tests/translator/output/state_machine_with_implicit_api_globals.json
@@ -172,7 +172,7 @@
                                     "httpMethod": "POST", 
                                     "requestTemplates": {
                                         "application/json": {
-                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                                            "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                                         }
                                     }, 
                                     "credentials": {

--- a/tests/translator/output/state_machine_with_permissions_boundary.json
+++ b/tests/translator/output/state_machine_with_permissions_boundary.json
@@ -191,7 +191,7 @@
                   "httpMethod": "POST", 
                   "requestTemplates": {
                     "application/json": {
-                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${StateMachine}\"}"
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$')).replaceAll(\\\"\\\\'\\\",\\\"'\\\")\", \"stateMachineArn\": \"${StateMachine}\"}"
                     }
                   }, 
                   "credentials": {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/serverless-application-model/issues/1895

*Description of changes:*

*Description of how you validated changes:*

Used this monstrosity to update the JSON outputs:

```bash
 find . -name \*.json | xargs -L 1 sed -i '' 's/$util.escapeJavaScript($input.json('"'"'$'"'"'))/$util.escapeJavaScript($input.json('"'"'$'"'"')).replaceAll(\\\\\\\"\\\\\\\\'"'"'\\\\\\\",\\\\\\\"'"'\\\\\\\\\\\\"'\")/g'
```

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
