### PR TITLE
feat: add metrics per resource transformation

### DIFF
--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -11,6 +11,7 @@ from samtranslator.feature_toggle.dialup import (
     ToggleDialup,
     SimpleAccountPercentileDialup,
 )
+from samtranslator.metrics.method_decorator import cw_timer
 
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, my_path + "/..")
@@ -130,6 +131,7 @@ class FeatureToggleLocalConfigProvider(FeatureToggleConfigProvider):
 class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
     """Feature toggle config provider which loads config from AppConfig."""
 
+    @cw_timer(prefix="External", name="AppConfig")
     def __init__(self, application_id, environment_id, configuration_profile_id):
         FeatureToggleConfigProvider.__init__(self)
         try:

--- a/samtranslator/metrics/method_decorator.py
+++ b/samtranslator/metrics/method_decorator.py
@@ -16,8 +16,8 @@ class MetricsMethodWrapperSingleton:
     This singleton will be alive until lambda receives shutdown event
     """
 
-    _METRICS_INSTANCE = None
     _DUMMY_INSTANCE = Metrics("ServerlessTransform", DummyMetricsPublisher())
+    _METRICS_INSTANCE = _DUMMY_INSTANCE
 
     @staticmethod
     def set_instance(metrics):
@@ -28,10 +28,7 @@ class MetricsMethodWrapperSingleton:
         """
         Return the instance, if nothing is set return a dummy one
         """
-        if MetricsMethodWrapperSingleton._METRICS_INSTANCE:
-            return MetricsMethodWrapperSingleton._METRICS_INSTANCE
-
-        return MetricsMethodWrapperSingleton._DUMMY_INSTANCE
+        return MetricsMethodWrapperSingleton._METRICS_INSTANCE
 
 
 def _get_metric_name(prefix, name, func, args):

--- a/samtranslator/metrics/method_decorator.py
+++ b/samtranslator/metrics/method_decorator.py
@@ -1,0 +1,107 @@
+import functools
+from datetime import datetime
+from samtranslator.metrics.metrics import DummyMetricsPublisher, Metrics
+from samtranslator.model import Resource
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class MetricsMethodWrapperSingleton:
+    """
+    Keeps the instance of Metrics object.
+    This singleton will be alive until lambda receives shutdown event
+    """
+
+    _METRICS_INSTANCE = None
+    _DUMMY_INSTANCE = Metrics("ServerlessTransform", DummyMetricsPublisher())
+
+    @staticmethod
+    def set_instance(metrics):
+        MetricsMethodWrapperSingleton._METRICS_INSTANCE = metrics
+
+    @staticmethod
+    def get_instance():
+        """
+        Return the instance, if nothing is set return a dummy one
+        """
+        if MetricsMethodWrapperSingleton._METRICS_INSTANCE:
+            return MetricsMethodWrapperSingleton._METRICS_INSTANCE
+
+        return MetricsMethodWrapperSingleton._DUMMY_INSTANCE
+
+
+def _get_metric_name(prefix, name, func, args):
+    """
+    Returns the metric name depending on the parameters
+
+    Parameters
+    ----------
+    prefix : str
+        A string that will always be added in the beginning of metric name.
+    name : str
+        The name of the metric. If None is given, it will try to read from function and argument details.
+    func : Function
+        The function that is decorated. This will be used as metric name if name is not provided and caller is not an
+        instance of Resource object.
+    args : args
+        Arguments that is originally passed to the caller. This function will check if first element in this function
+        is a Resource then it reads the 'resource_type' property out of it to generate the metric name.
+    """
+    if name:
+        metric_name = name
+    else:
+        if args > 0 and isinstance(args[0], Resource):
+            metric_name = args[0].resource_type
+        else:
+            metric_name = func.__name__
+
+    if prefix:
+        return "{}-{}".format(prefix, metric_name)
+
+    return metric_name
+
+
+def _send_cw_metric(prefix, name, execution_time_ms, func, args):
+    """
+    Gets metric name from 'prefix', 'name', 'func' and 'args' parameters, then calls metrics instance from its
+    singleton object to record the latency.
+    """
+    try:
+        metric_name = _get_metric_name(prefix, name, func, args)
+        LOG.info("Execution took %sms for %s", execution_time_ms, metric_name)
+        MetricsMethodWrapperSingleton.get_instance().record_latency(metric_name, execution_time_ms)
+    except Exception as e:
+        LOG.warning("Failed to add metrics", exc_info=e)
+
+
+def cw_timer(_func=None, name=None, prefix=None):
+    """
+    A method decorator, that will calculate execution time of the decorated method, and store this information as a
+    metric in CloudWatch by calling the metrics singleton instance.
+
+    The metric name is calculated with parameters.
+    - If 'name' is provided then it will be the metrics name.
+    - If 'name' is not provided and caller method is an instance of 'Resource' object, then 'resource_type' will be used
+    - If 'name' is not provided and caller is not instance of 'Resource' then it will be the name of the function
+
+    If prefix is defined, it will be added in the beginning of what is been generated above
+    """
+
+    def cw_timer_decorator(func):
+
+        @functools.wraps(func)
+        def wrapper_cw_timer(*args, **kwargs):
+            start_time = datetime.now()
+
+            exec_result = func(*args, **kwargs)
+
+            execution_time = datetime.now() - start_time
+            execution_time_ms = execution_time.total_seconds() * 1000
+            _send_cw_metric(prefix, name, execution_time_ms, func, args)
+
+            return exec_result
+
+        return wrapper_cw_timer
+
+    return cw_timer_decorator if _func is None else cw_timer_decorator(_func)

--- a/samtranslator/metrics/method_decorator.py
+++ b/samtranslator/metrics/method_decorator.py
@@ -54,7 +54,7 @@ def _get_metric_name(prefix, name, func, args):
     if name:
         metric_name = name
     else:
-        if args > 0 and isinstance(args[0], Resource):
+        if args and isinstance(args[0], Resource):
             metric_name = args[0].resource_type
         else:
             metric_name = func.__name__
@@ -92,7 +92,6 @@ def cw_timer(_func=None, name=None, prefix=None):
     """
 
     def cw_timer_decorator(func):
