### PR TITLE
Furl AutopublishAlias bug fix 

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -175,7 +175,7 @@ class SamFunction(SamResourceMacro):
         if self.FunctionUrlConfig:
             lambda_url = self._construct_function_url(lambda_function, lambda_alias)
             resources.append(lambda_url)
-            url_permission = self._construct_url_permission(lambda_function)
+            url_permission = self._construct_url_permission(lambda_function, lambda_alias)
             if url_permission:
                 resources.append(url_permission)
 
@@ -942,7 +942,7 @@ class SamFunction(SamResourceMacro):
                     "{} must be of type {}.".format(prop_name, str(prop_type).split("'")[1]),
                 )
 
-    def _construct_url_permission(self, lambda_function):
+    def _construct_url_permission(self, lambda_function, lambda_alias):
         """
         Construct the lambda permission associated with the function url resource in a case
         for public access when AuthType is NONE
@@ -951,6 +951,9 @@ class SamFunction(SamResourceMacro):
         ----------
         lambda_function : LambdaUrl
             Lambda Function resource
+
+        llambda_alias : LambdaAlias
+            Lambda Alias resource
 
         Returns
         -------
@@ -965,7 +968,9 @@ class SamFunction(SamResourceMacro):
         logical_id = f"{lambda_function.logical_id}UrlPublicPermissions"
         lambda_permission = LambdaPermission(logical_id=logical_id)
         lambda_permission.Action = "lambda:InvokeFunctionUrl"
-        lambda_permission.FunctionName = lambda_function.get_runtime_attr("name")
+        lambda_permission.FunctionName = (
+            lambda_alias.get_runtime_attr("arn") if lambda_alias else lambda_function.get_runtime_attr("name")
+        )
         lambda_permission.Principal = "*"
         lambda_permission.FunctionUrlAuthType = auth_type
         return lambda_permission

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -106,6 +106,7 @@ class TestHttpApiGenerator(TestCase):
             },
         }
         self.kwargs["definition_body"] = OpenApiEditor.gen_skeleton()
+        self.kwargs["definition_uri"] = None
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
         self.assertEqual(
             http_api.Body["components"]["securitySchemes"],

--- a/tests/translator/output/aws-cn/function_with_function_url_config_and_autopublishalias.json
+++ b/tests/translator/output/aws-cn/function_with_function_url_config_and_autopublishalias.json
@@ -85,7 +85,7 @@
             "Properties": {
                 "Action": "lambda:InvokeFunctionUrl",
                 "FunctionName": {
-                    "Ref": "MyFunction"
+                    "Ref": "MyFunctionAliaslive"
                 },
                 "Principal": "*",
                 "FunctionUrlAuthType": "NONE"

--- a/tests/translator/output/aws-us-gov/function_with_function_url_config_and_autopublishalias.json
+++ b/tests/translator/output/aws-us-gov/function_with_function_url_config_and_autopublishalias.json
@@ -85,7 +85,7 @@
             "Properties": {
                 "Action": "lambda:InvokeFunctionUrl",
                 "FunctionName": {
-                    "Ref": "MyFunction"
+                    "Ref": "MyFunctionAliaslive"
                 },
                 "Principal": "*",
                 "FunctionUrlAuthType": "NONE"

--- a/tests/translator/output/function_with_function_url_config_and_autopublishalias.json
+++ b/tests/translator/output/function_with_function_url_config_and_autopublishalias.json
@@ -85,7 +85,7 @@
             "Properties": {
                 "Action": "lambda:InvokeFunctionUrl",
                 "FunctionName": {
-                    "Ref": "MyFunction"
+                    "Ref": "MyFunctionAliaslive"
                 },
                 "Principal": "*",
                 "FunctionUrlAuthType": "NONE"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/serverless-application-model/issues/2373

*Description of changes:*
Grant public access to function alias

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
