### PR TITLE
fix: Check S3 Lambda Configuration Type is a List

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -403,6 +403,9 @@ class S3(PushEventSource):
             lambda_notifications = []
             notification_config["LambdaConfigurations"] = lambda_notifications
 
+        if not isinstance(lambda_notifications, list):
+            raise InvalidResourceException(self.logical_id, "Invalid type for LambdaConfigurations. Must be a list.")
+
         for event_mapping in event_mappings:
             if event_mapping not in lambda_notifications:
                 lambda_notifications.append(event_mapping)

--- a/tests/translator/input/error_s3_lambda_configuration_invalid_type.yaml
+++ b/tests/translator/input/error_s3_lambda_configuration_invalid_type.yaml
@@ -1,0 +1,24 @@
+Resources:
+  AppFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: app.lambdaHandler
+      Runtime: nodejs14.x
+      Architectures:
+        - x86_64
+      Events:
+        S3Event:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: RandomBucket
+            Events: s3:ObjectCreated:*
+
+  RandomBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      NotificationConfiguration:
+        LambdaConfigurations:
+          Event: s3:ObjectCreated:Put
+          Function: arn:aws:iam::...

--- a/tests/translator/output/error_s3_lambda_configuration_invalid_type.json
+++ b/tests/translator/output/error_s3_lambda_configuration_invalid_type.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [AppFunctionS3Event] is invalid. Invalid type for LambdaConfigurations. Must be a list."
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [AppFunctionS3Event] is invalid. Invalid type for LambdaConfigurations. Must be a list."
+} 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
