### PR TITLE
fix: use formatting instead of concatenating when preparing the exception messages

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -327,7 +327,7 @@ class Resource(object):
         if attr_name in self.runtime_attrs:
             return self.runtime_attrs[attr_name](self)
         else:
-            raise NotImplementedError(attr_name + " attribute is not implemented for resource " + self.resource_type)
+            raise NotImplementedError(f"{attr_name} attribute is not implemented for resource {self.resource_type}")
 
     def get_passthrough_resource_attributes(self):
         """
@@ -447,7 +447,7 @@ class SamResourceMacro(ResourceMacro):
         if reserved_tag_name in tags:
             raise InvalidResourceException(
                 self.logical_id,
-                reserved_tag_name + " is a reserved Tag key name and "
+                f"{reserved_tag_name} is a reserved Tag key name and "
                 "cannot be set on your resource. "
                 "Please change the tag key in the "
                 "input.",

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -247,13 +247,13 @@ class ApiGatewayAuthorizer(object):
         if function_payload_type not in ApiGatewayAuthorizer._VALID_FUNCTION_PAYLOAD_TYPES:
             raise InvalidResourceException(
                 api_logical_id,
-                name + " Authorizer has invalid " "'FunctionPayloadType': " + function_payload_type + ".",
+                f"{name} Authorizer has invalid 'FunctionPayloadType': {function_payload_type}.",
             )
 
         if function_payload_type == "REQUEST" and self._is_missing_identity_source(identity):
             raise InvalidResourceException(
                 api_logical_id,
-                name + " Authorizer must specify Identity with at least one "
+                f"{name} Authorizer must specify Identity with at least one "
                 "of Headers, QueryStrings, StageVariables, or Context.",
             )
 

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -151,26 +151,26 @@ class ApiGatewayV2Authorizer(object):
     def _validate_jwt_authorizer(self):
         if not self.jwt_configuration:
             raise InvalidResourceException(
-                self.api_logical_id, self.name + " OAuth2 Authorizer must define 'JwtConfiguration'."
+                self.api_logical_id, f"{self.name} OAuth2 Authorizer must define 'JwtConfiguration'."
             )
         if not self.id_source:
             raise InvalidResourceException(
-                self.api_logical_id, self.name + " OAuth2 Authorizer must define 'IdentitySource'."
+                self.api_logical_id, f"{self.name} OAuth2 Authorizer must define 'IdentitySource'."
             )
 
     def _validate_lambda_authorizer(self):
         if not self.function_arn:
             raise InvalidResourceException(
-                self.api_logical_id, self.name + " Lambda Authorizer must define 'FunctionArn'."
+                self.api_logical_id, f"{self.name} Lambda Authorizer must define 'FunctionArn'."
             )
         if not self.authorizer_payload_format_version:
             raise InvalidResourceException(
-                self.api_logical_id, self.name + " Lambda Authorizer must define 'AuthorizerPayloadFormatVersion'."
+                self.api_logical_id, f"{self.name} Lambda Authorizer must define 'AuthorizerPayloadFormatVersion'."
             )
 
         if self.identity and not isinstance(self.identity, dict):
             raise InvalidResourceException(
-                self.api_logical_id, self.name + " Lambda Authorizer property 'identity' is of invalid type."
+                self.api_logical_id, f"{self.name} Lambda Authorizer property 'identity' is of invalid type."
             )
 
     def generate_openapi(self):

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -189,10 +189,8 @@ class ImplicitApiPlugin(BasePlugin):
         if isinstance(api_id, dict) or is_referencing_http_from_api_event:
             raise InvalidEventException(
                 event_id,
-                self.api_id_property
-                + " must be a valid reference to an '"
-                + self._get_api_resource_type_name()
-                + "' resource in same template.",
+                f"{self.api_id_property} must be a valid reference to an '{self._get_api_resource_type_name()}'"
+                " resource in same template.",
             )
 
         # Make sure Swagger is valid

--- a/tests/model/test_api.py
+++ b/tests/model/test_api.py
@@ -3,6 +3,7 @@ import pytest
 
 from samtranslator.model import InvalidResourceException
 from samtranslator.model.apigateway import ApiGatewayAuthorizer
+from samtranslator.utils.py27hash_fix import Py27Dict
 
 
 class TestApiGatewayAuthorizer(TestCase):
@@ -23,6 +24,14 @@ class TestApiGatewayAuthorizer(TestCase):
                 name="authName",
                 identity={"ReauthorizeEvery": 10},
                 function_payload_type="REQUEST",
+            )
+
+    def test_create_authorizer_fails_with_invalid_function_payload_type(self):
+        with self.assertRaises(InvalidResourceException):
+            ApiGatewayAuthorizer(
+                api_logical_id="logicalId",
+                name="authName",
+                function_payload_type=Py27Dict({"key": "value"}),
             )
 
     def test_create_authorizer_fails_with_empty_identity(self):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Use string formatting when preparing the exception messages. Otherwise it is creating issues when concatenating a string with Py27Dict object.

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
