### PR TITLE
fix: Shared Usage Plan scenarios for Resource Level Attribute Support

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -1,6 +1,5 @@
 import logging
 from collections import namedtuple
-from copy import deepcopy
 
 from six import string_types
 from samtranslator.model.intrinsics import ref, fnGetAtt, make_or_condition

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -78,21 +78,33 @@ class SharedApiUsagePlan(object):
         self.update_replace_policy = None
 
     def get_combined_resource_attributes(self, resource_attributes, conditions):
-        self.set_deletion_policy(resource_attributes.get("DeletionPolicy"))
-        self.set_update_replace_policy(resource_attributes.get("UpdateReplacePolicy"))
-        self.set_condition(resource_attributes.get("Condition"), conditions)
+        """
+        This method returns a dictionary which combines 'DeletionPolicy', 'UpdateReplacePolicy' and 'Condition'
+        values of API definitions that could be used in Shared Usage Plan resources.
 
-        combined_resource_attributes = deepcopy(resource_attributes)
+        Parameters
+        ----------
+        resource_attributes: Dict[str]
+            A dictionary of resource level attributes of the API resource
+        conditions: Dict[str]
+            Conditions section of the template
+        """
+        self._set_deletion_policy(resource_attributes.get("DeletionPolicy"))
+        self._set_update_replace_policy(resource_attributes.get("UpdateReplacePolicy"))
+        self._set_condition(resource_attributes.get("Condition"), conditions)
+
+        combined_resource_attributes = dict()
         if self.deletion_policy:
             combined_resource_attributes["DeletionPolicy"] = self.deletion_policy
         if self.update_replace_policy:
             combined_resource_attributes["UpdateReplacePolicy"] = self.update_replace_policy
+        # do not set Condition if any of the API resource does not have Condition in it
         if self.conditions and not self.any_api_without_condition:
             combined_resource_attributes["Condition"] = SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME
 
         return combined_resource_attributes
 
-    def set_deletion_policy(self, deletion_policy):
+    def _set_deletion_policy(self, deletion_policy):
         if deletion_policy:
             if self.deletion_policy:
                 # update only if new deletion policy is Retain
@@ -101,7 +113,7 @@ class SharedApiUsagePlan(object):
             else:
                 self.deletion_policy = deletion_policy
 
-    def set_update_replace_policy(self, update_replace_policy):
+    def _set_update_replace_policy(self, update_replace_policy):
         if update_replace_policy:
             if self.update_replace_policy:
                 # if new value is Retain or
@@ -113,7 +125,7 @@ class SharedApiUsagePlan(object):
             else:
                 self.update_replace_policy = update_replace_policy
 
-    def set_condition(self, condition, template_conditions):
+    def _set_condition(self, condition, template_conditions):
         # if there are any API without condition, then skip
         if self.any_api_without_condition:
             return

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -1,7 +1,9 @@
 import logging
 from collections import namedtuple
+from copy import deepcopy
+
 from six import string_types
-from samtranslator.model.intrinsics import ref, fnGetAtt
+from samtranslator.model.intrinsics import ref, fnGetAtt, make_or_condition
 from samtranslator.model.apigateway import (
     ApiGatewayDeployment,
     ApiGatewayRestApi,
@@ -15,7 +17,7 @@ from samtranslator.model.apigateway import (
     ApiGatewayApiKey,
 )
 from samtranslator.model.route53 import Route53RecordSetGroup
-from samtranslator.model.exceptions import InvalidResourceException
+from samtranslator.model.exceptions import InvalidResourceException, InvalidTemplateException
 from samtranslator.model.s3_utils.uri_parser import parse_s3_uri
 from samtranslator.region_configuration import RegionConfiguration
 from samtranslator.swagger.swagger import SwaggerEditor
@@ -61,11 +63,79 @@ class SharedApiUsagePlan(object):
     so that these information can be used in the shared usage plan
     """
 
+    SHARED_USAGE_PLAN_CONDITION_NAME = "SharedUsagePlanCondition"
+
     def __init__(self):
         self.usage_plan_shared = False
         self.stage_keys_shared = list()
         self.api_stages_shared = list()
         self.depends_on_shared = list()
+
+        # shared resource level attributes
+        self.conditions = set()
+        self.any_api_without_condition = False
+        self.deletion_policy = None
+        self.update_replace_policy = None
+
+    def get_combined_resource_attributes(self, resource_attributes, conditions):
+        self.set_deletion_policy(resource_attributes.get("DeletionPolicy"))
+        self.set_update_replace_policy(resource_attributes.get("UpdateReplacePolicy"))
+        self.set_condition(resource_attributes.get("Condition"), conditions)
+
+        combined_resource_attributes = deepcopy(resource_attributes)
+        if self.deletion_policy:
+            combined_resource_attributes["DeletionPolicy"] = self.deletion_policy
+        if self.update_replace_policy:
+            combined_resource_attributes["UpdateReplacePolicy"] = self.update_replace_policy
+        if self.conditions and not self.any_api_without_condition:
+            combined_resource_attributes["Condition"] = SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME
+
+        return combined_resource_attributes
+
+    def set_deletion_policy(self, deletion_policy):
+        if deletion_policy:
+            if self.deletion_policy:
+                # update only if new deletion policy is Retain
+                if deletion_policy == "Retain":
+                    self.deletion_policy = deletion_policy
+            else:
+                self.deletion_policy = deletion_policy
+
+    def set_update_replace_policy(self, update_replace_policy):
+        if update_replace_policy:
+            if self.update_replace_policy:
+                # if new value is Retain or
+                # new value is retain and current value is Delete then update its value
+                if (update_replace_policy == "Retain") or (
+                    update_replace_policy == "Snapshot" and self.update_replace_policy == "Delete"
+                ):
+                    self.update_replace_policy = update_replace_policy
+            else:
+                self.update_replace_policy = update_replace_policy
+
+    def set_condition(self, condition, template_conditions):
+        # if there are any API without condition, then skip
+        if self.any_api_without_condition:
+            return
+
+        if condition and condition not in self.conditions:
+
+            if template_conditions is None:
+                raise InvalidTemplateException(
+                    "Can't have condition without having 'Conditions' section in the template"
+                )
+
+            if self.conditions:
+                self.conditions.add(condition)
+                or_condition = make_or_condition(self.conditions)
+                template_conditions[SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME] = or_condition
+            else:
+                self.conditions.add(condition)
+                template_conditions[SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME] = condition
+        elif condition is None:
+            self.any_api_without_condition = True
+            if template_conditions and SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME in template_conditions:
+                del template_conditions[SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME]
 
 
 class ApiGenerator(object):
@@ -81,6 +151,7 @@ class ApiGenerator(object):
         name,
         stage_name,
         shared_api_usage_plan,
+        template_conditions,
         tags=None,
         endpoint_configuration=None,
         method_settings=None,
@@ -147,6 +218,7 @@ class ApiGenerator(object):
         self.domain = domain
         self.description = description
         self.shared_api_usage_plan = shared_api_usage_plan
+        self.template_conditions = template_conditions
 
     def _construct_rest_api(self):
         """Constructs and returns the ApiGateway RestApi.
@@ -654,7 +726,9 @@ class ApiGenerator(object):
             usage_plan = ApiGatewayUsagePlan(
                 logical_id=usage_plan_logical_id,
                 depends_on=self.shared_api_usage_plan.depends_on_shared,
-                attributes=self.passthrough_resource_attributes,
+                attributes=self.shared_api_usage_plan.get_combined_resource_attributes(
+                    self.passthrough_resource_attributes, self.template_conditions
+                ),
             )
             api_stage = dict()
             api_stage["ApiId"] = ref(self.logical_id)
@@ -692,7 +766,9 @@ class ApiGenerator(object):
             api_key = ApiGatewayApiKey(
                 logical_id=api_key_logical_id,
                 depends_on=[usage_plan_logical_id],
-                attributes=self.passthrough_resource_attributes,
+                attributes=self.shared_api_usage_plan.get_combined_resource_attributes(
+                    self.passthrough_resource_attributes, self.template_conditions
+                ),
             )
             api_key.Enabled = True
             stage_key = dict()
@@ -710,7 +786,6 @@ class ApiGenerator(object):
                 depends_on=[usage_plan_logical_id],
                 attributes=self.passthrough_resource_attributes,
             )
