### PR TITLE
Fixing DisableExecuteApiEndpoint property for REST and adding integ t…

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -276,6 +276,9 @@ class ApiGenerator(object):
         self._add_binary_media_types()
         self._add_models()
 
+        if self.disable_execute_api_endpoint is not None:
+            self._add_endpoint_extension()
+
         if self.definition_uri:
             rest_api.BodyS3Location = self._construct_body_s3_dict()
         elif self.definition_body:
@@ -291,9 +294,6 @@ class ApiGenerator(object):
 
         if self.mode:
             rest_api.Mode = self.mode
-
-        if self.disable_execute_api_endpoint is not None:
-            self._add_endpoint_extension()
 
         return rest_api
 

--- a/tests/translator/input/api_with_disable_api_execute_endpoint.yaml
+++ b/tests/translator/input/api_with_disable_api_execute_endpoint.yaml
@@ -1,0 +1,22 @@
+Resources:
+  ApiGatewayApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      DisableExecuteApiEndpoint: True
+  ApiFunction: # Adds a GET api endpoint at "/" to the ApiGatewayApi via an Api event
+    Type: AWS::Serverless::Function
+    Properties:
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+            RestApiId:
+              Ref: ApiGatewayApi
+      Runtime: python3.7
+      Handler: index.handler
+      InlineCode: |
+        def handler(event, context):
+            return {'body': 'Hello World!', 'statusCode': 200}

--- a/tests/translator/output/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/api_with_disable_api_execute_endpoint.json
@@ -1,0 +1,130 @@
+{
+  "Resources": {
+    "ApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ApiFunctionApiEventPermissionprod": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "ApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__ApiId__": {
+                "Ref": "ApiGatewayApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "ApiGatewayApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            }
+          },
+          "x-amazon-apigateway-endpoint-configuration": {
+            "disableExecuteApiEndpoint": true
+          }
+        }
+      }
+    },
+    "ApiGatewayApiDeployment84a5818808": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 84a5818808759dd8d07350b436b7317bed964ab1",
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayApiprodStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayApiDeployment84a5818808"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "prod"
+      }
+    }
+  }
+}

--- a/tests/translator/output/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/api_with_disable_api_execute_endpoint.json
@@ -1,130 +1,87 @@
 {
-  "Resources": {
-    "ApiFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "ApiFunctionRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "python3.7",
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      }
-    },
-    "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      }
-    },
-    "ApiFunctionApiEventPermissionprod": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Ref": "ApiFunction"
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
-            {
-              "__ApiId__": {
-                "Ref": "ApiGatewayApi"
-              },
-              "__Stage__": "*"
-            }
-          ]
-        }
-      }
-    },
-    "ApiGatewayApi": {
-      "Type": "AWS::ApiGateway::RestApi",
-      "Properties": {
-        "Body": {
-          "swagger": "2.0",
-          "info": {
-            "version": "1.0",
-            "title": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          "paths": {
-            "/": {
-              "get": {
-                "x-amazon-apigateway-integration": {
-                  "type": "aws_proxy",
-                  "httpMethod": "POST",
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
-                  }
+    "Resources": {
+        "ApiFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Code": {
+                    "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
                 },
-                "responses": {}
-              }
-            }
-          },
-          "x-amazon-apigateway-endpoint-configuration": {
-            "disableExecuteApiEndpoint": true
-          }
-        }
-      }
-    },
-    "ApiGatewayApiDeployment84a5818808": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "Description": "RestApi deployment id: 84a5818808759dd8d07350b436b7317bed964ab1",
-        "RestApiId": {
-          "Ref": "ApiGatewayApi"
+                "Handler": "index.handler",
+                "Role": {"Fn::GetAtt": ["ApiFunctionRole", "Arn"]},
+                "Runtime": "python3.7",
+                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
+            },
         },
-        "StageName": "Stage"
-      }
-    },
-    "ApiGatewayApiprodStage": {
-      "Type": "AWS::ApiGateway::Stage",
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ApiGatewayApiDeployment84a5818808"
+        "ApiFunctionRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": ["sts:AssumeRole"],
+                            "Effect": "Allow",
+                            "Principal": {"Service": ["lambda.amazonaws.com"]},
+                        }
+                    ],
+                },
+                "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
+            },
         },
