### PR TITLE
fix: Check GatewayResponse value type.

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -858,6 +858,19 @@ class ApiGenerator(object):
 
         # Make sure keys in the dict are recognized
         for responses_key, responses_value in self.gateway_responses.items():
+            if is_intrinsic(responses_value):
+                # TODO: Add intrinsic support for this field.
+                raise InvalidResourceException(
+                    self.logical_id,
+                    "Unable to set GatewayResponses attribute because "
+                    "intrinsic functions are not supported for this field.",
+                )
+            elif not isinstance(responses_value, dict):
+                raise InvalidResourceException(
+                    self.logical_id,
+                    "Invalid property type '{}' for GatewayResponses. "
+                    "Expected an object of type 'GatewayResponse'.".format(type(responses_value).__name__),
+                )
             for response_key in responses_value.keys():
                 if response_key not in GatewayResponseProperties:
                     raise InvalidResourceException(

--- a/tests/translator/input/error_gateway_response_invalid_type_int.yaml
+++ b/tests/translator/input/error_gateway_response_invalid_type_int.yaml
@@ -1,0 +1,19 @@
+Resources:
+  ApiResource:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      GatewayResponses:
+        DEFAULT_5XX:
+          ResponseParameters:
+            Headers:
+              Access-Control-Allow-Origin: '''*'''
+              Access-Control-Allow-Methods: '''GET,OPTIONS'''
+              Access-Control-Allow-Headers: '''content-type'''
+        DEFAULT_4XX:
+          ResponseParameters:
+            Headers:
+              Access-Control-Allow-Origin: '''*'''
+              Access-Control-Allow-Methods: '''GET,PATCH,PUT,OPTIONS'''
+              Access-Control-Allow-Headers: '''content-type'''
+        StatusCode: 200

--- a/tests/translator/input/error_gateway_response_invalid_type_intrinsic.yaml
+++ b/tests/translator/input/error_gateway_response_invalid_type_intrinsic.yaml
@@ -7,8 +7,7 @@ Resources:
         DEFAULT_4XX:
           Fn::Select:
           - 0
-          - - DEFAULT_5XX:
-                ResponseParameters:
+          - - ResponseParameters:
                   Headers:
                     Access-Control-Allow-Origin: '''*'''
                     Access-Control-Allow-Methods: '''GET,OPTIONS'''

--- a/tests/translator/input/error_gateway_response_invalid_type_intrinsic.yaml
+++ b/tests/translator/input/error_gateway_response_invalid_type_intrinsic.yaml
@@ -1,0 +1,15 @@
+Resources:
+  ApiResource:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      GatewayResponses:
+        DEFAULT_4XX:
+          Fn::Select:
+          - 0
+          - - DEFAULT_5XX:
+                ResponseParameters:
+                  Headers:
+                    Access-Control-Allow-Origin: '''*'''
+                    Access-Control-Allow-Methods: '''GET,OPTIONS'''
+                    Access-Control-Allow-Headers: '''content-type'''

--- a/tests/translator/output/error_gateway_response_invalid_type_int.json
+++ b/tests/translator/output/error_gateway_response_invalid_type_int.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [ApiResource] is invalid. Invalid property type 'int' for GatewayResponses. Expected an object of type 'GatewayResponse'."
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [ApiResource] is invalid. Invalid property type 'int' for GatewayResponses. Expected an object of type 'GatewayResponse'."
+}

--- a/tests/translator/output/error_gateway_response_invalid_type_intrinsic.json
+++ b/tests/translator/output/error_gateway_response_invalid_type_intrinsic.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [ApiResource] is invalid. Unable to set GatewayResponses attribute because intrinsic functions are not supported for this field."
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [ApiResource] is invalid. Unable to set GatewayResponses attribute because intrinsic functions are not supported for this field."
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -793,6 +793,8 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
         "error_api_swagger_integration_with_sub_intrinsic_api_id",
         "error_api_swagger_integration_with_transform_intrinsic_api_id",
         "error_api_swagger_integration_with_getatt_intrinsic_api_id",
+        "error_gateway_response_invalid_type_int",
+        "error_gateway_response_invalid_type_intrinsic",
     ],
 )
 @patch("boto3.session.Session.region_name", "ap-southeast-1")


### PR DESCRIPTION
Thanks to Ruperto for helping with this PR.

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
