### PR TITLE
Validate swagger path item objects

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -53,6 +53,14 @@ class SwaggerEditor(object):
         self.resource_policy = self._doc.get(self._X_APIGW_POLICY, {})
         self.definitions = self._doc.get("definitions", {})
 
+        # https://swagger.io/specification/#path-item-object
+        # According to swagger spec,
+        # each path item object must be a dict (even it is empty).
+        # We can do an early path validation on path item objects,
+        # so we don't need to validate wherever we use them.
+        for path in self.iter_on_path():
+            SwaggerEditor.validate_path_item_is_dict(self.get_path(path), path)
+
     def get_path(self, path):
         path_dict = self.paths.get(path)
         if isinstance(path_dict, dict) and self._CONDITIONAL_IF in path_dict:

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -49,6 +49,13 @@ class TestSwaggerEditor_init(TestCase):
 
         self.assertEqual(editor.paths, {"/foo": {}, "/bar": {}})
 
+    @parameterized.expand([(None,), ("should-not-be-string",)])
+    def test_must_fail_with_bad_values_for_path(self, invalid_path_item):
+        invalid_swagger = {"openapi": "3.1.1.1", "paths": {"/foo": {}, "/bad": invalid_path_item}}
+
+        with self.assertRaises(ValueError):
+            SwaggerEditor(invalid_swagger)
+
 
 class TestSwaggerEditor_has_path(TestCase):
     def setUp(self):
@@ -57,7 +64,6 @@ class TestSwaggerEditor_has_path(TestCase):
             "paths": {
                 "/foo": {"get": {}, "somemethod": {}},
                 "/bar": {"post": {}, _X_ANY_METHOD: {}},
-                "badpath": "string value",
             },
         }
 
@@ -96,11 +102,6 @@ class TestSwaggerEditor_has_path(TestCase):
         self.assertFalse(self.editor.has_path("/foo", "abc"))
         self.assertFalse(self.editor.has_path("/bar", "get"))
         self.assertFalse(self.editor.has_path("/bar", "xyz"))
-
-    def test_must_not_fail_on_bad_path(self):
-
-        self.assertTrue(self.editor.has_path("badpath"))
-        self.assertFalse(self.editor.has_path("badpath", "somemethod"))
 
 
 class TestSwaggerEditor_has_integration(TestCase):
@@ -145,7 +146,10 @@ class TestSwaggerEditor_add_path(TestCase):
 
         self.original_swagger = {
             "swagger": "2.0",
-            "paths": {"/foo": {"get": {"a": "b"}}, "/bar": {}, "/badpath": "string value"},
+            "paths": {
+                "/foo": {"get": {"a": "b"}},
+                "/bar": {},
+            },
         }
 
         self.editor = SwaggerEditor(self.original_swagger)
@@ -164,14 +168,6 @@ class TestSwaggerEditor_add_path(TestCase):
 
         self.assertTrue(self.editor.has_path(path, method), "must add for " + case)
         self.assertEqual(self.editor.swagger["paths"][path][method], {})
