### PR TITLE
fix: Check Metrics List is Not Empty Before Publishing

### DIFF
--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -51,7 +51,8 @@ class CWMetricsPublisher(MetricsPublisher):
         """
         metric_data = list(map(lambda m: m.get_metric_data(), metrics))
         try:
-            self.cloudwatch_client.put_metric_data(Namespace=namespace, MetricData=metric_data)
+            if metric_data:
+                self.cloudwatch_client.put_metric_data(Namespace=namespace, MetricData=metric_data)
         except Exception as e:
             LOG.exception("Failed to report {} metrics".format(len(metric_data)), exc_info=e)
 

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -237,3 +237,11 @@ class TestCWMetricPublisher(TestCase):
         dummy_publisher = DummyMetricsPublisher()
         dummy_publisher.publish("NS", [None])
         self.assertTrue(True)
+
+    def test_publish_empty_metric(self):
+        mock_cw_client = MagicMock()
+        metric_publisher = CWMetricsPublisher(mock_cw_client)
+        metrics = []
+        namespace = "DummyNamespace"
+        metric_publisher.publish(namespace, metrics)
+        mock_cw_client.put_metric_data.assert_not_called()


### PR DESCRIPTION
*Issue #, if available:*
We're seeing noise in our logs when attempting to publish empty metrics.

```
Traceback (most recent call last):
File "/var/task/samtranslator/metrics/metrics.py", line 54, in _flush_metrics
self.cloudwatch_client.put_metric_data(Namespace=namespace, MetricData=metric_data)
File "/var/task/botocore/client.py", line 386, in _api_call
return self._make_api_call(operation_name, kwargs)
File "/var/task/aws_xray_sdk/ext/botocore/patch.py", line 42, in _xray_traced_botocore
meta_processor=aws_meta_processor,
File "/var/task/aws_xray_sdk/core/recorder.py", line 435, in record_subsegment
return_value = wrapped(*args, **kwargs)
File "/var/task/botocore/client.py", line 705, in _make_api_call
raise error_class(parsed_response, operation_name)
MissingRequiredParameterException: An error occurred (MissingParameter) when calling the PutMetricData operation: The parameter MetricData is required.
```

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
