### PR TITLE
feat(policy-templates): add policy template to send task statuses to …

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -2360,6 +2360,23 @@
           }
         ]
       }
+    },
+    "StepFunctionsSendTaskStatusPolicy": {
+      "Description": "Gives permission to send task status to a Step Function activity",
+      "Parameters": {},
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "states:SendTaskFailure",
+              "states:SendTaskHeartbeat",
+              "states:SendTaskSuccess"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
     }
   }
 }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -174,3 +174,5 @@ Resources:
 
         - Route53ChangeResourceRecordSetsPolicy:
             HostedZoneId: test
+        
+        - StepFunctionsSendTaskStatusPolicy: {}

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1610,6 +1610,22 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "states:SendTaskFailure",
+                    "states:SendTaskHeartbeat",
+                    "states:SendTaskSuccess"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1610,6 +1610,22 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "states:SendTaskFailure",
+                    "states:SendTaskHeartbeat",
+                    "states:SendTaskSuccess"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1610,6 +1610,22 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "states:SendTaskFailure",
+                    "states:SendTaskHeartbeat",
+                    "states:SendTaskSuccess"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [


### PR DESCRIPTION
…a step function

*Issue #, if available:* 2193

*Description of changes:* This adds a policy template giving permissions to send task status updates to a step function.

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