-            # api_key = ApiGatewayApiKey(logical_id=api_key_logical_id, depends_on=[usage_plan_logical_id])
             api_key.Enabled = True
             stage_keys = list()
             stage_key = dict()
@@ -730,17 +805,20 @@ class ApiGenerator(object):
         if create_usage_plan == "SHARED":
             # create a mapping between api key and the usage plan
             usage_plan_key_logical_id = "ServerlessUsagePlanKey"
+            resource_attributes = self.shared_api_usage_plan.get_combined_resource_attributes(
+                self.passthrough_resource_attributes, self.template_conditions
+            )
         # for create_usage_plan = "PER_API"
         else:
             # create a mapping between api key and the usage plan
             usage_plan_key_logical_id = self.logical_id + "UsagePlanKey"
+            resource_attributes = self.passthrough_resource_attributes
 
         usage_plan_key = ApiGatewayUsagePlanKey(
             logical_id=usage_plan_key_logical_id,
             depends_on=[api_key.logical_id],
-            attributes=self.passthrough_resource_attributes,
+            attributes=resource_attributes,
         )
-        # usage_plan_key = ApiGatewayUsagePlanKey(logical_id=usage_plan_key_logical_id, depends_on=[api_key.logical_id])
         usage_plan_key.KeyId = ref(api_key.logical_id)
         usage_plan_key.KeyType = "API_KEY"
         usage_plan_key.UsagePlanId = ref(usage_plan_logical_id)

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -960,9 +960,6 @@ class Cognito(PushEventSource):
         resources.append(lambda_permission)
 
         self._inject_lambda_config(function, userpool)
-        userpool_resource = CognitoUserPool.from_dict(userpool_id, userpool)
-        for attribute, value in function.get_passthrough_resource_attributes().items():
-            userpool_resource.set_resource_attribute(attribute, value)
         resources.append(CognitoUserPool.from_dict(userpool_id, userpool))
         return resources
 

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -862,6 +862,7 @@ class SamApi(SamResourceMacro):
         self.Auth = intrinsics_resolver.resolve_parameter_refs(self.Auth)
         redeploy_restapi_parameters = kwargs.get("redeploy_restapi_parameters")
         shared_api_usage_plan = kwargs.get("shared_api_usage_plan")
