### PR TITLE
fix: SAM translator fails if AutoPublishAlias is an empty string

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -147,7 +147,7 @@ class SamFunction(SamResourceMacro):
 
         lambda_alias = None
         alias_name = ""
-        if self.AutoPublishAlias:
+        if self.AutoPublishAlias is not None:
             alias_name = self._get_resolved_alias_name("AutoPublishAlias", self.AutoPublishAlias, intrinsics_resolver)
             code_sha256 = None
             if self.AutoPublishCodeSha256:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
