### PR TITLE
Add PartiQL support to DynamoDB policy templates

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -133,7 +133,11 @@
               "dynamodb:BatchWriteItem",
               "dynamodb:BatchGetItem",
               "dynamodb:DescribeTable",
-              "dynamodb:ConditionCheckItem"
+              "dynamodb:ConditionCheckItem",
+              "dynamodb:PartiQLSelect",
+              "dynamodb:PartiQLUpdate",
+              "dynamodb:PartiQLInsert",
+              "dynamodb:PartiQLDelete"
             ],
             "Resource": [
               {
@@ -177,7 +181,8 @@
               "dynamodb:Scan",
               "dynamodb:Query",
               "dynamodb:BatchGetItem",
-              "dynamodb:DescribeTable"
+              "dynamodb:DescribeTable",
+              "dynamodb:PartiQLSelect"
             ],
             "Resource": [
               {
@@ -219,7 +224,9 @@
             "Action": [
               "dynamodb:PutItem",
               "dynamodb:UpdateItem",
-              "dynamodb:BatchWriteItem"
+              "dynamodb:BatchWriteItem",
+              "dynamodb:PartiQLUpdate",
+              "dynamodb:PartiQLInsert"
             ],
             "Resource": [
               {

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -151,7 +151,11 @@
                     "dynamodb:BatchWriteItem", 
                     "dynamodb:BatchGetItem", 
                     "dynamodb:DescribeTable", 
-                    "dynamodb:ConditionCheckItem"
+                    "dynamodb:ConditionCheckItem",
+                    "dynamodb:PartiQLSelect",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert",
+                    "dynamodb:PartiQLDelete"
                   ], 
                   "Resource": [
                     {
@@ -186,7 +190,8 @@
                     "dynamodb:Scan", 
                     "dynamodb:Query", 
                     "dynamodb:BatchGetItem", 
-                    "dynamodb:DescribeTable"
+                    "dynamodb:DescribeTable",
+                    "dynamodb:PartiQLSelect"
                   ], 
                   "Resource": [
                     {
@@ -1526,7 +1531,9 @@
                   "Action": [
                     "dynamodb:PutItem",
                     "dynamodb:UpdateItem",
-                    "dynamodb:BatchWriteItem"
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -151,7 +151,11 @@
                     "dynamodb:BatchWriteItem", 
                     "dynamodb:BatchGetItem", 
                     "dynamodb:DescribeTable", 
-                    "dynamodb:ConditionCheckItem"
+                    "dynamodb:ConditionCheckItem",
+                    "dynamodb:PartiQLSelect",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert",
+                    "dynamodb:PartiQLDelete"
                   ], 
                   "Resource": [
                     {
@@ -186,7 +190,8 @@
                     "dynamodb:Scan", 
                     "dynamodb:Query", 
                     "dynamodb:BatchGetItem", 
-                    "dynamodb:DescribeTable"
+                    "dynamodb:DescribeTable",
+                    "dynamodb:PartiQLSelect"
                   ], 
                   "Resource": [
                     {
@@ -1526,7 +1531,9 @@
                   "Action": [
                     "dynamodb:PutItem",
                     "dynamodb:UpdateItem",
-                    "dynamodb:BatchWriteItem"
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/aws-cn/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/aws-cn/state_machine_with_sam_policy_templates.json
@@ -397,7 +397,9 @@
                   "Action": [
                     "dynamodb:PutItem",
                     "dynamodb:UpdateItem",
-                    "dynamodb:BatchWriteItem"
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -151,7 +151,11 @@
                     "dynamodb:BatchWriteItem", 
                     "dynamodb:BatchGetItem", 
                     "dynamodb:DescribeTable", 
-                    "dynamodb:ConditionCheckItem"
+                    "dynamodb:ConditionCheckItem",
+                    "dynamodb:PartiQLSelect",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert",
+                    "dynamodb:PartiQLDelete"
                   ], 
                   "Resource": [
                     {
@@ -186,7 +190,8 @@
                     "dynamodb:Scan", 
                     "dynamodb:Query", 
                     "dynamodb:BatchGetItem", 
-                    "dynamodb:DescribeTable"
+                    "dynamodb:DescribeTable",
+                    "dynamodb:PartiQLSelect"
                   ], 
                   "Resource": [
                     {
@@ -1526,7 +1531,9 @@
                   "Action": [
                     "dynamodb:PutItem",
                     "dynamodb:UpdateItem",
-                    "dynamodb:BatchWriteItem"
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/aws-us-gov/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_sam_policy_templates.json
@@ -397,7 +397,9 @@
                   "Action": [
                     "dynamodb:PutItem",
                     "dynamodb:UpdateItem",
-                    "dynamodb:BatchWriteItem"
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/state_machine_with_sam_policy_templates.json
@@ -397,7 +397,9 @@
                   "Action": [
                     "dynamodb:PutItem",
                     "dynamodb:UpdateItem",
-                    "dynamodb:BatchWriteItem"
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:PartiQLUpdate",
+                    "dynamodb:PartiQLInsert"
                   ],
                   "Resource": [
                     {


### PR DESCRIPTION
Adds support for PartiQL queries to DynamoDBCrudPolicy, DynamoDBReadPolicy and DynamoDBWritePolicy policy templates.

*Issue #, if available:* #2288

*Description of changes:*

To the policy `DynamoDBCrudPolicy`, add:
 * `dynamodb:PartiQLSelect`
 * `dynamodb:PartiQLUpdate`
 * `dynamodb:PartiQLInsert`
 * `dynamodb:PartiQLDelete`

To the policy `DynamoDBReadPolicy`, add:
 * `dynamodb:PartiQLSelect`

To the policy `DynamoDBWritePolicy`, add:
 * `dynamodb:PartiQLUpdate`
 * `dynamodb:PartiQLInsert`

*Description of how you validated changes:*

Validated manually that the proposed permissions are the correct ones for supporting PartiQL queries in a Python based Lambda function using Boto3.

*Checklist:*

- [ ] Add/update tests using:
    - [x] Correct values
    - [ ] ~~Bad/wrong values (None, empty, wrong type, length, etc.)~~ only extended existing test cases with changes
    - [ ] ~~[Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)~~ n/a
- [x] `make pr` passes
- [x] Update documentation See PR awsdocs/aws-sam-developer-guide#140
- [ ] ~~Verify transformed template deploys and application functions as expected~~ Transformation logic unchanged

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
