### PR TITLE
chore: remove sys.path override

### DIFF
--- a/bin/sam-translate.py
+++ b/bin/sam-translate.py
@@ -37,7 +37,6 @@ from samtranslator.public.translator import ManagedPolicyLoader
 from samtranslator.translator.transform import transform
 from samtranslator.yaml_helper import yaml_parse
 from samtranslator.model.exceptions import InvalidDocumentException
-from samtranslator.feature_toggle.feature_toggle import FeatureToggleLocalConfigProvider, FeatureToggle
 
 LOG = logging.getLogger(__name__)
 cli_options = docopt(__doc__)
@@ -98,15 +97,7 @@ def transform_template(input_file_path, output_file_path):
         sam_template = yaml_parse(f)
 
     try:
-        feature_toggle = FeatureToggle(
-            FeatureToggleLocalConfigProvider(
-                os.path.join(my_path, "..", "tests", "feature_toggle", "input", "feature_toggle_config.json")
-            ),
-            stage=None,
-            account_id=None,
-            region=None,
-        )
-        cloud_formation_template = transform(sam_template, {}, ManagedPolicyLoader(iam_client), feature_toggle)
+        cloud_formation_template = transform(sam_template, {}, ManagedPolicyLoader(iam_client))
         cloud_formation_template_prettified = json.dumps(cloud_formation_template, indent=1)
 
         with open(output_file_path, "w") as f:

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -13,9 +13,6 @@ from samtranslator.feature_toggle.dialup import (
 )
 from samtranslator.metrics.method_decorator import cw_timer
 
-my_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, my_path + "/..")
-
 LOG = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
*Issue #, if available:*
#1911 

*Description of changes:*
Remove `sys.path` overrides that were done to support a testing script.

*Description of how you validated changes:*
Remove `sys.path` overriding.

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