-        "RestApiId": {
-          "Ref": "ApiGatewayApi"
+        "ApiFunctionApiEventPermissionprod": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+                "Action": "lambda:InvokeFunction",
+                "FunctionName": {"Ref": "ApiFunction"},
+                "Principal": "apigateway.amazonaws.com",
+                "SourceArn": {
+                    "Fn::Sub": [
+                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+                        {"__ApiId__": {"Ref": "ApiGatewayApi"}, "__Stage__": "*"},
+                    ]
+                },
+            },
         },
-        "StageName": "prod"
-      }
+        "ApiGatewayApi": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "swagger": "2.0",
+                    "info": {"version": "1.0", "title": {"Ref": "AWS::StackName"}},
+                    "paths": {
+                        "/": {
+                            "get": {
+                                "x-amazon-apigateway-integration": {
+                                    "type": "aws_proxy",
+                                    "httpMethod": "POST",
+                                    "uri": {
+                                        "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                                    },
+                                },
+                                "responses": {},
+                            }
+                        }
+                    },
+                    "x-amazon-apigateway-endpoint-configuration": {"disableExecuteApiEndpoint": true},
+                }
+            },
+        },
+        "ApiGatewayApiDeployment84a5818808": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: 84a5818808759dd8d07350b436b7317bed964ab1",
+                "RestApiId": {"Ref": "ApiGatewayApi"},
+                "StageName": "Stage",
+            },
+        },
+        "ApiGatewayApiprodStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {"Ref": "ApiGatewayApiDeployment84a5818808"},
+                "RestApiId": {"Ref": "ApiGatewayApi"},
+                "StageName": "prod",
+            },
+        },
     }
-  }
 }

--- a/tests/translator/output/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/api_with_disable_api_execute_endpoint.json
@@ -1,87 +1,130 @@
 {
-    "Resources": {
-        "ApiFunction": {
-            "Type": "AWS::Lambda::Function",
-            "Properties": {
-                "Code": {
-                    "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+  "Resources": {
+    "ApiGatewayApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
                 },
-                "Handler": "index.handler",
-                "Role": {"Fn::GetAtt": ["ApiFunctionRole", "Arn"]},
-                "Runtime": "python3.7",
-                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
-            },
+                "responses": {}
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-endpoint-configuration": {
+            "disableExecuteApiEndpoint": true
+          }
+        }
+      }
+    },
+    "ApiGatewayApiDeploymenta13ba42368": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
         },
-        "ApiFunctionRole": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Action": ["sts:AssumeRole"],
-                            "Effect": "Allow",
-                            "Principal": {"Service": ["lambda.amazonaws.com"]},
-                        }
-                    ],
-                },
-                "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
-                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
-            },
+        "Description": "RestApi deployment id: a13ba42368cb482635c1d715f5e0199e94d79222",
+        "StageName": "Stage"
+      }
+    },
+    "ApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
         },
-        "ApiFunctionApiEventPermissionprod": {
-            "Type": "AWS::Lambda::Permission",
-            "Properties": {
-                "Action": "lambda:InvokeFunction",
-                "FunctionName": {"Ref": "ApiFunction"},
-                "Principal": "apigateway.amazonaws.com",
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
-                        {"__ApiId__": {"Ref": "ApiGatewayApi"}, "__Stage__": "*"},
-                    ]
-                },
-            },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
         },
-        "ApiGatewayApi": {
-            "Type": "AWS::ApiGateway::RestApi",
-            "Properties": {
-                "Body": {
-                    "swagger": "2.0",
-                    "info": {"version": "1.0", "title": {"Ref": "AWS::StackName"}},
-                    "paths": {
-                        "/": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "type": "aws_proxy",
-                                    "httpMethod": "POST",
-                                    "uri": {
-                                        "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
-                                    },
-                                },
-                                "responses": {},
-                            }
-                        }
-                    },
-                    "x-amazon-apigateway-endpoint-configuration": {"disableExecuteApiEndpoint": true},
-                }
-            },
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
         },
-        "ApiGatewayApiDeployment84a5818808": {
-            "Type": "AWS::ApiGateway::Deployment",
-            "Properties": {
-                "Description": "RestApi deployment id: 84a5818808759dd8d07350b436b7317bed964ab1",
-                "RestApiId": {"Ref": "ApiGatewayApi"},
-                "StageName": "Stage",
-            },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ApiFunctionApiEventPermissionprod": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "ApiFunction"
         },