-
         @functools.wraps(func)
         def wrapper_cw_timer(*args, **kwargs):
             start_time = datetime.now()

--- a/samtranslator/metrics/method_decorator.py
+++ b/samtranslator/metrics/method_decorator.py
@@ -1,3 +1,6 @@
+"""
+Method decorator for execution latency collection
+"""
 import functools
 from datetime import datetime
 from samtranslator.metrics.metrics import DummyMetricsPublisher, Metrics

--- a/samtranslator/metrics/method_decorator.py
+++ b/samtranslator/metrics/method_decorator.py
@@ -72,7 +72,7 @@ def _send_cw_metric(prefix, name, execution_time_ms, func, args):
     """
     try:
         metric_name = _get_metric_name(prefix, name, func, args)
-        LOG.info("Execution took %sms for %s", execution_time_ms, metric_name)
+        LOG.debug("Execution took %sms for %s", execution_time_ms, metric_name)
         MetricsMethodWrapperSingleton.get_instance().record_latency(metric_name, execution_time_ms)
     except Exception as e:
         LOG.warning("Failed to add metrics", exc_info=e)

--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -105,7 +105,7 @@ class MetricDatum:
             "Value": self.value,
             "Unit": self.unit,
             "Dimensions": self.dimensions,
-            "Timestamp": self.timestamp
+            "Timestamp": self.timestamp,
         }
 
 

--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -2,6 +2,7 @@
 Helper classes to publish metrics
 """
 import logging
+from datetime import datetime
 
 LOG = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ class MetricDatum:
     Class to hold Metric data.
     """
 
-    def __init__(self, name, value, unit, dimensions=None):
+    def __init__(self, name, value, unit, dimensions=None, timestamp=None):
         """
         Constructor
 
@@ -96,9 +97,16 @@ class MetricDatum:
         self.value = value
         self.unit = unit
         self.dimensions = dimensions if dimensions else []
+        self.timestamp = timestamp if timestamp else datetime.utcnow()
 
     def get_metric_data(self):
-        return {"MetricName": self.name, "Value": self.value, "Unit": self.unit, "Dimensions": self.dimensions}
+        return {
+            "MetricName": self.name,
+            "Value": self.value,
+            "Unit": self.unit,
+            "Dimensions": self.dimensions,
+            "Timestamp": self.timestamp
+        }
 
 
 class Metrics:
@@ -119,7 +127,7 @@ class Metrics:
             LOG.warn("There are unpublished metrics. Please make sure you call publish after you record all metrics.")
             self.publish()
 
-    def _record_metric(self, name, value, unit, dimensions=[]):
+    def _record_metric(self, name, value, unit, dimensions=None):
         """
         Create and save metric objects to an array.
 
@@ -130,7 +138,7 @@ class Metrics:
         """
         self.metrics_cache.append(MetricDatum(name, value, unit, dimensions))
 
-    def record_count(self, name, value, dimensions=[]):
+    def record_count(self, name, value, dimensions=None):
         """
         Create metric with unit Count.
 
@@ -141,7 +149,7 @@ class Metrics:
         """
         self._record_metric(name, value, Unit.Count, dimensions)
 
-    def record_latency(self, name, value, dimensions=[]):
+    def record_latency(self, name, value, dimensions=None):
         """
         Create metric with unit Milliseconds.
 

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -534,7 +534,7 @@ class ApiGenerator(object):
             alias_target["DNSName"] = route53.get("DistributionDomainName")
         return alias_target
 
-    @cw_timer(name="ApiGenerator")
+    @cw_timer(prefix="Generator", name="Api")
     def to_cloudformation(self, redeploy_restapi_parameters):
         """Generates CloudFormation resources from a SAM API resource
 

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -2,6 +2,8 @@ import logging
 from collections import namedtuple
 
 from six import string_types
