### PR TITLE
reduce CloudFormation template size

### DIFF
--- a/bin/sam-translate.py
+++ b/bin/sam-translate.py
@@ -107,7 +107,7 @@ def transform_template(input_file_path, output_file_path):
             region=None,
         )
         cloud_formation_template = transform(sam_template, {}, ManagedPolicyLoader(iam_client), feature_toggle)
-        cloud_formation_template_prettified = json.dumps(cloud_formation_template, indent=2)
+        cloud_formation_template_prettified = json.dumps(cloud_formation_template, indent=1)
 
         with open(output_file_path, "w") as f:
             f.write(cloud_formation_template_prettified)


### PR DESCRIPTION
also: https://github.com/aws/aws-cdk/pull/19656, https://github.com/cloudtools/troposphere/pull/2028, https://github.com/awslabs/goformation/pull/445

[CloudFormation templates can currently only be 1MB](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html), and [template size limits apply even after transformation processing](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html#template-macros-use)

Simply reducing indentation from 2 to 1 should remove ~1/4 of the template file size for everyone by default while still preserving indentation formatting. Beyond improving the default, those wishing to reduce readability for further reduced file size could opt into using something like [`jq`](https://stedolan.github.io/jq/) on their own for now

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
