### PR TITLE
chore(test): Move assert_ to assertTrue

### DIFF
--- a/tests/utils/test_py27hash_fix.py
+++ b/tests/utils/test_py27hash_fix.py
@@ -99,7 +99,7 @@ class TestPy27UniStr(TestCase):
 
     def test_deepcopy(self):
         a = Py27UniStr("abcdef")
-        self.assert_(a is copy.deepcopy(a))  # deepcopy should give back the same object
+        self.assertTrue(a is copy.deepcopy(a))  # deepcopy should give back the same object
 
 
 class TestPy27LongInt(TestCase):
@@ -123,7 +123,7 @@ class TestPy27LongInt(TestCase):
 
     def test_deepcopy(self):
         a = Py27LongInt(10)
-        self.assert_(a is copy.deepcopy(a))  # deepcopy should give back the same object
+        self.assertTrue(a is copy.deepcopy(a))  # deepcopy should give back the same object
 
 
 class TestPy27Keys(TestCase):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Remove usage of deprecate `self.assert_` for `self.assertTrue`

*Description of how you validated changes:*
Ran `make pr`

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Does this code change include validation to intrinsics that were not previously validated by SAM? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
