### PR TITLE
fix: ValueError is not caught by int()

### DIFF
--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -285,7 +285,7 @@ class ApiGatewayAuthorizer(object):
         try:
             ttl_int = int(ttl)
         # this will catch if ttl is None and not convertable to an int
-        except TypeError:
+        except (TypeError, ValueError):
             # previous behavior before trying to read ttl
             return required_properties_missing
 

--- a/tests/validator/input/api/error_auth_cognito.yaml
+++ b/tests/validator/input/api/error_auth_cognito.yaml
@@ -43,6 +43,10 @@ Resources:
             Identity:
               ReauthorizeEvery: "3"
             UserPoolArn: User.pool.arn
+          CognitoIdentityReauthorizeEveryValueError:
+            Identity:
+              ReauthorizeEvery: NotANumber
+            UserPoolArn: User.pool.arn
           CognitoIdentityReauthorizeEveryTooHigh:
             Identity:
               ReauthorizeEvery: 3601

--- a/tests/validator/output/api/error_auth_cognito.json
+++ b/tests/validator/output/api/error_auth_cognito.json
@@ -9,6 +9,7 @@
   "[Resources.MyApi.Properties.Auth.Authorizers.CognitoIdentityReauthorizeEveryNotInt.Identity.ReauthorizeEvery] '3' is not of type 'integer', 'intrinsic'",
   "[Resources.MyApi.Properties.Auth.Authorizers.CognitoIdentityReauthorizeEveryTooHigh.Identity.ReauthorizeEvery] 3601 is greater than the maximum of 3600",
   "[Resources.MyApi.Properties.Auth.Authorizers.CognitoIdentityReauthorizeEveryTooLow.Identity.ReauthorizeEvery] 0 is less than the minimum of 1",
+  "[Resources.MyApi.Properties.Auth.Authorizers.CognitoIdentityReauthorizeEveryValueError.Identity.ReauthorizeEvery] 'NotANumber' is not of type 'integer', 'intrinsic'",
   "[Resources.MyApi.Properties.Auth.Authorizers.CognitoIdentityValidationExpressionEmpty.Identity.ValidationExpression] Must not be empty",
   "[Resources.MyApi.Properties.Auth.Authorizers.CognitoIdentityValidationExpressionNotString.Identity.ValidationExpression] 3 is not of type 'string'",
   "[Resources.MyApi.Properties.Auth.Authorizers.CognitoUserPoolArnEmpty.UserPoolArn] Must not be empty",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