+
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.intrinsics import ref, fnGetAtt, make_or_condition
 from samtranslator.model.apigateway import (
     ApiGatewayDeployment,
@@ -532,6 +534,7 @@ class ApiGenerator(object):
             alias_target["DNSName"] = route53.get("DistributionDomainName")
         return alias_target
 
+    @cw_timer(name="ApiGenerator")
     def to_cloudformation(self, redeploy_restapi_parameters):
         """Generates CloudFormation resources from a SAM API resource
 

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -617,7 +617,7 @@ class HttpApiGenerator(object):
         open_api_editor.add_description(self.description)
         self.definition_body = open_api_editor.openapi
 
-    @cw_timer(name="HttpApiGenerator")
+    @cw_timer(prefix="Generator", name="HttpApi")
     def to_cloudformation(self):
         """Generates CloudFormation resources from a SAM HTTP API resource
 

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -1,6 +1,8 @@
 import re
 from collections import namedtuple
 from six import string_types
+
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.intrinsics import ref, fnGetAtt
 from samtranslator.model.apigatewayv2 import (
     ApiGatewayV2HttpApi,
@@ -615,6 +617,7 @@ class HttpApiGenerator(object):
         open_api_editor.add_description(self.description)
         self.definition_body = open_api_editor.openapi
 
+    @cw_timer(name="HttpApiGenerator")
     def to_cloudformation(self):
         """Generates CloudFormation resources from a SAM HTTP API resource
 

--- a/samtranslator/model/eventsources/__init__.py
+++ b/samtranslator/model/eventsources/__init__.py
@@ -1,2 +1,1 @@
-
 FUNCTION_EVETSOURCE_METRIC_PREFIX = "FunctionEventSource"

--- a/samtranslator/model/eventsources/__init__.py
+++ b/samtranslator/model/eventsources/__init__.py
@@ -1,0 +1,2 @@
+
+FUNCTION_EVETSOURCE_METRIC_PREFIX = "FunctionEventSource"

--- a/samtranslator/model/eventsources/cloudwatchlogs.py
+++ b/samtranslator/model/eventsources/cloudwatchlogs.py
@@ -1,10 +1,10 @@
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import PropertyType
 from samtranslator.model.intrinsics import fnSub
 from samtranslator.model.log import SubscriptionFilter
 from samtranslator.model.types import is_str
 from samtranslator.translator.arn_generator import ArnGenerator
 from .push import PushEventSource
-from ...metrics.method_decorator import cw_timer
 
 
 class CloudWatchLogs(PushEventSource):

--- a/samtranslator/model/eventsources/cloudwatchlogs.py
+++ b/samtranslator/model/eventsources/cloudwatchlogs.py
@@ -4,6 +4,7 @@ from samtranslator.model.log import SubscriptionFilter
 from samtranslator.model.types import is_str
 from samtranslator.translator.arn_generator import ArnGenerator
 from .push import PushEventSource
+from ...metrics.method_decorator import cw_timer
 
 
 class CloudWatchLogs(PushEventSource):
@@ -13,6 +14,7 @@ class CloudWatchLogs(PushEventSource):
     principal = "logs.amazonaws.com"
     property_types = {"LogGroupName": PropertyType(True, is_str()), "FilterPattern": PropertyType(True, is_str())}
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         """Returns the CloudWatch Logs Subscription Filter and Lambda Permission to which this CloudWatch Logs event source
         corresponds.

--- a/samtranslator/model/eventsources/cloudwatchlogs.py
+++ b/samtranslator/model/eventsources/cloudwatchlogs.py
@@ -4,6 +4,7 @@ from samtranslator.model.intrinsics import fnSub
 from samtranslator.model.log import SubscriptionFilter
 from samtranslator.model.types import is_str
 from samtranslator.translator.arn_generator import ArnGenerator
+from . import FUNCTION_EVETSOURCE_METRIC_PREFIX
 from .push import PushEventSource
 
 
@@ -14,7 +15,7 @@ class CloudWatchLogs(PushEventSource):
     principal = "logs.amazonaws.com"
     property_types = {"LogGroupName": PropertyType(True, is_str()), "FilterPattern": PropertyType(True, is_str())}
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         """Returns the CloudWatch Logs Subscription Filter and Lambda Permission to which this CloudWatch Logs event source
         corresponds.

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -1,3 +1,4 @@
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceMacro, PropertyType
 from samtranslator.model.types import is_type, is_str
 
@@ -45,6 +46,7 @@ class PullEventSource(ResourceMacro):
     def get_policy_statements(self):
         raise NotImplementedError("Subclass must implement this method")
 
+    @cw_timer(prefix="PullEventSource")
     def to_cloudformation(self, **kwargs):
         """Returns the Lambda EventSourceMapping to which this pull event corresponds. Adds the appropriate managed
         policy to the function's execution role, if such a role is provided.

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -1,5 +1,6 @@
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceMacro, PropertyType
+from samtranslator.model.eventsources import FUNCTION_EVETSOURCE_METRIC_PREFIX
 from samtranslator.model.types import is_type, is_str
 
 from samtranslator.model.lambda_ import LambdaEventSourceMapping
@@ -46,7 +47,7 @@ class PullEventSource(ResourceMacro):
     def get_policy_statements(self):
         raise NotImplementedError("Subclass must implement this method")
 
-    @cw_timer(prefix="PullEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         """Returns the Lambda EventSourceMapping to which this pull event corresponds. Adds the appropriate managed
         policy to the function's execution role, if such a role is provided.

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -4,6 +4,7 @@ from six import string_types
 
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceMacro, PropertyType
+from samtranslator.model.eventsources import FUNCTION_EVETSOURCE_METRIC_PREFIX
 from samtranslator.model.types import is_type, list_of, dict_of, one_of, is_str
 from samtranslator.model.intrinsics import ref, fnGetAtt, fnSub, make_shorthand, make_conditional
 from samtranslator.model.tags.resource_tagging import get_tag_list
@@ -101,7 +102,7 @@ class Schedule(PushEventSource):
         "RetryPolicy": PropertyType(False, is_type(dict)),
     }
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         """Returns the EventBridge Rule and Lambda Permission to which this Schedule event source corresponds.
 
@@ -175,7 +176,7 @@ class CloudWatchEvent(PushEventSource):
         "Target": PropertyType(False, is_type(dict)),
     }
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         """Returns the CloudWatch Events/EventBridge Rule and Lambda Permission to which
         this CloudWatch Events/EventBridge event source corresponds.
@@ -261,7 +262,7 @@ class S3(PushEventSource):
                 return {"bucket": resources[bucket_id], "bucket_id": bucket_id}
         raise InvalidEventException(self.relative_id, "S3 events must reference an S3 bucket in the same template.")
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         """Returns the Lambda Permission resource allowing S3 to invoke the function this event source triggers.
 
@@ -413,7 +414,7 @@ class SNS(PushEventSource):
         "SqsSubscription": PropertyType(False, one_of(is_type(bool), is_type(dict))),
     }
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         """Returns the Lambda Permission resource allowing SNS to invoke the function this event source triggers.
 
@@ -576,7 +577,7 @@ class Api(PushEventSource):
 
         return {"explicit_api": explicit_api, "explicit_api_stage": {"suffix": stage_suffix}}
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         """If the Api event source has a RestApi property, then simply return the Lambda Permission resource allowing
         API Gateway to call the function. If no RestApi is provided, then additionally inject the path, method, and the
@@ -897,7 +898,7 @@ class AlexaSkill(PushEventSource):
 
     property_types = {"SkillId": PropertyType(False, is_str())}
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         function = kwargs.get("function")
 
@@ -916,7 +917,7 @@ class IoTRule(PushEventSource):
 
     property_types = {"Sql": PropertyType(True, is_str()), "AwsIotSqlVersion": PropertyType(False, is_str())}
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         function = kwargs.get("function")
 
@@ -979,7 +980,7 @@ class Cognito(PushEventSource):
             self.relative_id, "Cognito events must reference a Cognito UserPool in the same template."
         )
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         function = kwargs.get("function")
 
@@ -1065,7 +1066,7 @@ class HttpApi(PushEventSource):
 
         return {"explicit_api": explicit_api}
 
-    @cw_timer(prefix="PushEventSource")
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, **kwargs):
         """If the Api event source has a RestApi property, then simply return the Lambda Permission resource allowing
         API Gateway to call the function. If no RestApi is provided, then additionally inject the path, method, and the

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -1,6 +1,8 @@
 import copy
 import re
 from six import string_types
+
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceMacro, PropertyType
 from samtranslator.model.types import is_type, list_of, dict_of, one_of, is_str
 from samtranslator.model.intrinsics import ref, fnGetAtt, fnSub, make_shorthand, make_conditional
@@ -99,6 +101,7 @@ class Schedule(PushEventSource):
         "RetryPolicy": PropertyType(False, is_type(dict)),
     }
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         """Returns the EventBridge Rule and Lambda Permission to which this Schedule event source corresponds.
 
@@ -172,6 +175,7 @@ class CloudWatchEvent(PushEventSource):
         "Target": PropertyType(False, is_type(dict)),
     }
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         """Returns the CloudWatch Events/EventBridge Rule and Lambda Permission to which
         this CloudWatch Events/EventBridge event source corresponds.
@@ -257,6 +261,7 @@ class S3(PushEventSource):
                 return {"bucket": resources[bucket_id], "bucket_id": bucket_id}
         raise InvalidEventException(self.relative_id, "S3 events must reference an S3 bucket in the same template.")
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         """Returns the Lambda Permission resource allowing S3 to invoke the function this event source triggers.
 
@@ -408,6 +413,7 @@ class SNS(PushEventSource):
         "SqsSubscription": PropertyType(False, one_of(is_type(bool), is_type(dict))),
     }
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         """Returns the Lambda Permission resource allowing SNS to invoke the function this event source triggers.
 
@@ -570,6 +576,7 @@ class Api(PushEventSource):
 
         return {"explicit_api": explicit_api, "explicit_api_stage": {"suffix": stage_suffix}}
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         """If the Api event source has a RestApi property, then simply return the Lambda Permission resource allowing
         API Gateway to call the function. If no RestApi is provided, then additionally inject the path, method, and the
@@ -890,6 +897,7 @@ class AlexaSkill(PushEventSource):
 
     property_types = {"SkillId": PropertyType(False, is_str())}
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         function = kwargs.get("function")
 
@@ -908,6 +916,7 @@ class IoTRule(PushEventSource):
 
     property_types = {"Sql": PropertyType(True, is_str()), "AwsIotSqlVersion": PropertyType(False, is_str())}
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         function = kwargs.get("function")
 
@@ -970,6 +979,7 @@ class Cognito(PushEventSource):
             self.relative_id, "Cognito events must reference a Cognito UserPool in the same template."
         )
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         function = kwargs.get("function")
 
@@ -1055,6 +1065,7 @@ class HttpApi(PushEventSource):
 
         return {"explicit_api": explicit_api}
 
+    @cw_timer(prefix="PushEventSource")
     def to_cloudformation(self, **kwargs):
         """If the Api event source has a RestApi property, then simply return the Lambda Permission resource allowing
         API Gateway to call the function. If no RestApi is provided, then additionally inject the path, method, and the

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -50,6 +50,7 @@ from samtranslator.model.sns import SNSTopic
 from samtranslator.model.stepfunctions import StateMachineGenerator
 from samtranslator.model.role_utils import construct_role_for_resource
 from samtranslator.model.xray_utils import get_xray_managed_policy_name
+from ..metrics.method_decorator import cw_timer
 
 
 class SamFunction(SamResourceMacro):
@@ -120,6 +121,7 @@ class SamFunction(SamResourceMacro):
         except InvalidEventException as e:
             raise InvalidResourceException(self.logical_id, e.message)
 
+    @cw_timer
     def to_cloudformation(self, **kwargs):
         """Returns the Lambda function, role, and event resources to which this SAM Function corresponds.
 
@@ -848,6 +850,7 @@ class SamApi(SamResourceMacro):
         "ApiKey": ApiGatewayApiKey.resource_type,
     }
 
+    @cw_timer
     def to_cloudformation(self, **kwargs):
         """Returns the API Gateway RestApi, Deployment, and Stage to which this SAM Api corresponds.
 
@@ -955,6 +958,7 @@ class SamHttpApi(SamResourceMacro):
         "DomainName": ApiGatewayV2DomainName.resource_type,
     }
 
