### PR TITLE
fix: Add check for event and invoke event destination config type

### DIFF
--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -117,6 +117,8 @@ class PullEventSource(ResourceMacro):
         if self.DestinationConfig:
             if self.DestinationConfig.get("OnFailure") is None:
                 raise InvalidEventException(self.logical_id, "'OnFailure' is a required field for 'DestinationConfig'")
+            if not isinstance(self.DestinationConfig.get("OnFailure"), dict):
+                raise InvalidEventException(self.logical_id, "'OnFailure' has invalid destination configuration")
 
             # `Type` property is for sam to attach the right policies
             destination_type = self.DestinationConfig.get("OnFailure").get("Type")

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -229,6 +229,8 @@ class SamFunction(SamResourceMacro):
         dest_config = {}
         input_dest_config = resolved_event_invoke_config.get("DestinationConfig")
         if input_dest_config and input_dest_config.get("OnSuccess") is not None:
+            if not isinstance(input_dest_config.get("OnSuccess"), dict):
+                raise InvalidResourceException(self.logical_id, "'OnSuccess' has invalid destination configuration")
             resource, on_success, policy = self._validate_and_inject_resource(
                 input_dest_config.get("OnSuccess"), "OnSuccess", logical_id, conditions
             )
@@ -240,6 +242,8 @@ class SamFunction(SamResourceMacro):
                 policy_document.append(policy)
 
         if input_dest_config and input_dest_config.get("OnFailure") is not None:
+            if not isinstance(input_dest_config.get("OnFailure"), dict):
+                raise InvalidResourceException(self.logical_id, "'OnFailure' has invalid destination configuration")
             resource, on_failure, policy = self._validate_and_inject_resource(
                 input_dest_config.get("OnFailure"), "OnFailure", logical_id, conditions
             )

--- a/tests/translator/input/error_function_with_invalid_event_destination_type.yaml
+++ b/tests/translator/input/error_function_with_invalid_event_destination_type.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  MyBatchingWindowParam:
+    Type: Number
+    Default: 45
+    Description: parameter for batching window in seconds
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      InlineCode: |
+        exports.handler = async (event) => {
+            return {
+            statusCode: 200,
+            body: JSON.stringify(event),
+            headers: {}
+            }
+        }
+      Runtime: nodejs12.x
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MySqsQueue.QueueName
+      Events:
+        StreamEvent:
+          Type: Kinesis
+          Properties:
+            Stream: !GetAtt KinesisStream.Arn
+            MaximumBatchingWindowInSeconds: !Ref MyBatchingWindowParam
+            StartingPosition: LATEST
+            DestinationConfig:
+              OnFailure:
+                - Type: SNS
+                  Destination: !Ref MySnsTopic
+                - Type: SNS
+                  Destination: !Ref MySnsTopic
+
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 1
+
+  MySnsTopic:
+    Type: AWS::SNS::Topic

--- a/tests/translator/input/error_function_with_invalid_invoke_destination_type.yaml
+++ b/tests/translator/input/error_function_with_invalid_invoke_destination_type.yaml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  MyBatchingWindowParam:
+    Type: Number
+    Default: 45
+    Description: parameter for batching window in seconds
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      InlineCode: |
+        exports.handler = async (event) => {
+            return {
+            statusCode: 200,
+            body: JSON.stringify(event),
+            headers: {}
+            }
+        }
+      Runtime: nodejs12.x
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MySqsQueue.QueueName
+      EventInvokeConfig:
+        DestinationConfig:
+          OnFailure:
+            - Type: SNS
+              Destination: !Ref MySnsTopic
+            - Type: SNS
+              Destination: !Ref MySnsTopic
+
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 1
+
+  MySnsTopic:
+    Type: AWS::SNS::Topic

--- a/tests/translator/output/error_function_with_invalid_event_destination_type.json
+++ b/tests/translator/output/error_function_with_invalid_event_destination_type.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' has invalid destination configuration"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' has invalid destination configuration"
+}

--- a/tests/translator/output/error_function_with_invalid_invoke_destination_type.json
+++ b/tests/translator/output/error_function_with_invalid_invoke_destination_type.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunction] is invalid. 'OnFailure' has invalid destination configuration"
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. 'OnFailure' has invalid destination configuration"
+}


### PR DESCRIPTION
*Issue #, if available:*
N.A.

*Description of changes:*
Adds a check on destination config format, to ensure on success and on failure events are inputted with correct format

*Description of how you validated changes:*
Added integration tests

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
