### PR TITLE
fix: don't try to resolve the reference id if get attribute fields ar…

### DIFF
--- a/samtranslator/intrinsics/actions.py
+++ b/samtranslator/intrinsics/actions.py
@@ -490,6 +490,12 @@ class GetAttAction(Action):
         if not isinstance(value, list) or len(value) < 2:
             return input_dict
 
+        # If items in value array is not a string, then following join line will fail. So if any element is not a string
+        # we just pass along the input to CFN for doing the validation
+        for item in value:
+            if not isinstance(item, string_types):
+                return input_dict
+
         value_str = self._resource_ref_separator.join(value)
         splits = value_str.split(self._resource_ref_separator)
         logical_id = splits[0]

--- a/tests/intrinsics/test_actions.py
+++ b/tests/intrinsics/test_actions.py
@@ -699,6 +699,15 @@ class TestGetAttCanResolveResourceIdRefs(TestCase):
 
         self.assertEqual(expected, output)
 
+    def test_must_ignore_non_string_types(self):
+        input = {"Fn::GetAtt": ["a", {"c": "d"}]}
+        expected = {"Fn::GetAtt": ["a", {"c": "d"}]}
+
+        getatt = GetAttAction()
+        output = getatt.resolve_resource_id_refs(input, self.supported_resource_id_refs)
+
+        self.assertEqual(expected, output)
+
     def test_must_ignore_missing_properties_with_dot_before(self):
         input = {"Fn::GetAtt": [".id1", "foo"]}
         expected = {"Fn::GetAtt": [".id1", "foo"]}


### PR DESCRIPTION
…e not string

*Issue #, if available:*
When trying to resolve resource id's for `GetAtt` intrinsic function, if parameters are not string, it will fail to resolve it.

*Description of changes:*
We don't try to resolve them if parameters are not string, we will just return the given dict, and let CFN to resolve it.

*Description of how you validated changes:*
Test with failure example and added unit tests

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