+        template_conditions = kwargs.get("conditions")
 
         api_generator = ApiGenerator(
             self.logical_id,
@@ -874,6 +875,7 @@ class SamApi(SamResourceMacro):
             self.Name,
             self.StageName,
             shared_api_usage_plan,
+            template_conditions,
             tags=self.Tags,
             endpoint_configuration=self.EndpointConfiguration,
             method_settings=self.MethodSettings,

--- a/tests/translator/input/api_with_usageplans_shared_attributes_three.yaml
+++ b/tests/translator/input/api_with_usageplans_shared_attributes_three.yaml
@@ -1,0 +1,102 @@
+Globals:
+  Api:
+    Auth:
+      ApiKeyRequired: true
+      UsagePlan:
+        CreateUsagePlan: SHARED
+
+Conditions:
+  C1:
+    Fn::Equals:
+      - test
+      - test
+  C2:
+    Fn::Equals:
+      - test
+      - test  
+
+Resources:
+  MyApiOne:
+    Type: AWS::Serverless::Api
+    Condition: C1
+    UpdateReplacePolicy: Delete
+    Properties:
+      StageName: Prod
+
+  MyApiTwo:
+    Type: AWS::Serverless::Api
+    Condition: C2
+    UpdateReplacePolicy: Snapshot
+    Properties:
+      StageName: Prod
+
+  MyApiThree:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+
+  MyFunctionOne:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      InlineCode: |
+        exports.handler = async (event) => {
+          return {
+          statusCode: 200,
+          body: JSON.stringify(event),
+          headers: {}
+          }
+        }
+      Events:
+        ApiKey:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: MyApiOne
+            Method: get
+            Path: /path/one
+
+  MyFunctionTwo:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      InlineCode: |
+        exports.handler = async (event) => {
+          return {
+          statusCode: 200,
+          body: JSON.stringify(event),
+          headers: {}
+          }
+        }
+      Events:
+        ApiKey:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: MyApiTwo
+            Method: get
+            Path: /path/two
+
+  MyFunctionThree:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      InlineCode: |
+        exports.handler = async (event) => {
+          return {
+          statusCode: 200,
+          body: JSON.stringify(event),
+          headers: {}
+          }
+        }
+      Events:
+        ApiKey:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: MyApiThree
+            Method: get
+            Path: /path/three

--- a/tests/translator/input/api_with_usageplans_shared_attributes_two.yaml
+++ b/tests/translator/input/api_with_usageplans_shared_attributes_two.yaml
@@ -1,0 +1,75 @@
+Globals:
+  Api:
+    Auth:
+      ApiKeyRequired: true
+      UsagePlan:
+        CreateUsagePlan: SHARED
+
+Conditions:
+  C1:
+    Fn::Equals:
+      - test
+      - test
+  C2:
+    Fn::Equals:
+      - test
+      - test  
+
+Resources:
+  MyApiOne:
+    Type: AWS::Serverless::Api
+    DeletionPolicy: Delete
+    Condition: C1
+    Properties:
+      StageName: Prod
+
+  MyApiTwo:
+    Type: AWS::Serverless::Api
+    DeletionPolicy: Retain
+    Condition: C2
+    Properties:
+      StageName: Prod
+
+  MyFunctionOne:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      InlineCode: |
+        exports.handler = async (event) => {
+          return {
+          statusCode: 200,
+          body: JSON.stringify(event),
+          headers: {}
+          }
+        }
+      Events:
+        ApiKey:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: MyApiOne
+            Method: get
+            Path: /path/one
+
+  MyFunctionTwo:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      InlineCode: |
+        exports.handler = async (event) => {
+          return {
+          statusCode: 200,
+          body: JSON.stringify(event),
+          headers: {}
+          }
+        }
+      Events:
+        ApiKey:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: MyApiTwo
+            Method: get
+            Path: /path/two

--- a/tests/translator/output/api_with_usageplans_shared_attributes_three.json
+++ b/tests/translator/output/api_with_usageplans_shared_attributes_three.json
@@ -275,12 +275,12 @@
         }
       }
     },
-    "MyApiOneDeployment593a0a0946": {
+    "MyApiOneDeployment46fb22a429": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C1",
       "UpdateReplacePolicy": "Delete",
       "Properties": {
-        "Description": "RestApi deployment id: 593a0a094683480e951e7daed89e6f2ea946b7c4",
+        "Description": "RestApi deployment id: 46fb22a42926db6f64e09966936d074ec6bb9392",
         "RestApiId": {
           "Ref": "MyApiOne"
         },
@@ -293,7 +293,7 @@
       "UpdateReplacePolicy": "Delete",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeployment593a0a0946"
+          "Ref": "MyApiOneDeployment46fb22a429"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -432,12 +432,12 @@
         }
       }
     },
-    "MyApiTwoDeployment0c6c2a5588": {
+    "MyApiTwoDeploymente9d97923b9": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C2",
       "UpdateReplacePolicy": "Snapshot",
       "Properties": {
-        "Description": "RestApi deployment id: 0c6c2a5588069f784aaa1c010c10055bdb5fd7f7",
+        "Description": "RestApi deployment id: e9d97923b94d0801cd85a8970b3c3f84aa274003",
         "RestApiId": {
           "Ref": "MyApiTwo"
         },
@@ -450,7 +450,7 @@
       "UpdateReplacePolicy": "Snapshot",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment0c6c2a5588"
+          "Ref": "MyApiTwoDeploymente9d97923b9"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -498,10 +498,10 @@
         }
       }
     },
-    "MyApiThreeDeployment8af42ea6fa": {
+    "MyApiThreeDeployment1d9cff47dc": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
-        "Description": "RestApi deployment id: 8af42ea6fa6c0dc81aa34a29baae4eb4670a7b8a",
+        "Description": "RestApi deployment id: 1d9cff47dc9b822750c668c73b4534022483de6d",
         "RestApiId": {
           "Ref": "MyApiThree"
         },
@@ -512,7 +512,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiThreeDeployment8af42ea6fa"
+          "Ref": "MyApiThreeDeployment1d9cff47dc"
         },
         "RestApiId": {
           "Ref": "MyApiThree"

--- a/tests/translator/output/api_with_usageplans_shared_attributes_three.json
+++ b/tests/translator/output/api_with_usageplans_shared_attributes_three.json
@@ -1,0 +1,524 @@
+{
+  "Conditions": {
+    "C1": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "C2": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    }
+  },
+  "Resources": {
+    "MyFunctionOne": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionOneRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionOne"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/one",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiOne"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionTwo": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionTwoRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionTwo"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/two",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiTwo"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionThree": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionThreeRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionThreeRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionThreeApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionThree"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/three",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiThree"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyApiOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionOne.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        }
+      }
+    },
+    "MyApiOneDeployment593a0a0946": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "Description": "RestApi deployment id: 593a0a094683480e951e7daed89e6f2ea946b7c4",
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiOneDeployment593a0a0946"
+        },
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessUsagePlan": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "DependsOn": [
+        "MyApiOne",
+        "MyApiTwo",
+        "MyApiThree"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "MyApiOne"
+            },
+            "Stage": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "Stage": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiThree"
+            },
+            "Stage": {
+              "Ref": "MyApiThreeProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessApiKey": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "DependsOn": [
+        "ServerlessUsagePlan"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Enabled": true,
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "MyApiOne"
+            },
+            "StageName": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "StageName": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiThree"
+            },
+            "StageName": {
+              "Ref": "MyApiThreeProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessUsagePlanKey": {
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+      "DependsOn": [
+        "ServerlessApiKey"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "KeyId": {
+          "Ref": "ServerlessApiKey"
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "ServerlessUsagePlan"
+        }
+      }
+    },
+    "MyApiTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/two": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionTwo.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        }
+      }
+    },
+    "MyApiTwoDeployment0c6c2a5588": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Description": "RestApi deployment id: 0c6c2a5588069f784aaa1c010c10055bdb5fd7f7",
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiTwoDeployment0c6c2a5588"
+        },
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyApiThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/three": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionThree.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        }
+      }
+    },
+    "MyApiThreeDeployment8af42ea6fa": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 8af42ea6fa6c0dc81aa34a29baae4eb4670a7b8a",
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiThreeDeployment8af42ea6fa"
+        },
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "StageName": "Prod"
+      }
+    }
+  }
+}