-        "ApiGatewayApiprodStage": {
-            "Type": "AWS::ApiGateway::Stage",
-            "Properties": {
-                "DeploymentId": {"Ref": "ApiGatewayApiDeployment84a5818808"},
-                "RestApiId": {"Ref": "ApiGatewayApi"},
-                "StageName": "prod",
-            },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "ApiGatewayApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ApiGatewayApiprodStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayApiDeploymenta13ba42368"
         },
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "prod"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/aws-cn/api_with_disable_api_execute_endpoint.json
@@ -1,0 +1,138 @@
+{
+  "Resources": {
+    "ApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ApiFunctionApiEventPermissionprod": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "ApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__ApiId__": {
+                "Ref": "ApiGatewayApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "ApiGatewayApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            }
+          },
+          "x-amazon-apigateway-endpoint-configuration": {
+            "disableExecuteApiEndpoint": true
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayApiDeploymentc50fa02660": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: c50fa02660c0f3d00b46b59c122ede78e89cdc30",
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayApiprodStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayApiDeploymentc50fa02660"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "prod"
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/aws-cn/api_with_disable_api_execute_endpoint.json
@@ -1,89 +1,138 @@
 {
-    "Resources": {
-        "ApiFunction": {
-            "Type": "AWS::Lambda::Function",
-            "Properties": {
-                "Code": {
-                    "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+  "Resources": {
+    "ApiGatewayApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
                 },
-                "Handler": "index.handler",
-                "Role": {"Fn::GetAtt": ["ApiFunctionRole", "Arn"]},
-                "Runtime": "python3.7",
-                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
-            },
+                "responses": {}
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-endpoint-configuration": {
+            "disableExecuteApiEndpoint": true
+          }
         },
-        "ApiFunctionRole": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Action": ["sts:AssumeRole"],
-                            "Effect": "Allow",
-                            "Principal": {"Service": ["lambda.amazonaws.com"]},
-                        }
-                    ],
-                },
-                "ManagedPolicyArns": ["arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
-                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
-            },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
         },
-        "ApiFunctionApiEventPermissionprod": {
-            "Type": "AWS::Lambda::Permission",
-            "Properties": {
-                "Action": "lambda:InvokeFunction",
-                "FunctionName": {"Ref": "ApiFunction"},
-                "Principal": "apigateway.amazonaws.com",
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
-                        {"__ApiId__": {"Ref": "ApiGatewayApi"}, "__Stage__": "*"},
-                    ]
-                },
-            },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ApiGatewayApiDeployment31ce724e39": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
         },
-        "ApiGatewayApi": {
-            "Type": "AWS::ApiGateway::RestApi",
-            "Properties": {
-                "Body": {
-                    "swagger": "2.0",
-                    "info": {"version": "1.0", "title": {"Ref": "AWS::StackName"}},
-                    "paths": {
-                        "/": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "type": "aws_proxy",
-                                    "httpMethod": "POST",
-                                    "uri": {
-                                        "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
-                                    },
-                                },
-                                "responses": {},
-                            }
-                        }
-                    },
-                    "x-amazon-apigateway-endpoint-configuration": {"disableExecuteApiEndpoint": true},
-                },
-                "Parameters": {"endpointConfigurationTypes": "REGIONAL"},
-                "EndpointConfiguration": {"Types": ["REGIONAL"]},
-            },
+        "Description": "RestApi deployment id: 31ce724e3998cb16b80266cfb4868670a87430bf",
+        "StageName": "Stage"
+      }
+    },
+    "ApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
         },
-        "ApiGatewayApiDeploymentc50fa02660": {
-            "Type": "AWS::ApiGateway::Deployment",
-            "Properties": {
-                "Description": "RestApi deployment id: c50fa02660c0f3d00b46b59c122ede78e89cdc30",
-                "RestApiId": {"Ref": "ApiGatewayApi"},
-                "StageName": "Stage",
-            },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
         },
-        "ApiGatewayApiprodStage": {
-            "Type": "AWS::ApiGateway::Stage",
-            "Properties": {
-                "DeploymentId": {"Ref": "ApiGatewayApiDeploymentc50fa02660"},
-                "RestApiId": {"Ref": "ApiGatewayApi"},
-                "StageName": "prod",
-            },
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
         },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ApiFunctionApiEventPermissionprod": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "ApiFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "ApiGatewayApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ApiGatewayApiprodStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayApiDeployment31ce724e39"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "prod"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-cn/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/aws-cn/api_with_disable_api_execute_endpoint.json
