### PR TITLE
Remove six as dependency

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -259,7 +259,7 @@ ignore-mixin-members=yes
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis
-ignored-modules=six.moves
+ignored-modules=
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,2 @@
 boto3~=1.5
 jsonschema~=3.2
-six~=1.15
-

--- a/samtranslator/intrinsics/actions.py
+++ b/samtranslator/intrinsics/actions.py
@@ -1,6 +1,5 @@
 import re
 
-from six import string_types
 from samtranslator.utils.py27hash_fix import Py27UniStr
 from samtranslator.model.exceptions import InvalidTemplateException, InvalidDocumentException
 
@@ -67,7 +66,7 @@ class Action(object):
         """
         no_result = (None, None)
 
-        if not isinstance(ref_value, string_types):
+        if not isinstance(ref_value, str):
             return no_result
 
         splits = ref_value.split(cls._resource_ref_separator, 1)
@@ -98,7 +97,7 @@ class RefAction(Action):
 
         param_name = input_dict[self.intrinsic_name]
 
-        if not isinstance(param_name, string_types):
+        if not isinstance(param_name, str):
             return input_dict
 
         if param_name in parameters:
@@ -153,7 +152,7 @@ class RefAction(Action):
             return input_dict
 
         ref_value = input_dict[self.intrinsic_name]
-        if not isinstance(ref_value, string_types) or self._resource_ref_separator in ref_value:
+        if not isinstance(ref_value, str) or self._resource_ref_separator in ref_value:
             return input_dict
 
         logical_id = ref_value
@@ -340,11 +339,11 @@ class SubAction(Action):
 
         # Just handle known references within the string to be substituted and return the whole dictionary
         # because that's the best we can do here.
-        if isinstance(sub_value, string_types):
+        if isinstance(sub_value, str):
             # Ex: {Fn::Sub: "some string"}
             sub_value = self._sub_all_refs(sub_value, handler_method)
 
-        elif isinstance(sub_value, list) and len(sub_value) > 0 and isinstance(sub_value[0], string_types):
+        elif isinstance(sub_value, list) and len(sub_value) > 0 and isinstance(sub_value[0], str):
             # Ex: {Fn::Sub: ["some string", {a:b}] }
             sub_value[0] = self._sub_all_refs(sub_value[0], handler_method)
 
@@ -495,7 +494,7 @@ class GetAttAction(Action):
         # If items in value array is not a string, then following join line will fail. So if any element is not a string
         # we just pass along the input to CFN for doing the validation
         for item in value:
-            if not isinstance(item, string_types):
+            if not isinstance(item, str):
                 return False
 
         return True
@@ -553,11 +552,7 @@ class FindInMapAction(Action):
         top_level_key = self.resolve_parameter_refs(value[1], parameters)
         second_level_key = self.resolve_parameter_refs(value[2], parameters)
 
-        if (
-            not isinstance(map_name, string_types)
-            or not isinstance(top_level_key, string_types)
-            or not isinstance(second_level_key, string_types)
-        ):
+        if not isinstance(map_name, str) or not isinstance(top_level_key, str) or not isinstance(second_level_key, str):
             return input_dict
 
         if (

--- a/samtranslator/intrinsics/resource_refs.py
+++ b/samtranslator/intrinsics/resource_refs.py
@@ -1,6 +1,3 @@
-from six import string_types
-
-
 class SupportedResourceReferences(object):
     """
     Class that contains information about the resource references supported in this SAM template, along with the
@@ -32,7 +29,7 @@ class SupportedResourceReferences(object):
         if not logical_id or not property:
             raise ValueError("LogicalId and property must be a non-empty string")
 
-        if not value or not isinstance(value, string_types):
+        if not value or not isinstance(value, str):
             raise ValueError("Property value must be a non-empty string")
 
         if logical_id not in self._refs:

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -1,6 +1,4 @@
 """ CloudFormation Resource serialization, deserialization, and validation """
-from six import string_types
-
 import re
 import inspect
 from samtranslator.model.exceptions import InvalidResourceException
