### PR TITLE
tests: add test for DefaultAuthorizers not a string in API

### DIFF
--- a/tests/translator/input/error_default_authorizer_should_be_string_in_api.yaml
+++ b/tests/translator/input/error_default_authorizer_should_be_string_in_api.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+
+Resources:
+  MyApi:
+    Type: "AWS::Serverless::Api"
+    Properties:
+      StageName: Prod
+      Auth:
+        DefaultAuthorizer: !Ref MyCognitoAuth
+        Authorizers:
+          MyCognitoAuth:
+            UserPoolArn: arn:aws:1
+            Identity:
+              Header: MyAuthorizationHeader
+              ValidationExpression: myauthvalidationexpression
+
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/thumbnails.zip
+      Handler: index.handler
+      Runtime: nodejs8.10
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApi
+            Path: /
+            Method: get

--- a/tests/translator/output/error_default_authorizer_should_be_string_in_api.json
+++ b/tests/translator/output/error_default_authorizer_should_be_string_in_api.json
@@ -1,0 +1,3 @@
+{
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApi] is invalid. DefaultAuthorizer is not a string."
+}


### PR DESCRIPTION
In issue #1245, we had a cases were SAM would fail due to improper validation.
In updating #1286, I noticed this was patched in #1774 but we only added tests
for AWS::Serverless::StateMachine. This commit adds an additional test to cover
AWS::Serverless::Api.

*Issue #, if available:*
n/a but is a test to cover #1245

*Description of changes:*
Adds additional test

*Description of how you validated changes:*
`make pr` ran successfully 

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
