### PR TITLE
Update python3.6 runtime in integration test templates

### DIFF
--- a/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
@@ -12,7 +12,7 @@ Resources:
       InlineCode: |
         print("hello")
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.8
       Events:
         API3:
           Type: Api

--- a/integration/resources/templates/single/basic_api_with_mode.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.8
       AutoPublishAlias: live
       InlineCode: |
         import json

--- a/integration/resources/templates/single/basic_api_with_mode_update.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode_update.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.8
       AutoPublishAlias: live
       InlineCode: |
         def handler(event, context):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Upgrade Python3.6 runtime to Python3.8 in integration test templates, as Python3.6 runtime is being deprecated

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
