### PR TITLE
fix: validate unknown method for a path in swagger definition for apigw

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -531,7 +531,17 @@ class SwaggerEditor(object):
             if add_default_auth_to_preflight or normalized_method_name != "options":
                 normalized_method_name = self._normalize_method_name(method_name)
                 # It is possible that the method could have two definitions in a Fn::If block.
-                for method_definition in self.get_method_contents(self.get_path(path)[normalized_method_name]):
+                method_dict = self.get_path(path).get(normalized_method_name)
+                if method_dict is None:
+                    raise InvalidDocumentException(
+                        [
+                            InvalidTemplateException(
+                                "Can't find method definition dictionary for method '{}'".format(normalized_method_name)
+                            )
+                        ]
+                    )
+
+                for method_definition in self.get_method_contents(method_dict):
 
                     # If no integration given, then we don't need to process this definition (could be AWS::NoValue)
                     if not isinstance(method_definition, dict):

--- a/tests/translator/input/error_api_invalid_any_method.yaml
+++ b/tests/translator/input/error_api_invalid_any_method.yaml
@@ -1,0 +1,44 @@
+Resources:
+  HttpApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/todo_list.zip
+      Handler: index.restapi
+      Runtime: python3.7
+      Events:
+        SimpleCase:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+        BasePath:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+            Path: /
+            Method: get
+
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName:
+        Ref: Stage
+      Auth:
+        DefaultAuthorizer: "LambdaAuthorizer"
+        Authorizers:
+          LambdaAuthorizer:
+            FunctionPayloadType: "REQUEST"
+            Identity:
+              Headers:
+                  - "Authorization"
+      DefinitionBody:
+        openapi: '3.0'
+        info:
+          title: !Sub ${AWS::StackName}-Api
+        paths:
+          /:
+            any:
+              x-amazon-apigateway-integration:
+                httpMethod: ANY
+                type: http_proxy
+                uri: https://www.alphavantage.co/
+                payloadFormatVersion: '1.0'

--- a/tests/translator/output/error_api_invalid_any_method.json
+++ b/tests/translator/output/error_api_invalid_any_method.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Can't find method definition dictionary for method 'x-amazon-apigateway-any-method'"
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -667,6 +667,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
         "error_api_gateway_responses_nonnumeric_status_code",
         "error_api_gateway_responses_unknown_responseparameter",
         "error_api_gateway_responses_unknown_responseparameter_property",
+        "error_api_invalid_any_method",
         "error_api_invalid_auth",
         "error_api_invalid_path",
         "error_api_invalid_definitionuri",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When setting path for default authorizers, SAM Transform tries to access specific method information from path definition inside swagger in this line; https://github.com/aws/serverless-application-model/blob/develop/samtranslator/swagger/swagger.py#L534

Since it is trying to access this dictionary directly, it might raise exception when a method is defined in function's event definition but not in swagger definition.

*Description of how you validated changes:*
Before setting up path for default authorizer, we first try to see if that path has the expected method definition, if not we are going to raise an invalid document exception rather than getting item not found exception from dictionary.

*Checklist:*

- [x] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
