### PR TITLE
fix: fix validation errors log message that calls join on a string

### DIFF
--- a/samtranslator/parser/parser.py
+++ b/samtranslator/parser/parser.py
@@ -63,7 +63,7 @@ class Parser:
             validation_errors = validator.validate(sam_template)
 
             if validation_errors:
-                LOG.warn("Template schema validation reported the following errors: " + ", ".join(validation_errors))
+                LOG.warning("Template schema validation reported the following errors: %s", validation_errors)
         except Exception as e:
             # Catching any exception and not re-raising to make sure any validation process won't break transform
             LOG.exception("Exception from SamTemplateValidator: %s", e)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/3493

*Description of changes:*
- remove `.join` call on `validation_errors`, which is already a string
- replace deprecated `LOG.warn` with `LOG.warning` (https://stackoverflow.com/questions/15539937/whats-the-difference-between-logging-warn-and-logging-warning-in-python)

*Description of how you validated changes:*
Ran transform with debugger and the message was printed properly

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