+    @cw_timer
     def to_cloudformation(self, **kwargs):
         """Returns the API GatewayV2 Api, Deployment, and Stage to which this SAM Api corresponds.
 
@@ -1027,6 +1031,7 @@ class SamSimpleTable(SamResourceMacro):
     }
     attribute_type_conversions = {"String": "S", "Number": "N", "Binary": "B"}
 
+    @cw_timer
     def to_cloudformation(self, **kwargs):
         dynamodb_resources = self._construct_dynamodb_table()
 
@@ -1091,6 +1096,7 @@ class SamApplication(SamResourceMacro):
         "TimeoutInMinutes": PropertyType(False, is_type(int)),
     }
 
+    @cw_timer
     def to_cloudformation(self, **kwargs):
         """Returns the stack with the proper parameters for this application"""
         nested_stack = self._construct_nested_stack()
@@ -1141,6 +1147,7 @@ class SamLayerVersion(SamResourceMacro):
     DELETE = "Delete"
     retention_policy_options = [RETAIN.lower(), DELETE.lower()]
 
+    @cw_timer
     def to_cloudformation(self, **kwargs):
         """Returns the Lambda layer to which this SAM Layer corresponds.
 
@@ -1269,6 +1276,7 @@ class SamStateMachine(SamResourceMacro):
         samtranslator.model.stepfunctions.events,
     )
 
