### PR TITLE
Run unit tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ init:
 	pip install -e '.[dev]'
 
 test:
-	pytest --cov samtranslator --cov-report term-missing --cov-fail-under 95 tests/*
+	pytest --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/*
 
 test-cov-report:
 	pytest --cov samtranslator --cov-report term-missing --cov-report html --cov-fail-under 95 tests/*

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,6 +2,7 @@ coverage~=5.3
 flake8~=3.8.4
 tox~=3.20.1
 pytest-cov~=2.10.1
+pytest-xdist~=1.34.0  # pytest-xdist 2 is not compatible with Python 2.7
 pylint>=1.7.2,<2.0
 pyyaml~=5.4
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Run unit tests in parallel, on my 16-inch macbook pro, the time of `make test` is reduced from 227.18s to 64.78s, which is a 72% reduction.

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
