### PR TITLE
fix: Allow multiple path segments in BasePath

### DIFF
--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -340,11 +340,8 @@ class HttpApiGenerator(object):
                 if re.search(invalid_regex, path) is not None:
                     raise InvalidResourceException(self.logical_id, "Invalid Basepath name provided.")
 
-                if path == "/":
-                    path = ""
-                else:
-                    # ignore leading and trailing `/` in the path name
-                    path = path.strip("/")
+                # ignore leading and trailing `/` in the path name
+                path = path.strip("/")
 
                 logical_id = "{}{}{}".format(self.logical_id, re.sub(r"[\-_/]+", "", path), "ApiMapping")
                 basepath_mapping = ApiGatewayV2ApiMapping(logical_id, attributes=self.passthrough_resource_attributes)

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -344,12 +344,9 @@ class HttpApiGenerator(object):
                     path = ""
                 else:
                     # ignore leading and trailing `/` in the path name
-                    m = re.search(r"[a-zA-Z0-9]+[\-\_]?[a-zA-Z0-9]+", path)
-                    path = m.string[m.start(0) : m.end(0)]
-                    if path is None:
-                        raise InvalidResourceException(self.logical_id, "Invalid Basepath name provided.")
+                    path = re.sub(r"^/+|/+$", "", path)
 
-                logical_id = "{}{}{}".format(self.logical_id, re.sub(r"[\-\_]+", "", path), "ApiMapping")
+                logical_id = "{}{}{}".format(self.logical_id, re.sub(r"[\-_/]+", "", path), "ApiMapping")
                 basepath_mapping = ApiGatewayV2ApiMapping(logical_id, attributes=self.passthrough_resource_attributes)
                 basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
                 basepath_mapping.ApiId = ref(http_api.logical_id)

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -344,7 +344,7 @@ class HttpApiGenerator(object):
                     path = ""
                 else:
                     # ignore leading and trailing `/` in the path name
-                    path = re.sub(r"^/+|/+$", "", path)
+                    path = path.strip("/")
 
                 logical_id = "{}{}{}".format(self.logical_id, re.sub(r"[\-_/]+", "", path), "ApiMapping")
                 basepath_mapping = ApiGatewayV2ApiMapping(logical_id, attributes=self.passthrough_resource_attributes)

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -250,15 +250,18 @@ class TestCustomDomains(TestCase):
         self.kwargs["domain"] = {
             "DomainName": "example.com",
             "CertificateArn": "some-url",
-            "BasePath": ["one-1", "two_2", "three", "/"],
+            "BasePath": ["one-1", "two_2", "three", "/", "api/v1"],
             "Route53": {"HostedZoneId": "xyz", "HostedZoneName": "abc", "IpV6": True},
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
         domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
         self.assertIsNotNone(domain, None)
         self.assertIsNotNone(basepath, None)
-        self.assertEqual(len(basepath), 4)
+        self.assertEqual(len(basepath), 5)
         self.assertIsNotNone(route, None)
         self.assertEqual(route.HostedZoneName, None)
         self.assertEqual(route.HostedZoneId, "xyz")
         self.assertEqual(len(route.RecordSets), 2)
+        self.assertEqual(
+            list(map(lambda base: base.ApiMappingKey, basepath)), ["one-1", "two_2", "three", "", "api/v1"]
+        )

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -250,18 +250,19 @@ class TestCustomDomains(TestCase):
         self.kwargs["domain"] = {
             "DomainName": "example.com",
             "CertificateArn": "some-url",
-            "BasePath": ["one-1", "two_2", "three", "/", "api/v1"],
+            "BasePath": ["one-1", "two_2", "three", "/", "/api", "api/v1", "api/v1/", "/api/v1/"],
             "Route53": {"HostedZoneId": "xyz", "HostedZoneName": "abc", "IpV6": True},
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
         domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
         self.assertIsNotNone(domain, None)
         self.assertIsNotNone(basepath, None)
-        self.assertEqual(len(basepath), 5)
+        self.assertEqual(len(basepath), 8)
         self.assertIsNotNone(route, None)
         self.assertEqual(route.HostedZoneName, None)
         self.assertEqual(route.HostedZoneId, "xyz")
         self.assertEqual(len(route.RecordSets), 2)
         self.assertEqual(
-            list(map(lambda base: base.ApiMappingKey, basepath)), ["one-1", "two_2", "three", "", "api/v1"]
+            list(map(lambda base: base.ApiMappingKey, basepath)),
+            ["one-1", "two_2", "three", "", "api", "api/v1", "api/v1", "api/v1"],
         )


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
The API gateway supports multiple segments in the base path mappings like specified in this [repository](https://github.com/aws-samples/sessions-with-aws-sam/blob/master/multi-level-mapping/reportingv1.yaml#L21). However, whenever a ```BasePath``` with multiple segments is specified in a ```AWS::Serverless::HttpApi``` (see examples below), than the template does not contain these multiple segments after the transformation anymore.

```yaml
# SAM Template:
HttpApi:
    Type: AWS::Serverless::HttpApi
    Properties:
      Domain:
        DomainName: somedomain.com
        CertificateArn: some-certificate-arn
        BasePath:
          - "api/v1"
        EndpointConfiguration: REGIONAL
        Route53:
          HostedZoneId: some-hosted-zone
```
```json
// transformed template
"HttpApiapiApiMapping": {
  "Type": "AWS::ApiGatewayV2::ApiMapping",
  "Properties": {
    "ApiId": {
      "Ref": "HttpApi"
    },
    "ApiMappingKey": "api",
    "DomainName": {
      "Ref": "ApiGatewayDomainNameV2dc0129008b"
    },
    "Stage": {
      "Ref": "HttpApiApiGatewayDefaultStage"
    }
  }
}
```
The implementation fixes the regex that strips trailing and leading forward slashes (the segments). After that, the transformed template looks as following example:
```json
// transformed template
"HttpApiapiv1ApiMapping": {
  "Type": "AWS::ApiGatewayV2::ApiMapping",
  "Properties": {
    "ApiId": {
      "Ref": "HttpApi"
    },
    "ApiMappingKey": "api/v1",
    "DomainName": {
      "Ref": "ApiGatewayDomainNameV2dc0129008b"
    },
    "Stage": {
      "Ref": "HttpApiApiGatewayDefaultStage"
    }
  }
},
```

*Description of how you validated changes:*
I used my SAM template with a ```BasePath``` with multiple segments. After transformation and deployment, the ApiMappingKey was correct for my Domain.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
