### PR TITLE
Raise InvalidEventException when RestApiId/ApiId is not resolved to a string

### DIFF
--- a/samtranslator/plugins/api/implicit_http_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_http_api_plugin.py
@@ -87,9 +87,11 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
                 key = "Path" if not isinstance(path, six.string_types) else "Method"
                 raise InvalidEventException(logicalId, "Api Event must have a String specified for '{}'.".format(key))
 
-            # !Ref is resolved by this time. If it is still a dict, we can't parse/use this Api.
-            if isinstance(api_id, dict):
-                raise InvalidEventException(logicalId, "Api Event must reference an Api in the same template.")
+            # !Ref is resolved by this time. If it is not a string, we can't parse/use this Api.
+            if api_id and not isinstance(api_id, six.string_types):
+                raise InvalidEventException(
+                    logicalId, "Api Event's ApiId must be a string referencing an Api in the same template."
+                )
 
             api_dict_condition = self.api_conditions.setdefault(api_id, {})
             method_conditions = api_dict_condition.setdefault(path, {})

--- a/samtranslator/plugins/api/implicit_rest_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_rest_api_plugin.py
@@ -85,9 +85,11 @@ class ImplicitRestApiPlugin(ImplicitApiPlugin):
             if not isinstance(method, six.string_types):
                 raise InvalidEventException(logicalId, "Api Event must have a String specified for 'Method'.")
 
-            # !Ref is resolved by this time. If it is still a dict, we can't parse/use this Api.
-            if isinstance(api_id, dict):
-                raise InvalidEventException(logicalId, "Api Event must reference an Api in the same template.")
+            # !Ref is resolved by this time. If it is not a string, we can't parse/use this Api.
+            if api_id and not isinstance(api_id, six.string_types):
+                raise InvalidEventException(
+                    logicalId, "Api Event's RestApiId must be a string referencing an Api in the same template."
+                )
 
             api_dict_condition = self.api_conditions.setdefault(api_id, {})
             method_conditions = api_dict_condition.setdefault(path, {})

--- a/tests/translator/input/error_function_invalid_event_api_ref.yaml
+++ b/tests/translator/input/error_function_invalid_event_api_ref.yaml
@@ -1,0 +1,16 @@
+Resources:
+  FunctionApiRestApiRefError:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: hello.handler
+      Runtime: python2.7
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Method: get
+            Path: /
+            # RestApiId should not be a list
+            RestApiId:
+              - Fn::Sub: ServerlessRestApi

--- a/tests/translator/input/error_function_invalid_event_http_api_ref.yaml
+++ b/tests/translator/input/error_function_invalid_event_http_api_ref.yaml
@@ -1,0 +1,17 @@
+Resources:
+  FunctionApiHttpApiRefError:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: hello.handler
+      Runtime: python2.7
+      Events:
+        ApiEvent:
+          Type: HttpApi
+          Properties:
+            Method: get
+            Path: /
+            # ApiId should not be a list
+            ApiId:
+              - Fn::Sub: ServerlessHttpApi
+

--- a/tests/translator/output/error_api_event_import_vaule_reference.json
+++ b/tests/translator/output/error_api_event_import_vaule_reference.json
@@ -1,1 +1,1 @@
-{"errorMessage":"Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Function] is invalid. Event with id [GetHtml] is invalid. Api Event must reference an Api in the same template."}
+{"errorMessage":"Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Function] is invalid. Event with id [GetHtml] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."}

--- a/tests/translator/output/error_api_swagger_integration_with_condition_intrinsic_api_id.json
+++ b/tests/translator/output/error_api_swagger_integration_with_condition_intrinsic_api_id.json
@@ -1,4 +1,4 @@
 {
-    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event must reference an Api in the same template."
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
   }
   

--- a/tests/translator/output/error_api_swagger_integration_with_find_in_map_intrinsic_api_id.json
+++ b/tests/translator/output/error_api_swagger_integration_with_find_in_map_intrinsic_api_id.json
@@ -1,4 +1,4 @@
 {
-    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event must reference an Api in the same template."
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
   }
   

--- a/tests/translator/output/error_api_swagger_integration_with_getatt_intrinsic_api_id.json
+++ b/tests/translator/output/error_api_swagger_integration_with_getatt_intrinsic_api_id.json
@@ -1,4 +1,4 @@
 {
-    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event must reference an Api in the same template."
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
   }
   

--- a/tests/translator/output/error_api_swagger_integration_with_join_intrinsic_api_id.json
+++ b/tests/translator/output/error_api_swagger_integration_with_join_intrinsic_api_id.json
@@ -1,4 +1,4 @@
 {
-    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event must reference an Api in the same template."
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
   }
   

--- a/tests/translator/output/error_api_swagger_integration_with_select_intrinsic_api_id.json
+++ b/tests/translator/output/error_api_swagger_integration_with_select_intrinsic_api_id.json
@@ -1,4 +1,4 @@
 {
-    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event must reference an Api in the same template."
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
   }
   

--- a/tests/translator/output/error_api_swagger_integration_with_sub_intrinsic_api_id.json
+++ b/tests/translator/output/error_api_swagger_integration_with_sub_intrinsic_api_id.json
@@ -1,4 +1,4 @@
 {
-    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event must reference an Api in the same template."
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
   }
   

--- a/tests/translator/output/error_api_swagger_integration_with_transform_intrinsic_api_id.json
+++ b/tests/translator/output/error_api_swagger_integration_with_transform_intrinsic_api_id.json
@@ -1,4 +1,4 @@
 {
-    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event must reference an Api in the same template."
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HtmlFunction] is invalid. Event with id [GetHtml] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
   }
   

--- a/tests/translator/output/error_function_invalid_event_api_ref.json
+++ b/tests/translator/output/error_function_invalid_event_api_ref.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [FunctionApiRestApiRefError] is invalid. Event with id [ApiEvent] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [FunctionApiRestApiRefError] is invalid. Event with id [ApiEvent] is invalid. Api Event's RestApiId must be a string referencing an Api in the same template."
+}

--- a/tests/translator/output/error_function_invalid_event_http_api_ref.json
+++ b/tests/translator/output/error_function_invalid_event_http_api_ref.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [FunctionApiHttpApiRefError] is invalid. Event with id [ApiEvent] is invalid. Api Event's ApiId must be a string referencing an Api in the same template."
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [FunctionApiHttpApiRefError] is invalid. Event with id [ApiEvent] is invalid. Api Event's ApiId must be a string referencing an Api in the same template."
+}


### PR DESCRIPTION
… string

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
