### PR TITLE
fix: raise InvalidEventException for incorrect Properties field usage for Api event type

### DIFF
--- a/samtranslator/plugins/api/implicit_http_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_http_api_plugin.py
@@ -58,7 +58,7 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
             # api_events only contains HttpApi events
             event_properties = event.get("Properties", {})
 
-            if event_properties and not isinstance(event_properties, dict):
+            if not isinstance(event_properties, dict):
                 raise InvalidEventException(
                     logicalId,
                     "Event 'Properties' must be an Object. If you're using YAML, this may be an indentation issue.",

--- a/tests/translator/input/error_function_api_invalid_properties.yaml
+++ b/tests/translator/input/error_function_api_invalid_properties.yaml
@@ -1,0 +1,21 @@
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.7
+      Handler: index.handler
+      CodeUri: s3://bucket/key
+      Events:
+        Api:
+          Type: HttpApi
+          Properties: ''
+  Function2:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.7
+      Handler: index.handler
+      CodeUri: s3://bucket/key
+      Events:
+        Api2:
+          Type: RestApi
+          Properties: ''

--- a/tests/translator/output/error_function_api_invalid_properties.json
+++ b/tests/translator/output/error_function_api_invalid_properties.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Function] is invalid. Event with id [Api] is invalid. Event 'Properties' must be an Object. If you're using YAML, this may be an indentation issue."
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fix validation for `Properties` field of `HttpApi` event source for Serverless Function.

*Description of how you validated changes:*
Tested with the case where `Properties` field would be an empty string, and added error test cases to cover that.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
