### PR TITLE
Do not abort SAR loop on throttling

### DIFF
--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -316,6 +316,8 @@ class ServerlessAppPlugin(BasePlugin):
             while (time() - start_time) < self.TEMPLATE_WAIT_TIMEOUT_SECONDS:
                 temp = self._in_progress_templates
                 self._in_progress_templates = []
+                # it's either our first time in this loop or we just slept SLEEP_TIME_SECONDS so we can
+                # try calling SAR
                 throttled = False
 
                 # Check each resource to make sure it's active

--- a/tests/plugins/application/test_serverless_app_plugin.py
+++ b/tests/plugins/application/test_serverless_app_plugin.py
@@ -257,9 +257,6 @@ class ApplicationResource(object):
 
 
 class TestServerlessAppPlugin_on_after_transform_template(TestCase):
-    def setUp(self):
-        pass
-
     def test_sar_throttling_doesnt_stop_processing(self):
         client = Mock()
         client.get_cloud_formation_template = Mock()

--- a/tests/plugins/application/test_serverless_app_plugin.py
+++ b/tests/plugins/application/test_serverless_app_plugin.py
@@ -1,5 +1,6 @@
 import boto3
 import itertools
+from botocore.exceptions import ClientError
 
 from mock import Mock, patch
 from unittest import TestCase
@@ -7,6 +8,7 @@ from parameterized import parameterized, param
 
 from samtranslator.plugins.application.serverless_app_plugin import ServerlessAppPlugin
 from samtranslator.plugins.exceptions import InvalidPluginException
+from samtranslator.model.exceptions import InvalidResourceException
 
 # TODO: run tests when AWS CLI is not configured (so they can run in brazil)
 
@@ -253,9 +255,53 @@ class ApplicationResource(object):
 
 #     self.plugin.on_before_transform_resource(app_resources[0][0], 'AWS::Serverless::Application', app_resources[0][1].properties)
 
-# class TestServerlessAppPlugin_on_after_transform_template(TestCase):
 
-#     def setUp(self):
-#         self.plugin = SeverlessAppPlugin()
+class TestServerlessAppPlugin_on_after_transform_template(TestCase):
+    def setUp(self):
+        pass
 
-# # TODO: test this lifecycle event
+    def test_sar_throttling_doesnt_stop_processing(self):
+        client = Mock()
+        client.get_cloud_formation_template = Mock()
+        client.get_cloud_formation_template.side_effect = ClientError(
+            {"Error": {"Code": "TooManyRequestsException"}}, "GetCloudFormationTemplate"
+        )
+        plugin = ServerlessAppPlugin(sar_client=client, wait_for_template_active_status=True, validate_only=False)
+        plugin._in_progress_templates = [("appid", "template")]
+        plugin.SLEEP_TIME_SECONDS = 0.05
+        plugin.TEMPLATE_WAIT_TIMEOUT_SECONDS = 0.3
+        with self.assertRaises(InvalidResourceException):
+            plugin.on_after_transform_template("template")
+        # confirm we had at least two attempts to call SAR
+        self.assertGreater(client.get_cloud_formation_template.call_count, 1)
+
+    def test_unexpected_sar_error_stops_processing(self):
+        client = Mock()
+        client.get_cloud_formation_template = Mock()
+        client.get_cloud_formation_template.side_effect = ClientError(
+            {"Error": {"Code": "BadBadError"}}, "GetCloudFormationTemplate"
+        )
+        plugin = ServerlessAppPlugin(sar_client=client, wait_for_template_active_status=True, validate_only=False)
+        plugin._in_progress_templates = [("appid", "template")]
+        with self.assertRaises(ClientError):
+            plugin.on_after_transform_template("template")
+
+    def test_sar_success_one_app(self):
+        client = Mock()
+        client.get_cloud_formation_template = Mock()
+        client.get_cloud_formation_template.return_value = {"Status": "ACTIVE"}
+        plugin = ServerlessAppPlugin(sar_client=client, wait_for_template_active_status=True, validate_only=False)
+        plugin._in_progress_templates = [("appid", "template")]
+        plugin.on_after_transform_template("template")
+        # should have exactly one call to SAR
+        self.assertEqual(client.get_cloud_formation_template.call_count, 1)
+
+    def test_sar_success_two_apps(self):
+        client = Mock()
+        client.get_cloud_formation_template = Mock()
+        client.get_cloud_formation_template.return_value = {"Status": "ACTIVE"}
+        plugin = ServerlessAppPlugin(sar_client=client, wait_for_template_active_status=True, validate_only=False)
+        plugin._in_progress_templates = [("appid1", "template1"), ("appid2", "template2")]
+        plugin.on_after_transform_template("template")
+        # should have exactly one call to SAR per app
+        self.assertEqual(client.get_cloud_formation_template.call_count, 2)


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Currently, if an API call to Serverless Application Repository (SAR) is throttled while querying for the status of an application, the transform fails.  This change allows the transform to sleep and then retry, up to the time limit configured in code.

*Description of how you validated changes:*
Unit tests were added.

*Checklist:*

- [x] Add/update tests using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] ~[Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)~ - n/a
- [x] `make pr` passes
- [ ] ~Update documentation~ - n/a
- [ ] ~Verify transformed template deploys and application functions as expected~ no changes to transformation logic

*Examples?*
