### PR TITLE
test: Add logging for relevant Amazon headers useful for debugging

### DIFF
--- a/integration/combination/test_api_settings.py
+++ b/integration/combination/test_api_settings.py
@@ -1,18 +1,13 @@
 import hashlib
 
-from integration.config.logger_configurations import CustomLoggers
-
 try:
     from pathlib import Path
 except ImportError:
     from pathlib2 import Path
 
-import requests
 from parameterized import parameterized
 
 from integration.helpers.base_test import BaseTest
-
-REQUEST_LOG = CustomLoggers.get_request_logger(__name__)
 
 
 class TestApiSettings(BaseTest):
@@ -162,7 +157,7 @@ class TestApiSettings(BaseTest):
 
     def verify_binary_media_request(self, url, expected_status_code):
         headers = {"accept": "image/png"}
-        response = requests.get(url, headers=headers)
+        response = BaseTest.do_get_request_with_logging(url, headers)
 
         status = response.status_code
         expected_file_path = str(Path(self.code_dir, "AWS_logo_RGB.png"))

--- a/integration/combination/test_api_settings.py
+++ b/integration/combination/test_api_settings.py
@@ -1,5 +1,7 @@
 import hashlib
 
+from integration.config.logger_configurations import CustomLoggers
+
 try:
     from pathlib import Path
 except ImportError:
@@ -9,6 +11,8 @@ import requests
 from parameterized import parameterized
 
 from integration.helpers.base_test import BaseTest
+
+REQUEST_LOG = CustomLoggers.get_request_logger(__name__)
 
 
 class TestApiSettings(BaseTest):

--- a/integration/combination/test_api_with_authorizer_apikey.py
+++ b/integration/combination/test_api_with_authorizer_apikey.py
@@ -1,12 +1,6 @@
-from unittest.case import skipIf
-
-import requests
-
 from integration.helpers.base_test import BaseTest
 from integration.helpers.deployer.utils.retry import retry
 from integration.helpers.exception import StatusCodeError
-from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import COGNITO
 
 
 class TestApiWithAuthorizerApiKey(BaseTest):
@@ -82,10 +76,10 @@ class TestApiWithAuthorizerApiKey(BaseTest):
         header_value=None,
     ):
         if not header_key or not header_value:
-            response = requests.get(url)
+            response = BaseTest.do_get_request_with_logging(url)
         else:
             headers = {header_key: header_value}
