### PR TITLE
Add method for determining service availability in a region

### DIFF
--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -111,7 +111,7 @@ class ServerlessAppPlugin(BasePlugin):
 
             if key not in self._applications:
                 try:
-                    if not RegionConfiguration.is_sar_supported():
+                    if not RegionConfiguration.is_service_supported("serverlessrepo"):
                         raise InvalidResourceException(
                             logical_id, "Serverless Application Repository is not available in this region."
                         )

--- a/tests/unit/test_region_configuration.py
+++ b/tests/unit/test_region_configuration.py
@@ -36,3 +36,27 @@ class TestRegionConfiguration(TestCase):
             get_partition_name_patch.return_value = partition
 
             self.assertFalse(RegionConfiguration.is_apigw_edge_configuration_supported())
+
+    @parameterized.expand(
+        [
+            # use ec2 as it's just about everywhere
+            ["ec2", "cn-north-1"],
+            ["ec2", "us-west-2"],
+            ["ec2", "us-gov-east-1"],
+            ["ec2", "us-isob-east-1"],
+            ["ec2", None],
+            # test SAR since SAM uses that
+            ["serverlessrepo", "us-east-1"],
+            ["serverlessrepo", "ap-southeast-2"],
+        ]
+    )
+    def test_is_service_supported_positive(self, service, region):
+        self.assertTrue(RegionConfiguration.is_service_supported(service, region))
+
+    def test_is_service_supported_negative(self):
+        # use an unknown service name
+        self.assertFalse(RegionConfiguration.is_service_supported("ec1", "us-east-1"))
+        # use a region that does not exist
+        self.assertFalse(RegionConfiguration.is_service_supported("ec2", "us-east-0"))
+        # hard to test with a real service, since the test may start failing once that
+        # service is rolled out to more regions...


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Generalize existing `RegionConfiguration.is_sar_supported` method into a `is_service_supported` method as we'll need to check availability of other services as well.

*Description of how you validated changes:*
Unit tests.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] ~[Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)~ n/a
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md) -- covered by existing tests that use SAR
- [x] `make pr` passes
- [ ] ~Update documentation~ n/a
- [ ] ~Verify transformed template deploys and application functions as expected~ n/a, low-level change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
