### PR TITLE
Update integ test expected result to incorporate py27hashfix changes

### DIFF
--- a/integration/resources/expected/single/basic_api_with_mode_update.json
+++ b/integration/resources/expected/single/basic_api_with_mode_update.json
@@ -1,6 +1,6 @@
 [
         {"LogicalResourceId": "MyApi", "ResourceType": "AWS::ApiGateway::RestApi"},
-        {"LogicalResourceId": "MyApiDeploymentada889e3ac", "ResourceType": "AWS::ApiGateway::Deployment"},
+        {"LogicalResourceId": "MyApiDeploymentb30ecf9df1", "ResourceType": "AWS::ApiGateway::Deployment"},
         {"LogicalResourceId": "MyApiMyNewStageNameStage", "ResourceType": "AWS::ApiGateway::Stage"},
         {"LogicalResourceId": "TestFunction", "ResourceType": "AWS::Lambda::Function"},
         {"LogicalResourceId": "TestFunctionAliaslive", "ResourceType": "AWS::Lambda::Alias"},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update expected result for a integration test case to incorporate py27hashfix changes

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