-
-    def test_must_raise_non_dict_path_values(self):
-
-        path = "/badpath"
-        method = "get"
-
-        with self.assertRaises(InvalidDocumentException):
-            self.editor.add_path(path, method)
 
     def test_must_skip_existing_path(self):
         """
@@ -295,13 +291,13 @@ class TestSwaggerEditor_add_lambda_integration(TestCase):
 class TestSwaggerEditor_iter_on_path(TestCase):
     def setUp(self):
 
-        self.original_swagger = {"swagger": "2.0", "paths": {"/foo": {}, "/bar": {}, "/baz": "some value"}}
+        self.original_swagger = {"swagger": "2.0", "paths": {"/foo": {}, "/bar": {}}}
 
         self.editor = SwaggerEditor(self.original_swagger)
 
     def test_must_iterate_on_paths(self):
 
-        expected = {"/foo", "/bar", "/baz"}
+        expected = {"/foo", "/bar"}
         actual = set(list(self.editor.iter_on_path()))
 
         self.assertEqual(expected, actual)
@@ -312,7 +308,10 @@ class TestSwaggerEditor_add_cors(TestCase):
 
         self.original_swagger = {
             "swagger": "2.0",
-            "paths": {"/foo": {}, "/withoptions": {"options": {"some": "value"}}, "/bad": "some value"},
+            "paths": {
+                "/foo": {},
+                "/withoptions": {"options": {"some": "value"}},
+            },
         }
 
         self.editor = SwaggerEditor(self.original_swagger)
@@ -342,12 +341,6 @@ class TestSwaggerEditor_add_cors(TestCase):
 
         self.editor.add_cors(path, "origins", "headers", "methods")
         self.assertEqual(expected, self.editor.swagger["paths"][path]["options"])
-
-    def test_must_fail_with_bad_values_for_path(self):
-        path = "/bad"
-
-        with self.assertRaises(InvalidDocumentException):
-            self.editor.add_cors(path, "origins", "headers", "methods")
 
     def test_must_fail_for_invalid_allowed_origin(self):
 

--- a/tests/translator/input/error_api_auth_invalid_path_item.yaml
+++ b/tests/translator/input/error_api_auth_invalid_path_item.yaml
@@ -1,0 +1,28 @@
+Resources:
+  ExplicitApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: SomeStage
+      Auth:
+        DefaultAuthorizer: MyCognitoAuth
+        Authorizers:
+          MyCognitoAuth:
+            UserPoolArn: !GetAtt MyUserPool.Arn
+      DefinitionBody:
+        swagger: 2.0
+        paths:
+          "/": null
+
+  MyUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: UserPoolName
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 8
+      UsernameAttributes:
+        - email
+      Schema:
+        - AttributeDataType: String
+          Name: email
+          Required: false

--- a/tests/translator/input/error_api_auth_null_path_item.yaml
+++ b/tests/translator/input/error_api_auth_null_path_item.yaml
@@ -1,0 +1,28 @@
+Resources:
+  ExplicitApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: SomeStage
+      Auth:
+        DefaultAuthorizer: MyCognitoAuth
+        Authorizers:
+          MyCognitoAuth:
+            UserPoolArn: !GetAtt MyUserPool.Arn
+      DefinitionBody:
+        swagger: 2.0
+        paths:
+          "/": ""
+
+  MyUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: UserPoolName
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 8
+      UsernameAttributes:
+        - email
+      Schema:
+        - AttributeDataType: String
+          Name: email
+          Required: false

--- a/tests/translator/output/error_api_auth_invalid_path_item.json
+++ b/tests/translator/output/error_api_auth_invalid_path_item.json
@@ -1,0 +1,1 @@
+ {"errorMessage":"Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Value of '/' path must be a dictionary according to Swagger spec."}

--- a/tests/translator/output/error_api_auth_null_path_item.json
+++ b/tests/translator/output/error_api_auth_null_path_item.json
@@ -1,0 +1,1 @@
+ {"errorMessage":"Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Value of '/' path must be a dictionary according to Swagger spec."}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add validation of path item objects when creating the SwaggerEditor object.

Possible concerns:

**What if it breaks some existing template despite they are invalid, customers are still using them?**

I just did a test with CFN, turns out even we don't do validation ourselves, CFN/Api Gateway will fail.

Tested templates:

```
# Failed with rollback: Invalid OpenAPI input
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31

Resources:
  ApiWithInvalidPath:
    Type: AWS::Serverless::Api
    Properties:
      StageName: Prod
      DefinitionBody:
        swagger: 2.0
        paths:
          /foo: ""
```

```
# Failed with rollback: Invalid OpenAPI input
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31

Resources:
  ApiWithInvalidPath:
    Type: AWS::Serverless::Api
    Properties:
      StageName: Prod
      DefinitionBody:
        swagger: 2.0
        paths:
          /foo: "some string"
```

```
# Failed with rollback: Invalid OpenAPI input
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31

Resources:
  ApiWithInvalidPath:
    Type: AWS::Serverless::Api
    Properties:
      StageName: Prod
      DefinitionBody:
        swagger: 2.0
        paths:
          /foo: 123
```

```
# Failed during creating changeset
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31

Resources:
  ApiWithInvalidPath:
    Type: AWS::Serverless::Api
    Properties:
      StageName: Prod
      DefinitionBody:
        swagger: 2.0
        paths:
          /foo:
```

```
# Failed during creating changeset
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31

Resources:
  ApiWithInvalidPath:
    Type: AWS::Serverless::Api
    Properties:
      StageName: Prod
      DefinitionBody:
        swagger: 2.0
        paths:
          /foo: null
```


*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
