### PR TITLE
chore: Enable pylint on project

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@
 
 # Add files or directories to the ignore list. They should be base names, not
 # paths.
-ignore=compat.py
+ignore=compat.py, __main__.py
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -17,8 +17,13 @@ persistent=yes
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 load-plugins=
+    pylint.extensions.check_elif, # Else If Used checker
+    pylint.extensions.emptystring, # compare to empty string
+    pylint.extensions.comparetozero, # compare to 0
+    pylint.extensions.docparams, # Parameter documentation checker
 
 # Use multiple processes to speed up Pylint.
+# Pylint has a bug on multitread, turn it off.
 jobs=1
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
@@ -59,7 +64,103 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=R0201,W0613,I0021,I0020,W1618,W1619,R0902,R0903,W0231,W0611,R0913,W0703,C0330,R0204,I0011,R0904
+disable=
+    W0613, # Unused argument %r
+    W0640, # Cell variable %s defined in loop A variable used in a closure is defined in a loop
+    R0902, # Too many instance attributes (%s/%s)
+    R0903, # Too few public methods (%s/%s)
+    R0913, # Too many arguments (%s/%s)
+    W0703, # Catching too general exception %s
+    R0904, # Too many public methods (%s/%s)
+    R0914, # Too many local variables (%s/%s)
+    R0915, # Too many statements
+    C0415, # Import outside toplevel (%s) Used when an import statement is used anywhere other than the module toplevel. Move this import to the top of the file.
+    C0115, # missing-class-docstring
+    # below are docstring lint rules, in order to incrementally improve our docstring while
+    # without introduce too much effort at a time, we exclude most of the docstring lint rules.
+    # We will remove them one by one.
+    # W9005, # "%s" has constructor parameters documented in class and __init__
+    W9006, # "%s" not documented as being raised
+    # W9008, # Redundant returns documentation
+    # W9010, # Redundant yields documentation
+    W9011, # Missing return documentation
+    W9012, # Missing return type documentation
+    # W9013, # Missing yield documentation
+    # W9014, # Missing yield type documentation
+    # W9015, # "%s" missing in parameter documentation
+    W9016, # "%s" missing in parameter type documentation
+    # W9017, # "%s" differing in parameter documentation
+    # W9018, # "%s" differing in parameter type documentation
+    # W9019, # "%s" useless ignored parameter documentation
+    # W9020, # "%s" useless ignored parameter type documentation
+    # Constant name style warnings. We will remove them one by one.
+    C0103, # Class constant name "%s" doesn't conform to UPPER_CASE naming style ('([^\\W\\da-z][^\\Wa-z]*|__.*__)$' pattern) (invalid-name)
+    # New recommendations, disable for now to avoid introducing behaviour changes.
+    R1729, # Use a generator instead '%s' (use-a-generator)
+    R1732, # Consider using 'with' for resource-allocating operations (consider-using-with)
+    # This applies to CPython only.
+    I1101, # Module 'math' has no 'pow' member, but source is unavailable. Consider adding this module to extension-pkg-allow-list if you want to perform analysis based on run-time introspection of living objects. (c-extension-no-member)    
+    # Added to allow linting. Need to work on removing over time
+    R0801, # dupilcated code
+    R0401, # Cyclic import
+    C0411, # import ordering
+    W9015, # missing parameter in doc strings
+    W0612, # unused variable
+    R0205, # useless-object-inheritanc
+    C0301, # line to long
+    R0201, # no self use, method could be a function
+    C0114, # missing-module-docstring
+    W1202, # Use lazy % formatting in logging functions (logging-format-interpolation)
+    E1101, # No member 
+    W0622, # Redefining built-in 'property' (redefined-builtin)
+    W0611, # unused imports
+    W0231, # super not called
+    W0212, # protected-access
+    W0201, # attribute-defined-outside-init
+    R1725, # Consider using Python 3 style super() without arguments (super-with-arguments)
+    C2001, # Avoid comparisons to zero (compare-to-zero)
+    R0912, # too many branches
+    W0235, # Useless super delegation in method '__init__' (useless-super-delegation)
+    C0412, # Imports from package samtranslator are not grouped (ungrouped-imports)
+    W0223, # abstract-method
+    W0107, # unnecessary-pass
+    W0707, # raise-missing-from
+    R1720, # no-else-raise
+    W0621, # redefined-outer-name
+    E0203, # access-member-before-definition
+    W0221, # arguments-differ
+    R1710, # inconsistent-return-statements
+    R1702, # too-many-nested-blocks
+    C0123, # Use isinstance() rather than type() for a typecheck. (unidiomatic-typecheck)
+    W0105, # String statement has no effect (pointless-string-statement)
+    C0206, # Consider iterating with .items() (consider-using-dict-items)
+    W9008, # Redundant returns documentation (redundant-returns-doc)
+    E0602, # undefined-variable
+    C0112, # empty-docstring
+    C0116, # missing-function-docstring
+    C0200, # consider-using-enumerate
+    R5501, # Consider using "elif" instead of "else if" (else-if-used)
+    W9017, # differing-param-doc
+    W9018, # differing-type-doc
+    W0511, # fixme
+    C0325, # superfluous-parens
+    R1701, # consider-merging-isinstance
+    C0302, # too-many-lines
+    C0303, # trailing-whitespace
+    R1721, # unnecessary-comprehension
+    C0121, # singleton-comparison
+    E1305, # too-many-format-args
+    R1724, # no-else-continue
+    E0611, # no-name-in-module
+    W9013, # missing-yield-doc
+    W9014, # missing-yield-type-doc
+    C0201, # consider-iterating-dictionary
+    W0237, # arguments-renamed
+    R1718, # consider-using-set-comprehension
+    R1723, # no-else-break
+    E1133, # not-an-iterable
+    E1135, # unsupported-membership-test
+    R1705, # no-else-return
 
 
 [REPORTS]
