### PR TITLE
Fix no allowed origin

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -603,14 +603,17 @@ class ApiGenerator(object):
 
         editor = SwaggerEditor(self.definition_body)
         for path in editor.iter_on_path():
-            editor.add_cors(
-                path,
-                properties.AllowOrigin,
-                properties.AllowHeaders,
-                properties.AllowMethods,
-                max_age=properties.MaxAge,
-                allow_credentials=properties.AllowCredentials,
-            )
+            try:
+                editor.add_cors(
+                    path,
+                    properties.AllowOrigin,
+                    properties.AllowHeaders,
+                    properties.AllowMethods,
+                    max_age=properties.MaxAge,
+                    allow_credentials=properties.AllowCredentials,
+                )
+            except InvalidTemplateException as ex:
+                raise InvalidResourceException(self.logical_id, ex.message)
 
         # Assign the Swagger back to template
         self.definition_body = editor.swagger

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -321,7 +321,7 @@ class SwaggerEditor(object):
             return
 
         if not allowed_origins:
-            raise ValueError("Invalid input. Value for AllowedOrigins is required")
+            raise InvalidTemplateException("Invalid input. Value for AllowedOrigins is required")
 
         if not allowed_methods:
             # AllowMethods is not given. Let's try to generate the list from the given Swagger.

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -5,7 +5,7 @@ from mock import Mock
 from parameterized import parameterized, param
 
 from samtranslator.swagger.swagger import SwaggerEditor
-from samtranslator.model.exceptions import InvalidDocumentException
+from samtranslator.model.exceptions import InvalidDocumentException, InvalidTemplateException
 from tests.translator.test_translator import deep_sort_lists
 
 _X_INTEGRATION = "x-amazon-apigateway-integration"
@@ -352,7 +352,7 @@ class TestSwaggerEditor_add_cors(TestCase):
     def test_must_fail_for_invalid_allowed_origin(self):
 
         path = "/foo"
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InvalidTemplateException):
             self.editor.add_cors(path, None, "headers", "methods")
 
     def test_must_work_for_optional_allowed_headers(self):

--- a/tests/translator/input/error_api_with_cors_and_empty_allow_origin.yaml
+++ b/tests/translator/input/error_api_with_cors_and_empty_allow_origin.yaml
@@ -1,0 +1,80 @@
+Globals:
+  Api:
+    Cors: {
+    "Fn::Join": [",", ["www.amazon.com", "www.google.com"]]
+    }
+
+Resources:
+  ImplicitApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs12.x
+      Events:
+        GetHtml:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+        AnyApi:
+          Type: Api
+          Properties:
+            Path: /foo
+            Method: any
+  RestApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.handler
+      Runtime: nodejs12.x
+  GetHtmlFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.handler
+      Runtime: nodejs12.x
+  ExplicitApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      DefinitionBody:  {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/add": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            },
+            "/{proxy+}": {
+              "x-amazon-apigateway-any-method": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            }
+          },
+          "swagger": "2.0"
+        }
+      Cors:
+        AllowMethods: "methods"
+        AllowHeaders: "headers"
+        AllowOrigin: ""
+        AllowCredentials: true

--- a/tests/translator/output/error_api_with_cors_and_empty_allow_origin.json
+++ b/tests/translator/output/error_api_with_cors_and_empty_allow_origin.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [ExplicitApi] is invalid. Structure of the SAM template is invalid. Invalid input. Value for AllowedOrigins is required"
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [ExplicitApi] is invalid. Structure of the SAM template is invalid. Invalid input. Value for AllowedOrigins is required"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If a template with empty AllowOrigins is passed to SAM we detect and throw `ValueError`, this error is then left uncaught and causes service error. This PR Is converting that `ValueError` to a SAM specific error which is then handled properly and proper error message is returned as part of transform failure.

*Description of how you validated changes:*
Added functional test.

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values (already exist)
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
