### PR TITLE
fix: Resources missing when named the same as implicit APIs

### DIFF
--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -38,7 +38,6 @@ class ImplicitApiPlugin(BasePlugin):
         """
         super(ImplicitApiPlugin, self).__init__(name)
 
-        self.existing_implicit_api_resource = None
         # dict containing condition (or None) for each resource path+method for all APIs. dict format:
         # {api_id: {path: {method: condition_name_or_None}}}
         self.api_conditions = {}
@@ -75,11 +74,6 @@ class ImplicitApiPlugin(BasePlugin):
         # Temporarily add Serverless::Api resource corresponding to Implicit API to the template.
         # This will allow the processing code to work the same way for both Implicit & Explicit APIs
         # If there are no implicit APIs, we will remove from the template later.
-
-        # If the customer has explicitly defined a resource with the id of "ServerlessRestApi",
-        # capture it.  If the template ends up not defining any implicit api's, instead of just
-        # removing the "ServerlessRestApi" resource, we just restore what the author defined.
-        self.existing_implicit_api_resource = copy.deepcopy(template.get(self.implicit_api_logical_id))
 
         template.set(self.implicit_api_logical_id, self._generate_implicit_api_resource())
 
@@ -426,12 +420,7 @@ class ImplicitApiPlugin(BasePlugin):
         implicit_api_resource = template.get(self.implicit_api_logical_id)
 
         if implicit_api_resource and len(implicit_api_resource.properties["DefinitionBody"]["paths"]) == 0:
-            # If there's no implicit api and the author defined a "ServerlessRestApi"
-            # resource, restore it
-            if self.existing_implicit_api_resource:
-                template.set(self.implicit_api_logical_id, self.existing_implicit_api_resource)
-            else:
-                template.delete(self.implicit_api_logical_id)
+            template.delete(self.implicit_api_logical_id)
 
     def _generate_implicit_api_resource(self):
         """

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -1,10 +1,13 @@
 import copy
+import logging
 
 from samtranslator.model.intrinsics import make_combined_condition
 from samtranslator.public.plugins import BasePlugin
 from samtranslator.public.exceptions import InvalidDocumentException, InvalidResourceException, InvalidEventException
 from samtranslator.public.sdk.resource import SamResourceType
 from samtranslator.public.sdk.template import SamTemplate
+
+LOG = logging.getLogger(__name__)
 
 
 class ImplicitApiPlugin(BasePlugin):