@@ -1,138 +1,89 @@
 {
-  "Resources": {
-    "ApiFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "ApiFunctionRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "python3.7",
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      }
-    },
-    "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        },
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      }
-    },
-    "ApiFunctionApiEventPermissionprod": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Ref": "ApiFunction"
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
-            {
-              "__ApiId__": {
-                "Ref": "ApiGatewayApi"
-              },
-              "__Stage__": "*"
-            }
-          ]
-        }
-      }
-    },
-    "ApiGatewayApi": {
-      "Type": "AWS::ApiGateway::RestApi",
-      "Properties": {
-        "Body": {
-          "swagger": "2.0",
-          "info": {
-            "version": "1.0",
-            "title": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          "paths": {
-            "/": {
-              "get": {
-                "x-amazon-apigateway-integration": {
-                  "type": "aws_proxy",
-                  "httpMethod": "POST",
-                  "uri": {
-                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
-                  }
+    "Resources": {
+        "ApiFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Code": {
+                    "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
                 },
-                "responses": {}
-              }
-            }
-          },
-          "x-amazon-apigateway-endpoint-configuration": {
-            "disableExecuteApiEndpoint": true
-          }
+                "Handler": "index.handler",
+                "Role": {"Fn::GetAtt": ["ApiFunctionRole", "Arn"]},
+                "Runtime": "python3.7",
+                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
+            },
         },
-        "Parameters": {
-          "endpointConfigurationTypes": "REGIONAL"
+        "ApiFunctionRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": ["sts:AssumeRole"],
+                            "Effect": "Allow",
+                            "Principal": {"Service": ["lambda.amazonaws.com"]},
+                        }
+                    ],
+                },
+                "ManagedPolicyArns": ["arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
+            },
         },
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL"
-          ]
-        }
-      }
-    },
-    "ApiGatewayApiDeploymentc50fa02660": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "Description": "RestApi deployment id: c50fa02660c0f3d00b46b59c122ede78e89cdc30",
-        "RestApiId": {
-          "Ref": "ApiGatewayApi"
+        "ApiFunctionApiEventPermissionprod": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+                "Action": "lambda:InvokeFunction",
+                "FunctionName": {"Ref": "ApiFunction"},
+                "Principal": "apigateway.amazonaws.com",
+                "SourceArn": {
+                    "Fn::Sub": [
+                        "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+                        {"__ApiId__": {"Ref": "ApiGatewayApi"}, "__Stage__": "*"},
+                    ]
+                },
+            },
         },
-        "StageName": "Stage"
-      }
-    },
-    "ApiGatewayApiprodStage": {
-      "Type": "AWS::ApiGateway::Stage",
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ApiGatewayApiDeploymentc50fa02660"
+        "ApiGatewayApi": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "swagger": "2.0",
+                    "info": {"version": "1.0", "title": {"Ref": "AWS::StackName"}},
+                    "paths": {
+                        "/": {
+                            "get": {
+                                "x-amazon-apigateway-integration": {
+                                    "type": "aws_proxy",
+                                    "httpMethod": "POST",
+                                    "uri": {
+                                        "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                                    },
+                                },
+                                "responses": {},
+                            }
+                        }
+                    },
+                    "x-amazon-apigateway-endpoint-configuration": {"disableExecuteApiEndpoint": true},
+                },
+                "Parameters": {"endpointConfigurationTypes": "REGIONAL"},
+                "EndpointConfiguration": {"Types": ["REGIONAL"]},
+            },
         },
-        "RestApiId": {
-          "Ref": "ApiGatewayApi"
+        "ApiGatewayApiDeploymentc50fa02660": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: c50fa02660c0f3d00b46b59c122ede78e89cdc30",
+                "RestApiId": {"Ref": "ApiGatewayApi"},
+                "StageName": "Stage",
+            },
         },
-        "StageName": "prod"
-      }
+        "ApiGatewayApiprodStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {"Ref": "ApiGatewayApiDeploymentc50fa02660"},
+                "RestApiId": {"Ref": "ApiGatewayApi"},
+                "StageName": "prod",
+            },
+        },
     }
-  }
 }

--- a/tests/translator/output/aws-us-gov/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/aws-us-gov/api_with_disable_api_execute_endpoint.json
@@ -1,89 +1,138 @@
 {
-    "Resources": {
-        "ApiFunction": {
-            "Type": "AWS::Lambda::Function",
-            "Properties": {
-                "Code": {
-                    "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+  "Resources": {
+    "ApiGatewayApiDeployment88816bd125": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "Description": "RestApi deployment id: 88816bd1258061ab1a1138fb2723a76f221c5111",
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
                 },
-                "Handler": "index.handler",
-                "Role": {"Fn::GetAtt": ["ApiFunctionRole", "Arn"]},
-                "Runtime": "python3.7",
-                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
-            },
+                "responses": {}
+              }
+            }
+          },
+          "swagger": "2.0",
+          "x-amazon-apigateway-endpoint-configuration": {
+            "disableExecuteApiEndpoint": true
+          }
         },
