### PR TITLE
Validate swagger method value is a valid dict before processing

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -537,12 +537,18 @@ class SwaggerEditor(object):
             if normalized_method_name in SwaggerEditor._EXCLUDED_PATHS_FIELDS:
                 continue
             if add_default_auth_to_preflight or normalized_method_name != "options":
-                normalized_method_name = self._normalize_method_name(method_name)
+                SwaggerEditor.validate_is_dict(
+                    method,
+                    'Value of "{}" ({}) for path {} is not a valid dictionary.'.format(method_name, method, path),
+                )
                 # It is possible that the method could have two definitions in a Fn::If block.
                 for method_definition in self.get_method_contents(method):
 
                     SwaggerEditor.validate_is_dict(
-                        method_definition, "{} for path {} is not a valid dictionary.".format(method_definition, path)
+                        method_definition,
+                        'Value of "{}" ({}) for path {} is not a valid dictionary.'.format(
+                            method_name, method_definition, path
+                        ),
                     )
                     # If no integration given, then we don't need to process this definition (could be AWS::NoValue)
                     if not self.method_definition_has_integration(method_definition):

--- a/tests/translator/input/error_null_method_definition.yaml
+++ b/tests/translator/input/error_null_method_definition.yaml
@@ -1,0 +1,29 @@
+Resources:
+  ExplicitApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: SomeStage
+      Auth:
+        DefaultAuthorizer: MyCognitoAuth
+        Authorizers:
+          MyCognitoAuth:
+            UserPoolArn: !GetAtt MyUserPool.Arn
+      DefinitionBody:
+        swagger: 2.0
+        paths:
+          "/":
+            get: null
+
+  MyUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: UserPoolName
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 8
+      UsernameAttributes:
+        - email
+      Schema:
+        - AttributeDataType: String
+          Name: email
+          Required: false

--- a/tests/translator/output/error_invalid_method_definition.json
+++ b/tests/translator/output/error_invalid_method_definition.json
@@ -1,1 +1,1 @@
-{"errorMessage":"Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. ['InvalidMethodDefinition'] for path / is not a valid dictionary."}
+{"errorMessage":"Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Value of \"tags\" (['InvalidMethodDefinition']) for path / is not a valid dictionary."}

--- a/tests/translator/output/error_null_method_definition.json
+++ b/tests/translator/output/error_null_method_definition.json
@@ -1,0 +1,1 @@
+{"errorMessage":"Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Value of \"get\" (None) for path / is not a valid dictionary."}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
