### PR TITLE
refactor: Replace mock with unittest.mock

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,6 @@ pyyaml~=5.4
 # Test requirements
 pytest~=6.1.1; python_version >= '3.6'
 pytest~=4.6.11; python_version < '3.6' # pytest dropped python 2 support after 4.6.x
-mock>=3.0.5,<4.0.0  # 4.0.0 drops Python 2 support
 parameterized~=0.7.4
 
 # Integration tests

--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -124,7 +124,9 @@ class Metrics:
     def __del__(self):
         if len(self.metrics_cache) > 0:
             # attempting to publish if user forgot to call publish in code
-            LOG.warn("There are unpublished metrics. Please make sure you call publish after you record all metrics.")
+            LOG.warning(
+                "There are unpublished metrics. Please make sure you call publish after you record all metrics."
+            )
             self.publish()
 
     def _record_metric(self, name, value, unit, dimensions=None):

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -1,4 +1,4 @@
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from parameterized import parameterized, param
 from unittest import TestCase
 import os, sys

--- a/tests/intrinsics/test_actions.py
+++ b/tests/intrinsics/test_actions.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from samtranslator.intrinsics.actions import Action, RefAction, SubAction, GetAttAction, FindInMapAction
 from samtranslator.intrinsics.resource_refs import SupportedResourceReferences
 from samtranslator.model.exceptions import InvalidTemplateException, InvalidDocumentException

--- a/tests/intrinsics/test_resolver.py
+++ b/tests/intrinsics/test_resolver.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.intrinsics.actions import Action
 from samtranslator.model.exceptions import InvalidDocumentException

