### PR TITLE
Validation for API property Model

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -5,7 +5,7 @@ from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import ResourceMacro, PropertyType
 from samtranslator.model.eventsources import FUNCTION_EVETSOURCE_METRIC_PREFIX
 from samtranslator.model.types import is_type, list_of, dict_of, one_of, is_str
-from samtranslator.model.intrinsics import ref, fnGetAtt, fnSub, make_shorthand, make_conditional
+from samtranslator.model.intrinsics import is_intrinsic, ref, fnGetAtt, fnSub, make_shorthand, make_conditional
 from samtranslator.model.tags.resource_tagging import get_tag_list
 
 from samtranslator.model.s3 import S3Bucket
@@ -764,6 +764,14 @@ class Api(PushEventSource):
                         self.relative_id,
                         "Unable to set RequestModel [{model}] on API method [{method}] for path [{path}] "
                         "because the related API does not define any Models.".format(
+                            model=method_model, method=self.Method, path=self.Path
+                        ),
+                    )
+                if not is_intrinsic(api_models) and not isinstance(api_models, dict):
+                    raise InvalidEventException(
+                        self.relative_id,
+                        "Unable to set RequestModel [{model}] on API method [{method}] for path [{path}] "
+                        "because the related API Models defined is of invalid type.".format(
                             model=method_model, method=self.Method, path=self.Path
                         ),
                     )

--- a/tests/translator/input/error_api_with_models_of_invalid_type.yaml
+++ b/tests/translator/input/error_api_with_models_of_invalid_type.yaml
@@ -1,0 +1,37 @@
+Resources:
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      Models:
+        - Invalid_value
+
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      InlineCode: |
+        exports.handler = async (event, context, callback) => {
+          return {
+            statusCode: 200,
+            body: 'Success'
+          }
+        }
+      Events:
+        None:
+          Type: Api
+          Properties:
+            RequestModel:
+              Model: User
+              Required: true
+            RestApiId:
+              Ref: MyApi
+            Method: get
+            Path: /none
+
+Outputs:
+  ApiUrl:
+    Description: "API endpoint URL for Prod environment"
+    Value:
+      Fn::Sub: 'https://${MyApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'

--- a/tests/translator/output/error_api_with_models_of_invalid_type.json
+++ b/tests/translator/output/error_api_with_models_of_invalid_type.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [MyApi] is invalid. Type of property 'Models' is invalid. Resource with id [MyFunction] is invalid. Event with id [None] is invalid. Unable to set RequestModel [User] on API method [get] for path [/none] because the related API Models defined is of invalid type."
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added validation to Api property Model to ensure that its either of type dict or an intrinsic function.

*Description of how you validated changes:*
if a customer provides in a SAM a value API property Model and its neither a type dict nor an intrinsic function. An error is raised notifying the customer of the invalid type.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
