### PR TITLE
Update doc: Add missing attribute in RequestModel

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -1281,6 +1281,7 @@ Configure Request Model for a specific Api+Path+Method.
 RequestModel:
   Model: User # REQUIRED; must match the name of a model defined in the Models property of the AWS::Serverless::API
   Required: true # OPTIONAL; boolean
+  ValidateBody: true # OPTIONAL; boolean
 ```
 
 #### Function Request Parameter Object


### PR DESCRIPTION
*Issue #, if available:*
In doc ReuqestModel has only two attributes. But RequestModel has an attribute call `ValidateBody`
*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [x] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