+    @cw_timer
     def to_cloudformation(self, **kwargs):
         managed_policy_map = kwargs.get("managed_policy_map", {})
         intrinsics_resolver = kwargs["intrinsics_resolver"]

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -11,6 +11,7 @@ from .api.http_api_generator import HttpApiGenerator
 from .packagetype import ZIP, IMAGE
 from .s3_utils.uri_parser import construct_s3_location_object, construct_image_code_object
 from .tags.resource_tagging import get_tag_list
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import PropertyType, SamResourceMacro, ResourceTypeResolver
 from samtranslator.model.apigateway import (
     ApiGatewayDeployment,
@@ -50,7 +51,6 @@ from samtranslator.model.sns import SNSTopic
 from samtranslator.model.stepfunctions import StateMachineGenerator
 from samtranslator.model.role_utils import construct_role_for_resource
 from samtranslator.model.xray_utils import get_xray_managed_policy_name
-from ..metrics.method_decorator import cw_timer
 
 
 class SamFunction(SamResourceMacro):

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -1,6 +1,7 @@
 from six import string_types
 import json
 
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import PropertyType, ResourceMacro
 from samtranslator.model.events import EventsRule
 from samtranslator.model.iam import IAMRole, IAMRolePolicies
@@ -87,6 +88,7 @@ class Schedule(EventSource):
         "RetryPolicy": PropertyType(False, is_type(dict)),
     }
 
+    @cw_timer(prefix="EventSource")
     def to_cloudformation(self, resource, **kwargs):
         """Returns the EventBridge Rule and IAM Role to which this Schedule event source corresponds.
 
@@ -160,6 +162,7 @@ class CloudWatchEvent(EventSource):
         "RetryPolicy": PropertyType(False, is_type(dict)),
     }
 
+    @cw_timer(prefix="EventSource")
     def to_cloudformation(self, resource, **kwargs):
         """Returns the CloudWatch Events/EventBridge Rule and IAM Role to which this
         CloudWatch Events/EventBridge event source corresponds.
@@ -283,6 +286,7 @@ class Api(EventSource):
 
         return {"explicit_api": explicit_api, "explicit_api_stage": {"suffix": stage_suffix}}
 
+    @cw_timer(prefix="EventSource")
     def to_cloudformation(self, resource, **kwargs):
         """If the Api event source has a RestApi property, then simply return the IAM role resource
         allowing API Gateway to start the state machine execution. If no RestApi is provided, then

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -16,6 +16,7 @@ from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.open_api.open_api import OpenApiEditor
 
 CONDITION = "Condition"
+SFN_EVETSOURCE_METRIC_PREFIX = "SFNEventSource"
 
 
 class EventSource(ResourceMacro):
@@ -88,7 +89,7 @@ class Schedule(EventSource):
         "RetryPolicy": PropertyType(False, is_type(dict)),
     }
 
-    @cw_timer(prefix="EventSource")
+    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, resource, **kwargs):
         """Returns the EventBridge Rule and IAM Role to which this Schedule event source corresponds.
 
@@ -162,7 +163,7 @@ class CloudWatchEvent(EventSource):
         "RetryPolicy": PropertyType(False, is_type(dict)),
     }
 
-    @cw_timer(prefix="EventSource")
+    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, resource, **kwargs):
         """Returns the CloudWatch Events/EventBridge Rule and IAM Role to which this
         CloudWatch Events/EventBridge event source corresponds.
@@ -286,7 +287,7 @@ class Api(EventSource):
 
         return {"explicit_api": explicit_api, "explicit_api_stage": {"suffix": stage_suffix}}
 
-    @cw_timer(prefix="EventSource")
+    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, resource, **kwargs):
         """If the Api event source has a RestApi property, then simply return the IAM role resource
         allowing API Gateway to start the state machine execution. If no RestApi is provided, then

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -100,7 +100,7 @@ class StateMachineGenerator(object):
         )
         self.substitution_counter = 1
 