--- a/tests/translator/output/api_with_usageplans_shared_attributes_two.json
+++ b/tests/translator/output/api_with_usageplans_shared_attributes_two.json
@@ -212,12 +212,12 @@
         }
       }
     },
-    "MyApiOneDeployment593a0a0946": {
+    "MyApiOneDeployment46fb22a429": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C1",
       "DeletionPolicy": "Delete",
       "Properties": {
-        "Description": "RestApi deployment id: 593a0a094683480e951e7daed89e6f2ea946b7c4",
+        "Description": "RestApi deployment id: 46fb22a42926db6f64e09966936d074ec6bb9392",
         "RestApiId": {
           "Ref": "MyApiOne"
         },
@@ -230,7 +230,7 @@
       "DeletionPolicy": "Delete",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeployment593a0a0946"
+          "Ref": "MyApiOneDeployment46fb22a429"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -355,12 +355,12 @@
         }
       }
     },
-    "MyApiTwoDeployment0c6c2a5588": {
+    "MyApiTwoDeploymente9d97923b9": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C2",
       "DeletionPolicy": "Retain",
       "Properties": {
-        "Description": "RestApi deployment id: 0c6c2a5588069f784aaa1c010c10055bdb5fd7f7",
+        "Description": "RestApi deployment id: e9d97923b94d0801cd85a8970b3c3f84aa274003",
         "RestApiId": {
           "Ref": "MyApiTwo"
         },
@@ -373,7 +373,7 @@
       "DeletionPolicy": "Retain",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment0c6c2a5588"
+          "Ref": "MyApiTwoDeploymente9d97923b9"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"

--- a/tests/translator/output/api_with_usageplans_shared_attributes_two.json
+++ b/tests/translator/output/api_with_usageplans_shared_attributes_two.json
@@ -1,0 +1,385 @@
+{
+  "Conditions": {
+    "C1": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "C2": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "SharedUsagePlanCondition": {
+      "Fn::Or": [
+        {
+          "Condition": "C2"
+        },
+        {
+          "Condition": "C1"
+        }
+      ]
+    }
+  },
+  "Resources": {
+    "MyFunctionOne": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionOneRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionOne"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/one",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiOne"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionTwo": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionTwoRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionTwo"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/two",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiTwo"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyApiOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "DeletionPolicy": "Delete",
+      "Condition": "C1",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionOne.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        }
+      }
+    },
+    "MyApiOneDeployment593a0a0946": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C1",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "RestApi deployment id: 593a0a094683480e951e7daed89e6f2ea946b7c4",
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C1",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiOneDeployment593a0a0946"
+        },
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessUsagePlan": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "DependsOn": [
+        "MyApiOne",
+        "MyApiTwo"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "MyApiOne"
+            },
+            "Stage": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "Stage": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessApiKey": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "DependsOn": [
+        "ServerlessUsagePlan"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Enabled": true,
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "MyApiOne"
+            },
+            "StageName": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "StageName": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessUsagePlanKey": {
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+      "DependsOn": [
+        "ServerlessApiKey"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "KeyId": {
+          "Ref": "ServerlessApiKey"
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "ServerlessUsagePlan"
+        }
+      }
+    },
+    "MyApiTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "DeletionPolicy": "Retain",
+      "Condition": "C2",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/two": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionTwo.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        }
+      }
+    },
+    "MyApiTwoDeployment0c6c2a5588": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C2",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "RestApi deployment id: 0c6c2a5588069f784aaa1c010c10055bdb5fd7f7",
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C2",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiTwoDeployment0c6c2a5588"
+        },
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Prod"
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_usageplans_shared_attributes_three.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans_shared_attributes_three.json
@@ -283,12 +283,12 @@
         }
       }
     },
-    "MyApiOneDeploymented8916593e": {
+    "MyApiOneDeployment7997029260": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C1",
       "UpdateReplacePolicy": "Delete",
       "Properties": {
-        "Description": "RestApi deployment id: ed8916593eee3d5996ff3d7912710b8fac532e60",
+        "Description": "RestApi deployment id: 79970292604071da8105ffd8503f82af32b30550",
         "RestApiId": {
           "Ref": "MyApiOne"
         },
@@ -301,7 +301,7 @@
       "UpdateReplacePolicy": "Delete",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeploymented8916593e"
+          "Ref": "MyApiOneDeployment7997029260"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -448,12 +448,12 @@
         }
       }
     },
-    "MyApiTwoDeployment17dd9ed926": {
+    "MyApiTwoDeployment03730b64c4": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C2",
       "UpdateReplacePolicy": "Snapshot",
       "Properties": {
-        "Description": "RestApi deployment id: 17dd9ed92642dde88467fc566c4a64befb1d3a2d",
+        "Description": "RestApi deployment id: 03730b64c486cc490deefb3b8225244b0fe85d34",
         "RestApiId": {
           "Ref": "MyApiTwo"
         },
@@ -466,7 +466,7 @@
       "UpdateReplacePolicy": "Snapshot",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment17dd9ed926"
+          "Ref": "MyApiTwoDeployment03730b64c4"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -522,10 +522,10 @@
         }
       }
     },
