### PR TITLE
Ensure AutoPublishCodeSha256 resolves to a string

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -157,6 +157,11 @@ class SamFunction(SamResourceMacro):
             code_sha256 = None
             if self.AutoPublishCodeSha256:
                 code_sha256 = intrinsics_resolver.resolve_parameter_refs(self.AutoPublishCodeSha256)
+                if not isinstance(code_sha256, string_types):
+                    raise InvalidResourceException(
+                        self.logical_id,
+                        "AutoPublishCodeSha256 must be a string",
+                    )
             lambda_version = self._construct_version(
                 lambda_function, intrinsics_resolver=intrinsics_resolver, code_sha256=code_sha256
             )

--- a/samtranslator/translator/logical_id_generator.py
+++ b/samtranslator/translator/logical_id_generator.py
@@ -16,6 +16,7 @@ class LogicalIdGenerator(object):
 
         :param prefix: Prefix for the logicalId
         :param data_obj: Data object to trigger new changes on. If set to None, this is ignored
+        :param data_hash: Pre-computed hash, must be a string
         """
 
         data_str = ""

--- a/tests/translator/input/error_function_fnsub_in_auto_publish_hash.yaml
+++ b/tests/translator/input/error_function_fnsub_in_auto_publish_hash.yaml
@@ -1,0 +1,24 @@
+Description: Dip Investigation
+Parameters:
+  GitCommitInfo: 
+    Type: String
+    Default: hashhash
+  GitDirtInfo: 
+    Type: String
+    Default: dirtyyy
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      VersionDescription:
+        Fn::Sub: ${GitCommitInfo}-${GitDirtyInfo}
+      MemorySize: 128
+      Handler: loader
+      Role:
+        Ref: IamRole
+      CodeUri: s3://some-bucket/somekey
+      AutoPublishCodeSha256:
+        Fn::Sub: ${GitCommitInfo}-${GitDirtInfo}-1
+      Runtime: go1.x
+      AutoPublishAlias: Alias1

--- a/tests/translator/output/error_function_fnsub_in_auto_publish_hash.json
+++ b/tests/translator/output/error_function_fnsub_in_auto_publish_hash.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "[Function] is invalid. AutoPublishCodeSha256 must be a string"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Function] is invalid. AutoPublishCodeSha256 must be a string"
+}


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Check that `AutoPublishCodeSha256` resolves to a string and fail gracefully if it doesn't.

*Description of how you validated changes:*
Added a unit test to check the failure and ran existing unit tests to confirm there's no regression.

*Checklist:*

- [x] Add/update tests using:
    - [x] Correct values - existing tests cover this field
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation - not needed
- [ ] Verify transformed template deploys and application functions as expected
