### PR TITLE
Fix DestinationConfig in streaming event sources

### DIFF
--- a/tests/translator/input/error_function_with_invalid_stream_eventsource_dest_type.yaml
+++ b/tests/translator/input/error_function_with_invalid_stream_eventsource_dest_type.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  MyBatchingWindowParam:
+    Type: Number
+    Default: 45
+    Description: parameter for batching window in seconds
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      InlineCode: |
+        exports.handler = async (event) => {
+            return {
+            statusCode: 200,
+            body: JSON.stringify(event),
+            headers: {}
+            }
+        }
+      Runtime: nodejs12.x
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MySqsQueue.QueueName
+      Events:
+        StreamEvent:
+          Type: Kinesis
+          Properties:
+            Stream: !GetAtt KinesisStream.Arn
+            MaximumBatchingWindowInSeconds: !Ref MyBatchingWindowParam
+            StartingPosition: LATEST
+            DestinationConfig:
+              OnFailure:
+                Type: INVALID_VALID
+                Destination: !Ref MySnsTopic
+
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 1
+
+  MySnsTopic:
+    Type: AWS::SNS::Topic

--- a/tests/translator/input/error_function_with_missing_on_failure_in_stream_event_destination_config.yaml
+++ b/tests/translator/input/error_function_with_missing_on_failure_in_stream_event_destination_config.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  MyBatchingWindowParam:
+    Type: Number
+    Default: 45
+    Description: parameter for batching window in seconds
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      InlineCode: |
+        exports.handler = async (event) => {
+            return {
+            statusCode: 200,
+            body: JSON.stringify(event),
+            headers: {}
+            }
+        }
+      Runtime: nodejs12.x
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MySqsQueue.QueueName
+      Events:
+        StreamEvent:
+          Type: Kinesis
+          Properties:
+            Stream: !GetAtt KinesisStream.Arn
+            MaximumBatchingWindowInSeconds: !Ref MyBatchingWindowParam
+            StartingPosition: LATEST
+            DestinationConfig:
+              InvalidConfig:
+                Type: SNS
+                Destination: !Ref MySnsTopic
+
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 1
+
+  MySnsTopic:
+    Type: AWS::SNS::Topic

--- a/tests/translator/input/function_with_event_source_mapping.yaml
+++ b/tests/translator/input/function_with_event_source_mapping.yaml
@@ -59,6 +59,22 @@ Resources:
               OnFailure:
                 Type: SQS
                 Destination: !GetAtt MySqsQueue.Arn
+        StreamEventWithoutDestinationConfigType:
+          Type: Kinesis
+          Properties:
+            Stream: !GetAtt KinesisStream1.Arn
+            MaximumBatchingWindowInSeconds: !Ref MyBatchingWindowParam
+            StartingPosition: LATEST
+            DestinationConfig:
+              OnFailure:
+                Destination: !Ref MySnsTopic
+        StreamEventWithEmptyDestinationConfig:
+          Type: Kinesis
+          Properties:
+            Stream: !GetAtt KinesisStream1.Arn
+            MaximumBatchingWindowInSeconds: !Ref MyBatchingWindowParam
+            StartingPosition: LATEST
+            DestinationConfig:
 
   KinesisStream:
     Type: AWS::Kinesis::Stream

--- a/tests/translator/output/aws-cn/error_function_with_invalid_stream_eventsource_dest_type.json
+++ b/tests/translator/output/aws-cn/error_function_with_invalid_stream_eventsource_dest_type.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. The only valid values for 'Type' are 'SQS' and 'SNS'"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. The only valid values for 'Type' are 'SQS' and 'SNS'"
+}

--- a/tests/translator/output/aws-cn/error_function_with_missing_on_failure_in_stream_event_destination_config.json
+++ b/tests/translator/output/aws-cn/error_function_with_missing_on_failure_in_stream_event_destination_config.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
+}

--- a/tests/translator/output/aws-cn/function_with_event_source_mapping.json
+++ b/tests/translator/output/aws-cn/function_with_event_source_mapping.json
@@ -233,6 +233,49 @@
         }
       }
     },
