### PR TITLE
fix: Add handling for OpenApi definition that has tags with invalid format

### DIFF
--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -455,8 +455,8 @@ class OpenApiEditor(object):
                 raise InvalidDocumentException(
                     [
                         InvalidTemplateException(
-                            "Tags in open api definition needs to be a list. {} is a {} not a list.".format(
-                                self.tags, type(self.tags)
+                            "Tags in OpenApi DefinitionBody needs to be a list. {} is a {} not a list.".format(
+                                self.tags, type(self.tags).__name__
                             )
                         )
                     ]

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -450,6 +450,17 @@ class OpenApiEditor(object):
         :param dict tags: dictionary of tagName:tagValue pairs.
         """
         for name, value in tags.items():
+            # verify the tags definition is in the right format
+            if not isinstance(self.tags, list):
+                raise InvalidDocumentException(
+                    [
+                        InvalidTemplateException(
+                            "Tags in open api definition needs to be a list. {} is a {} not a list.".format(
+                                self.tags, type(self.tags)
+                            )
+                        )
+                    ]
+                )
             # find an existing tag with this name if it exists
             existing_tag = next((existing_tag for existing_tag in self.tags if existing_tag.get("name") == name), None)
             if existing_tag:

--- a/tests/translator/input/error_http_api_invalid_tags_format.yaml
+++ b/tests/translator/input/error_http_api_invalid_tags_format.yaml
@@ -1,0 +1,71 @@
+Conditions:
+  condition:
+    Fn::Equals:
+      - true
+      - true
+Resources:
+  HttpApiFunction: 
+    Condition: condition
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/todo_list.zip
+      Handler: index.restapi
+      Runtime: python3.7
+      Events:
+        SimpleCase:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+  MyApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      DefinitionBody:
+        info:
+          version: '1.0'
+          title:
+            Ref: AWS::StackName
+        paths:
+          "/basic":
+            post:
+              x-amazon-apigateway-integration:
+                httpMethod: POST
+                type: aws_proxy
+                uri:
+                  Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DifferentFunction.Arn}/invocations
+                payloadFormatVersion: '1.0'
+              security:
+              - OpenIdAuth:
+                - scope3
+              responses: {}
+            get:
+              x-amazon-apigateway-integration:
+                httpMethod: POST
+                type: aws_proxy
+                uri:
+                  Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DifferentFunction.Arn}/invocations
+                payloadFormatVersion: '1.0'
+              responses: {}
+        openapi: 3.0.1
+        tags:
+          name: tag1
+        components:
+          securitySchemes:
+            oauth2Auth:
+              type: oauth2
+              x-amazon-apigateway-authorizer:
+                identitySource: "$request.querystring.param"
+                type: jwt
+                jwtConfiguration:
+                  audience:
+                  - MyApi
+                  issuer: https://www.example.com/v1/connect/oidc
+            OpenIdAuth:
+              type: openIdConnect
+              x-amazon-apigateway-authorizer:
+                identitySource: "$request.querystring.param"
+                type: jwt
+                jwtConfiguration:
+                  audience:
+                  - MyApi
+                  issuer: https://www.example.com/v1/connect/oidc
+                openIdConnectUrl: https://www.example.com/v1/connect

--- a/tests/translator/output/error_http_api_invalid_tags_format.json
+++ b/tests/translator/output/error_http_api_invalid_tags_format.json
@@ -1,8 +1,8 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Tags in open api definition needs to be a list. {'name': 'tag1'} is a <class 'dict'> not a list.",
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Tags in OpenApi DefinitionBody needs to be a list. {'name': 'tag1'} is a dict not a list.",
   "errors": [
     {
-      "errorMessage": "Structure of the SAM template is invalid. Tags in open api definition needs to be a list. {'name': 'tag1'} is a <class 'dict'> not a list."
+      "errorMessage": "Structure of the SAM template is invalid. Tags in OpenApi DefinitionBody needs to be a list. {'name': 'tag1'} is a dict not a list."
     }
   ]
 }

--- a/tests/translator/output/error_http_api_invalid_tags_format.json
+++ b/tests/translator/output/error_http_api_invalid_tags_format.json
@@ -1,0 +1,9 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Tags in open api definition needs to be a list. {'name': 'tag1'} is a <class 'dict'> not a list.",
+  "errors": [
+    {
+      "errorMessage": "Structure of the SAM template is invalid. Tags in open api definition needs to be a list. {'name': 'tag1'} is a <class 'dict'> not a list."
+    }
+  ]
+}
+  


### PR DESCRIPTION
*Issue #, if available:*
N.A.

*Description of changes:*
If the tags in the definition body is not a list, the tags parsing will cause iteration errors.

*Description of how you validated changes:*
Added a check for the validity of the definition body that has tags specified.

*Checklist:*

- [x] Add/update tests using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