-    "MyApiThreeDeployment0ac39d26ff": {
+    "MyApiThreeDeploymentfa9f73f027": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
-        "Description": "RestApi deployment id: 0ac39d26ffc79dae8849daf66e76214028279104",
+        "Description": "RestApi deployment id: fa9f73f0272017527c24cc93cc4440dd4476b9f4",
         "RestApiId": {
           "Ref": "MyApiThree"
         },
@@ -536,7 +536,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiThreeDeployment0ac39d26ff"
+          "Ref": "MyApiThreeDeploymentfa9f73f027"
         },
         "RestApiId": {
           "Ref": "MyApiThree"

--- a/tests/translator/output/aws-cn/api_with_usageplans_shared_attributes_three.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans_shared_attributes_three.json
@@ -1,0 +1,548 @@
+{
+  "Conditions": {
+    "C1": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "C2": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    }
+  },
+  "Resources": {
+    "MyFunctionOne": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionOneRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionOne"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/one",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiOne"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionTwo": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionTwoRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionTwo"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/two",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiTwo"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionThree": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionThreeRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionThreeRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionThreeApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionThree"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/three",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiThree"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyApiOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionOne.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiOneDeploymented8916593e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "Description": "RestApi deployment id: ed8916593eee3d5996ff3d7912710b8fac532e60",
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiOneDeploymented8916593e"
+        },
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessUsagePlan": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "DependsOn": [
+        "MyApiOne",
+        "MyApiTwo",
+        "MyApiThree"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "MyApiOne"
+            },
+            "Stage": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "Stage": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiThree"
+            },
+            "Stage": {
+              "Ref": "MyApiThreeProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessApiKey": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "DependsOn": [
+        "ServerlessUsagePlan"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Enabled": true,
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "MyApiOne"
+            },
+            "StageName": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "StageName": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiThree"
+            },
+            "StageName": {
+              "Ref": "MyApiThreeProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessUsagePlanKey": {
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+      "DependsOn": [
+        "ServerlessApiKey"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "KeyId": {
+          "Ref": "ServerlessApiKey"
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "ServerlessUsagePlan"
+        }
+      }
+    },
+    "MyApiTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/two": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionTwo.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiTwoDeployment17dd9ed926": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Description": "RestApi deployment id: 17dd9ed92642dde88467fc566c4a64befb1d3a2d",
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiTwoDeployment17dd9ed926"
+        },
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyApiThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/three": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionThree.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiThreeDeployment0ac39d26ff": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 0ac39d26ffc79dae8849daf66e76214028279104",
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiThreeDeployment0ac39d26ff"
+        },
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "StageName": "Prod"
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_usageplans_shared_attributes_two.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans_shared_attributes_two.json
@@ -220,12 +220,12 @@
         }
       }
     },
-    "MyApiOneDeploymented8916593e": {
+    "MyApiOneDeployment7997029260": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C1",
       "DeletionPolicy": "Delete",
       "Properties": {
-        "Description": "RestApi deployment id: ed8916593eee3d5996ff3d7912710b8fac532e60",
+        "Description": "RestApi deployment id: 79970292604071da8105ffd8503f82af32b30550",
         "RestApiId": {
           "Ref": "MyApiOne"
         },
@@ -238,7 +238,7 @@
       "DeletionPolicy": "Delete",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeploymented8916593e"
+          "Ref": "MyApiOneDeployment7997029260"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -371,12 +371,12 @@
         }
       }
     },
-    "MyApiTwoDeployment17dd9ed926": {
+    "MyApiTwoDeployment03730b64c4": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C2",
       "DeletionPolicy": "Retain",
       "Properties": {
-        "Description": "RestApi deployment id: 17dd9ed92642dde88467fc566c4a64befb1d3a2d",
+        "Description": "RestApi deployment id: 03730b64c486cc490deefb3b8225244b0fe85d34",
         "RestApiId": {
           "Ref": "MyApiTwo"
         },
@@ -389,7 +389,7 @@
       "DeletionPolicy": "Retain",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment17dd9ed926"
+          "Ref": "MyApiTwoDeployment03730b64c4"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"

--- a/tests/translator/output/aws-cn/api_with_usageplans_shared_attributes_two.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans_shared_attributes_two.json
@@ -1,0 +1,401 @@
+{
+  "Conditions": {
+    "C1": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "C2": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "SharedUsagePlanCondition": {
+      "Fn::Or": [
+        {
+          "Condition": "C1"
+        },
+        {
+          "Condition": "C2"
+        }
+      ]
+    }
+  },
+  "Resources": {
+    "MyFunctionOne": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionOneRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionOne"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/one",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiOne"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionTwo": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionTwoRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionTwo"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/two",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiTwo"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyApiOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "DeletionPolicy": "Delete",
+      "Condition": "C1",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionOne.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiOneDeploymented8916593e": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C1",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "RestApi deployment id: ed8916593eee3d5996ff3d7912710b8fac532e60",
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C1",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiOneDeploymented8916593e"
+        },
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessUsagePlan": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "DependsOn": [
+        "MyApiOne",
+        "MyApiTwo"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "MyApiOne"
+            },
+            "Stage": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "Stage": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessApiKey": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "DependsOn": [
+        "ServerlessUsagePlan"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Enabled": true,
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "MyApiOne"
+            },
+            "StageName": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "StageName": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessUsagePlanKey": {
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+      "DependsOn": [
+        "ServerlessApiKey"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "KeyId": {
+          "Ref": "ServerlessApiKey"
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "ServerlessUsagePlan"
+        }
+      }
+    },
+    "MyApiTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "DeletionPolicy": "Retain",
+      "Condition": "C2",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/two": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionTwo.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiTwoDeployment17dd9ed926": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C2",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "RestApi deployment id: 17dd9ed92642dde88467fc566c4a64befb1d3a2d",
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C2",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiTwoDeployment17dd9ed926"
+        },
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Prod"
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_with_usageplans_shared_attributes_three.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans_shared_attributes_three.json
@@ -1,0 +1,548 @@
+{
+  "Conditions": {
+    "C1": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "C2": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    }
+  },
+  "Resources": {
+    "MyFunctionOne": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionOneRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionOne"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/one",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiOne"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionTwo": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionTwoRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionTwo"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/two",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiTwo"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionThree": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionThreeRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionThreeRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionThreeApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionThree"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/three",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiThree"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyApiOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionOne.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiOneDeploymentb12c8b5b0a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "Description": "RestApi deployment id: b12c8b5b0aed50622a06dd52b372f8213a63b39b",
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C1",
+      "UpdateReplacePolicy": "Delete",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiOneDeploymentb12c8b5b0a"
+        },
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessUsagePlan": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "DependsOn": [
+        "MyApiOne",
+        "MyApiTwo",
+        "MyApiThree"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "MyApiOne"
+            },
+            "Stage": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "Stage": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiThree"
+            },
+            "Stage": {
+              "Ref": "MyApiThreeProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessApiKey": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "DependsOn": [
+        "ServerlessUsagePlan"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Enabled": true,
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "MyApiOne"
+            },
+            "StageName": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "StageName": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiThree"
+            },
+            "StageName": {
+              "Ref": "MyApiThreeProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessUsagePlanKey": {
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+      "DependsOn": [
+        "ServerlessApiKey"
+      ],
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "KeyId": {
+          "Ref": "ServerlessApiKey"
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "ServerlessUsagePlan"
+        }
+      }
+    },
+    "MyApiTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/two": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionTwo.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiTwoDeployment15a3902b45": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "Description": "RestApi deployment id: 15a3902b458d0a1a4f8803252344e76b43375bbb",
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C2",
+      "UpdateReplacePolicy": "Snapshot",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiTwoDeployment15a3902b45"
+        },
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyApiThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/three": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionThree.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiThreeDeploymentac8c00f0e1": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: ac8c00f0e1e81ee603d7b7bd216d64a1cd4f93c4",
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiThreeDeploymentac8c00f0e1"
+        },
+        "RestApiId": {
+          "Ref": "MyApiThree"
+        },
+        "StageName": "Prod"
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_with_usageplans_shared_attributes_three.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans_shared_attributes_three.json
@@ -283,12 +283,12 @@
         }
       }
     },