@@ -460,7 +458,7 @@ class SamResourceMacro(ResourceMacro):
             return parameter_value
         value = intrinsics_resolver.resolve_parameter_refs(parameter_value)
 
-        if not isinstance(value, string_types) and not isinstance(value, dict):
+        if not isinstance(value, str) and not isinstance(value, dict):
             raise InvalidResourceException(
                 self.logical_id,
                 "Could not resolve parameter for '{}' or parameter is not a String.".format(parameter_name),
@@ -489,7 +487,7 @@ class ResourceTypeResolver(object):
                 self.resource_types[resource_class.resource_type] = resource_class
 
     def can_resolve(self, resource_dict):
-        if not isinstance(resource_dict, dict) or not isinstance(resource_dict.get("Type"), string_types):
+        if not isinstance(resource_dict, dict) or not isinstance(resource_dict.get("Type"), str):
             return False
 
         return resource_dict["Type"] in self.resource_types

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -1,8 +1,6 @@
 import logging
 from collections import namedtuple
 
-from six import string_types
-
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.intrinsics import ref, fnGetAtt, make_or_condition
 from samtranslator.model.apigateway import (
@@ -381,7 +379,7 @@ class ApiGenerator(object):
 
         # If StageName is some intrinsic function, then don't prefix the Stage's logical ID
         # This will NOT create duplicates because we allow only ONE stage per API resource
-        stage_name_prefix = self.stage_name if isinstance(self.stage_name, string_types) else ""
+        stage_name_prefix = self.stage_name if isinstance(self.stage_name, str) else ""
         if stage_name_prefix.isalnum():
             stage_logical_id = self.logical_id + stage_name_prefix + "Stage"
         else:
@@ -481,7 +479,7 @@ class ApiGenerator(object):
             domain.OwnershipVerificationCertificateArn = self.domain["OwnershipVerificationCertificateArn"]
 
         # Create BasepathMappings
-        if self.domain.get("BasePath") and isinstance(self.domain.get("BasePath"), string_types):
+        if self.domain.get("BasePath") and isinstance(self.domain.get("BasePath"), str):
             basepaths = [self.domain.get("BasePath")]
         elif self.domain.get("BasePath") and isinstance(self.domain.get("BasePath"), list):
             basepaths = self.domain.get("BasePath")
@@ -608,7 +606,7 @@ class ApiGenerator(object):
                 self.logical_id, "Cors works only with inline Swagger specified in 'DefinitionBody' property."
             )
 
-        if isinstance(self.cors, string_types) or is_intrinsic(self.cors):
+        if isinstance(self.cors, str) or is_intrinsic(self.cors):
             # Just set Origin property. Others will be defaults
             properties = CorsProperties(AllowOrigin=self.cors)
         elif isinstance(self.cors, dict):
@@ -1129,7 +1127,7 @@ class ApiGenerator(object):
         if not default_authorizer:
             return
 
-        if not isinstance(default_authorizer, string_types):
+        if not isinstance(default_authorizer, str):
             raise InvalidResourceException(
                 self.logical_id,
                 "DefaultAuthorizer is not a string.",

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -1,6 +1,5 @@
 import re
 from collections import namedtuple
-from six import string_types
 
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.intrinsics import ref, fnGetAtt
@@ -294,7 +293,7 @@ class HttpApiGenerator(object):
                 )
 
         # Create BasepathMappings
-        if self.domain.get("BasePath") and isinstance(self.domain.get("BasePath"), string_types):
+        if self.domain.get("BasePath") and isinstance(self.domain.get("BasePath"), str):
             basepaths = [self.domain.get("BasePath")]
         elif self.domain.get("BasePath") and isinstance(self.domain.get("BasePath"), list):
             basepaths = self.domain.get("BasePath")
@@ -346,7 +345,7 @@ class HttpApiGenerator(object):
                 # search for invalid characters in the path and raise error if there are
                 invalid_regex = r"[^0-9a-zA-Z\/\-\_]+"
 
-                if not isinstance(path, string_types):
+                if not isinstance(path, str):
                     raise InvalidResourceException(self.logical_id, "Basepath must be a string.")
 
                 if re.search(invalid_regex, path) is not None:
@@ -580,7 +579,7 @@ class HttpApiGenerator(object):
 
         # If StageName is some intrinsic function, then don't prefix the Stage's logical ID
         # This will NOT create duplicates because we allow only ONE stage per API resource
-        stage_name_prefix = self.stage_name if isinstance(self.stage_name, string_types) else ""
+        stage_name_prefix = self.stage_name if isinstance(self.stage_name, str) else ""
         if stage_name_prefix.isalnum():
             stage_logical_id = self.logical_id + stage_name_prefix + "Stage"
         elif stage_name_prefix == DefaultStageName:

--- a/samtranslator/model/eventbridge_utils.py
+++ b/samtranslator/model/eventbridge_utils.py
@@ -1,5 +1,3 @@
-from six import string_types
-
 from samtranslator.model.sqs import SQSQueue, SQSQueuePolicy, SQSQueuePolicies
 from samtranslator.model.exceptions import InvalidEventException
 
@@ -49,7 +47,7 @@ class EventBridgeRuleUtils:
         if dlq_queue_arn is not None:
             return dlq_queue_arn, []
         queue_logical_id = cw_event_source.DeadLetterConfig.get("QueueLogicalId")
-        if queue_logical_id is not None and not isinstance(queue_logical_id, string_types):
+        if queue_logical_id is not None and not isinstance(queue_logical_id, str):
             raise InvalidEventException(
                 cw_event_source.logical_id,
                 "QueueLogicalId must be a string",

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -1,4 +1,3 @@
-from six import string_types
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceMacro, PropertyType
 from samtranslator.model.eventsources import FUNCTION_EVETSOURCE_METRIC_PREFIX
@@ -423,7 +422,7 @@ class SelfManagedKafka(PullEventSource):
                 "No {} URI property specified in SourceAccessConfigurations for self managed kafka event.".format(msg),
             )
 
-        if not isinstance(config.get("URI"), string_types) and not is_intrinsic(config.get("URI")):
+        if not isinstance(config.get("URI"), str) and not is_intrinsic(config.get("URI")):
             raise InvalidEventException(
                 self.relative_id,
                 "Wrong Type for {} URI property specified in SourceAccessConfigurations for self managed kafka event.".format(

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -1,6 +1,5 @@
 import copy
 import re
-from six import string_types
 
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceMacro, PropertyType
@@ -257,7 +256,7 @@ class S3(PushEventSource):
     def resources_to_link(self, resources):
         if isinstance(self.Bucket, dict) and "Ref" in self.Bucket:
             bucket_id = self.Bucket["Ref"]
-            if not isinstance(bucket_id, string_types):
+            if not isinstance(bucket_id, str):
                 raise InvalidEventException(self.relative_id, "'Ref' value in S3 events is not a valid string.")
             if bucket_id in resources:
                 return {"bucket": resources[bucket_id], "bucket_id": bucket_id}
@@ -326,7 +325,7 @@ class S3(PushEventSource):
         depends_on = bucket.get("DependsOn", [])
 
         # DependsOn can be either a list of strings or a scalar string
-        if isinstance(depends_on, string_types):
+        if isinstance(depends_on, str):
             depends_on = [depends_on]
 
         try:
@@ -377,7 +376,7 @@ class S3(PushEventSource):
             base_event_mapping["Filter"] = self.Filter
 
         event_types = self.Events
-        if isinstance(self.Events, string_types):
+        if isinstance(self.Events, str):
             event_types = [self.Events]
 
         event_mappings = []
@@ -557,7 +556,7 @@ class Api(PushEventSource):
         stage_suffix = "AllStages"
         explicit_api = None
         rest_api_id = self.get_rest_api_id_string(self.RestApiId)
-        if isinstance(rest_api_id, string_types):
+        if isinstance(rest_api_id, str):
 
             if (
                 rest_api_id in resources
@@ -569,7 +568,7 @@ class Api(PushEventSource):
                 permitted_stage = explicit_api["StageName"]
 
                 # Stage could be a intrinsic, in which case leave the suffix to default value
-                if isinstance(permitted_stage, string_types):
+                if isinstance(permitted_stage, str):
                     if not permitted_stage:
                         raise InvalidResourceException(rest_api_id, "StageName cannot be empty.")
                     stage_suffix = permitted_stage
@@ -702,7 +701,7 @@ class Api(PushEventSource):
                             ),
                         )
 
-                    if not isinstance(method_authorizer, string_types):
+                    if not isinstance(method_authorizer, str):
                         raise InvalidEventException(
                             self.relative_id,
                             "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "
@@ -770,7 +769,7 @@ class Api(PushEventSource):
                             model=method_model, method=self.Method, path=self.Path
                         ),
                     )
-                if not isinstance(method_model, string_types):
+                if not isinstance(method_model, str):
                     raise InvalidEventException(
                         self.relative_id,
                         "Unable to set RequestModel [{model}] on API method [{method}] for path [{path}] "
@@ -855,7 +854,7 @@ class Api(PushEventSource):
 
                     parameters.append(settings)
 
-                elif isinstance(parameter, string_types):
+                elif isinstance(parameter, str):
                     if not re.match("method\.request\.(querystring|path|header)\.", parameter):
                         raise InvalidEventException(
                             self.relative_id,
@@ -970,7 +969,7 @@ class Cognito(PushEventSource):
     def resources_to_link(self, resources):
         if isinstance(self.UserPool, dict) and "Ref" in self.UserPool:
             userpool_id = self.UserPool["Ref"]
-            if not isinstance(userpool_id, string_types):
+            if not isinstance(userpool_id, str):
                 raise InvalidEventException(
                     self.logical_id,
                     "Ref in Userpool is not a string.",
@@ -1012,7 +1011,7 @@ class Cognito(PushEventSource):
 
     def _inject_lambda_config(self, function, userpool):
         event_triggers = self.Trigger
-        if isinstance(self.Trigger, string_types):
+        if isinstance(self.Trigger, str):
             event_triggers = [self.Trigger]
 
         # TODO can these be conditional?
@@ -1197,7 +1196,7 @@ class HttpApi(PushEventSource):
         """
         method_authorizer = self.Auth.get("Authorizer")
 
-        if method_authorizer is not None and not isinstance(method_authorizer, string_types):
+        if method_authorizer is not None and not isinstance(method_authorizer, str):
             raise InvalidEventException(
                 self.relative_id,
                 "'Authorizer' in the 'Auth' section must be a string.",

--- a/samtranslator/model/function_policies.py
+++ b/samtranslator/model/function_policies.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from collections import namedtuple
 
-from six import string_types
-
 from samtranslator.model.intrinsics import (
     is_intrinsic,
     is_intrinsic_if,
@@ -123,7 +121,7 @@ class FunctionPolicies(object):
         # Must handle intrinsic functions. Policy could be a primitive type or an intrinsic function
 
         # Managed policies are of type string
-        if isinstance(policy, string_types):
+        if isinstance(policy, str):
             return PolicyTypes.MANAGED_POLICY
 
         # Handle the special case for 'if' intrinsic function

--- a/samtranslator/model/resource_policies.py
+++ b/samtranslator/model/resource_policies.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from collections import namedtuple
 
-from six import string_types
-
 from samtranslator.model.intrinsics import (
     is_intrinsic,
     is_intrinsic_if,
@@ -123,7 +121,7 @@ class ResourcePolicies(object):
         # Must handle intrinsic functions. Policy could be a primitive type or an intrinsic function
 
         # Managed policies are of type string
-        if isinstance(policy, string_types):
+        if isinstance(policy, str):
             return PolicyTypes.MANAGED_POLICY
 
         # Handle the special case for 'if' intrinsic function

--- a/samtranslator/model/role_utils/role_constructor.py
+++ b/samtranslator/model/role_utils/role_constructor.py
@@ -1,5 +1,3 @@
-from six import string_types
-
 from samtranslator.model.iam import IAMRole
 from samtranslator.model.resource_policies import ResourcePolicies, PolicyTypes
 from samtranslator.model.intrinsics import is_intrinsic_if, is_intrinsic_no_value
@@ -86,7 +84,7 @@ def construct_role_for_resource(
             #
 
             policy_arn = policy_entry.data
-            if isinstance(policy_entry.data, string_types) and policy_entry.data in managed_policy_map:
+            if isinstance(policy_entry.data, str) and policy_entry.data in managed_policy_map:
                 policy_arn = managed_policy_map[policy_entry.data]
 
             # De-Duplicate managed policy arns before inserting. Mainly useful

--- a/samtranslator/model/s3_utils/uri_parser.py
+++ b/samtranslator/model/s3_utils/uri_parser.py
@@ -1,5 +1,4 @@
-from six import string_types
-from six.moves.urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs
 from samtranslator.model.exceptions import InvalidResourceException
 
 
@@ -9,7 +8,7 @@ def parse_s3_uri(uri):
     :return: a BodyS3Location dict or None if not an S3 Uri
     :rtype: dict
     """
-    if not isinstance(uri, string_types):
+    if not isinstance(uri, str):
         return None
 
     url = urlparse(uri)

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1,5 +1,4 @@
 ﻿""" SAM macro definitions """
-from six import string_types
 import copy
 
 import samtranslator.model.eventsources
@@ -157,7 +156,7 @@ class SamFunction(SamResourceMacro):
             code_sha256 = None
             if self.AutoPublishCodeSha256:
                 code_sha256 = intrinsics_resolver.resolve_parameter_refs(self.AutoPublishCodeSha256)
-                if not isinstance(code_sha256, string_types):
+                if not isinstance(code_sha256, str):
                     raise InvalidResourceException(
                         self.logical_id,
                         "AutoPublishCodeSha256 must be a string",
@@ -389,7 +388,7 @@ class SamFunction(SamResourceMacro):
         # Try to resolve.
         resolved_alias_name = intrinsics_resolver.resolve_parameter_refs(original_alias_value)
 
-        if not isinstance(resolved_alias_name, string_types):
+        if not isinstance(resolved_alias_name, str):
             # This is still a dictionary which means we are not able to completely resolve intrinsics
             raise InvalidResourceException(
                 self.logical_id, "'{}' must be a string or a Ref to a template parameter".format(property_name)

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -1,4 +1,3 @@
-from six import string_types
 import json
 
 from samtranslator.metrics.method_decorator import cw_timer
@@ -261,7 +260,7 @@ class Api(EventSource):
         stage_suffix = "AllStages"
         explicit_api = None
         rest_api_id = PushApi.get_rest_api_id_string(self.RestApiId)
-        if isinstance(rest_api_id, string_types):
+        if isinstance(rest_api_id, str):
 
             if (
                 rest_api_id in resources
@@ -273,7 +272,7 @@ class Api(EventSource):
                 permitted_stage = explicit_api["StageName"]
 
                 # Stage could be a intrinsic, in which case leave the suffix to default value
-                if isinstance(permitted_stage, string_types):
+                if isinstance(permitted_stage, str):
                     stage_suffix = permitted_stage
                 else:
                     stage_suffix = "Stage"

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -2,8 +2,6 @@ import json
 from uuid import uuid4
 from copy import deepcopy
 
-from six import string_types
-
 import samtranslator.model.eventsources.push
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceTypeResolver

--- a/samtranslator/model/types.py
+++ b/samtranslator/model/types.py
@@ -8,7 +8,6 @@ Validators should cover any validation logic that is *not* done by CloudFormatio
 the Permissions property is an ARN or list of ARNs. In this situation, we validate that the Permissions property is
 either a string or a list of strings, but do not validate whether the string(s) are valid IAM policy ARNs.
 """
-from six import string_types
 import samtranslator.model.exceptions
 
 
@@ -123,7 +122,7 @@ def is_str():
     :returns: a string validator
     :rtype: callable
     """
-    return is_type(string_types)
+    return is_type(str)
 
 
 def any_type():

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -1,6 +1,5 @@
 import copy
 import re
-from six import string_types
 
 from samtranslator.model.intrinsics import ref
 from samtranslator.model.intrinsics import make_conditional
@@ -652,7 +651,7 @@ class OpenApiEditor(object):
         :param string method: Name of the HTTP Method
         :return string: Normalized method name
         """
-        if not method or not isinstance(method, string_types):
+        if not method or not isinstance(method, str):
             return method
 
         method = method.lower()

--- a/samtranslator/plugins/api/implicit_http_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_http_api_plugin.py
@@ -1,5 +1,3 @@
-import six
-
 from samtranslator.model.intrinsics import make_conditional
 from samtranslator.model.naming import GeneratedLogicalId
 from samtranslator.plugins.api.implicit_api_plugin import ImplicitApiPlugin
@@ -83,12 +81,12 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
                 key = "Path" if not path else "Method"
                 raise InvalidEventException(logicalId, "Event is missing key '{}'.".format(key))
 
-            if not isinstance(path, six.string_types) or not isinstance(method, six.string_types):
-                key = "Path" if not isinstance(path, six.string_types) else "Method"
+            if not isinstance(path, str) or not isinstance(method, str):
+                key = "Path" if not isinstance(path, str) else "Method"
                 raise InvalidEventException(logicalId, "Api Event must have a String specified for '{}'.".format(key))
 
             # !Ref is resolved by this time. If it is not a string, we can't parse/use this Api.
-            if api_id and not isinstance(api_id, six.string_types):
+            if api_id and not isinstance(api_id, str):
                 raise InvalidEventException(
                     logicalId, "Api Event's ApiId must be a string referencing an Api in the same template."
                 )

--- a/samtranslator/plugins/api/implicit_rest_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_rest_api_plugin.py
@@ -1,5 +1,3 @@
-import six
-
 from samtranslator.model.naming import GeneratedLogicalId
 from samtranslator.plugins.api.implicit_api_plugin import ImplicitApiPlugin
 from samtranslator.public.swagger import SwaggerEditor
@@ -80,13 +78,13 @@ class ImplicitRestApiPlugin(ImplicitApiPlugin):
             except KeyError as e:
                 raise InvalidEventException(logicalId, "Event is missing key {}.".format(e))
 
-            if not isinstance(path, six.string_types):
+            if not isinstance(path, str):
                 raise InvalidEventException(logicalId, "Api Event must have a String specified for 'Path'.")
-            if not isinstance(method, six.string_types):
+            if not isinstance(method, str):
                 raise InvalidEventException(logicalId, "Api Event must have a String specified for 'Method'.")
 
             # !Ref is resolved by this time. If it is not a string, we can't parse/use this Api.
-            if api_id and not isinstance(api_id, six.string_types):
+            if api_id and not isinstance(api_id, str):
                 raise InvalidEventException(
                     logicalId, "Api Event's RestApiId must be a string referencing an Api in the same template."
                 )

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -1,7 +1,6 @@
 ﻿from samtranslator.public.sdk.resource import SamResourceType
 from samtranslator.public.intrinsics import is_intrinsics
 from samtranslator.swagger.swagger import SwaggerEditor
-from six import string_types
 
 
 class Globals(object):
@@ -156,7 +155,7 @@ class Globals(object):
                         SwaggerEditor.get_openapi_version_3_regex(), properties[cls._OPENAPIVERSION]
                     )
                 ):
-                    if not isinstance(properties[cls._OPENAPIVERSION], string_types):
+                    if not isinstance(properties[cls._OPENAPIVERSION], str):
                         properties[cls._OPENAPIVERSION] = str(properties[cls._OPENAPIVERSION])
                         resource["Properties"] = properties
                     if "DefinitionBody" in properties:

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -1,7 +1,6 @@
 ﻿import copy
 import json
 import re
-from six import string_types
 
 from samtranslator.model.intrinsics import ref
 from samtranslator.model.intrinsics import make_conditional, fnSub
@@ -381,7 +380,7 @@ class SwaggerEditor(object):
                 return to_return
             if isinstance(bmt, list):
                 return [replace_recursively(item) for item in bmt]
-            if isinstance(bmt, string_types) or isinstance(bmt, Py27UniStr):
+            if isinstance(bmt, str) or isinstance(bmt, Py27UniStr):
                 return Py27UniStr(bmt.replace("~1", "/"))
             return bmt
 
@@ -1377,7 +1376,7 @@ class SwaggerEditor(object):
         :param string method: Name of the HTTP Method
         :return string: Normalized method name
         """
-        if not method or not isinstance(method, string_types):
+        if not method or not isinstance(method, str):
             return method
 
         method = method.lower()
@@ -1437,7 +1436,7 @@ class SwaggerEditor(object):
         :return bool: True if the property_list is all of type string otherwise False
         """
 
-        if property_list is not None and not all(isinstance(x, string_types) for x in property_list):
+        if property_list is not None and not all(isinstance(x, str) for x in property_list):
             return False
 
         return True

--- a/samtranslator/translator/logical_id_generator.py
+++ b/samtranslator/translator/logical_id_generator.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import sys
-from six import string_types
 
 
 class LogicalIdGenerator(object):
@@ -88,7 +87,7 @@ class LogicalIdGenerator(object):
         :return: string representation of the dictionary
         :rtype string
         """
-        if isinstance(data, string_types):
+        if isinstance(data, str):
             return data
 
         # Get the most compact dictionary (separators) and sort the keys recursively to get a stable output

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -1,5 +1,4 @@
 import copy
-from six import string_types
 
 from samtranslator.metrics.method_decorator import MetricsMethodWrapperSingleton
 from samtranslator.metrics.metrics import DummyMetricsPublisher, Metrics
@@ -70,7 +69,7 @@ class Translator:
                     if item.get("Type") == "Api" and item.get("Properties") and item.get("Properties").get("RestApiId"):
                         rest_api = item.get("Properties").get("RestApiId")
                         api_name = Api.get_rest_api_id_string(rest_api)
-                        if isinstance(api_name, string_types):
+                        if isinstance(api_name, str):
                             resource_dict_copy = copy.deepcopy(resource_dict)
                             function_name = intrinsics_resolver.resolve_parameter_refs(
                                 resource_dict_copy.get("Properties").get("FunctionName")

--- a/samtranslator/yaml_helper.py
+++ b/samtranslator/yaml_helper.py
@@ -1,6 +1,5 @@
 import yaml
 from yaml import ScalarNode, SequenceNode
-from six import string_types
 
 # This helper copied almost entirely from
 # https://github.com/aws/aws-cli/blob/develop/awscli/customizations/cloudformation/yamlhelper.py
@@ -28,7 +27,7 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
 
     cfntag = prefix + tag
 
-    if tag == "GetAtt" and isinstance(node.value, string_types):
+    if tag == "GetAtt" and isinstance(node.value, str):
         # ShortHand notation for !GetAtt accepts Resource.Attribute format
         # while the standard notation is to use an array
         # [Resource, Attribute]. Convert shorthand to standard format

--- a/tests/sdk/test_template.py
+++ b/tests/sdk/test_template.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from six import assertCountEqual
 
 from samtranslator.sdk.template import SamTemplate
 from samtranslator.sdk.resource import SamResource
@@ -31,7 +30,7 @@ class TestSamTemplate(TestCase):
         ]
 
         actual = [(id, resource.to_dict()) for id, resource in template.iterate()]
-        assertCountEqual(self, expected, actual)
+        self.assertCountEqual(expected, actual)
 
     def test_iterate_must_filter_by_resource_type(self):
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Remove `six`

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