-    @cw_timer(name="StateMachineGenerator")
+    @cw_timer(prefix="Generator", name="StateMachine")
     def to_cloudformation(self):
         """
         Constructs and returns the State Machine resource and any additional resources associated with it.

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from six import string_types
 
 import samtranslator.model.eventsources.push
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceTypeResolver
 from samtranslator.model.exceptions import InvalidEventException, InvalidResourceException
 from samtranslator.model.iam import IAMRolePolicies
@@ -99,6 +100,7 @@ class StateMachineGenerator(object):
         )
         self.substitution_counter = 1
 
+    @cw_timer(name="StateMachineGenerator")
     def to_cloudformation(self):
         """
         Constructs and returns the State Machine resource and any additional resources associated with it.

--- a/samtranslator/plugins/api/default_definition_body_plugin.py
+++ b/samtranslator/plugins/api/default_definition_body_plugin.py
@@ -1,3 +1,4 @@
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.plugins import BasePlugin
 from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.open_api.open_api import OpenApiEditor
@@ -20,6 +21,7 @@ class DefaultDefinitionBodyPlugin(BasePlugin):
 
         super(DefaultDefinitionBodyPlugin, self).__init__(DefaultDefinitionBodyPlugin.__name__)
 
+    @cw_timer(prefix="Plugin-DefaultDefinitionBody")
     def on_before_transform_template(self, template_dict):
         """
         Hook method that gets called before the SAM template is processed.

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -1,5 +1,6 @@
 import copy
 
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.intrinsics import make_combined_condition
 from samtranslator.model.eventsources.push import Api
 from samtranslator.public.plugins import BasePlugin
@@ -49,6 +50,7 @@ class ImplicitApiPlugin(BasePlugin):
             "Method _setup_api_properties() must be implemented in a " "subclass of ImplicitApiPlugin"
         )
 
+    @cw_timer(prefix="Plugin-ImplicitApi")
     def on_before_transform_template(self, template_dict):
         """
         Hook method that gets called before the SAM template is processed.

--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -19,6 +19,7 @@ LOG = logging.getLogger(__name__)
 
 PLUGIN_METRICS_PREFIX = "Plugin-ServerlessApp"
 
+
 class ServerlessAppPlugin(BasePlugin):
     """
     Resolves all of the ApplicationId and Semantic Version pairs

--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -5,6 +5,7 @@ import logging
 from time import sleep, time
 import copy
 
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.plugins import BasePlugin
 from samtranslator.plugins.exceptions import InvalidPluginException
@@ -16,6 +17,7 @@ from samtranslator.region_configuration import RegionConfiguration
 
 LOG = logging.getLogger(__name__)
 
+PLUGIN_METRICS_PREFIX = "Plugin-ServerlessApp"
 
 class ServerlessAppPlugin(BasePlugin):
     """
@@ -66,6 +68,7 @@ class ServerlessAppPlugin(BasePlugin):
             message = "Cannot set both validate_only and wait_for_template_active_status flags to True."
             raise InvalidPluginException(ServerlessAppPlugin.__name__, message)
 
+    @cw_timer(prefix=PLUGIN_METRICS_PREFIX)
     def on_before_transform_template(self, template_dict):
         """
         Hook method that gets called before the SAM template is processed.
@@ -211,6 +214,7 @@ class ServerlessAppPlugin(BasePlugin):
             return None
         return str(param)
 
+    @cw_timer(prefix=PLUGIN_METRICS_PREFIX)
     def on_before_transform_resource(self, logical_id, resource_type, resource_properties):
         """
         Hook method that gets called before "each" SAM resource gets processed
@@ -288,6 +292,7 @@ class ServerlessAppPlugin(BasePlugin):
                     logical_id, "Resource is missing the required [{}] " "property.".format(key)
                 )
 
+    @cw_timer(prefix=PLUGIN_METRICS_PREFIX)
     def on_after_transform_template(self, template):
         """
         Hook method that gets called after the template is processed
@@ -349,6 +354,7 @@ class ServerlessAppPlugin(BasePlugin):
                 raise InvalidResourceException(application_id, message)
             self._in_progress_templates.append((application_id, template_id))
 
+    @cw_timer(prefix="External", name="SAR")
     def _sar_service_call(self, service_call_lambda, logical_id, *args):
         """
         Handles service calls and exception management for service calls

--- a/samtranslator/plugins/globals/globals_plugin.py
+++ b/samtranslator/plugins/globals/globals_plugin.py
@@ -1,3 +1,4 @@
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.public.sdk.template import SamTemplate
 from samtranslator.public.plugins import BasePlugin
 from samtranslator.public.exceptions import InvalidDocumentException
@@ -18,6 +19,7 @@ class GlobalsPlugin(BasePlugin):
         """
         super(GlobalsPlugin, self).__init__(GlobalsPlugin.__name__)
 
+    @cw_timer(prefix="Plugin-Globals")
     def on_before_transform_template(self, template_dict):
         """
         Hook method that runs before a template gets transformed. In this method, we parse and process Globals section

--- a/samtranslator/plugins/policies/policy_templates_plugin.py
+++ b/samtranslator/plugins/policies/policy_templates_plugin.py
@@ -1,3 +1,4 @@
+from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.plugins import BasePlugin
 from samtranslator.model.resource_policies import ResourcePolicies, PolicyTypes
 from samtranslator.model.exceptions import InvalidResourceException