@@ -162,18 +263,20 @@ module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-z_][a-z0-9_]{2,50}$
 
 # Naming hint for method names
 method-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=.*
+no-docstring-rgx=^_
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
-docstring-min-length=-1
+# To improve our docstring without spending too much effort at a time,
+# here set it to 30 and decrease it gradually in the future.
+docstring-min-length=30
 
 
 [FORMAT]
@@ -221,16 +324,16 @@ notes=FIXME,XXX
 [SIMILARITIES]
 
 # Minimum lines number of a similarity.
-min-similarity-lines=5
+min-similarity-lines=12
 
 # Ignore comments when computing similarities.
-ignore-comments=no
+ignore-comments=yes
 
 # Ignore docstrings when computing similarities.
-ignore-docstrings=no
+ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 
 [SPELLING]
@@ -315,7 +418,7 @@ max-args=5
 ignored-argument-names=_.*
 
 # Maximum number of locals for function / method body
-max-locals=15
+max-locals=17
 
 # Maximum number of return / yield for function / method body
 max-returns=6

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,15 @@ black:
 black-check:
 	black --check setup.py samtranslator/* tests/* integration/* bin/*.py
 
+lint:
+	# Linter performs static analysis to catch latent bugs
+	pylint --rcfile .pylintrc samtranslator
+
 # Command to run everytime you make changes to verify everything works
 dev: test
 
 # Verifications to run before sending a pull request
-pr: black-check init dev
+pr: black-check lint init dev
 
 define HELP_MESSAGE
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ tox~=3.24
 pytest-cov~=2.10.1
 pytest-xdist~=2.5
 pytest-env~=0.6.2
-pylint>=1.7.2,<2.0
+pylint~=2.9.0
 pyyaml~=5.4
 
 # Test requirements


### PR DESCRIPTION
Previously, this repo did not do any linting. The linting that is enabled
is basic, as this commit disables all of what pylint was complaining about.

*Issue #, if available:*
Linting was not done on commits, this update changes this. The `.pylintrc` file was copied from our other repos (aws-sam-cli) that we maintain.

*Description of changes:*
Add linting and make linting run on `make pr`.

I will make this more useful to us in the near future by fixing some of the smaller issues and likely just forcing pylint to ignore the rest. That way new code is always linted and we can work on removing/update the "legacy" code to be cleaner.

*Description of how you validated changes:*
Ran `make pr`

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
