### PR TITLE
[minor docs] Updates examples link to current non-archived repo

### DIFF
--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -1,1 +1,1 @@
-All example applications have been moved to [aws-samples/serverless-app-examples](https://github.com/aws-samples/serverless-app-examples).
+All example/template applications have been moved to [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The repo pointed to by the link to examples is archived an no longer current. This changes the link to the correct repo which the SAM CLI pulls down the quickstart templates from in `sam init`.

*Description of how you validated changes:*
Verified this is the repo outputted by the SAM CLI during cloning.

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] `make pr` passes
- [X] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
