### PR TITLE
validate Http Api Authorizers identity Header

### DIFF
--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -172,10 +172,18 @@ class ApiGatewayV2Authorizer(object):
                 self.api_logical_id, f"{self.name} Lambda Authorizer must define 'AuthorizerPayloadFormatVersion'."
             )
 
-        if self.identity and not isinstance(self.identity, dict):
-            raise InvalidResourceException(
-                self.api_logical_id, f"{self.name} Lambda Authorizer property 'identity' is of invalid type."
-            )
+        if self.identity:
+            if not isinstance(self.identity, dict):
+                raise InvalidResourceException(
+                    self.api_logical_id, self.name + " Lambda Authorizer property 'identity' is of invalid type."
+                )
+            if self.identity.get("Headers"):
+                headers = self.identity.get("Headers")
+                if not isinstance(headers, list) or any([not isinstance(header, str) for header in headers]):
+                    raise InvalidResourceException(
+                        self.api_logical_id,
+                        self.name + " Lambda Authorizer property identity's 'Headers' is of invalid type.",
+                    )
 
     def generate_openapi(self):
         """

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -177,8 +177,8 @@ class ApiGatewayV2Authorizer(object):
                 raise InvalidResourceException(
                     self.api_logical_id, self.name + " Lambda Authorizer property 'identity' is of invalid type."
                 )
-            if self.identity.get("Headers"):
-                headers = self.identity.get("Headers")
+            headers = self.identity.get("Headers")
+            if headers:
                 if not isinstance(headers, list) or any([not isinstance(header, str) for header in headers]):
                     raise InvalidResourceException(
                         self.api_logical_id,

--- a/tests/translator/input/error_api_authorizer_property_indentity_header_with_invalid_type.yaml
+++ b/tests/translator/input/error_api_authorizer_property_indentity_header_with_invalid_type.yaml
@@ -1,0 +1,58 @@
+Parameters:
+  AuthKeyName:
+    Type: String
+    Default: Auth_name
+
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.7
+      InlineCode: |
+        def handler(event, context):
+            return {'body': 'Hello World!', 'statusCode': 200}
+      MemorySize: 128
+      Events:
+        PostApi:
+          Type: HttpApi
+          Properties:
+            Auth:
+              Authorizer: MyLambdaAuthUpdated
+            ApiId: 
+              Ref: MyApi
+            Method: POST
+            Path: /post
+
+  MyAuthFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |
+        print("hello")
+      Handler: index.handler
+      Runtime: nodejs12.x
+
+  MyApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Tags:
+        Tag1: value1
+        Tag2: value2
+      Auth:
+        Authorizers:
+          MyLambdaAuthUpdated:
+            FunctionArn: 
+              Fn::GetAtt:
+                - MyAuthFn
+                - Arn
+            FunctionInvokeRole:
+              Fn::GetAtt:
+                - MyAuthFnRole
+                - Arn
+            Identity: 
+              Headers:
+                - Ref: AuthKeyName
+            AuthorizerPayloadFormatVersion: 1.0
+        DefaultAuthorizer: MyLambdaAuthUpdated
+
+      

--- a/tests/translator/output/error_api_authorizer_property_indentity_header_with_invalid_type.json
+++ b/tests/translator/output/error_api_authorizer_property_indentity_header_with_invalid_type.json
@@ -1,0 +1,8 @@
+{
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApi] is invalid. MyLambdaAuthUpdated Lambda Authorizer property identity's 'Headers' is of invalid type.",
+    "errors": [
+        {
+            "errorMessage": "Resource with id [MyApi] is invalid. MyLambdaAuthUpdated Lambda Authorizer property identity's 'Headers' is of invalid type."
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
added validation to validate the property type of Authorizers Identity parameter Headers to arrest a situation where an intrinsic value can't be resolved.

*Description of how you validated changes:*
created a test sam template and tested the exception

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [x] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