-        "ApiFunctionRole": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Action": ["sts:AssumeRole"],
-                            "Effect": "Allow",
-                            "Principal": {"Service": ["lambda.amazonaws.com"]},
-                        }
-                    ],
-                },
-                "ManagedPolicyArns": ["arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
-                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
-            },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
         },
-        "ApiFunctionApiEventPermissionprod": {
-            "Type": "AWS::Lambda::Permission",
-            "Properties": {
-                "Action": "lambda:InvokeFunction",
-                "FunctionName": {"Ref": "ApiFunction"},
-                "Principal": "apigateway.amazonaws.com",
-                "SourceArn": {
-                    "Fn::Sub": [
-                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
-                        {"__ApiId__": {"Ref": "ApiGatewayApi"}, "__Stage__": "*"},
-                    ]
-                },
-            },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "ApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
         },
-        "ApiGatewayApi": {
-            "Type": "AWS::ApiGateway::RestApi",
-            "Properties": {
-                "Body": {
-                    "swagger": "2.0",
-                    "info": {"version": "1.0", "title": {"Ref": "AWS::StackName"}},
-                    "paths": {
-                        "/": {
-                            "get": {
-                                "x-amazon-apigateway-integration": {
-                                    "type": "aws_proxy",
-                                    "httpMethod": "POST",
-                                    "uri": {
-                                        "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
-                                    },
-                                },
-                                "responses": {},
-                            }
-                        }
-                    },
-                    "x-amazon-apigateway-endpoint-configuration": {"disableExecuteApiEndpoint": true},
-                },
-                "Parameters": {"endpointConfigurationTypes": "REGIONAL"},
-                "EndpointConfiguration": {"Types": ["REGIONAL"]},
-            },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
         },
-        "ApiGatewayApiDeploymenta4852d5d7a": {
-            "Type": "AWS::ApiGateway::Deployment",
-            "Properties": {
-                "Description": "RestApi deployment id: a4852d5d7acda9703a3c4621e2e2708baed954c0",
-                "RestApiId": {"Ref": "ApiGatewayApi"},
-                "StageName": "Stage",
-            },
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
         },
-        "ApiGatewayApiprodStage": {
-            "Type": "AWS::ApiGateway::Stage",
-            "Properties": {
-                "DeploymentId": {"Ref": "ApiGatewayApiDeploymenta4852d5d7a"},
-                "RestApiId": {"Ref": "ApiGatewayApi"},
-                "StageName": "prod",
-            },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ApiFunctionApiEventPermissionprod": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "ApiFunction"
         },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "ApiGatewayApi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ApiGatewayApiprodStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayApiDeployment88816bd125"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "prod"
+      }
     }
+  }
 }

--- a/tests/translator/output/aws-us-gov/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/aws-us-gov/api_with_disable_api_execute_endpoint.json
@@ -1,138 +1,89 @@
 {
-  "Resources": {
-    "ApiFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "ApiFunctionRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "python3.7",
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      }
-    },
-    "ApiFunctionRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        },
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      }
-    },
-    "ApiFunctionApiEventPermissionprod": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Ref": "ApiFunction"
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
-            {
-              "__ApiId__": {
-                "Ref": "ApiGatewayApi"
-              },
-              "__Stage__": "*"
-            }
-          ]
-        }
-      }
-    },
-    "ApiGatewayApi": {
-      "Type": "AWS::ApiGateway::RestApi",
-      "Properties": {
-        "Body": {
-          "swagger": "2.0",
-          "info": {
-            "version": "1.0",
-            "title": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          "paths": {
-            "/": {
-              "get": {
-                "x-amazon-apigateway-integration": {
-                  "type": "aws_proxy",
-                  "httpMethod": "POST",
-                  "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
-                  }
+    "Resources": {
+        "ApiFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Code": {
+                    "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
                 },
-                "responses": {}
-              }
-            }
-          },
-          "x-amazon-apigateway-endpoint-configuration": {
-            "disableExecuteApiEndpoint": true
-          }
+                "Handler": "index.handler",
+                "Role": {"Fn::GetAtt": ["ApiFunctionRole", "Arn"]},
+                "Runtime": "python3.7",
+                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
+            },
         },
-        "Parameters": {
-          "endpointConfigurationTypes": "REGIONAL"
+        "ApiFunctionRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": ["sts:AssumeRole"],
+                            "Effect": "Allow",
+                            "Principal": {"Service": ["lambda.amazonaws.com"]},
+                        }
+                    ],
+                },
+                "ManagedPolicyArns": ["arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+                "Tags": [{"Key": "lambda:createdBy", "Value": "SAM"}],
+            },
         },
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL"
-          ]
-        }
-      }
-    },
-    "ApiGatewayApiDeploymenta4852d5d7a": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "Description": "RestApi deployment id: a4852d5d7acda9703a3c4621e2e2708baed954c0",
-        "RestApiId": {
-          "Ref": "ApiGatewayApi"
+        "ApiFunctionApiEventPermissionprod": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+                "Action": "lambda:InvokeFunction",
+                "FunctionName": {"Ref": "ApiFunction"},
+                "Principal": "apigateway.amazonaws.com",
+                "SourceArn": {
+                    "Fn::Sub": [
+                        "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+                        {"__ApiId__": {"Ref": "ApiGatewayApi"}, "__Stage__": "*"},
+                    ]
+                },
+            },
         },
