### PR TITLE
fix: fix Lambda Function permission for functions with AutoPublish, and Function URL configurations

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -175,7 +175,7 @@ class SamFunction(SamResourceMacro):
         if self.FunctionUrlConfig:
             lambda_url = self._construct_function_url(lambda_function, lambda_alias)
             resources.append(lambda_url)
-            url_permission = self._construct_url_permission(lambda_function)
+            url_permission = self._construct_url_permission(lambda_function, lambda_alias)
             if url_permission:
                 resources.append(url_permission)
 
@@ -942,7 +942,7 @@ class SamFunction(SamResourceMacro):
                     "{} must be of type {}.".format(prop_name, str(prop_type).split("'")[1]),
                 )
 
-    def _construct_url_permission(self, lambda_function):
+    def _construct_url_permission(self, lambda_function, lambda_alias):
         """
         Construct the lambda permission associated with the function url resource in a case
         for public access when AuthType is NONE
@@ -951,6 +951,8 @@ class SamFunction(SamResourceMacro):
         ----------
         lambda_function : LambdaUrl
             Lambda Function resource
+        lambda_alias : LambdaAlias
+            Lambda Alias resource
 
         Returns
         -------
@@ -965,7 +967,9 @@ class SamFunction(SamResourceMacro):
         logical_id = f"{lambda_function.logical_id}UrlPublicPermissions"
         lambda_permission = LambdaPermission(logical_id=logical_id)
         lambda_permission.Action = "lambda:InvokeFunctionUrl"
-        lambda_permission.FunctionName = lambda_function.get_runtime_attr("name")
+        lambda_permission.FunctionName = (
+            lambda_alias.get_runtime_attr("arn") if lambda_alias else lambda_function.get_runtime_attr("name")
+        )
         lambda_permission.Principal = "*"
         lambda_permission.FunctionUrlAuthType = auth_type
         return lambda_permission

--- a/tests/translator/output/aws-cn/function_with_function_url_config_and_autopublishalias.json
+++ b/tests/translator/output/aws-cn/function_with_function_url_config_and_autopublishalias.json
@@ -85,7 +85,7 @@
             "Properties": {
                 "Action": "lambda:InvokeFunctionUrl",
                 "FunctionName": {
-                    "Ref": "MyFunction"
+                    "Ref": "MyFunctionAliaslive"
                 },
                 "Principal": "*",
                 "FunctionUrlAuthType": "NONE"

--- a/tests/translator/output/aws-us-gov/function_with_function_url_config_and_autopublishalias.json
+++ b/tests/translator/output/aws-us-gov/function_with_function_url_config_and_autopublishalias.json
@@ -85,7 +85,7 @@
             "Properties": {
                 "Action": "lambda:InvokeFunctionUrl",
                 "FunctionName": {
-                    "Ref": "MyFunction"
+                    "Ref": "MyFunctionAliaslive"
                 },
                 "Principal": "*",
                 "FunctionUrlAuthType": "NONE"

--- a/tests/translator/output/function_with_function_url_config_and_autopublishalias.json
+++ b/tests/translator/output/function_with_function_url_config_and_autopublishalias.json
@@ -85,7 +85,7 @@
             "Properties": {
                 "Action": "lambda:InvokeFunctionUrl",
                 "FunctionName": {
-                    "Ref": "MyFunction"
+                    "Ref": "MyFunctionAliaslive"
                 },
                 "Principal": "*",
                 "FunctionUrlAuthType": "NONE"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/serverless-application-model/issues/2386

*Description of changes:*
change the Lambda Permission to refer to the Lambda Function alias instead of the lambda function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
