### PR TITLE
Add try catch to prevent schema validation fails transform while parsing

### DIFF
--- a/samtranslator/parser/parser.py
+++ b/samtranslator/parser/parser.py
@@ -58,9 +58,12 @@ class Parser:
                         )
                     ]
                 )
+        try:
+            validator = SamTemplateValidator()
+            validation_errors = validator.validate(sam_template)
 
-        validator = SamTemplateValidator()
-        validation_errors = validator.validate(sam_template)
-
-        if validation_errors:
-            LOG.warn("Template schema validation reported the following errors: " + ", ".join(validation_errors))
+            if validation_errors:
+                LOG.warn("Template schema validation reported the following errors: " + ", ".join(validation_errors))
+        except Exception as e:
+            # Catching any exception and not re-raising to make sure any validation process won't break transform
+            LOG.exception("Exception from SamTemplateValidator: %s", e)

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+from mock import patch, Mock, call
+
+from samtranslator.parser.parser import Parser
+from samtranslator.plugins import LifeCycleEvents
+from samtranslator.model.exceptions import InvalidDocumentException, InvalidTemplateException, InvalidResourceException
+
+
+class TestParser(TestCase):
+    def test_parse(self):
+        parser = Parser()
+        parser._validate = Mock()
+        sam_plugins_mock = Mock()
+        sam_plugins_mock.act = Mock()
+        sam_template = {}
+        parameter_values = {}
+
+        parser.parse(sam_template, parameter_values, sam_plugins_mock)
+        parser._validate.assert_has_calls([call(sam_template, parameter_values)])
+        sam_plugins_mock.act.assert_has_calls([call(LifeCycleEvents.before_transform_template, sam_template)])
+
+    @patch("samtranslator.parser.parser.SamTemplateValidator")
+    @patch("samtranslator.parser.parser.LOG")
+    def test_validate_validator_failure(self, log_mock, sam_template_validator_class_mock):
+        exception = Exception()
+        sam_template_validator_class_mock.side_effect = exception
+        log_mock.exception = Mock()
+
+        sam_template = {
+            "Resources": {
+                "Function": {},
+                "Api": {},
+            }
+        }
+        paramerter_values = {"Param": "value"}
+        parser = Parser()
+        parser._validate(sam_template, paramerter_values)
+        log_mock.exception.assert_has_calls([call("Exception from SamTemplateValidator: %s", exception)])
+
+    def test_validate_parameter_values_is_required(self):
+        parser = Parser()
+        with self.assertRaises(ValueError):
+            parser._validate({}, None)
+
+    def test_validate_template_with_no_resource(self):
+        parser = Parser()
+        with self.assertRaises(InvalidDocumentException):
+            parser._validate({}, {})
+
+    def test_validate_template_with_non_dict_resources(self):
+        parser = Parser()
+        with self.assertRaises(InvalidDocumentException):
+            parser._validate({"Resources": "string"}, {})
+
+    def test_validate_template_with_empty_resources(self):
+        parser = Parser()
+        with self.assertRaises(InvalidDocumentException):
+            parser._validate({"Resources": {}}, {})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A follow-up to #2032 to try/catch potential failures from schema validation during parsing.

*Description of how you validated changes:*
Added unit tests for `Parser` to address particular failure points.

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