-    "MyApiOneDeploymentb12c8b5b0a": {
+    "MyApiOneDeploymentdccbc5fda1": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C1",
       "UpdateReplacePolicy": "Delete",
       "Properties": {
-        "Description": "RestApi deployment id: b12c8b5b0aed50622a06dd52b372f8213a63b39b",
+        "Description": "RestApi deployment id: dccbc5fda163e1abe712073ffacdcc47776a5a09",
         "RestApiId": {
           "Ref": "MyApiOne"
         },
@@ -301,7 +301,7 @@
       "UpdateReplacePolicy": "Delete",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeploymentb12c8b5b0a"
+          "Ref": "MyApiOneDeploymentdccbc5fda1"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -448,12 +448,12 @@
         }
       }
     },
-    "MyApiTwoDeployment15a3902b45": {
+    "MyApiTwoDeployment0e45b81469": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C2",
       "UpdateReplacePolicy": "Snapshot",
       "Properties": {
-        "Description": "RestApi deployment id: 15a3902b458d0a1a4f8803252344e76b43375bbb",
+        "Description": "RestApi deployment id: 0e45b814691166a59217a088512ee30710a12369",
         "RestApiId": {
           "Ref": "MyApiTwo"
         },
@@ -466,7 +466,7 @@
       "UpdateReplacePolicy": "Snapshot",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment15a3902b45"
+          "Ref": "MyApiTwoDeployment0e45b81469"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"
@@ -522,10 +522,10 @@
         }
       }
     },
-    "MyApiThreeDeploymentac8c00f0e1": {
+    "MyApiThreeDeployment5206882d23": {
       "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
-        "Description": "RestApi deployment id: ac8c00f0e1e81ee603d7b7bd216d64a1cd4f93c4",
+        "Description": "RestApi deployment id: 5206882d23d2cf7913f0fffea98644f959b433f2",
         "RestApiId": {
           "Ref": "MyApiThree"
         },
@@ -536,7 +536,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiThreeDeploymentac8c00f0e1"
+          "Ref": "MyApiThreeDeployment5206882d23"
         },
         "RestApiId": {
           "Ref": "MyApiThree"

--- a/tests/translator/output/aws-us-gov/api_with_usageplans_shared_attributes_two.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans_shared_attributes_two.json
@@ -1,0 +1,401 @@
+{
+  "Conditions": {
+    "C1": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "C2": {
+      "Fn::Equals": [
+        "test",
+        "test"
+      ]
+    },
+    "SharedUsagePlanCondition": {
+      "Fn::Or": [
+        {
+          "Condition": "C1"
+        },
+        {
+          "Condition": "C2"
+        }
+      ]
+    }
+  },
+  "Resources": {
+    "MyFunctionOne": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionOneRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionOneApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionOne"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/one",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiOne"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyFunctionTwo": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event) => {\n  return {\n  statusCode: 200,\n  body: JSON.stringify(event),\n  headers: {}\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionTwoRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyFunctionTwoApiKeyPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunctionTwo"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/path/two",
+            {
+              "__ApiId__": {
+                "Ref": "MyApiTwo"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyApiOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "DeletionPolicy": "Delete",
+      "Condition": "C1",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/one": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionOne.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiOneDeploymentb12c8b5b0a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C1",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "RestApi deployment id: b12c8b5b0aed50622a06dd52b372f8213a63b39b",
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C1",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiOneDeploymentb12c8b5b0a"
+        },
+        "RestApiId": {
+          "Ref": "MyApiOne"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "ServerlessUsagePlan": {
+      "Type": "AWS::ApiGateway::UsagePlan",
+      "DependsOn": [
+        "MyApiOne",
+        "MyApiTwo"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "MyApiOne"
+            },
+            "Stage": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "ApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "Stage": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessApiKey": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "DependsOn": [
+        "ServerlessUsagePlan"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Enabled": true,
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "MyApiOne"
+            },
+            "StageName": {
+              "Ref": "MyApiOneProdStage"
+            }
+          },
+          {
+            "RestApiId": {
+              "Ref": "MyApiTwo"
+            },
+            "StageName": {
+              "Ref": "MyApiTwoProdStage"
+            }
+          }
+        ]
+      }
+    },
+    "ServerlessUsagePlanKey": {
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+      "DependsOn": [
+        "ServerlessApiKey"
+      ],
+      "Condition": "SharedUsagePlanCondition",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "KeyId": {
+          "Ref": "ServerlessApiKey"
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "ServerlessUsagePlan"
+        }
+      }
+    },
+    "MyApiTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "DeletionPolicy": "Retain",
+      "Condition": "C2",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/path/two": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionTwo.Arn}/invocations"
+                  }
+                },
+                "responses": {},
+                "security": [
+                  {
+                    "api_key": []
+                  }
+                ]
+              }
+            }
+          },
+          "securityDefinitions": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "x-api-key",
+              "in": "header"
+            }
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "MyApiTwoDeployment15a3902b45": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Condition": "C2",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "RestApi deployment id: 15a3902b458d0a1a4f8803252344e76b43375bbb",
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApiTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Condition": "C2",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiTwoDeployment15a3902b45"
+        },
+        "RestApiId": {
+          "Ref": "MyApiTwo"
+        },
+        "StageName": "Prod"
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_with_usageplans_shared_attributes_two.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans_shared_attributes_two.json
@@ -220,12 +220,12 @@
         }
       }
     },