+    "MyFunctionForBatchingExampleStreamEventWithoutDestinationConfigType": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "MaximumBatchingWindowInSeconds": {
+          "Ref": "MyBatchingWindowParam"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream1",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "MyFunctionForBatchingExample"
+        },
+        "StartingPosition": "LATEST",
+        "DestinationConfig": {
+            "OnFailure": {
+                "Destination": {
+                    "Ref": "MySnsTopic"
+                }
+            }
+        }
+      }
+    },
+    "MyFunctionForBatchingExampleStreamEventWithEmptyDestinationConfig": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "MaximumBatchingWindowInSeconds": {
+          "Ref": "MyBatchingWindowParam"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream1",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "MyFunctionForBatchingExample"
+        },
+        "StartingPosition": "LATEST"
+      }
+    },
     "KinesisStream": {
       "Type": "AWS::Kinesis::Stream",
       "Properties": {

--- a/tests/translator/output/aws-us-gov/error_function_with_invalid_stream_eventsource_dest_type.json
+++ b/tests/translator/output/aws-us-gov/error_function_with_invalid_stream_eventsource_dest_type.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. The only valid values for 'Type' are 'SQS' and 'SNS'"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. The only valid values for 'Type' are 'SQS' and 'SNS'"
+}

--- a/tests/translator/output/aws-us-gov/error_function_with_missing_on_failure_in_stream_event_destination_config.json
+++ b/tests/translator/output/aws-us-gov/error_function_with_missing_on_failure_in_stream_event_destination_config.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
+}

--- a/tests/translator/output/aws-us-gov/function_with_event_source_mapping.json
+++ b/tests/translator/output/aws-us-gov/function_with_event_source_mapping.json
@@ -233,6 +233,49 @@
         }
       }
     },
+    "MyFunctionForBatchingExampleStreamEventWithoutDestinationConfigType": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "MaximumBatchingWindowInSeconds": {
+          "Ref": "MyBatchingWindowParam"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream1",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "MyFunctionForBatchingExample"
+        },
+        "StartingPosition": "LATEST",
+        "DestinationConfig": {
+            "OnFailure": {
+                "Destination": {
+                    "Ref": "MySnsTopic"
+                }
+            }
+        }
+      }
+    },
+    "MyFunctionForBatchingExampleStreamEventWithEmptyDestinationConfig": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "MaximumBatchingWindowInSeconds": {
+          "Ref": "MyBatchingWindowParam"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream1",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "MyFunctionForBatchingExample"
+        },
+        "StartingPosition": "LATEST"
+      }
+    },
     "KinesisStream": {
       "Type": "AWS::Kinesis::Stream",
       "Properties": {

--- a/tests/translator/output/error_function_with_invalid_stream_eventsource_dest_type.json
+++ b/tests/translator/output/error_function_with_invalid_stream_eventsource_dest_type.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. The only valid values for 'Type' are 'SQS' and 'SNS'"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. The only valid values for 'Type' are 'SQS' and 'SNS'"
+}

--- a/tests/translator/output/error_function_with_missing_on_failure_in_stream_event_destination_config.json
+++ b/tests/translator/output/error_function_with_missing_on_failure_in_stream_event_destination_config.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
+}

--- a/tests/translator/output/function_with_event_source_mapping.json
+++ b/tests/translator/output/function_with_event_source_mapping.json
@@ -233,6 +233,49 @@
         }
       }
     },
+    "MyFunctionForBatchingExampleStreamEventWithoutDestinationConfigType": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "MaximumBatchingWindowInSeconds": {
+          "Ref": "MyBatchingWindowParam"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream1",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "MyFunctionForBatchingExample"
+        },
+        "StartingPosition": "LATEST",
+        "DestinationConfig": {
+            "OnFailure": {
+                "Destination": {
+                    "Ref": "MySnsTopic"
+                }
+            }
+        }
+      }
+    },
+    "MyFunctionForBatchingExampleStreamEventWithEmptyDestinationConfig": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "MaximumBatchingWindowInSeconds": {
+          "Ref": "MyBatchingWindowParam"
+        },
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream1",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "MyFunctionForBatchingExample"
+        },
+        "StartingPosition": "LATEST"
+      }
+    },
     "KinesisStream": {
       "Type": "AWS::Kinesis::Stream",
       "Properties": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix `DestinationConfig` of streaming event sources by ensuring `OnFailure` is defined before it's used.
If `OnFailure` is missing, an error will be thrown.

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update tests using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
