### PR TITLE
fix: Check type of resource type is a string

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -489,10 +489,7 @@ class ResourceTypeResolver(object):
                 self.resource_types[resource_class.resource_type] = resource_class
 
     def can_resolve(self, resource_dict):
-        if (
-            not isinstance(resource_dict, dict)
-            or not isinstance(resource_dict.get('Type'), string_types)
-        ):
+        if not isinstance(resource_dict, dict) or not isinstance(resource_dict.get("Type"), string_types):
             return False
 
         return resource_dict["Type"] in self.resource_types

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -489,7 +489,11 @@ class ResourceTypeResolver(object):
                 self.resource_types[resource_class.resource_type] = resource_class
 
     def can_resolve(self, resource_dict):
-        if not isinstance(resource_dict, dict) or "Type" not in resource_dict:
+        if (
+            not isinstance(resource_dict, dict)
+            or "Type" not in resource_dict
+            or not isinstance(resource_dict["Type"], string_types)
+        ):
             return False
 
         return resource_dict["Type"] in self.resource_types

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -491,8 +491,7 @@ class ResourceTypeResolver(object):
     def can_resolve(self, resource_dict):
         if (
             not isinstance(resource_dict, dict)
-            or "Type" not in resource_dict
-            or not isinstance(resource_dict["Type"], string_types)
+            or not isinstance(resource_dict.get('Type'), string_types)
         ):
             return False
 

--- a/tests/translator/input/resource_with_invalid_type.yaml
+++ b/tests/translator/input/resource_with_invalid_type.yaml
@@ -1,0 +1,14 @@
+Resources:
+  FunctionInvalid:
+    Type:
+      AWS::Serverless::Function: invalid_field
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs12.x
+  FunctionValid:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs12.x

--- a/tests/translator/output/aws-cn/resource_with_invalid_type.json
+++ b/tests/translator/output/aws-cn/resource_with_invalid_type.json
@@ -1,0 +1,67 @@
+{
+  "Resources": {
+    "FunctionInvalid": {
+      "Type": {
+        "AWS::Serverless::Function": "invalid_field"
+      },
+      "Properties": {
+        "CodeUri": "s3://sam-demo-bucket/member_portal.zip",
+        "Handler": "index.gethtml",
+        "Runtime": "nodejs12.x"
+      }
+    },
+    "FunctionValid": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionValidRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionValidRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/resource_with_invalid_type.json
+++ b/tests/translator/output/aws-us-gov/resource_with_invalid_type.json
@@ -1,0 +1,67 @@
+{
+  "Resources": {
+    "FunctionInvalid": {
+      "Type": {
+        "AWS::Serverless::Function": "invalid_field"
+      },
+      "Properties": {
+        "CodeUri": "s3://sam-demo-bucket/member_portal.zip",
+        "Handler": "index.gethtml",
+        "Runtime": "nodejs12.x"
+      }
+    },
+    "FunctionValid": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionValidRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionValidRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/resource_with_invalid_type.json
+++ b/tests/translator/output/resource_with_invalid_type.json
@@ -1,0 +1,67 @@
+{
+  "Resources": {
+    "FunctionInvalid": {
+      "Type": {
+        "AWS::Serverless::Function": "invalid_field"
+      },
+      "Properties": {
+        "CodeUri": "s3://sam-demo-bucket/member_portal.zip",
+        "Handler": "index.gethtml",
+        "Runtime": "nodejs12.x"
+      }
+    },
+    "FunctionValid": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionValidRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionValidRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -282,6 +282,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "function_with_mq_virtual_host",
                 "simpletable",
                 "simpletable_with_sse",
+                "resource_with_invalid_type",
                 "implicit_api",
                 "explicit_api",
                 "api_description",


### PR DESCRIPTION
We should verify that the type of resource type is a string before trying to hash it. It should then work similarly to the current behaviour. If the type of a resource is invalid, we should skip that resource and continue processing the other resources.

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
