### PR TITLE
feat: Schema validation for SimpleTable

### DIFF
--- a/samtranslator/validator/sam_schema/definitions/simpletable.json
+++ b/samtranslator/validator/sam_schema/definitions/simpletable.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "AWS::Serverless::SimpleTable": {
+      "if": {
+        "properties": {
+          "Type": {
+            "const": "AWS::Serverless::SimpleTable"
+          }
+        },
+        "required": [
+          "Type"
+        ]
+      },
+      "then": {
+        "additionalProperties": false,
+        "properties": {
+          "Condition": {
+            "$ref": "common.json#definitions/Condition"
+          },
+          "DeletionPolicy": {
+            "$ref": "common.json#definitions/DeletionPolicy"
+          },
+          "DependsOn": {
+            "$ref": "common.json#definitions/DependsOn"
+          },
+          "Metadata": {
+            "type": "object"
+          },
+          "Properties": {
+            "additionalProperties": false,
+            "properties": {
+              "PrimaryKey": {
+                "$ref": "#definitions/AWS::Serverless::SimpleTable.PrimaryKey"
+              },
+              "ProvisionedThroughput": {
+                "$ref": "#definitions/AWS::Serverless::SimpleTable.ProvisionedThroughput"
+              },
+              "SSESpecification": {
+                "$ref": "#definitions/AWS::Serverless::SimpleTable.SSESpecification"
+              },
+              "TableName": {
+                "type": [
+                  "string",
+                  "intrinsic"
+                ],
+                "minLength": 3,
+                "maxLength": 255,
+                "pattern": "^[a-zA-Z0-9_.-]+$"
+              },
+              "Tags": {
+                "$ref": "common.json#definitions/TagsMap"
+              }
+            },
+            "type": "object"
+          },
+          "Type": {
+            "const": "AWS::Serverless::SimpleTable"
+          },
+          "UpdatePolicy": {
+            "$ref": "common.json#definitions/UpdatePolicy"
+          },
+          "UpdateReplacePolicy": {
+            "$ref": "common.json#definitions/UpdateReplacePolicy"
+          }
+        },
+        "required": [
+          "Type"
+        ],
+        "type": "object"
+      }
+    },
+    "AWS::Serverless::SimpleTable.PrimaryKey": {
+      "additionalProperties": false,
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "intrinsic"
+          ]
+        },
+        "Type": {
+          "enum": [
+            "String",
+            "Number",
+            "Binary"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "Name",
+        "Type"
+      ],
+      "type": "object"
+    },
+    "AWS::Serverless::SimpleTable.ProvisionedThroughput": {
+      "additionalProperties": false,
+      "properties": {
+        "ReadCapacityUnits": {
+          "type": [
+            "number",
+            "intrinsic"
+          ]
+        },
+        "WriteCapacityUnits": {
+          "type": [
+            "number",
+            "intrinsic"
+          ]
+        }
+      },
+      "required": [
+        "ReadCapacityUnits",
+        "WriteCapacityUnits"
+      ],
+      "type": [
+        "object",
+        "intrinsic"
+      ]
+    },
+    "AWS::Serverless::SimpleTable.SSESpecification": {
+      "additionalProperties": false,
+      "properties": {
+        "KMSMasterKeyId": {
+          "type": [
+            "string",
+            "intrinsic"
+          ]
+        },
+        "SSEEnabled": {
+          "type": [
+            "boolean",
+            "intrinsic"
+          ]
+        },
+        "SSEType": {
+          "enum": [
+            "KMS"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "SSEEnabled"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/samtranslator/validator/sam_schema/schema_new.json
+++ b/samtranslator/validator/sam_schema/schema_new.json
@@ -67,6 +67,9 @@
               "$ref": "api.json#/definitions/AWS::Serverless::Api"
             },
             {
+              "$ref": "simpletable.json#/definitions/AWS::Serverless::SimpleTable"
+            },
+            {
               "if": {
                 "properties": {
                   "Type": {

--- a/tests/translator/input/simple_table_with_extra_tags.yaml
+++ b/tests/translator/input/simple_table_with_extra_tags.yaml
@@ -5,11 +5,11 @@ Parameters:
 
 Resources:
   MinimalTableWithTags:
-      Type: 'AWS::Serverless::SimpleTable'
-      Properties:
-        Tags:
-          TagKey1: TagValue1
-          TagKey2: ""
-          TagKey3:
-            Ref: TagValueParam
-          TagKey4: "123"
+    Type: "AWS::Serverless::SimpleTable"
+    Properties:
+      Tags:
+        TagKey1: TagValue1
+        TagKey2: "a"
+        TagKey3:
+          Ref: TagValueParam
+        TagKey4: "123"

--- a/tests/translator/output/aws-cn/simple_table_with_extra_tags.json
+++ b/tests/translator/output/aws-cn/simple_table_with_extra_tags.json
@@ -28,7 +28,7 @@
             "Key": "TagKey1"
           },
           {
-            "Value": "",
+            "Value": "a",
             "Key": "TagKey2"
           },
           {

--- a/tests/translator/output/aws-us-gov/simple_table_with_extra_tags.json
+++ b/tests/translator/output/aws-us-gov/simple_table_with_extra_tags.json
@@ -28,7 +28,7 @@
             "Key": "TagKey1"
           },
           {
-            "Value": "",
+            "Value": "a",
             "Key": "TagKey2"
           },
           {

--- a/tests/translator/output/simple_table_with_extra_tags.json
+++ b/tests/translator/output/simple_table_with_extra_tags.json
@@ -28,7 +28,7 @@
             "Key": "TagKey1"
           },
           {
-            "Value": "",
+            "Value": "a",
             "Key": "TagKey2"
           },
           {

--- a/tests/validator/input/simpletable/error_primarykey.yaml
+++ b/tests/validator/input/simpletable/error_primarykey.yaml
@@ -1,0 +1,61 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  PrimaryKeyEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+
+  PrimaryKeyTypeMissing:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: MyKey
+
+  PrimaryKeyNameMissing:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Type: String
+
+  PrimaryKeyNameEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name:
+        Type: String
+
+  PrimaryKeyNameNotString:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: 3
+        Type: String
+
+  PrimaryKeyTypeEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: MyKey
+        Type:
+
+  PrimaryKeyTypeNotString:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: MyKey
+        Type: 3
+
+  PrimaryKeyTypeUnknown:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: MyKey
+        Type: Float
+
+  PrimaryKeyTypeIntrinsic:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: MyKey
+        Type:
+          Ref: MyKeyType

--- a/tests/validator/input/simpletable/error_provisionedthroughput.yaml
+++ b/tests/validator/input/simpletable/error_provisionedthroughput.yaml
@@ -1,0 +1,32 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  ProvisionedThroughputEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      ProvisionedThroughput:
+
+  ProvisionedThroughputReadCapacityUnitsMissing:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      ProvisionedThroughput:
+        WriteCapacityUnits: 2
+
+  ProvisionedThroughputWriteCapacityUnitsMissing:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+
+  ProvisionedThroughputReadCapacityUnitsNotNumber:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      ProvisionedThroughput:
+        ReadCapacityUnits: "1"
+        WriteCapacityUnits: 2
+
+  ProvisionedThroughputWriteCapacityUnitsNotNumber:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: "2"

--- a/tests/validator/input/simpletable/error_ssespecification.yaml
+++ b/tests/validator/input/simpletable/error_ssespecification.yaml
@@ -1,0 +1,54 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  SSESpecificationEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      SSESpecification:
+
+  SSESpecificationSSEEnabledMissing:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      SSESpecification:
+        KMSMasterKeyId: MyKMSMasterKeyId
+
+  SSESpecificationSSEEnabledEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      SSESpecification:
+        KMSMasterKeyId: MyKMSMasterKeyId
+        SSEEnabled:
+
+  SSESpecificationSSEEnabledNotBoolean:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      SSESpecification:
+        KMSMasterKeyId: MyKMSMasterKeyId
+        SSEEnabled: 3
+
+  SSESpecificationKMSMasterKeyIdEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      SSESpecification:
+        KMSMasterKeyId:
+        SSEEnabled: False
+
+  SSESpecificationKMSMasterKeyIdNotString:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      SSESpecification:
+        KMSMasterKeyId: 3
+        SSEEnabled: False
+
+  SSESpecificationSSETypeEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      SSESpecification:
+        SSEEnabled: False
+        SSEType:
+
+  SSESpecificationSSETypeUnknown:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      SSESpecification:
+        SSEEnabled: False
+        SSEType: MySSEType

--- a/tests/validator/input/simpletable/error_tablename.yaml
+++ b/tests/validator/input/simpletable/error_tablename.yaml
@@ -1,0 +1,26 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  TableNameEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName:
+
+  TableNameNotString:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName: 3
+
+  TableNameTooShort:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName: My
+
+  TableNameTooLong:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongTableName
+
+  TableNameInvalidChar:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName: My&TableName

--- a/tests/validator/input/simpletable/success_complete_simpletable.yaml
+++ b/tests/validator/input/simpletable/success_complete_simpletable.yaml
@@ -1,0 +1,18 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  PrimaryKeyEmpty:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: MyKey
+        Type: Number
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 2
+      SSESpecification:
+        KMSMasterKeyId: MyKMSMasterKeyId
+        SSEEnabled: True
+        SSEType: KMS
+      TableName: MyTable
+      Tags:
+        MyTagName: MyTagValue

--- a/tests/validator/input/simpletable/success_complete_simpletable.yaml
+++ b/tests/validator/input/simpletable/success_complete_simpletable.yaml
@@ -1,6 +1,30 @@
 Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  PrimaryKeyNameParam:
+    Default: MyKeyName
+    Type: String
+  ReadCapacityUnitsParam:
+    Default: 1
+    Type: Number
+  WriteCapacityUnitsParam:
+    Default: 2
+    Type: Number
+  KMSMasterKeyIdParam:
+    Default: MyKMSMasterKeyId
+    Type: String
+  SSEEnabledParam:
+    Default: True
+    Type: String
+  TableNameParam:
+    Default: MyTableName
+    Type: String
+  TagValueParam:
+    Default: MyTagValue
+    Type: String
+
 Resources:
-  PrimaryKeyEmpty:
+  CompleteTable:
     Type: AWS::Serverless::SimpleTable
     Properties:
       PrimaryKey:
@@ -16,3 +40,20 @@ Resources:
       TableName: MyTable
       Tags:
         MyTagName: MyTagValue
+
+  CompleteTableIntrinsics:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: !Ref PrimaryKeyNameParam
+        Type: Number
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnitsParam
+        WriteCapacityUnits: !Ref WriteCapacityUnitsParam
+      SSESpecification:
+        KMSMasterKeyId: !Ref KMSMasterKeyIdParam
+        SSEEnabled: !Ref WriteCapacityUnitsParam
+        SSEType: KMS
+      TableName: !Ref TableNameParam
+      Tags:
+        MyTagName: !Ref TagValueParam

--- a/tests/validator/input/simpletable/success_minimal_simpletable.yaml
+++ b/tests/validator/input/simpletable/success_minimal_simpletable.yaml
@@ -1,0 +1,4 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MinimalTable:
+    Type: AWS::Serverless::SimpleTable

--- a/tests/validator/input/simpletable/success_resource_attributes.yaml
+++ b/tests/validator/input/simpletable/success_resource_attributes.yaml
@@ -1,0 +1,45 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  TableCondition:
+    Condition: MyCondition
+    Type: AWS::Serverless::SimpleTable
+
+  TableDeletionPolicyDelete:
+    DeletionPolicy: Delete
+    Type: AWS::Serverless::SimpleTable
+
+  TableDeletionPolicyRetain:
+    DeletionPolicy: Retain
+    Type: AWS::Serverless::SimpleTable
+
+  TableDeletionPolicySnapshot:
+    DeletionPolicy: Snapshot
+    Type: AWS::Serverless::SimpleTable
+
+  TableDependsOn:
+    DependsOn: MyOtherResource
+    Type: AWS::Serverless::SimpleTable
+
+  TableUpdatePolicyDelete:
+    UpdatePolicy: Delete
+    Type: AWS::Serverless::SimpleTable
+
+  TableUpdatePolicyRetain:
+    UpdatePolicy: Retain
+    Type: AWS::Serverless::SimpleTable
+
+  TableUpdatePolicySnapshot:
+    UpdatePolicy: Snapshot
+    Type: AWS::Serverless::SimpleTable
+
+  TableUpdateReplacePolicyDelete:
+    UpdateReplacePolicy: Delete
+    Type: AWS::Serverless::SimpleTable
+
+  TableUpdateReplacePolicyRetain:
+    UpdateReplacePolicy: Retain
+    Type: AWS::Serverless::SimpleTable
+
+  TableUpdateReplacePolicySnapshot:
+    UpdateReplacePolicy: Snapshot
+    Type: AWS::Serverless::SimpleTable

--- a/tests/validator/output/simpletable/error_primarykey.json
+++ b/tests/validator/output/simpletable/error_primarykey.json
@@ -1,0 +1,13 @@
+[
+  "[Resources.PrimaryKeyEmpty.Properties.PrimaryKey] Must not be empty",
+  "[Resources.PrimaryKeyNameEmpty.Properties.PrimaryKey.Name] Must not be empty",
+  "[Resources.PrimaryKeyNameMissing.Properties.PrimaryKey] 'Name' is a required property",
+  "[Resources.PrimaryKeyNameNotString.Properties.PrimaryKey.Name] 3 is not of type 'string', 'intrinsic'",
+  "[Resources.PrimaryKeyTypeEmpty.Properties.PrimaryKey.Type] Must not be empty",
+  "[Resources.PrimaryKeyTypeIntrinsic.Properties.PrimaryKey.Type] {'Ref': 'MyKeyType'} is not of type 'string'",
+  "[Resources.PrimaryKeyTypeIntrinsic.Properties.PrimaryKey.Type] {'Ref': 'MyKeyType'} is not one of ['String', 'Number', 'Binary']",
+  "[Resources.PrimaryKeyTypeMissing.Properties.PrimaryKey] 'Type' is a required property",
+  "[Resources.PrimaryKeyTypeNotString.Properties.PrimaryKey.Type] 3 is not of type 'string'",
+  "[Resources.PrimaryKeyTypeNotString.Properties.PrimaryKey.Type] 3 is not one of ['String', 'Number', 'Binary']",
+  "[Resources.PrimaryKeyTypeUnknown.Properties.PrimaryKey.Type] 'Float' is not one of ['String', 'Number', 'Binary']"
+]

--- a/tests/validator/output/simpletable/error_provisionedthroughput.json
+++ b/tests/validator/output/simpletable/error_provisionedthroughput.json
@@ -1,0 +1,7 @@
+[
+  "[Resources.ProvisionedThroughputEmpty.Properties.ProvisionedThroughput] Must not be empty",
+  "[Resources.ProvisionedThroughputReadCapacityUnitsMissing.Properties.ProvisionedThroughput] 'ReadCapacityUnits' is a required property",
+  "[Resources.ProvisionedThroughputReadCapacityUnitsNotNumber.Properties.ProvisionedThroughput.ReadCapacityUnits] '1' is not of type 'number', 'intrinsic'",
+  "[Resources.ProvisionedThroughputWriteCapacityUnitsMissing.Properties.ProvisionedThroughput] 'WriteCapacityUnits' is a required property",
+  "[Resources.ProvisionedThroughputWriteCapacityUnitsNotNumber.Properties.ProvisionedThroughput.WriteCapacityUnits] '2' is not of type 'number', 'intrinsic'"
+]

--- a/tests/validator/output/simpletable/error_ssespecification.json
+++ b/tests/validator/output/simpletable/error_ssespecification.json
@@ -1,0 +1,10 @@
+[
+  "[Resources.SSESpecificationEmpty.Properties.SSESpecification] Must not be empty",
+  "[Resources.SSESpecificationKMSMasterKeyIdEmpty.Properties.SSESpecification.KMSMasterKeyId] Must not be empty",
+  "[Resources.SSESpecificationKMSMasterKeyIdNotString.Properties.SSESpecification.KMSMasterKeyId] 3 is not of type 'string', 'intrinsic'",
+  "[Resources.SSESpecificationSSEEnabledEmpty.Properties.SSESpecification.SSEEnabled] Must not be empty",
+  "[Resources.SSESpecificationSSEEnabledMissing.Properties.SSESpecification] 'SSEEnabled' is a required property",
+  "[Resources.SSESpecificationSSEEnabledNotBoolean.Properties.SSESpecification.SSEEnabled] 3 is not of type 'boolean', 'intrinsic'",
+  "[Resources.SSESpecificationSSETypeEmpty.Properties.SSESpecification.SSEType] Must not be empty",
+  "[Resources.SSESpecificationSSETypeUnknown.Properties.SSESpecification.SSEType] 'MySSEType' is not one of ['KMS']"
+]

--- a/tests/validator/output/simpletable/error_tablename.json
+++ b/tests/validator/output/simpletable/error_tablename.json
@@ -1,0 +1,7 @@
+[
+  "[Resources.TableNameEmpty.Properties.TableName] Must not be empty",
+  "[Resources.TableNameInvalidChar.Properties.TableName] 'My&TableName' does not match '^[a-zA-Z0-9_.-]+$'",
+  "[Resources.TableNameNotString.Properties.TableName] 3 is not of type 'string', 'intrinsic'",
+  "[Resources.TableNameTooLong.Properties.TableName] 'MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongTableName' is too long",
+  "[Resources.TableNameTooShort.Properties.TableName] 'My' is too short"
+]

--- a/tests/validator/test_validator_api.py
+++ b/tests/validator/test_validator_api.py
@@ -1,9 +1,5 @@
 import os.path
 from parameterized import parameterized
-import pytest
-from unittest import TestCase
-from samtranslator.yaml_helper import yaml_parse
-from samtranslator.validator.validator import SamTemplateValidator
 from tests.validator.test_validator import TestValidatorBase
 
 BASE_PATH = os.path.dirname(__file__)

--- a/tests/validator/test_validator_simpletable.py
+++ b/tests/validator/test_validator_simpletable.py
@@ -1,0 +1,26 @@
+import os.path
+from parameterized import parameterized
+from tests.validator.test_validator import TestValidatorBase
+
+BASE_PATH = os.path.dirname(__file__)
+INPUT_FOLDER = os.path.join(BASE_PATH, "input", "simpletable")
+OUTPUT_FOLDER = os.path.join(BASE_PATH, "output", "simpletable")
+
+
+class TestValidatorSimpleTable(TestValidatorBase):
+    @parameterized.expand(
+        [
+            "error_primarykey",
+            "error_provisionedthroughput",
+            "error_ssespecification",
+            "error_tablename",
+        ],
+    )
+    def test_errors(self, template):
+        self._test_validator_error(os.path.join(INPUT_FOLDER, template), os.path.join(OUTPUT_FOLDER, template))
+
+    @parameterized.expand(
+        ["success_complete_simpletable", "success_minimal_simpletable", "success_resource_attributes"],
+    )
+    def test_success(self, template):
+        self._test_validator_success(os.path.join(INPUT_FOLDER, template))


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**
Added schema validation for the `AWS::Serverless::SimpleTable` resource.

**Description of how you validated changes:**
Unit tests with yaml files + ran the validation over the Translator test files.

One file returned a validation error and was updated:
`tests/translator/input/simple_table_with_extra_tags.yaml`

Indeed, according to the [CFN doc](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html#cfn-resource-tags-value), a tag value must be at least 1 character long, this test file had a tag value with an empty string.

**Checklist:**

- [x] Add/update tests using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [x] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

**Examples?**

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
