### PR TITLE
fix: handle non-dict DefinitionBody path item in _openapi_postprocess

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -972,7 +972,7 @@ class ApiGenerator(object):
             paths = definition_body.get("paths")
             if paths:
                 for path, path_item in paths.items():
-                    if path_item and path_item.get("options"):
+                    if isinstance(path_item, dict) and path_item.get("options"):
                         options = path_item.get("options").copy()
                         for field, field_val in options.items():
                             # remove unsupported produces and consumes in options for openapi3
@@ -981,7 +981,7 @@ class ApiGenerator(object):
                             # add schema for the headers in options section for openapi3
                             if (
                                 field in ["responses"]
-                                and field_val
+                                and isinstance(field_val, dict)
                                 and field_val.get("200")
                                 and field_val.get("200").get("headers")
                             ):

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -972,7 +972,8 @@ class ApiGenerator(object):
             paths = definition_body.get("paths")
             if paths:
                 for path, path_item in paths.items():
-                    if isinstance(path_item, dict) and path_item.get("options"):
+                    SwaggerEditor.validate_path_item_is_dict(path_item, path)
+                    if path_item.get("options"):
                         options = path_item.get("options").copy()
                         for field, field_val in options.items():
                             # remove unsupported produces and consumes in options for openapi3
@@ -980,15 +981,11 @@ class ApiGenerator(object):
                                 del definition_body["paths"][path]["options"][field]
                             # add schema for the headers in options section for openapi3
                             if field in ["responses"]:
-                                if not isinstance(field_val, dict):
-                                    raise InvalidDocumentException(
-                                        [
-                                            InvalidTemplateException(
-                                                "Value of responses in options method for path {} must be a "
-                                                "dictionary according to Swagger spec.".format(path)
-                                            )
-                                        ]
-                                    )
+                                SwaggerEditor.validate_is_dict(
+                                    field_val,
+                                    "Value of responses in options method for path {} must be a "
+                                    "dictionary according to Swagger spec.".format(path),
+                                )
                                 if field_val.get("200") and field_val.get("200").get("headers"):
                                     headers = field_val["200"]["headers"]
                                     for header, header_val in headers.items():

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -969,32 +969,28 @@ class ApiGenerator(object):
                 del definition_body["definitions"]
             # removes `consumes` and `produces` options for CORS in openapi3 and
             # adds `schema` for the headers in responses for openapi3
-            if definition_body.get("paths"):
-                for path in definition_body.get("paths"):
-                    if definition_body.get("paths").get(path).get("options"):
-                        definition_body_options = definition_body.get("paths").get(path).get("options").copy()
-                        for field in definition_body_options.keys():
+            paths = definition_body.get("paths")
+            if paths:
+                for path, path_item in paths.items():
+                    if path_item and path_item.get("options"):
+                        options = path_item.get("options").copy()
+                        for field, field_val in options.items():
                             # remove unsupported produces and consumes in options for openapi3
                             if field in ["produces", "consumes"]:
                                 del definition_body["paths"][path]["options"][field]
                             # add schema for the headers in options section for openapi3
-                            if field in ["responses"]:
-                                options_path = definition_body["paths"][path]["options"]
-                                if (
-                                    options_path
-                                    and options_path.get(field).get("200")
-                                    and options_path.get(field).get("200").get("headers")
-                                ):
-                                    headers = definition_body["paths"][path]["options"][field]["200"]["headers"]
-                                    for header in headers.keys():
-                                        header_value = {
-                                            "schema": definition_body["paths"][path]["options"][field]["200"][
-                                                "headers"
-                                            ][header]
-                                        }
-                                        definition_body["paths"][path]["options"][field]["200"]["headers"][
-                                            header
-                                        ] = header_value
+                            if (
+                                field in ["responses"]
+                                and field_val
+                                and field_val.get("200")
+                                and field_val.get("200").get("headers")
+                            ):
+                                headers = field_val["200"]["headers"]
+                                for header, header_val in headers.items():
+                                    new_header_val_with_schema = {"schema": header_val}
+                                    definition_body["paths"][path]["options"][field]["200"]["headers"][
+                                        header
+                                    ] = new_header_val_with_schema
 
         return definition_body
 

--- a/tests/translator/input/error_api_no_cors_invalid_openapi_null_path.yaml
+++ b/tests/translator/input/error_api_no_cors_invalid_openapi_null_path.yaml
@@ -1,0 +1,12 @@
+Resources:
+  ApiWithInvalidPath:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      OpenApiVersion: 3.0.1
+      DefinitionBody:
+        openapi: 3.0.1
+        info:
+          title: test invalid paths Api
+        paths:
+          /foo: null

--- a/tests/translator/input/error_api_no_cors_invalid_openapi_string_path.yaml
+++ b/tests/translator/input/error_api_no_cors_invalid_openapi_string_path.yaml
@@ -1,0 +1,12 @@
+Resources:
+  ApiWithInvalidPath:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      OpenApiVersion: 3.0.1
+      DefinitionBody:
+        openapi: 3.0.1
+        info:
+          title: test invalid paths Api
+        paths:
+          /foo: invalid

--- a/tests/translator/output/error_api_no_cors_invalid_openapi_null_path.json
+++ b/tests/translator/output/error_api_no_cors_invalid_openapi_null_path.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Value of '/foo' path must be a dictionary according to Swagger spec."
+}

--- a/tests/translator/output/error_api_no_cors_invalid_openapi_string_path.json
+++ b/tests/translator/output/error_api_no_cors_invalid_openapi_string_path.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Value of '/foo' path must be a dictionary according to Swagger spec."
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`_openapi_postprocess` expects the value at a path to be a dict. The following template would cause an unhandled error: 
```
Resources:
  ApiWithInvalidPath:
    Type: AWS::Serverless::Api
    Properties:
      StageName: Prod
      OpenApiVersion: 3.0.1
      DefinitionBody:
        openapi: 3.0.1
        info:
          title: test invalid paths Api
        paths:
          /foo: null
```

This PR checks that it is a dict and throws an error if it's not. Also did some refactoring while I updated this part of the code.

*Description of how you validated changes:*
Added end-to-end tests

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