-            response = requests.get(url, headers=headers)
+            response = BaseTest.do_get_request_with_logging(url, headers)
         status = response.status_code
         if status != expected_status_code:
             raise StatusCodeError(

--- a/integration/combination/test_api_with_authorizers.py
+++ b/integration/combination/test_api_with_authorizers.py
@@ -1,12 +1,18 @@
 from unittest.case import skipIf
 
+import logging
 import requests
 
+from integration.config.logger_configurations import LoggerConfigurations
 from integration.helpers.base_test import BaseTest
 from integration.helpers.deployer.utils.retry import retry
 from integration.helpers.exception import StatusCodeError
+from integration.helpers.request_utils import RequestUtils
 from integration.helpers.resource import current_region_does_not_support
 from integration.config.service_names import COGNITO
+
+LOG = logging.getLogger(__name__)
+LoggerConfigurations.configure_request_logging(LOG)
 
 
 @skipIf(current_region_does_not_support([COGNITO]), "Cognito is not supported in this testing region")
@@ -441,6 +447,9 @@ class TestApiWithAuthorizers(BaseTest):
             headers = {header_key: header_value}
             response = requests.get(url, headers=headers)
         status = response.status_code
+        amazon_headers = RequestUtils(response).get_amazon_headers()
+        LOG.info("Calling API Gateway", extra={"status": status, "headers": amazon_headers})
+
         if status != expected_status_code:
             raise StatusCodeError(
                 "Request to {} failed with status: {}, expected status: {}".format(url, status, expected_status_code)

--- a/integration/combination/test_api_with_authorizers.py
+++ b/integration/combination/test_api_with_authorizers.py
@@ -1,18 +1,10 @@
 from unittest.case import skipIf
 
-import logging
-import requests
-
-from integration.config.logger_configurations import LoggerConfigurations
 from integration.helpers.base_test import BaseTest
 from integration.helpers.deployer.utils.retry import retry
 from integration.helpers.exception import StatusCodeError
-from integration.helpers.request_utils import RequestUtils
 from integration.helpers.resource import current_region_does_not_support
 from integration.config.service_names import COGNITO
-
-LOG = logging.getLogger(__name__)
-LoggerConfigurations.configure_request_logging(LOG)
 
 
 @skipIf(current_region_does_not_support([COGNITO]), "Cognito is not supported in this testing region")
@@ -442,13 +434,11 @@ class TestApiWithAuthorizers(BaseTest):
         header_value=None,
     ):
         if not header_key or not header_value:
-            response = requests.get(url)
+            response = BaseTest.do_get_request_with_logging(url)
         else:
             headers = {header_key: header_value}
-            response = requests.get(url, headers=headers)
+            response = BaseTest.do_get_request_with_logging(url, headers)
         status = response.status_code
-        amazon_headers = RequestUtils(response).get_amazon_headers()
-        LOG.info("Calling API Gateway", extra={"status": status, "headers": amazon_headers})
 
         if status != expected_status_code:
             raise StatusCodeError(

--- a/integration/config/logger_configurations.py
+++ b/integration/config/logger_configurations.py
@@ -2,9 +2,9 @@
 import logging
 
 
-class LoggerConfigurations:
+class CustomLoggers:
     @staticmethod
-    def configure_request_logging(logger):
+    def configure_request_logger(logger):
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(
             logging.Formatter("%(asctime)s %(message)s | Status: %(status)s | Headers: %(headers)s ")

--- a/integration/config/logger_configurations.py
+++ b/integration/config/logger_configurations.py
@@ -2,12 +2,13 @@
 import logging
 
 
-class CustomLoggers:
+class LoggingConfiguration:
     @staticmethod
     def configure_request_logger(logger):
         console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
         console_handler.setFormatter(
             logging.Formatter("%(asctime)s %(message)s | Status: %(status)s | Headers: %(headers)s ")
         )
-        console_handler.setLevel(logging.INFO)
         logger.addHandler(console_handler)
+        logger.propagate = False

--- a/integration/config/logger_configurations.py
+++ b/integration/config/logger_configurations.py
@@ -1,0 +1,13 @@
+# Logger configurations
+import logging
+
+
+class LoggerConfigurations:
+    @staticmethod
+    def configure_request_logging(logger):
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(message)s | Status: %(status)s | Headers: %(headers)s ")
+        )
+        console_handler.setLevel(logging.INFO)
+        logger.addHandler(console_handler)

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -4,9 +4,7 @@ import shutil
 
 import botocore
 import pytest
-import requests
 
-from integration.config.logger_configurations import LoggerConfigurations
 from integration.helpers.client_provider import ClientProvider
 from integration.helpers.deployer.exceptions.exceptions import ThrottlingError
 from integration.helpers.deployer.utils.retry import retry_with_exponential_backoff_and_jitter
@@ -30,8 +28,6 @@ from integration.helpers.template import transform_template
 from integration.helpers.file_resources import FILE_TO_S3_URI_MAP, CODE_KEY_TO_FILE_MAP
 
 LOG = logging.getLogger(__name__)
-REQUEST_LOG = logging.getLogger(f"{__name__}.requests")
-LoggerConfigurations.configure_request_logging(REQUEST_LOG)
 STACK_NAME_PREFIX = "sam-integ-stack-"
 S3_BUCKET_PREFIX = "sam-integ-bucket-"
 
@@ -511,12 +507,8 @@ class BaseTest(TestCase):
         expected_status_code : string
             the expected status code
         """
-        REQUEST_LOG.info("Making request to " + url)
-        response = requests.get(url)
-        status = response.status_code
-        amazon_headers = RequestUtils(response).get_amazon_headers()
-        REQUEST_LOG.info("Calling API Gateway", extra={"status": status, "headers": amazon_headers})
-        self.assertEqual(status, expected_status_code, " must return HTTP " + str(expected_status_code))
+        response = RequestUtils().do_get_request_with_logging(url)
+        self.assertEqual(response.status_code, expected_status_code, " must return HTTP " + str(expected_status_code))
         return response
 
     def get_default_test_template_parameters(self):

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -1,10 +1,12 @@
 import logging
 import os
+import requests
 import shutil
 
 import botocore
 import pytest
 
+from integration.config.logger_configurations import LoggingConfiguration
 from integration.helpers.client_provider import ClientProvider
 from integration.helpers.deployer.exceptions.exceptions import ThrottlingError
 from integration.helpers.deployer.utils.retry import retry_with_exponential_backoff_and_jitter
@@ -28,6 +30,10 @@ from integration.helpers.template import transform_template
 from integration.helpers.file_resources import FILE_TO_S3_URI_MAP, CODE_KEY_TO_FILE_MAP
 
 LOG = logging.getLogger(__name__)
+
+REQUEST_LOGGER = logging.getLogger(f"{__name__}.requests")
+LoggingConfiguration.configure_request_logger(REQUEST_LOGGER)
+
 STACK_NAME_PREFIX = "sam-integ-stack-"
 S3_BUCKET_PREFIX = "sam-integ-bucket-"
 
@@ -496,7 +502,7 @@ class BaseTest(TestCase):
         if error:
             self.fail(error)
 
-    def verify_get_request_response(self, url, expected_status_code):
+    def verify_get_request_response(self, url, expected_status_code, headers=None):
         """
         Verify if the get request to a certain url return the expected status code
 
@@ -506,8 +512,10 @@ class BaseTest(TestCase):
             the url for the get request
         expected_status_code : string
             the expected status code
+        headers : dict
+            headers to use in request
         """
-        response = RequestUtils().do_get_request_with_logging(url)
+        response = BaseTest.do_get_request_with_logging(url, headers)
         self.assertEqual(response.status_code, expected_status_code, " must return HTTP " + str(expected_status_code))
         return response
 
@@ -546,3 +554,19 @@ class BaseTest(TestCase):
             "ResolvedValue": resolved_value,
         }
         return parameter
+
+    @staticmethod
+    def do_get_request_with_logging(url, headers=None):
+        """
+        Perform a get request to an APIGW endpoint and log relevant info
+        Parameters
+        ----------
+        url : string
+            the url for the get request
+        headers : dict
+            headers to use in request
+        """
+        response = requests.get(url, headers=headers) if headers else requests.get(url)
+        amazon_headers = RequestUtils(response).get_amazon_headers()
+        REQUEST_LOGGER.info("Request made to " + url, extra={"status": response.status_code, "headers": amazon_headers})
+        return response

--- a/integration/helpers/request_utils.py
+++ b/integration/helpers/request_utils.py
@@ -1,4 +1,13 @@
 # Utils for requests
+import logging
+
+import requests
+
+from integration.config.logger_configurations import CustomLoggers
+
+
+REQUEST_LOGGER = logging.getLogger(__name__)
+CustomLoggers.configure_request_logger(REQUEST_LOGGER)
 
 # Relevant headers that should be captured for debugging
 AMAZON_HEADERS = [
@@ -12,11 +21,11 @@ AMAZON_HEADERS = [
 
 class RequestUtils:
 
-    def __init__(self, response):
-        self.response = response
-        self.headers = self._normalize_response_headers()
+    def __init__(self):
+        self.response = None
+        self.headers = None
 
-    def get_amazon_headers(self):
+    def _get_amazon_headers(self):
         """
         Get a list of relevant amazon headers that could be useful for debugging
         """
@@ -36,3 +45,12 @@ class RequestUtils:
             return {}
 
         return dict((k.lower(), v) for k, v in self.response.headers.items())
+
+    def do_get_request_with_logging(self, url):
+        REQUEST_LOGGER.info("Making request to " + url)
+        self.response = requests.get(url)
+        self.headers = self._normalize_response_headers()
+        status = self.response.status_code
+        amazon_headers = self._get_amazon_headers()
+        REQUEST_LOGGER.info("Calling API Gateway", extra={"status": status, "headers": amazon_headers})
+        return self.response

--- a/integration/helpers/request_utils.py
+++ b/integration/helpers/request_utils.py
@@ -1,13 +1,4 @@
 # Utils for requests
-import logging
-
-import requests
-
-from integration.config.logger_configurations import CustomLoggers
-
-
-REQUEST_LOGGER = logging.getLogger(__name__)
-CustomLoggers.configure_request_logger(REQUEST_LOGGER)
 
 # Relevant headers that should be captured for debugging
 AMAZON_HEADERS = [
@@ -20,12 +11,11 @@ AMAZON_HEADERS = [
 
 
 class RequestUtils:
+    def __init__(self, response):
+        self.response = response
+        self.headers = self._normalize_response_headers()
 
-    def __init__(self):
-        self.response = None
-        self.headers = None
-
-    def _get_amazon_headers(self):
+    def get_amazon_headers(self):
         """
         Get a list of relevant amazon headers that could be useful for debugging
         """
@@ -45,12 +35,3 @@ class RequestUtils:
             return {}
 
         return dict((k.lower(), v) for k, v in self.response.headers.items())
-
-    def do_get_request_with_logging(self, url):
-        REQUEST_LOGGER.info("Making request to " + url)
-        self.response = requests.get(url)
-        self.headers = self._normalize_response_headers()
-        status = self.response.status_code
-        amazon_headers = self._get_amazon_headers()
-        REQUEST_LOGGER.info("Calling API Gateway", extra={"status": status, "headers": amazon_headers})
-        return self.response

--- a/integration/helpers/request_utils.py
+++ b/integration/helpers/request_utils.py
@@ -1,0 +1,38 @@
+# Utils for requests
+
+# Relevant headers that should be captured for debugging
+AMAZON_HEADERS = [
+    "x-amzn-requestid",
+    "x-amz-apigw-id",
+    "x-amz-cf-id",
+    "x-amzn-errortype",
+    "apigw-requestid",
+]
+
+
+class RequestUtils:
+
+    def __init__(self, response):
+        self.response = response
+        self.headers = self._normalize_response_headers()
+
+    def get_amazon_headers(self):
+        """
+        Get a list of relevant amazon headers that could be useful for debugging
+        """
+        amazon_headers = {}
+        for header, header_val in self.headers.items():
+            if header in AMAZON_HEADERS:
+                amazon_headers[header] = header_val
+        return amazon_headers
+
+    def _normalize_response_headers(self):
+        """
+        API gateway can return headers with letters in different cases i.e. x-amzn-requestid or x-amzn-requestId
+        We make them all lowercase here to more easily match them up
+        """
+        if self.response is None or not self.response.headers:
+            # Need to check for response is None here since the __bool__ method checks 200 <= status < 400
+            return {}
+
+        return dict((k.lower(), v) for k, v in self.response.headers.items())

--- a/integration/single/test_basic_api.py
+++ b/integration/single/test_basic_api.py
@@ -2,7 +2,6 @@ import time
 from unittest.case import skipIf
 
 from integration.helpers.base_test import BaseTest
-import requests
 
 from integration.helpers.resource import current_region_does_not_support
 from integration.config.service_names import MODE
@@ -40,17 +39,17 @@ class TestBasicApi(BaseTest):
 
         stack_output = self.get_stack_outputs()
         api_endpoint = stack_output.get("ApiEndpoint")
-        response = requests.get(f"{api_endpoint}/get")
+        response = BaseTest.do_get_request_with_logging(f"{api_endpoint}/get")
         self.assertEqual(response.status_code, 200)
 
         # Removes get from the API
         self.update_and_verify_stack(file_path="single/basic_api_with_mode_update")
-        response = requests.get(f"{api_endpoint}/get")
+        response = BaseTest.do_get_request_with_logging(f"{api_endpoint}/get")
         # API Gateway by default returns 403 if a path do not exist
         retries = 20
         while retries > 0:
             retries -= 1
-            response = requests.get(f"{api_endpoint}/get")
+            response = BaseTest.do_get_request_with_logging(f"{api_endpoint}/get")
             if response.status_code != 500:
                 break
             time.sleep(5)

--- a/integration/single/test_basic_function.py
+++ b/integration/single/test_basic_function.py
@@ -1,7 +1,5 @@
 from unittest.case import skipIf
 
-import requests
-
 from integration.config.service_names import KMS, XRAY, ARM
 from integration.helpers.resource import current_region_does_not_support
 from parameterized import parameterized
@@ -42,7 +40,7 @@ class TestBasicFunction(BaseTest):
 
         endpoint = self.get_api_v2_endpoint("MyHttpApi")
 
-        self.assertEqual(requests.get(endpoint).text, self.FUNCTION_OUTPUT)
+        self.assertEqual(BaseTest.do_get_request_with_logging(endpoint).text, self.FUNCTION_OUTPUT)
 
     @parameterized.expand(
         [

--- a/integration/single/test_function_with_http_api_and_auth.py
+++ b/integration/single/test_function_with_http_api_and_auth.py
@@ -1,5 +1,3 @@
-import requests
-from parameterized import parameterized
 from integration.helpers.base_test import BaseTest
 
 
@@ -16,14 +14,22 @@ class TestFunctionWithHttpApiAndAuth(BaseTest):
         self.create_and_verify_stack("function_with_http_api_events_and_auth")
 
         implicitEndpoint = self.get_api_v2_endpoint("ServerlessHttpApi")
-        self.assertEqual(requests.get(implicitEndpoint + "/default-auth").text, self.FUNCTION_OUTPUT)
-        self.assertEqual(requests.get(implicitEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
+        self.assertEqual(
+            BaseTest.do_get_request_with_logging(implicitEndpoint + "/default-auth").text, self.FUNCTION_OUTPUT
+        )
+        self.assertEqual(BaseTest.do_get_request_with_logging(implicitEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
 
         defaultIamEndpoint = self.get_api_v2_endpoint("MyDefaultIamAuthHttpApi")
-        self.assertEqual(requests.get(defaultIamEndpoint + "/no-auth").text, self.FUNCTION_OUTPUT)
-        self.assertEqual(requests.get(defaultIamEndpoint + "/default-auth").text, IAM_AUTH_OUTPUT)
-        self.assertEqual(requests.get(defaultIamEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
+        self.assertEqual(
+            BaseTest.do_get_request_with_logging(defaultIamEndpoint + "/no-auth").text, self.FUNCTION_OUTPUT
+        )
+        self.assertEqual(
+            BaseTest.do_get_request_with_logging(defaultIamEndpoint + "/default-auth").text, IAM_AUTH_OUTPUT
+        )
+        self.assertEqual(BaseTest.do_get_request_with_logging(defaultIamEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
 
         iamEnabledEndpoint = self.get_api_v2_endpoint("MyIamAuthEnabledHttpApi")
-        self.assertEqual(requests.get(iamEnabledEndpoint + "/default-auth").text, self.FUNCTION_OUTPUT)
-        self.assertEqual(requests.get(iamEnabledEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
+        self.assertEqual(
+            BaseTest.do_get_request_with_logging(iamEnabledEndpoint + "/default-auth").text, self.FUNCTION_OUTPUT
+        )
+        self.assertEqual(BaseTest.do_get_request_with_logging(iamEnabledEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,5 @@ env =
     AWS_DEFAULT_REGION = ap-southeast-1
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
-
+log_cli = 1
+log_cli_level = INFO


### PR DESCRIPTION
*Description of changes:*

We've seen errors in APIGW requests before that we haven't been able to debug since we haven't logged the necessary request IDs. This PR adds some filtering to extract relevant headers for all requests to APIGW and log them to the console.

Unfortunately, since the `requests` and `urllib3` libraries don't use Python's logger module, we have to add some custom logic here to log the relevant headers.

Relevant link: https://stackoverflow.com/questions/16337511/log-all-requests-from-the-python-requests-module

*Checklist:*
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
