### PR TITLE
Raise InvalidResourceException when UsagePlan type is not correct

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -697,6 +697,9 @@ class ApiGenerator(object):
         if auth_properties.UsagePlan is None:
             return []
         usage_plan_properties = auth_properties.UsagePlan
+        # throws error if UsagePlan is not a dict
+        if not isinstance(usage_plan_properties, dict):
+            raise InvalidResourceException(self.logical_id, "'UsagePlan' must be a dictionary")
         # throws error if the property invalid/ unsupported for UsagePlan
         if not all(key in UsagePlanProperties._fields for key in usage_plan_properties.keys()):
             raise InvalidResourceException(self.logical_id, "Invalid property for 'UsagePlan'")

--- a/tests/model/api/test_api_generator.py
+++ b/tests/model/api/test_api_generator.py
@@ -1,0 +1,52 @@
+from unittest import TestCase
+from mock import Mock, patch
+
+from parameterized import parameterized
+
+from samtranslator.model import InvalidResourceException
+from samtranslator.model.api.api_generator import ApiGenerator
+
+
+class TestApiGenerator(TestCase):
+    @parameterized.expand([("this should be a dict",), ("123",), ([{}],)])
+    @patch("samtranslator.model.api.api_generator.AuthProperties")
+    def test_construct_usage_plan_with_invalid_usage_plan_type(self, invalid_usage_plan, AuthProperties_mock):
+        AuthProperties_mock.return_value = Mock(UsagePlan=invalid_usage_plan)
+        api_generator = ApiGenerator(
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            auth={"some": "value"},
+        )
+        with self.assertRaises(InvalidResourceException) as cm:
+            api_generator._construct_usage_plan()
+            self.assertIn("Invalid type", str(cm.exception))
+
+    @patch("samtranslator.model.api.api_generator.AuthProperties")
+    def test_construct_usage_plan_with_invalid_usage_plan_fields(self, AuthProperties_mock):
+        AuthProperties_mock.return_value = Mock(UsagePlan={"Unknown_field": "123"})
+        api_generator = ApiGenerator(
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+            auth={"some": "value"},
+        )
+        with self.assertRaises(InvalidResourceException) as cm:
+            api_generator._construct_usage_plan()
+            self.assertIn("Invalid property for", str(cm.exception))

--- a/tests/translator/input/error_api_invalid_usage_plan.yaml
+++ b/tests/translator/input/error_api_invalid_usage_plan.yaml
@@ -1,0 +1,24 @@
+Resources:
+  MyApiWithCognitoAuth:
+    Type: "AWS::Serverless::Api"
+    Properties:
+      StageName: Prod
+      Auth:
+        Authorizers:
+          MyCognitoAuth:
+            UserPoolArn: !GetAtt MyUserPool.Arn
+        UsagePlan: "Should not be a string"
+
+  MyUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: UserPoolName
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 8
+      UsernameAttributes:
+        - email
+      Schema:
+        - AttributeDataType: String
+          Name: email
+          Required: false

--- a/tests/translator/output/error_api_invalid_usage_plan.json
+++ b/tests/translator/output/error_api_invalid_usage_plan.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyApiWithCognitoAuth] is invalid. 'UsagePlan' must be a dictionary"
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApiWithCognitoAuth] is invalid. 'UsagePlan' must be a dictionary"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
