### PR TITLE
Added Exclusion for Non-Method Path Sections

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -28,6 +28,7 @@ class SwaggerEditor(object):
     _CACHE_KEY_PARAMETERS = "cacheKeyParameters"
     # https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
     _ALL_HTTP_METHODS = ["OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"]
+    _EXCLUDED_PATHS_FIELDS = ["summary", "description", "parameters"]
     _POLICY_TYPE_IAM = "Iam"
     _POLICY_TYPE_IP = "Ip"
     _POLICY_TYPE_VPC = "Vpc"
@@ -527,8 +528,8 @@ class SwaggerEditor(object):
         for method_name, method in self.get_path(path).items():
             normalized_method_name = self._normalize_method_name(method_name)
 
-            # Excluding parameters section
-            if normalized_method_name == "parameters":
+            # Excluding non-method sections
+            if normalized_method_name in SwaggerEditor._EXCLUDED_PATHS_FIELDS:
                 continue
             if add_default_auth_to_preflight or normalized_method_name != "options":
                 normalized_method_name = self._normalize_method_name(method_name)
@@ -623,8 +624,8 @@ class SwaggerEditor(object):
         """
 
         for method_name, method in self.get_path(path).items():
-            # Excluding parameters section
-            if method_name == "parameters":
+            # Excluding non-method sections
+            if method_name in SwaggerEditor._EXCLUDED_PATHS_FIELDS:
                 continue
 
             # It is possible that the method could have two definitions in a Fn::If block.


### PR DESCRIPTION
*Issue #, if available:*
OAS 3 added `summary` and `description` fields to path. SAM tries to resolve these fields as valid method sections.
https://swagger.io/docs/specification/paths-and-operations/
Example:
```
paths:
  /abc:
    summary: dummy summary
    get:
      x-amazon-apigateway-integration:
      contentHandling: CONVERT_TO_TEXT
```
```
method_definition.get(self._X_APIGW_INTEGRATION): -> "dummy summary".get(self._X_APIGW_INTEGRATION)
```


*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
