### PR TITLE
fix: wrap InvalidTemplateException's with InvalidDocumentException

### DIFF
--- a/samtranslator/plugins/sam_plugins.py
+++ b/samtranslator/plugins/sam_plugins.py
@@ -1,5 +1,5 @@
 import logging
-from samtranslator.model.exceptions import InvalidResourceException, InvalidDocumentException
+from samtranslator.model.exceptions import InvalidResourceException, InvalidDocumentException, InvalidTemplateException
 from samtranslator.plugins import BasePlugin, LifeCycleEvents
 
 LOG = logging.getLogger(__name__)
@@ -130,7 +130,7 @@ class SamPlugins(object):
 
             try:
                 getattr(plugin, method_name)(*args, **kwargs)
-            except (InvalidResourceException, InvalidDocumentException) as ex:
+            except (InvalidResourceException, InvalidDocumentException, InvalidTemplateException) as ex:
                 # Don't need to log these because they don't result in crashes
                 raise ex
             except Exception as ex:

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -16,6 +16,7 @@ from samtranslator.model.exceptions import (
     InvalidResourceException,
     DuplicateLogicalIdException,
     InvalidEventException,
+    InvalidTemplateException,
 )
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.intrinsics.actions import FindInMapAction
@@ -163,7 +164,7 @@ class Translator:
                         document_errors.append(
                             DuplicateLogicalIdException(logical_id, resource.logical_id, resource.resource_type)
                         )
-            except (InvalidResourceException, InvalidEventException) as e:
+            except (InvalidResourceException, InvalidEventException, InvalidTemplateException) as e:
                 document_errors.append(e)
 
         if deployment_preference_collection.any_enabled():
@@ -183,7 +184,7 @@ class Translator:
         # Run the after-transform plugin target
         try:
             sam_plugins.act(LifeCycleEvents.after_transform_template, template)
-        except (InvalidDocumentException, InvalidResourceException) as e:
+        except (InvalidDocumentException, InvalidResourceException, InvalidTemplateException) as e:
             document_errors.append(e)
 
         # Cleanup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
InvalidTemplateException would be unhandled before unless it was raised already wrapped with InvalidDocumentException (as we often do, e.g. in swagger.py). This should catch it and wrap it. 

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