-    "MyApiOneDeploymentb12c8b5b0a": {
+    "MyApiOneDeploymentdccbc5fda1": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C1",
       "DeletionPolicy": "Delete",
       "Properties": {
-        "Description": "RestApi deployment id: b12c8b5b0aed50622a06dd52b372f8213a63b39b",
+        "Description": "RestApi deployment id: dccbc5fda163e1abe712073ffacdcc47776a5a09",
         "RestApiId": {
           "Ref": "MyApiOne"
         },
@@ -238,7 +238,7 @@
       "DeletionPolicy": "Delete",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiOneDeploymentb12c8b5b0a"
+          "Ref": "MyApiOneDeploymentdccbc5fda1"
         },
         "RestApiId": {
           "Ref": "MyApiOne"
@@ -371,12 +371,12 @@
         }
       }
     },
-    "MyApiTwoDeployment15a3902b45": {
+    "MyApiTwoDeployment0e45b81469": {
       "Type": "AWS::ApiGateway::Deployment",
       "Condition": "C2",
       "DeletionPolicy": "Retain",
       "Properties": {
-        "Description": "RestApi deployment id: 15a3902b458d0a1a4f8803252344e76b43375bbb",
+        "Description": "RestApi deployment id: 0e45b814691166a59217a088512ee30710a12369",
         "RestApiId": {
           "Ref": "MyApiTwo"
         },
@@ -389,7 +389,7 @@
       "DeletionPolicy": "Retain",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiTwoDeployment15a3902b45"
+          "Ref": "MyApiTwoDeployment0e45b81469"
         },
         "RestApiId": {
           "Ref": "MyApiTwo"

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -400,6 +400,8 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "function_with_event_dest_basic",
                 "function_with_event_dest_conditional",
                 "api_with_usageplans",
+                "api_with_usageplans_shared_attributes_two",
+                "api_with_usageplans_shared_attributes_three",
                 "api_with_usageplans_intrinsics",
                 "state_machine_with_inline_definition",
                 "state_machine_with_tags",

--- a/tests/unit/model/api/TestSharedApiUsagePlan.py
+++ b/tests/unit/model/api/TestSharedApiUsagePlan.py
@@ -7,7 +7,6 @@ from samtranslator.model.exceptions import InvalidTemplateException
 
 
 class TestSharedApiUsagePlan(TestCase):
-
     def setUp(self):
         self.shared_usage_plan = SharedApiUsagePlan()
 
@@ -19,7 +18,7 @@ class TestSharedApiUsagePlan(TestCase):
                 "DeletionPolicy": "Delete",
                 "UpdateReplacePolicy": "Delete",
             },
-            conditions
+            conditions,
         )
 
         self.assertEqual(
@@ -28,25 +27,26 @@ class TestSharedApiUsagePlan(TestCase):
                 "DeletionPolicy": "Delete",
                 "UpdateReplacePolicy": "Delete",
             },
-            actual_attributes
+            actual_attributes,
         )
 
-        self.assertEqual(conditions, {'SharedUsagePlanCondition': 'C1'})
+        self.assertEqual(conditions, {"SharedUsagePlanCondition": "C1"})
 
-    @parameterized.expand([
-        ([None], ),
-        ([None, "C1"], ),
-        (["C1", None], ),
-        (["C1", "C2"], ),
-        (["C1", "C2", "C3"], ),
-    ])
+    @parameterized.expand(
+        [
+            ([None],),
+            ([None, "C1"],),
+            (["C1", None],),
+            (["C1", "C2"],),
+            (["C1", "C2", "C3"],),
+        ]
+    )
     def test_multiple_apis_with_conditions(self, api_conditions):
         template_conditions = dict()
         result = {}
         for api_condition in api_conditions:
             result = self.shared_usage_plan.get_combined_resource_attributes(
-                {"Condition": api_condition},
-                template_conditions
+                {"Condition": api_condition}, template_conditions
             )
             print(f"Calling with {api_condition} result {result}")
 
@@ -59,100 +59,61 @@ class TestSharedApiUsagePlan(TestCase):
             self.assertEqual({"Condition": "SharedUsagePlanCondition"}, result)
             combined_conditions = [
                 condition.get("Condition")
-                for condition in
-                template_conditions.get("SharedUsagePlanCondition", {}).get("Fn::Or")
+                for condition in template_conditions.get("SharedUsagePlanCondition", {}).get("Fn::Or")
             ]
             for combined_condition in combined_conditions:
                 self.assertTrue(combined_condition in api_conditions)
 
-
     def test_should_raise_invalid_template_when_no_conditions_section(self):
         with self.assertRaises(InvalidTemplateException):
-            self.shared_usage_plan.get_combined_resource_attributes(
-                {"Condition": "C1"},
-                None
-            )
+            self.shared_usage_plan.get_combined_resource_attributes({"Condition": "C1"}, None)
 
     def test_deletion_policy_priority(self):
         # first api sets it to delete
-        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "DeletionPolicy": "Delete"
-            },
-            {}
-        )
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes({"DeletionPolicy": "Delete"}, {})
         self.assertEqual(actual_attributes["DeletionPolicy"], "Delete")
 
         # then second api sets it to Retain