@@ -58,6 +61,16 @@ class ImplicitApiPlugin(BasePlugin):
         """
 
         template = SamTemplate(template_dict)
+
+        # Adjust self.implicit_api_logical_id if the template already contains a resource with the same logical ID
+        # Appending a number (2) to it. If it is still not unique, increment the number until the logical ID is unique.
+        resource_logical_ids = set(template.resources.keys())
+        if self.implicit_api_logical_id in resource_logical_ids:
+            suffix = 2
+            while (self.implicit_api_logical_id + str(suffix)) in resource_logical_ids:
+                suffix = suffix + 1
+            self.implicit_api_logical_id = self.implicit_api_logical_id + str(suffix)
+            LOG.debug('Adjust implicit API logical ID to "%s"', self.implicit_api_logical_id)
 
         # Temporarily add Serverless::Api resource corresponding to Implicit API to the template.
         # This will allow the processing code to work the same way for both Implicit & Explicit APIs

--- a/tests/plugins/api/test_implicit_api_plugin.py
+++ b/tests/plugins/api/test_implicit_api_plugin.py
@@ -79,6 +79,8 @@ class TestImplicitRestApiPlugin_on_before_transform_template(TestCase):
 
         sam_template = Mock()
         SamTemplateMock.return_value = sam_template
+        sam_template.resources = Mock()
+        sam_template.resources.keys.return_value = ("id1", "id2", "id3")
         sam_template.set = Mock()
         sam_template.iterate = Mock()
         sam_template.iterate.return_value = function_resources
@@ -116,6 +118,8 @@ class TestImplicitRestApiPlugin_on_before_transform_template(TestCase):
 
         sam_template = Mock()
         SamTemplateMock.return_value = sam_template
+        sam_template.resources = Mock()
+        sam_template.resources.keys.return_value = ("id1", "id2", "id3")
         sam_template.set = Mock()
         sam_template.iterate = Mock()
         sam_template.iterate.return_value = statemachine_resources
@@ -154,6 +158,8 @@ class TestImplicitRestApiPlugin_on_before_transform_template(TestCase):
 
         sam_template = Mock()
         SamTemplateMock.return_value = sam_template
+        sam_template.resources = Mock()
+        sam_template.resources.keys.return_value = ("id1", "id2", "id3")
         sam_template.set = Mock()
         sam_template.iterate = Mock()
         sam_template.iterate.return_value = function_resources
@@ -179,6 +185,8 @@ class TestImplicitRestApiPlugin_on_before_transform_template(TestCase):
 
         sam_template = Mock()
         SamTemplateMock.return_value = sam_template
+        sam_template.resources = Mock()
+        sam_template.resources.keys.return_value = ("id1", "id2", "id3")
         sam_template.set = Mock()
         sam_template.iterate = Mock()
         sam_template.iterate.return_value = statemachine_resources
@@ -200,6 +208,8 @@ class TestImplicitRestApiPlugin_on_before_transform_template(TestCase):
 
         sam_template = Mock()
         SamTemplateMock.return_value = sam_template
+        sam_template.resources = Mock()
+        sam_template.resources.keys.return_value = ()
         sam_template.set = Mock()
         sam_template.iterate = Mock()
         sam_template.iterate.return_value = function_resources
@@ -229,6 +239,8 @@ class TestImplicitRestApiPlugin_on_before_transform_template(TestCase):
 
         sam_template = Mock()
         SamTemplateMock.return_value = sam_template
+        sam_template.resources = Mock()
+        sam_template.resources.keys.return_value = ("id1", "id2", "id3")
         sam_template.set = Mock()
         sam_template.iterate = Mock()
         sam_template.iterate.return_value = function_resources
@@ -252,6 +264,33 @@ class TestImplicitRestApiPlugin_on_before_transform_template(TestCase):
             self.assertEqual(api_event_errors[index].message, cause._message)
 
         # Must cleanup even if there an exception
+        self.plugin._maybe_remove_implicit_api.assert_called_with(sam_template)
+
+    @patch("samtranslator.plugins.api.implicit_api_plugin.SamTemplate")
+    def test_must_not_override_api_with_same_logical_id_as_implicit_api(self, SamTemplateMock):
+        template_dict = {"a": "b"}
+        function1 = SamResource({"Type": "AWS::Serverless::Function"})
+        rest_api_1 = SamResource({"Type": "AWS::Serverless::Api"})
+        rest_api_2 = SamResource({"Type": "AWS::Serverless::Api"})
+        resources = [("id1", function1), ("ServerlessRestApi", rest_api_1), ("ServerlessRestApi2", rest_api_2)]
+        api_events = ["event1", "event2"]
+
+        expected_rest_api_logical_id = "ServerlessRestApi3"
+
+        sam_template = Mock()
+        SamTemplateMock.return_value = sam_template
+        sam_template.resources = Mock()
+        sam_template.resources.keys.return_value = ("id1", "ServerlessRestApi", "ServerlessRestApi2")
+        sam_template.set = Mock()
+        sam_template.iterate = Mock()
+        sam_template.iterate.return_value = resources
+        self.plugin._get_api_events.return_value = api_events
+
+        self.plugin.on_before_transform_template(template_dict)
+
+        SamTemplateMock.assert_called_with(template_dict)
+        sam_template.set.assert_called_with(expected_rest_api_logical_id, ImplicitApiResource().to_dict())
+
         self.plugin._maybe_remove_implicit_api.assert_called_with(sam_template)
 
 

--- a/tests/plugins/api/test_implicit_api_plugin.py
+++ b/tests/plugins/api/test_implicit_api_plugin.py
@@ -839,20 +839,6 @@ class TestImplicitRestApiPlugin_maybe_remove_implicit_api(TestCase):
         # Must not delete
         template.delete.assert_not_called()
 
-    def test_must_restore_if_existing_resource_present(self):
-        resource = SamResource({"Type": "AWS::Serverless::Api", "Properties": {"DefinitionBody": {"paths": {}}}})
-        template = Mock()
-        template.get = Mock()
-        template.set = Mock()
-        template.get.return_value = resource
-
-        self.plugin.existing_implicit_api_resource = resource
-        self.plugin._maybe_remove_implicit_api(template)
-        template.get.assert_called_with(IMPLICIT_API_LOGICAL_ID)
-
-        # Must restore original resource
-        template.set.assert_called_with(IMPLICIT_API_LOGICAL_ID, resource)
-
 
 class TestImplicitApiPlugin_generate_resource_attributes(TestCase):
     def setUp(self):

--- a/tests/translator/output/aws-cn/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/aws-cn/implicit_api_with_serverless_rest_api_resource.json
@@ -45,7 +45,7 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
@@ -66,21 +66,21 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
         }
       }
     }, 
-    "ServerlessRestApiProdStage": {
+    "ServerlessRestApi2ProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentb5184bf2cc"
+          "Ref": "ServerlessRestApi2Deploymentb5184bf2cc"
         }, 
         "RestApiId": {
-          "Ref": "ServerlessRestApi"
+          "Ref": "ServerlessRestApi2"
         }, 
         "StageName": "Prod"
       }
@@ -162,11 +162,11 @@
         ]
       }
     }, 
-    "ServerlessRestApiDeploymentb5184bf2cc": {
+    "ServerlessRestApi2Deploymentb5184bf2cc": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
-          "Ref": "ServerlessRestApi"
+          "Ref": "ServerlessRestApi2"
         }, 
         "Description": "RestApi deployment id: b5184bf2cccc18d4a1efae523c2c88fd5282c8a3", 
         "StageName": "Stage"
@@ -186,14 +186,67 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ServerlessRestApiRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi2": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
         "Body": {
@@ -279,7 +332,7 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]

--- a/tests/translator/output/aws-us-gov/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/aws-us-gov/implicit_api_with_serverless_rest_api_resource.json
@@ -45,7 +45,7 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
@@ -66,30 +66,30 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
         }
       }
     }, 
-    "ServerlessRestApiProdStage": {
+    "ServerlessRestApi2ProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentaaf8bd4588"
+          "Ref": "ServerlessRestApi2Deploymentaaf8bd4588"
         }, 
         "RestApiId": {
-          "Ref": "ServerlessRestApi"
+          "Ref": "ServerlessRestApi2"
         }, 
         "StageName": "Prod"
       }
     }, 
-    "ServerlessRestApiDeploymentaaf8bd4588": {
+    "ServerlessRestApi2Deploymentaaf8bd4588": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
-          "Ref": "ServerlessRestApi"
+          "Ref": "ServerlessRestApi2"
         }, 
         "Description": "RestApi deployment id: aaf8bd4588f47e1167b22b3aadb5fdf6f2d306aa", 
         "StageName": "Stage"
@@ -186,14 +186,67 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ServerlessRestApiRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi2": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
         "Body": {
@@ -279,7 +332,7 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]

--- a/tests/translator/output/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/implicit_api_with_serverless_rest_api_resource.json
@@ -45,7 +45,7 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
@@ -66,21 +66,21 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
         }
       }
     }, 
-    "ServerlessRestApiProdStage": {
+    "ServerlessRestApi2ProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment127e3fb911"
+          "Ref": "ServerlessRestApi2Deployment127e3fb911"
         }, 
         "RestApiId": {
-          "Ref": "ServerlessRestApi"
+          "Ref": "ServerlessRestApi2"
         }, 
         "StageName": "Prod"
       }
@@ -162,11 +162,11 @@
         ]
       }
     }, 
-    "ServerlessRestApiDeployment127e3fb911": {
+    "ServerlessRestApi2Deployment127e3fb911": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
-          "Ref": "ServerlessRestApi"
+          "Ref": "ServerlessRestApi2"
         }, 
         "Description": "RestApi deployment id: 127e3fb91142ab1ddc5f5446adb094442581a90d", 
         "StageName": "Stage"
@@ -186,14 +186,67 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]
         }
       }
-    }, 
+    },
     "ServerlessRestApi": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ServerlessRestApiRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApiRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ServerlessRestApi2": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
         "Body": {
@@ -271,7 +324,7 @@
             {
               "__Stage__": "*",
               "__ApiId__": {
-                "Ref": "ServerlessRestApi"
+                "Ref": "ServerlessRestApi2"
               }
             }
           ]

--- a/tests/translator/test_api_resource.py
+++ b/tests/translator/test_api_resource.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 
@@ -71,24 +72,24 @@ def test_redeploy_implicit_api():
         },
     }
 
-    original_deployment_ids = translate_and_find_deployment_ids(manifest)
+    original_deployment_ids = translate_and_find_deployment_ids(copy.deepcopy(manifest))
 
     # Update API of one Lambda function should redeploy API
     manifest["Resources"]["FirstLambdaFunction"]["Properties"]["Events"]["MyApi"]["Properties"]["Method"] = "post"
-    first_updated_deployment_ids = translate_and_find_deployment_ids(manifest)
+    first_updated_deployment_ids = translate_and_find_deployment_ids(copy.deepcopy(manifest))
     assert original_deployment_ids != first_updated_deployment_ids
 
     # Update API of second Lambda function should redeploy API
     manifest["Resources"]["SecondLambdaFunction"]["Properties"]["Events"]["MyApi"]["Properties"]["Method"] = "post"
-    second_updated_deployment_ids = translate_and_find_deployment_ids(manifest)
+    second_updated_deployment_ids = translate_and_find_deployment_ids(copy.deepcopy(manifest))
     assert first_updated_deployment_ids != second_updated_deployment_ids
 
     # Now, update an unrelated property. This should NOT generate a new deploymentId
     manifest["Resources"]["SecondLambdaFunction"]["Properties"]["Runtime"] = "java"
-    assert second_updated_deployment_ids == translate_and_find_deployment_ids(manifest)
+    assert second_updated_deployment_ids == translate_and_find_deployment_ids(copy.deepcopy(manifest))
 
     manifest["Resources"]["FirstLambdaFunction"]["Properties"]["FunctionName"] = "ChangedFunctionName"
-    fourth_updated_deployment_ids = translate_and_find_deployment_ids(manifest)
+    fourth_updated_deployment_ids = translate_and_find_deployment_ids(copy.deepcopy(manifest))
     assert fourth_updated_deployment_ids != second_updated_deployment_ids
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`ServerlessRestApi` and `ServerlessHttpApi` are two implicit resource logical IDs created by SAM. However, customers could totally create their own resources with these two logical IDs. And when that happens, at the same time, if customers define some implicit api events in their templates, those resources will be removed, without customers knowing what happened.

This PR will adjust implicit api logical id when naming collision is detected. For example, if `ServerlessRestApi` already exists, the implicit api local id will become `ServerlessRestApi2`, if `ServerlessRestApi2` also exists, `ServerlessRestApi3` will be used, and so on so forth.

*Description of how you validated changes:*

- Also updated the end to end tests. Previously, the test `implicit_api_with_serverless_rest_api_resource` template contains a function with name `ServerlessRestApi` and expected output does not contain that function. I think the test is not right. This PR also fixes it. 

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