-        "StageName": "Stage"
-      }
-    },
-    "ApiGatewayApiprodStage": {
-      "Type": "AWS::ApiGateway::Stage",
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ApiGatewayApiDeploymenta4852d5d7a"
+        "ApiGatewayApi": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "swagger": "2.0",
+                    "info": {"version": "1.0", "title": {"Ref": "AWS::StackName"}},
+                    "paths": {
+                        "/": {
+                            "get": {
+                                "x-amazon-apigateway-integration": {
+                                    "type": "aws_proxy",
+                                    "httpMethod": "POST",
+                                    "uri": {
+                                        "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                                    },
+                                },
+                                "responses": {},
+                            }
+                        }
+                    },
+                    "x-amazon-apigateway-endpoint-configuration": {"disableExecuteApiEndpoint": true},
+                },
+                "Parameters": {"endpointConfigurationTypes": "REGIONAL"},
+                "EndpointConfiguration": {"Types": ["REGIONAL"]},
+            },
         },
-        "RestApiId": {
-          "Ref": "ApiGatewayApi"
+        "ApiGatewayApiDeploymenta4852d5d7a": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: a4852d5d7acda9703a3c4621e2e2708baed954c0",
+                "RestApiId": {"Ref": "ApiGatewayApi"},
+                "StageName": "Stage",
+            },
         },
-        "StageName": "prod"
-      }
+        "ApiGatewayApiprodStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {"Ref": "ApiGatewayApiDeploymenta4852d5d7a"},
+                "RestApiId": {"Ref": "ApiGatewayApi"},
+                "StageName": "prod",
+            },
+        },
     }
-  }
 }

--- a/tests/translator/output/aws-us-gov/api_with_disable_api_execute_endpoint.json
+++ b/tests/translator/output/aws-us-gov/api_with_disable_api_execute_endpoint.json
@@ -1,0 +1,138 @@
+{
+  "Resources": {
+    "ApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ApiFunctionApiEventPermissionprod": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "ApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__ApiId__": {
+                "Ref": "ApiGatewayApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "ApiGatewayApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "swagger": "2.0",
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "type": "aws_proxy",
+                  "httpMethod": "POST",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            }
+          },
+          "x-amazon-apigateway-endpoint-configuration": {
+            "disableExecuteApiEndpoint": true
+          }
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayApiDeploymenta4852d5d7a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: a4852d5d7acda9703a3c4621e2e2708baed954c0",
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayApiprodStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayApiDeploymenta4852d5d7a"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayApi"
+        },
+        "StageName": "prod"
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -329,6 +329,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "api_with_stage_tags",
                 "api_with_mode",
                 "api_with_no_properties",
+                "api_with_disable_api_execute_endpoint",
                 "s3",
                 "s3_create_remove",
                 "s3_existing_lambda_notification_configuration",


### PR DESCRIPTION
…ests.

*Issue #, if available:*
https://github.com/aws/serverless-application-model/issues/2270

*Description of changes:*
Adding DisableExecuteApiEndpoint into definition_body.

*Description of how you validated changes:*
Added integration tests.
Check with transforming the SAM template to CF and uploading it to stack.

*Checklist:*

- [ ] Add/update tests using:
    - [X] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [X] `make pr` passes
- [] Update documentation
- [X] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