--- a/tests/metrics/test_method_decorator.py
+++ b/tests/metrics/test_method_decorator.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch, ANY
+from unittest.mock import Mock, patch, ANY
 
 from samtranslator.metrics.method_decorator import (
     MetricsMethodWrapperSingleton,

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -1,6 +1,6 @@
 from parameterized import parameterized, param
 from unittest import TestCase
-from mock import MagicMock, call, ANY
+from unittest.mock import MagicMock, call, ANY
 from samtranslator.metrics.metrics import (
     Metrics,
     MetricsPublisher,

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 import pytest
 from functools import reduce
 

--- a/tests/model/eventsources/test_api_event_source.py
+++ b/tests/model/eventsources/test_api_event_source.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 
 from samtranslator.model.eventsources.push import Api

--- a/tests/model/eventsources/test_cloudwatch_event_source.py
+++ b/tests/model/eventsources/test_cloudwatch_event_source.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 
 from samtranslator.model.eventsources.push import CloudWatchEvent

--- a/tests/model/eventsources/test_cloudwatchlogs_event_source.py
+++ b/tests/model/eventsources/test_cloudwatchlogs_event_source.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 from samtranslator.model.eventsources.cloudwatchlogs import CloudWatchLogs
 

--- a/tests/model/eventsources/test_eventbridge_rule_source.py
+++ b/tests/model/eventsources/test_eventbridge_rule_source.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 
 from samtranslator.model.eventsources.push import EventBridgeRule

--- a/tests/model/eventsources/test_schedule_event_source.py
+++ b/tests/model/eventsources/test_schedule_event_source.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 
 from samtranslator.model.eventsources.push import Schedule

--- a/tests/model/eventsources/test_sns_event_source.py
+++ b/tests/model/eventsources/test_sns_event_source.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 from samtranslator.model.eventsources.push import SNS
 

--- a/tests/model/stepfunctions/test_api_event.py
+++ b/tests/model/stepfunctions/test_api_event.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 
 from samtranslator.model.stepfunctions.events import Api

--- a/tests/model/stepfunctions/test_cloudwatchevents_event.py
+++ b/tests/model/stepfunctions/test_cloudwatchevents_event.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 from samtranslator.model.stepfunctions.events import CloudWatchEvent
 from samtranslator.model.exceptions import InvalidEventException

--- a/tests/model/stepfunctions/test_schedule_event.py
+++ b/tests/model/stepfunctions/test_schedule_event.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 from samtranslator.model.stepfunctions.events import Schedule
 from samtranslator.model.exceptions import InvalidEventException

--- a/tests/model/stepfunctions/test_state_machine_generator.py
+++ b/tests/model/stepfunctions/test_state_machine_generator.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 
 from samtranslator.model import ResourceTypeResolver

--- a/tests/model/test_api_v2.py
+++ b/tests/model/test_api_v2.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 import pytest
-import mock
+from unittest.mock import patch, MagicMock
 
 from samtranslator.model import InvalidResourceException
 from samtranslator.model.apigatewayv2 import ApiGatewayV2Authorizer
@@ -64,9 +64,7 @@ class TestApiGatewayV2Authorizer(TestCase):
             + "AuthorizationScopes must be defined only for OAuth2 Authorizer.",
         )
 
-    @mock.patch(
-        "samtranslator.model.apigatewayv2.ApiGatewayV2Authorizer._get_auth_type", mock.MagicMock(return_value="INVALID")
-    )
+    @patch("samtranslator.model.apigatewayv2.ApiGatewayV2Authorizer._get_auth_type", MagicMock(return_value="INVALID"))
     def test_create_authorizer_fails_with_jtw_configuration_non_oauth2(self):
         with pytest.raises(InvalidResourceException) as e:
             ApiGatewayV2Authorizer(
@@ -165,9 +163,7 @@ class TestApiGatewayV2Authorizer(TestCase):
             + "EnableSimpleResponses must be defined only for Lambda Authorizer.",
         )
 
-    @mock.patch(
-        "samtranslator.model.apigatewayv2.ApiGatewayV2Authorizer._get_auth_type", mock.MagicMock(return_value="JWT")
-    )
+    @patch("samtranslator.model.apigatewayv2.ApiGatewayV2Authorizer._get_auth_type", MagicMock(return_value="JWT"))
     def test_create_jwt_authorizer_no_jwt_configuration(self):
         with pytest.raises(InvalidResourceException) as e:
             ApiGatewayV2Authorizer(api_logical_id="logicalId", name="authName")

--- a/tests/model/test_function_policies.py
+++ b/tests/model/test_function_policies.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 
 from samtranslator.model.function_policies import FunctionPolicies, PolicyTypes, PolicyEntry

--- a/tests/model/test_resource_policies.py
+++ b/tests/model/test_resource_policies.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 
 from samtranslator.model.resource_policies import ResourcePolicies, PolicyTypes, PolicyEntry

--- a/tests/model/test_sam_resources.py
+++ b/tests/model/test_sam_resources.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 import pytest
 
 from samtranslator.intrinsics.resolver import IntrinsicsResolver

--- a/tests/plugins/api/test_default_definition_body_plugin.py
+++ b/tests/plugins/api/test_default_definition_body_plugin.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 
 from samtranslator.plugins.api.default_definition_body_plugin import DefaultDefinitionBodyPlugin

--- a/tests/plugins/api/test_implicit_api_plugin.py
+++ b/tests/plugins/api/test_implicit_api_plugin.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 
 from samtranslator.public.sdk.resource import SamResource, SamResourceType
 from samtranslator.public.exceptions import InvalidEventException, InvalidResourceException, InvalidDocumentException

--- a/tests/plugins/application/test_serverless_app_plugin.py
+++ b/tests/plugins/application/test_serverless_app_plugin.py
@@ -1,7 +1,7 @@
 import boto3
 import itertools
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from unittest import TestCase
 from parameterized import parameterized, param
 

--- a/tests/plugins/globals/test_globals.py
+++ b/tests/plugins/globals/test_globals.py
@@ -1,7 +1,7 @@
 from parameterized import parameterized
 
 from unittest import TestCase
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from samtranslator.plugins.globals.globals import GlobalProperties, Globals, InvalidGlobalsSectionException
 

--- a/tests/plugins/globals/test_globals_plugin.py
+++ b/tests/plugins/globals/test_globals_plugin.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from samtranslator.public.exceptions import InvalidDocumentException
 from samtranslator.public.plugins import BasePlugin

--- a/tests/plugins/policies/test_policy_templates_plugin.py
+++ b/tests/plugins/policies/test_policy_templates_plugin.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, MagicMock, patch, call
+from unittest.mock import Mock, MagicMock, patch, call
 
 from samtranslator.plugins import BasePlugin
 from samtranslator.model.resource_policies import PolicyTypes, PolicyEntry

--- a/tests/policy_template_processor/test_processor.py
+++ b/tests/policy_template_processor/test_processor.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import mock_open, Mock, patch
+from unittest.mock import mock_open, Mock, patch
 
 import jsonschema
 import json

--- a/tests/policy_template_processor/test_template.py
+++ b/tests/policy_template_processor/test_template.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import Mock, patch, ANY
+from unittest.mock import Mock, patch, ANY
 
 from samtranslator.policy_template_processor.template import Template
 from samtranslator.policy_template_processor.exceptions import InvalidParameterValues, InsufficientParameterValues

--- a/tests/sdk/test_parameter.py
+++ b/tests/sdk/test_parameter.py
@@ -2,7 +2,7 @@ from parameterized import parameterized, param
 
 from unittest import TestCase
 from samtranslator.sdk.parameter import SamParameterValues
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from samtranslator.translator.arn_generator import NoRegionFound
 

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -1,7 +1,7 @@
 import copy
 
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 from parameterized import parameterized, param
 
 from samtranslator.swagger.swagger import SwaggerEditor

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,7 @@
 import pytest
 
 from unittest import TestCase
-from mock import Mock, call, ANY
+from unittest.mock import Mock, call, ANY
 from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.model import PropertyType, Resource, SamResourceMacro, ResourceTypeResolver
 from samtranslator.intrinsics.resource_refs import SupportedResourceReferences

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,7 +2,7 @@ from enum import Enum
 from samtranslator.plugins import SamPlugins, BasePlugin, LifeCycleEvents
 
 from unittest import TestCase
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 
 
 class TestSamPluginsRegistration(TestCase):

--- a/tests/translator/model/preferences/test_deployment_preference_collection.py
+++ b/tests/translator/model/preferences/test_deployment_preference_collection.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 from unittest import TestCase
 
 from samtranslator.model.codedeploy import CodeDeployApplication

--- a/tests/translator/test_api_resource.py
+++ b/tests/translator/test_api_resource.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from unittest import TestCase
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from tests.translator.helpers import get_template_parameter_values
 from samtranslator.translator.transform import transform
 from samtranslator.model.apigateway import ApiGatewayDeployment

--- a/tests/translator/test_arn_generator.py
+++ b/tests/translator/test_arn_generator.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from parameterized import parameterized
-from mock import patch
+from unittest.mock import patch
 
 from samtranslator.translator.arn_generator import ArnGenerator, NoRegionFound
 

--- a/tests/translator/test_function_resources.py
+++ b/tests/translator/test_function_resources.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import os
 from samtranslator.model.sam_resources import SamFunction
 from samtranslator.model.lambda_ import LambdaAlias, LambdaVersion, LambdaFunction

--- a/tests/translator/test_logical_id_generator.py
+++ b/tests/translator/test_logical_id_generator.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 from samtranslator.translator.logical_id_generator import LogicalIdGenerator
 
 

--- a/tests/translator/test_managed_policies_translator.py
+++ b/tests/translator/test_managed_policies_translator.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
 
 

--- a/tests/translator/test_resource_level_attributes.py
+++ b/tests/translator/test_resource_level_attributes.py
@@ -1,5 +1,5 @@
 import itertools
-from mock import patch
+from unittest.mock import patch
 
 from parameterized import parameterized
 

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -21,7 +21,7 @@ import pytest
 import yaml
 from unittest import TestCase
 from samtranslator.translator.transform import transform
-from mock import Mock, MagicMock, patch
+from unittest.mock import Mock, MagicMock, patch
 
 BASE_PATH = os.path.dirname(__file__)
 INPUT_FOLDER = BASE_PATH + "/input"

--- a/tests/unit/model/preferences/test_deployment_preference_collection.py
+++ b/tests/unit/model/preferences/test_deployment_preference_collection.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch
+from unittest.mock import patch
 from parameterized import parameterized
 
 from samtranslator.model.preferences.deployment_preference_collection import DeploymentPreferenceCollection

--- a/tests/unit/test_region_configuration.py
+++ b/tests/unit/test_region_configuration.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch
+from unittest.mock import patch
 from parameterized import parameterized
 
 from samtranslator.region_configuration import RegionConfiguration

--- a/tests/unit/translator/test_arn_generator.py
+++ b/tests/unit/translator/test_arn_generator.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch
+from unittest.mock import patch
 from parameterized import parameterized
 
 from samtranslator.translator.arn_generator import ArnGenerator


### PR DESCRIPTION
Note: this won't pass on Python 2 because of the mock -> unittest.mock changes. I guess this other PR (where python 2 testing is removed) has to be merged first:
https://github.com/aws/serverless-application-model/pull/2182

*Issue #, if available:*

*Description of changes:*
- replace mock imports with unittest.mock (part of python 2 deprecation, mock is part of the standard library as unittest.mock from Python 3.3 onwards)
- fix a deprecation warning

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
