### PR TITLE
Py27dict deepcopy performance

### DIFF
--- a/samtranslator/utils/py27hash_fix.py
+++ b/samtranslator/utils/py27hash_fix.py
@@ -133,6 +133,9 @@ class Py27UniStr(unicode_string_type):
     def split(self, sep=None, maxsplit=-1):
         return [Py27UniStr(s) for s in super(Py27UniStr, self).split(sep, maxsplit)]
 
+    def __deepcopy__(self, memo):
+        return self  # strings are immutable
+
 
 class Py27LongInt(long_int_type):
     """
@@ -146,6 +149,9 @@ class Py27LongInt(long_int_type):
         if sys.version_info.major >= 3 and self > Py27LongInt.PY2_MAX_INT:
             return super(Py27LongInt, self).__repr__() + "L"
         return super(Py27LongInt, self).__repr__()
+
+    def __deepcopy__(self, memo):
+        return self  # primitive types (ints) are immutable
 
 
 class Py27Keys(object):
@@ -166,6 +172,16 @@ class Py27Keys(object):
         self.size = 0  # current size of the keys, equivalent to ma_used in dictobject.c
         self.fill = 0  # increment count when a key is added, equivalent to ma_fill in dictobject.c
         self.mask = MINSIZE - 1  # Python2 default dict size
+
+    def __deepcopy__(self, memo):
+        # add keys in the py2 order -- we can't do a straigh-up deep copy of keyorder because
+        # in py2 copy.deepcopy of a dict may result in reordering of the keys
+        ret = Py27Keys()
+        for k in self.keys():
+            if k is self.DUMMY:
+                continue
+            ret.add(copy.deepcopy(k, memo))
+        return ret
 
     def _get_key_idx(self, k):
         """Gets insert location for k"""
@@ -336,6 +352,17 @@ class Py27Dict(dict):
 
         # Initialize base arguments
         self.update(*args, **kwargs)
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        for k, v in self.__dict__.items():
+            setattr(result, k, copy.deepcopy(v, memo))
+
+        for key, value in super(Py27Dict, self).items():
+            super(Py27Dict, result).__setitem__(copy.deepcopy(key, memo), copy.deepcopy(value, memo))
+
+        return result
 
     def __reduce__(self):
         """

--- a/samtranslator/utils/py27hash_fix.py
+++ b/samtranslator/utils/py27hash_fix.py
@@ -136,6 +136,12 @@ class Py27UniStr(unicode_string_type):
     def __deepcopy__(self, memo):
         return self  # strings are immutable
 
+    def _get_py27_hash(self):
+        h = getattr(self, "_py27_hash", None)
+        if h is None:
+            self._py27_hash = h = ctypes.c_size_t(Hash.hash(self)).value
+        return h
+
 
 class Py27LongInt(long_int_type):
     """
@@ -185,15 +191,20 @@ class Py27Keys(object):
 
     def _get_key_idx(self, k):
         """Gets insert location for k"""
-        freeslot = None
-        # C API uses unsigned values
-        h = ctypes.c_size_t(Hash.hash(k)).value
+
+        # Py27UniStr caches the hash to improve performance so use its method instead of always computing the hash
+        if isinstance(k, Py27UniStr):
+            h = k._get_py27_hash()
+        else:
+            h = ctypes.c_size_t(Hash.hash(k)).value
+
         i = h & self.mask
 
         if i not in self.keyorder or self.keyorder[i] == k:
             # empty slot or keys match
             return i
 
+        freeslot = None
         if i in self.keyorder and self.keyorder[i] is self.DUMMY:
             # dummy slot
             freeslot = i

--- a/tests/utils/test_py27hash_fix.py
+++ b/tests/utils/test_py27hash_fix.py
@@ -91,6 +91,16 @@ class TestPy27UniStr(TestCase):
         for c in after:
             self.assertIsInstance(c, Py27UniStr)
 
+    def test_py27_hash(self):
+        a = Py27UniStr("abcdef")
+        self.assertEqual(a._get_py27_hash(), 484452592760221083)
+        # do it twice since _get_py27_hash caches the hash
+        self.assertEqual(a._get_py27_hash(), 484452592760221083)
+
+    def test_deepcopy(self):
+        a = Py27UniStr("abcdef")
+        self.assert_(a is copy.deepcopy(a))  # deepcopy should give back the same object
+
 
 class TestPy27LongInt(TestCase):
     def test_long_int(self):
@@ -110,6 +120,10 @@ class TestPy27LongInt(TestCase):
         i = Py27LongInt(100)
         d = {"num": i}
         self.assertEqual(str(d), "{'num': 100}")
+
+    def test_deepcopy(self):
+        a = Py27LongInt(10)
+        self.assert_(a is copy.deepcopy(a))  # deepcopy should give back the same object
 
 
 class TestPy27Keys(TestCase):


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Implement `__deepcopy__` for `Py27Dict` and related classes in order to improve performance.  The generic deep copy in `copy` works, but is slow.

*Description of how you validated changes:*
Unit tests were added, and existing unit tests cover `Py27Dict` functionality.  We also timed how long the transform took for a large template before and after the changes (for a very large template, these changes reduced processing time by ~80%). We confirmed that the transformed templates were the same before and after the changes.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [ ] ~Bad/wrong values (None, empty, wrong type, length, etc.)~ n/a
    - [ ] ~[Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)~ n/a
- [ ] ~Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)~ n/a
- [x] `make pr` passes
- [ ] ~Update documentation~ not necessary
- [x] Verify transformed template deploys and application functions as expected -- confirmed transformed template didn't change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