-        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "DeletionPolicy": "Retain"
-            },
-            {}
-        )
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes({"DeletionPolicy": "Retain"}, {})
         self.assertEqual(actual_attributes["DeletionPolicy"], "Retain")
 
         # if third api sets it to delete, it should keep retain value
-        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "DeletionPolicy": "Delete"
-            },
-            {}
-        )
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes({"DeletionPolicy": "Delete"}, {})
         self.assertEqual(actual_attributes["DeletionPolicy"], "Retain")
 
     def test_update_replace_policy_priority(self):
         # first api sets it to delete
         actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "UpdateReplacePolicy": "Delete"
-            },
-            {}
+            {"UpdateReplacePolicy": "Delete"}, {}
         )
         self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Delete")
 
         # then second api sets it to Retain
         actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "UpdateReplacePolicy": "Snapshot"
-            },
-            {}
+            {"UpdateReplacePolicy": "Snapshot"}, {}
         )
         self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Snapshot")
 
         # if third api sets it to delete, it should keep retain value
         actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "UpdateReplacePolicy": "Delete"
-            },
-            {}
+            {"UpdateReplacePolicy": "Delete"}, {}
         )
         self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Snapshot")
 
         # if third api sets it to delete, it should keep retain value
         actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "UpdateReplacePolicy": "Retain"
-            },
-            {}
+            {"UpdateReplacePolicy": "Retain"}, {}
         )
         self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Retain")
 
         # if third api sets it to delete, it should keep retain value
         actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "UpdateReplacePolicy": "Snapshot"
-            },
-            {}
+            {"UpdateReplacePolicy": "Snapshot"}, {}
         )
         self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Retain")
 
         # if third api sets it to delete, it should keep retain value
         actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
-            {
-                "UpdateReplacePolicy": "Delete"
-            },
-            {}
+            {"UpdateReplacePolicy": "Delete"}, {}
         )
         self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Retain")
-

--- a/tests/unit/model/api/TestSharedApiUsagePlan.py
+++ b/tests/unit/model/api/TestSharedApiUsagePlan.py
@@ -1,0 +1,158 @@
+from unittest import TestCase
+
+from parameterized import parameterized, param
+
+from samtranslator.model.api.api_generator import SharedApiUsagePlan
+from samtranslator.model.exceptions import InvalidTemplateException
+
+
+class TestSharedApiUsagePlan(TestCase):
+
+    def setUp(self):
+        self.shared_usage_plan = SharedApiUsagePlan()
+
+    def test_values_should_be_propagated(self):
+        conditions = {}
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "Condition": "C1",
+                "DeletionPolicy": "Delete",
+                "UpdateReplacePolicy": "Delete",
+            },
+            conditions
+        )
+
+        self.assertEqual(
+            {
+                "Condition": SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME,
+                "DeletionPolicy": "Delete",
+                "UpdateReplacePolicy": "Delete",
+            },
+            actual_attributes
+        )
+
+        self.assertEqual(conditions, {'SharedUsagePlanCondition': 'C1'})
+
+    @parameterized.expand([
+        ([None], ),
+        ([None, "C1"], ),
+        (["C1", None], ),
+        (["C1", "C2"], ),
+        (["C1", "C2", "C3"], ),
+    ])
+    def test_multiple_apis_with_conditions(self, api_conditions):
+        template_conditions = dict()
+        result = {}
+        for api_condition in api_conditions:
+            result = self.shared_usage_plan.get_combined_resource_attributes(
+                {"Condition": api_condition},
+                template_conditions
+            )
+            print(f"Calling with {api_condition} result {result}")
+
+        if None in api_conditions:
+            self.assertEqual({}, result)
+            self.assertEqual({}, template_conditions)
+        else:
+            print(template_conditions)
+            self.assertTrue("SharedUsagePlanCondition" in template_conditions)
+            self.assertEqual({"Condition": "SharedUsagePlanCondition"}, result)
+            combined_conditions = [
+                condition.get("Condition")
+                for condition in
+                template_conditions.get("SharedUsagePlanCondition", {}).get("Fn::Or")
+            ]
+            for combined_condition in combined_conditions:
+                self.assertTrue(combined_condition in api_conditions)
+
+
+    def test_should_raise_invalid_template_when_no_conditions_section(self):
+        with self.assertRaises(InvalidTemplateException):
+            self.shared_usage_plan.get_combined_resource_attributes(
+                {"Condition": "C1"},
+                None
+            )
+
+    def test_deletion_policy_priority(self):
+        # first api sets it to delete
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "DeletionPolicy": "Delete"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["DeletionPolicy"], "Delete")
+
+        # then second api sets it to Retain
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "DeletionPolicy": "Retain"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["DeletionPolicy"], "Retain")
+
+        # if third api sets it to delete, it should keep retain value
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "DeletionPolicy": "Delete"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["DeletionPolicy"], "Retain")
+
+    def test_update_replace_policy_priority(self):
+        # first api sets it to delete
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "UpdateReplacePolicy": "Delete"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Delete")
+
+        # then second api sets it to Retain
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "UpdateReplacePolicy": "Snapshot"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Snapshot")
+
+        # if third api sets it to delete, it should keep retain value
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "UpdateReplacePolicy": "Delete"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Snapshot")
+
+        # if third api sets it to delete, it should keep retain value
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "UpdateReplacePolicy": "Retain"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Retain")
+
+        # if third api sets it to delete, it should keep retain value
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "UpdateReplacePolicy": "Snapshot"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Retain")
+
+        # if third api sets it to delete, it should keep retain value
+        actual_attributes = self.shared_usage_plan.get_combined_resource_attributes(
+            {
+                "UpdateReplacePolicy": "Delete"
+            },
+            {}
+        )
+        self.assertEqual(actual_attributes["UpdateReplacePolicy"], "Retain")
+


### PR DESCRIPTION
*Description of changes:*
When using Shared Usage plan for `AWS::Serverless::Api` resource, following auto-generated resources should contain the resource level attributes from (multiple) API definitions `ApiGatewayUsagePlan`, `ApiGatewayApiKey`, `ApiGatewayUsagePlanKey`

*Description of how you validated changes:*
Added unit tests and additional templates for validation

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
