### PR TITLE
Update FURL integ test to test invoke

### DIFF
--- a/integration/single/test_basic_function.py
+++ b/integration/single/test_basic_function.py
@@ -98,6 +98,7 @@ class TestBasicFunction(BaseTest):
 
         self.assertEqual(function_url_config["AuthType"], "NONE")
         self.assertEqual(function_url_config["Cors"], cors_config)
+        self._assert_invoke(lambda_client, function_name, qualifier, 200)
 
     def test_function_with_deployment_preference_alarms_intrinsic_if(self):
         self.create_and_verify_stack("single/function_with_deployment_preference_alarms_intrinsic_if")
@@ -256,3 +257,28 @@ class TestBasicFunction(BaseTest):
         )
 
         self.assertEqual(function_configuration_result.get("EphemeralStorage", {}).get("Size", 0), 1024)
+
+    def _assert_invoke(self, lambda_client, function_name, qualifier=None, expected_status_code=200):
+        """
+        Assert if a Lambda invocation returns the expected status code
+
+        Parameters
+        ----------
+        lambda_client : boto3.BaseClient
+            boto3 Lambda client
+        function_name : string
+            Function name
+        qualifier : string
+            Specify a version or alias to invoke a published version of the function
+        expected_status_code : int
+            Expected status code from the invocation
+        """
+        request_params = {
+            "FunctionName": function_name,
+            "Payload": '{}',
+        }
+        if qualifier:
+            request_params["Qualifier"] = qualifier
+
+        response = lambda_client.invoke(**request_params)
+        self.assertEqual(response.get("StatusCode"), expected_status_code)

--- a/integration/single/test_basic_function.py
+++ b/integration/single/test_basic_function.py
@@ -275,7 +275,7 @@ class TestBasicFunction(BaseTest):
         """
         request_params = {
             "FunctionName": function_name,
-            "Payload": '{}',
+            "Payload": "{}",
         }
         if qualifier:
             request_params["Qualifier"] = qualifier

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ parameterized~=0.7.4
 # Integration tests
 click~=7.1
 dateparser~=0.7
-boto3~=1.17
+boto3>=1.23,<2
 
 # Requirements for examples
 requests~=2.24.0


### PR DESCRIPTION
*Issue #, if available:* 
N/A

*Description of changes:*
Update FURL integration test to test invoke the created Lambda Function

*Description of how you validated changes:*
Running the updated tests from my laptop

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
