### PR TITLE
fix: Update tag count check for apigw v2 resources

### DIFF
--- a/integration/combination/test_http_api_with_cors.py
+++ b/integration/combination/test_http_api_with_cors.py
@@ -34,7 +34,7 @@ class TestHttpApiWithCors(BaseTest):
 
         # Every HttpApi should have a default tag created by SAM (httpapi:createdby: SAM)
         tags = api_result["Tags"]
-        self.assertEqual(len(tags), 1)
+        self.assertGreaterEqual(len(tags), 1)
         self.assertEqual(tags["httpapi:createdBy"], "SAM")
 
         # verifying if TimeoutInMillis is set properly in the integration


### PR DESCRIPTION
*Issue #, if available:*
Cfn recently released an update to add default tags to APIGW V2 resources to include some additional default tags. Our tests need to be updated to reflect these changes.

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
