### PR TITLE
Improve exception processing for Route53 with invalid type

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -515,29 +515,28 @@ class ApiGenerator(object):
         record_set_group = None
         if self.domain.get("Route53") is not None:
             route53 = self.domain.get("Route53")
-            if isinstance(route53, dict):
-                if route53.get("HostedZoneId") is None and route53.get("HostedZoneName") is None:
-                    raise InvalidResourceException(
-                        self.logical_id,
-                        "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
-                    )
-                logical_id = logical_id_generator.LogicalIdGenerator(
-                    "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
-                ).gen()
-                record_set_group = Route53RecordSetGroup(
-                    "RecordSetGroup" + logical_id, attributes=self.passthrough_resource_attributes
-                )
-                if "HostedZoneId" in route53:
-                    record_set_group.HostedZoneId = route53.get("HostedZoneId")
-                if "HostedZoneName" in route53:
-                    record_set_group.HostedZoneName = route53.get("HostedZoneName")
-                record_set_group.RecordSets = self._construct_record_sets_for_domain(self.domain)
-            else:
+            if not isinstance(route53, dict):
                 raise InvalidResourceException(
                     self.logical_id,
                     "Invalid property type '{}' for Route53. "
                     "Expected a map defines an Amazon Route 53 configuration'.".format(type(route53).__name__),
                 )
+            if route53.get("HostedZoneId") is None and route53.get("HostedZoneName") is None:
+                raise InvalidResourceException(
+                    self.logical_id,
+                    "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
+                )
+            logical_id = logical_id_generator.LogicalIdGenerator(
+                "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
+            ).gen()
+            record_set_group = Route53RecordSetGroup(
+                "RecordSetGroup" + logical_id, attributes=self.passthrough_resource_attributes
+            )
+            if "HostedZoneId" in route53:
+                record_set_group.HostedZoneId = route53.get("HostedZoneId")
+            if "HostedZoneName" in route53:
+                record_set_group.HostedZoneName = route53.get("HostedZoneName")
+            record_set_group.RecordSets = self._construct_record_sets_for_domain(self.domain)
 
         return domain, basepath_resource_list, record_set_group
 

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -536,9 +536,7 @@ class ApiGenerator(object):
                 raise InvalidResourceException(
                     self.logical_id,
                     "Invalid property type '{}' for Route53. "
-                    "Expected a map defines an Amazon Route 53 configuration'.".format(
-                        type(route53).__name__
-                    ),
+                    "Expected a map defines an Amazon Route 53 configuration'.".format(type(route53).__name__),
                 )
 
         return domain, basepath_resource_list, record_set_group

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -515,22 +515,31 @@ class ApiGenerator(object):
         record_set_group = None
         if self.domain.get("Route53") is not None:
             route53 = self.domain.get("Route53")
-            if route53.get("HostedZoneId") is None and route53.get("HostedZoneName") is None:
+            if isinstance(route53, dict):
+                if route53.get("HostedZoneId") is None and route53.get("HostedZoneName") is None:
+                    raise InvalidResourceException(
+                        self.logical_id,
+                        "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
+                    )
+                logical_id = logical_id_generator.LogicalIdGenerator(
+                    "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
+                ).gen()
+                record_set_group = Route53RecordSetGroup(
+                    "RecordSetGroup" + logical_id, attributes=self.passthrough_resource_attributes
+                )
+                if "HostedZoneId" in route53:
+                    record_set_group.HostedZoneId = route53.get("HostedZoneId")
+                if "HostedZoneName" in route53:
+                    record_set_group.HostedZoneName = route53.get("HostedZoneName")
+                record_set_group.RecordSets = self._construct_record_sets_for_domain(self.domain)
+            else:
                 raise InvalidResourceException(
                     self.logical_id,
-                    "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
+                    "Invalid property type '{}' for Route53. "
+                    "Expected a map defines an Amazon Route 53 configuration'.".format(
+                        type(route53).__name__
+                    ),
                 )
-            logical_id = logical_id_generator.LogicalIdGenerator(
-                "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
-            ).gen()
-            record_set_group = Route53RecordSetGroup(
-                "RecordSetGroup" + logical_id, attributes=self.passthrough_resource_attributes
-            )
-            if "HostedZoneId" in route53:
-                record_set_group.HostedZoneId = route53.get("HostedZoneId")
-            if "HostedZoneName" in route53:
-                record_set_group.HostedZoneName = route53.get("HostedZoneName")
-            record_set_group.RecordSets = self._construct_record_sets_for_domain(self.domain)
 
         return domain, basepath_resource_list, record_set_group
 

--- a/tests/translator/input/error_api_with_custom_domains_route53_invalid_type.yaml
+++ b/tests/translator/input/error_api_with_custom_domains_route53_invalid_type.yaml
@@ -1,0 +1,33 @@
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |
+        exports.handler = async (event) => {
+          const response = {
+            statusCode: 200,
+            body: JSON.stringify('Hello from Lambda!'),
+          };
+          return response;
+        };
+      Handler: index.handler
+      Runtime: nodejs12.x
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApi
+            Method: Put
+            Path: /get
+
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      OpenApiVersion: 3.0.1
+      StageName: Prod
+      Domain:
+        DomainName: 'api-example.com'
+        CertificateArn: 'my-api-cert-arn'
+        EndpointConfiguration: 'EDGE'
+        BasePath: [ "/get"]
+        Route53: 'InvalidString'

--- a/tests/translator/output/error_api_with_custom_domains_route53_invalid_type.json
+++ b/tests/translator/output/error_api_with_custom_domains_route53_invalid_type.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyApi] is invalid. Invalid property type 'Py27UniStr' for Route53. Expected a map defines an Amazon Route 53 configuration'."
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApi] is invalid. Invalid property type 'Py27UniStr' for Route53. Expected a map defines an Amazon Route 53 configuration'."
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