@@ -30,6 +31,7 @@ class PolicyTemplatesForResourcePlugin(BasePlugin):
 
         self._policy_template_processor = policy_template_processor
 
+    @cw_timer(prefix="Plugin-PolicyTemplates")
     def on_before_transform_resource(self, logical_id, resource_type, resource_properties):
         """
         Hook method that gets called before "each" SAM resource gets processed

--- a/samtranslator/translator/managed_policy_translator.py
+++ b/samtranslator/translator/managed_policy_translator.py
@@ -1,5 +1,7 @@
 import logging
 
+from samtranslator.metrics.method_decorator import cw_timer
+
 LOG = logging.getLogger(__name__)
 
 
@@ -9,22 +11,26 @@ class ManagedPolicyLoader(object):
         self._policy_map = None
         self.max_items = 1000
 
+    @cw_timer(prefix="External", name="IAM")
+    def _load_policies_from_iam(self):
+        LOG.info("Loading policies from IAM...")
+
+        paginator = self._iam_client.get_paginator("list_policies")
+        # Setting the scope to AWS limits the returned values to only AWS Managed Policies and will
+        # not returned policies owned by any specific account.
+        # http://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicies.html#API_ListPolicies_RequestParameters
+        # Note(jfuss): boto3 PaginationConfig MaxItems does not control the number of items returned from the API
+        # call. This is actually controlled by PageSize.
+        page_iterator = paginator.paginate(Scope="AWS", PaginationConfig={"PageSize": self.max_items})
+        name_to_arn_map = {}
+
+        for page in page_iterator:
+            name_to_arn_map.update(map(lambda x: (x["PolicyName"], x["Arn"]), page["Policies"]))
+
+        LOG.info("Finished loading policies from IAM.")
+        self._policy_map = name_to_arn_map
+
     def load(self):
         if self._policy_map is None:
-            LOG.info("Loading policies from IAM...")
-
-            paginator = self._iam_client.get_paginator("list_policies")
-            # Setting the scope to AWS limits the returned values to only AWS Managed Policies and will
-            # not returned policies owned by any specific account.
-            # http://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicies.html#API_ListPolicies_RequestParameters
-            # Note(jfuss): boto3 PaginationConfig MaxItems does not control the number of items returned from the API
-            # call. This is actually controlled by PageSize.
-            page_iterator = paginator.paginate(Scope="AWS", PaginationConfig={"PageSize": self.max_items})
-            name_to_arn_map = {}
-
-            for page in page_iterator:
-                name_to_arn_map.update(map(lambda x: (x["PolicyName"], x["Arn"]), page["Policies"]))
-
-            LOG.info("Finished loading policies from IAM.")
-            self._policy_map = name_to_arn_map
+            self._load_policies_from_iam()
         return self._policy_map

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -1,5 +1,7 @@
 import copy
 from six import string_types
+
+from samtranslator.metrics.method_decorator import MetricsMethodWrapperSingleton
 from samtranslator.metrics.metrics import DummyMetricsPublisher, Metrics
 
 from samtranslator.feature_toggle.feature_toggle import (
@@ -47,6 +49,7 @@ class Translator:
         self.feature_toggle = None
         self.boto_session = boto_session
         self.metrics = metrics if metrics else Metrics("ServerlessTransform", DummyMetricsPublisher())
+        MetricsMethodWrapperSingleton.set_instance(self.metrics)
 
         if self.boto_session:
             ArnGenerator.BOTO_SESSION_REGION_NAME = self.boto_session.region_name

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -1,7 +1,6 @@
 import copy
 from six import string_types
 
-from samtranslator.metrics.method_decorator import MetricsMethodWrapperSingleton
 from samtranslator.metrics.metrics import DummyMetricsPublisher, Metrics
 
 from samtranslator.feature_toggle.feature_toggle import (
@@ -49,7 +48,6 @@ class Translator:
         self.feature_toggle = None
         self.boto_session = boto_session
         self.metrics = metrics if metrics else Metrics("ServerlessTransform", DummyMetricsPublisher())
-        MetricsMethodWrapperSingleton.set_instance(self.metrics)
 
         if self.boto_session:
             ArnGenerator.BOTO_SESSION_REGION_NAME = self.boto_session.region_name

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -49,7 +49,7 @@ class Translator:
         self.feature_toggle = None
         self.boto_session = boto_session
         self.metrics = metrics if metrics else Metrics("ServerlessTransform", DummyMetricsPublisher())
-        MetricsMethodWrapperSingleton.set_instance(metrics)
+        MetricsMethodWrapperSingleton.set_instance(self.metrics)
 
         if self.boto_session:
             ArnGenerator.BOTO_SESSION_REGION_NAME = self.boto_session.region_name

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -1,6 +1,5 @@
 import copy
 from six import string_types
-
 from samtranslator.metrics.metrics import DummyMetricsPublisher, Metrics
 
 from samtranslator.feature_toggle.feature_toggle import (

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -1,5 +1,7 @@
 import copy
 from six import string_types
+
+from samtranslator.metrics.method_decorator import MetricsMethodWrapperSingleton
 from samtranslator.metrics.metrics import DummyMetricsPublisher, Metrics
 
 from samtranslator.feature_toggle.feature_toggle import (
@@ -47,6 +49,7 @@ class Translator:
         self.feature_toggle = None
         self.boto_session = boto_session
         self.metrics = metrics if metrics else Metrics("ServerlessTransform", DummyMetricsPublisher())
+        MetricsMethodWrapperSingleton.set_instance(metrics)
 
         if self.boto_session:
             ArnGenerator.BOTO_SESSION_REGION_NAME = self.boto_session.region_name

--- a/tests/metrics/test_method_decorator.py
+++ b/tests/metrics/test_method_decorator.py
@@ -1,19 +1,22 @@
 from unittest import TestCase
 from mock import Mock, patch, ANY
 
-from samtranslator.metrics.method_decorator import MetricsMethodWrapperSingleton, _get_metric_name, _send_cw_metric, \
-    cw_timer
+from samtranslator.metrics.method_decorator import (
+    MetricsMethodWrapperSingleton,
+    _get_metric_name,
+    _send_cw_metric,
+    cw_timer,
+)
 from samtranslator.model import Resource
 
 
 class MyClass:
-
     @cw_timer
     def my_method(self):
         return True
 
-class TestMetricsMethodWrapperSingleton(TestCase):
 
+class TestMetricsMethodWrapperSingleton(TestCase):
     def test_default_instance(self):
         default_instance = MetricsMethodWrapperSingleton.get_instance()
         self.assertEqual(default_instance, MetricsMethodWrapperSingleton._DUMMY_INSTANCE)
@@ -25,7 +28,6 @@ class TestMetricsMethodWrapperSingleton(TestCase):
 
 
 class TestMetricsMethodDecoratorMetricName(TestCase):
-
     def test_get_metric_name_with_name(self):
         given_metric_name = "MetricName"
         metric_name = _get_metric_name(None, given_metric_name, None, [])

--- a/tests/metrics/test_method_decorator.py
+++ b/tests/metrics/test_method_decorator.py
@@ -1,0 +1,85 @@
+from unittest import TestCase
+from mock import Mock, patch, ANY
+
+from samtranslator.metrics.method_decorator import MetricsMethodWrapperSingleton, _get_metric_name, _send_cw_metric, \
+    cw_timer
+from samtranslator.model import Resource
+
+
+class MyClass:
+
+    @cw_timer
+    def my_method(self):
+        return True
+
+class TestMetricsMethodWrapperSingleton(TestCase):
+
+    def test_default_instance(self):
+        default_instance = MetricsMethodWrapperSingleton.get_instance()
+        self.assertEqual(default_instance, MetricsMethodWrapperSingleton._DUMMY_INSTANCE)
+
+    def test_given_instance(self):
+        given_instance = Mock()
+        MetricsMethodWrapperSingleton.set_instance(given_instance)
+        self.assertEqual(given_instance, MetricsMethodWrapperSingleton.get_instance())
+
+
+class TestMetricsMethodDecoratorMetricName(TestCase):
+
+    def test_get_metric_name_with_name(self):
+        given_metric_name = "MetricName"
+        metric_name = _get_metric_name(None, given_metric_name, None, [])
+        self.assertEqual(metric_name, given_metric_name)
+
+    def test_get_metric_name_with_name_and_prefix(self):
+        given_metric_name = "MetricName"
+        given_prefix = "Prefix"
+        metric_name = _get_metric_name(given_prefix, given_metric_name, None, [])
+        self.assertEqual(metric_name, "{}-{}".format(given_prefix, given_metric_name))
+
+    def test_get_metric_name_with_function(self):
+        def my_function():
+            return True
+
+        metric_name = _get_metric_name(None, None, my_function, [])
+        self.assertEqual(metric_name, "my_function")
+
+    def test_get_metric_name_with_resource_type(self):
+        given_resource_type = "AWS::Serverless::MyResource"
+        mock_resource = Mock(spec=Resource, resource_type=given_resource_type)
+
+        metric_name = _get_metric_name(None, None, None, [mock_resource])
+        self.assertEqual(metric_name, given_resource_type)
+
+    @patch("samtranslator.metrics.method_decorator.MetricsMethodWrapperSingleton")
+    @patch("samtranslator.metrics.method_decorator._get_metric_name")
+    def test_send_cw_metric(self, patched_metric_name, patched_singleton):
+        given_execution_time = Mock()
+        given_metric_name = "MetricName"
+        patched_metric_name.return_value = given_metric_name
+
+        _send_cw_metric(None, given_metric_name, given_execution_time, None, [])
+        patched_metric_name.assert_called_with(None, given_metric_name, None, [])
+        patched_singleton.get_instance.assert_called_once()
+        patched_singleton.get_instance().record_latency.assert_called_with(given_metric_name, given_execution_time)
+
+    def test_cw_timer_decorator(self):
+        given_metrics_instance = Mock()
+        MetricsMethodWrapperSingleton.set_instance(given_metrics_instance)
+
+        my_class = MyClass()
+        return_value = my_class.my_method()
+
+        self.assertTrue(return_value)
+        given_metrics_instance.record_latency.assert_called_with("my_method", ANY)
+
+    def test_cw_timer_should_not_break_the_method(self):
+        given_metrics_instance = Mock()
+        given_metrics_instance.record_latency.side_effect = Exception()
+        MetricsMethodWrapperSingleton.set_instance(given_metrics_instance)
+
+        my_class = MyClass()
+        return_value = my_class.my_method()
+
+        self.assertTrue(return_value)
+        given_metrics_instance.record_latency.assert_called_with("my_method", ANY)


### PR DESCRIPTION
This commit enables metric collection per resource, if a `Metrics` instance is been defined and configured to use CloudWatch.

*Checklist:*

- [x] Add/update tests using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
