### PR TITLE
test: Add retries on flaky integration test

### DIFF
--- a/integration/combination/test_api_with_gateway_responses.py
+++ b/integration/combination/test_api_with_gateway_responses.py
@@ -1,6 +1,7 @@
 from unittest.case import skipIf
 
 from integration.helpers.base_test import BaseTest
+from integration.helpers.deployer.utils.retry import retry
 from integration.helpers.resource import current_region_does_not_support
 from integration.config.service_names import GATEWAY_RESPONSES
 
@@ -30,8 +31,12 @@ class TestApiWithGatewayResponses(BaseTest):
         self.assertEqual(gateway_response.get("statusCode"), None, "gatewayResponse: status code must be none")
 
         base_url = stack_outputs["ApiUrl"]
-        response = self.verify_get_request_response(base_url + "iam", 403)
-        access_control_allow_origin = response.headers["Access-Control-Allow-Origin"]
+        self._verify_request_response_and_cors(base_url + "iam", 403)
+
+    @retry(AssertionError, exc_raise=AssertionError, exc_raise_msg="Unable to verify GatewayResponse request.")
+    def _verify_request_response_and_cors(self, url, expected_response):
+        response = self.verify_get_request_response(url, expected_response)
+        access_control_allow_origin = response.headers.get("Access-Control-Allow-Origins", "")
         self.assertEqual(access_control_allow_origin, "*", "Access-Control-Allow-Origin must be '*'")
 
 

--- a/integration/combination/test_api_with_gateway_responses.py
+++ b/integration/combination/test_api_with_gateway_responses.py
@@ -36,7 +36,7 @@ class TestApiWithGatewayResponses(BaseTest):
     @retry(AssertionError, exc_raise=AssertionError, exc_raise_msg="Unable to verify GatewayResponse request.")
     def _verify_request_response_and_cors(self, url, expected_response):
         response = self.verify_get_request_response(url, expected_response)
-        access_control_allow_origin = response.headers.get("Access-Control-Allow-Origins", "")
+        access_control_allow_origin = response.headers.get("Access-Control-Allow-Origin", "")
         self.assertEqual(access_control_allow_origin, "*", "Access-Control-Allow-Origin must be '*'")
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
