### PR TITLE
test: Add tests for intrinsics support for DefinitionBody

### DIFF
--- a/tests/translator/input/definition_body_intrinsics_support.yaml
+++ b/tests/translator/input/definition_body_intrinsics_support.yaml
@@ -4,6 +4,8 @@ Description: >
   DefinitionBody currently only supports intrinsics when SwaggerEditor/OpenApiEditor is not used (as of 2022-05-30).
   Let's add tests to make sure we keep this support, because we've had a regression where we accidentally
   removed this intrinsics support by using the SwaggerEditor.
+  Note that the only supported intrinsic function for DefinitionBody is Fn::If. Other intrinsics are not supported
+  because they don't resolve to dictionary. 
 
 Conditions:
   FalseCondition:
@@ -77,25 +79,3 @@ Resources:
                       type: aws_proxy
                       uri: https://www.otheruri.co/
                       payloadFormatVersion: '1.0'
-
-  # Rest Api with DefinitionBody under Transform with AWS::Include, SwaggerEditor not used
-  RestApiAwsIncludeNoSwaggerEditor:
-    Type: AWS::Serverless::Api
-    Properties:
-      StageName: prod
-      DefinitionBody:
-        'Fn::Transform':
-          Name: AWS::Include
-          Parameters:
-            Location: s3://bucket/swagger.yaml
-
-  # HttpApi with DefinitionBody under Transform with AWS::Include, OpenApiEditor not used
-  HttpApiAwsIncludeAndNoOpenApiEditor:
-    Type: AWS::Serverless::HttpApi
-    Properties:
-      StageName: prod
-      DefinitionBody:
-        'Fn::Transform':
-          Name: AWS::Include
-          Parameters:
-            Location: s3://bucket/openapi.yaml

--- a/tests/translator/input/definition_body_intrinsics_support.yaml
+++ b/tests/translator/input/definition_body_intrinsics_support.yaml
@@ -1,0 +1,101 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  DefinitionBody currently only supports intrinsics when SwaggerEditor/OpenApiEditor is not used (as of 2022-05-30).
+  Let's add tests to make sure we keep this support, because we've had a regression where we accidentally
+  removed this intrinsics support by using the SwaggerEditor.
+
+Conditions:
+  FalseCondition:
+    Fn::Equals:
+      - true
+      - false
+
+Resources:
+  # Rest Api with DefinitionBody under If intrinsic, SwaggerEditor not used
+  RestApiIfIntrinsicAndNoSwaggerEditor:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      DefinitionBody:
+          Fn::If:
+            - FalseCondition
+            - 
+              swagger: '2.0'
+              info:
+                title: !Sub ${AWS::StackName}-Api
+              paths:
+                /post:
+                  post:
+                    x-amazon-apigateway-integration:
+                      httpMethod: POST
+                      type: aws_proxy
+                      uri: https://www.alphavantage.co/
+                      payloadFormatVersion: '1.0'
+            - 
+              swagger: '2.0'
+              info:
+                title: !Sub ${AWS::StackName}-Api
+              paths:
+                /post:
+                  post:
+                    x-amazon-apigateway-integration:
+                      httpMethod: POST
+                      type: aws_proxy
+                      uri: https://www.otheruri.co/
+                      payloadFormatVersion: '1.0'
+
+  # HttpApi with DefinitionBody under If intrinsic, OpenApiEditor not used
+  HttpApiIfIntrinsicAndNoOpenApiEditor:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: prod
+      DefinitionBody:
+          Fn::If:
+            - FalseCondition
+            - 
+              openapi: '3.0'
+              info:
+                title: !Sub ${AWS::StackName}-Api
+              paths:
+                /post:
+                  post:
+                    x-amazon-apigateway-integration:
+                      httpMethod: POST
+                      type: aws_proxy
+                      uri: https://www.alphavantage.co/
+                      payloadFormatVersion: '1.0'
+            - 
+              openapi: '3.0'
+              info:
+                title: !Sub ${AWS::StackName}-Api
+              paths:
+                /post:
+                  post:
+                    x-amazon-apigateway-integration:
+                      httpMethod: POST
+                      type: aws_proxy
+                      uri: https://www.otheruri.co/
+                      payloadFormatVersion: '1.0'
+
+  # Rest Api with DefinitionBody under Transform with AWS::Include, SwaggerEditor not used
+  RestApiAwsIncludeNoSwaggerEditor:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      DefinitionBody:
+        'Fn::Transform':
+          Name: AWS::Include
+          Parameters:
+            Location: s3://bucket/swagger.yaml
+
+  # HttpApi with DefinitionBody under Transform with AWS::Include, OpenApiEditor not used
+  HttpApiAwsIncludeAndNoOpenApiEditor:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: prod
+      DefinitionBody:
+        'Fn::Transform':
+          Name: AWS::Include
+          Parameters:
+            Location: s3://bucket/openapi.yaml

--- a/tests/translator/output/aws-cn/definition_body_intrinsics_support.json
+++ b/tests/translator/output/aws-cn/definition_body_intrinsics_support.json
@@ -1,0 +1,154 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "DefinitionBody currently only supports intrinsics when SwaggerEditor/OpenApiEditor is not used (as of 2022-05-30). Let's add tests to make sure we keep this support, because we've had a regression where we accidentally removed this intrinsics support by using the SwaggerEditor. Note that the only supported intrinsic function for DefinitionBody is Fn::If. Other intrinsics are not supported because they don't resolve to dictionary. \n",
+    "Conditions": {
+        "FalseCondition": {
+            "Fn::Equals": [
+                true,
+                false
+            ]
+        }
+    },
+    "Resources": {
+        "RestApiIfIntrinsicAndNoSwaggerEditorDeployment2f0411dccd": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: 2f0411dccde517dcb5c82d3848dbc431e7479ebc",
+                "RestApiId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditor"
+                },
+                "StageName": "Stage"
+            }
+        },
+        "RestApiIfIntrinsicAndNoSwaggerEditorprodStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditorDeployment2f0411dccd"
+                },
+                "RestApiId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditor"
+                },
+                "StageName": "prod"
+            }
+        },
+        "HttpApiIfIntrinsicAndNoOpenApiEditorprodStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "HttpApiIfIntrinsicAndNoOpenApiEditor"
+                },
+                "StageName": "prod",
+                "AutoDeploy": true
+            }
+        },
+        "RestApiIfIntrinsicAndNoSwaggerEditor": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "Fn::If": [
+                        "FalseCondition",
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.alphavantage.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "swagger": "2.0"
+                        },
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.otheruri.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "swagger": "2.0"
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "endpointConfigurationTypes": "REGIONAL"
+                },
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }
+        },
+        "HttpApiIfIntrinsicAndNoOpenApiEditor": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "Fn::If": [
+                        "FalseCondition",
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.alphavantage.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "openapi": "3.0"
+                        },
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.otheruri.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "openapi": "3.0"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tests/translator/output/aws-us-gov/definition_body_intrinsics_support.json
+++ b/tests/translator/output/aws-us-gov/definition_body_intrinsics_support.json
@@ -1,0 +1,154 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "DefinitionBody currently only supports intrinsics when SwaggerEditor/OpenApiEditor is not used (as of 2022-05-30). Let's add tests to make sure we keep this support, because we've had a regression where we accidentally removed this intrinsics support by using the SwaggerEditor. Note that the only supported intrinsic function for DefinitionBody is Fn::If. Other intrinsics are not supported because they don't resolve to dictionary. \n",
+    "Conditions": {
+        "FalseCondition": {
+            "Fn::Equals": [
+                true,
+                false
+            ]
+        }
+    },
+    "Resources": {
+        "RestApiIfIntrinsicAndNoSwaggerEditorDeployment2f0411dccd": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: 2f0411dccde517dcb5c82d3848dbc431e7479ebc",
+                "RestApiId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditor"
+                },
+                "StageName": "Stage"
+            }
+        },
+        "RestApiIfIntrinsicAndNoSwaggerEditorprodStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditorDeployment2f0411dccd"
+                },
+                "RestApiId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditor"
+                },
+                "StageName": "prod"
+            }
+        },
+        "HttpApiIfIntrinsicAndNoOpenApiEditorprodStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "HttpApiIfIntrinsicAndNoOpenApiEditor"
+                },
+                "StageName": "prod",
+                "AutoDeploy": true
+            }
+        },
+        "RestApiIfIntrinsicAndNoSwaggerEditor": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "Fn::If": [
+                        "FalseCondition",
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.alphavantage.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "swagger": "2.0"
+                        },
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.otheruri.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "swagger": "2.0"
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "endpointConfigurationTypes": "REGIONAL"
+                },
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }
+        },
+        "HttpApiIfIntrinsicAndNoOpenApiEditor": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "Fn::If": [
+                        "FalseCondition",
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.alphavantage.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "openapi": "3.0"
+                        },
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.otheruri.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "openapi": "3.0"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tests/translator/output/definition_body_intrinsics_support.json
+++ b/tests/translator/output/definition_body_intrinsics_support.json
@@ -1,0 +1,146 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "DefinitionBody currently only supports intrinsics when SwaggerEditor/OpenApiEditor is not used (as of 2022-05-30). Let's add tests to make sure we keep this support, because we've had a regression where we accidentally removed this intrinsics support by using the SwaggerEditor. Note that the only supported intrinsic function for DefinitionBody is Fn::If. Other intrinsics are not supported because they don't resolve to dictionary. \n",
+    "Conditions": {
+        "FalseCondition": {
+            "Fn::Equals": [
+                true,
+                false
+            ]
+        }
+    },
+    "Resources": {
+        "RestApiIfIntrinsicAndNoSwaggerEditorDeployment2f0411dccd": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: 2f0411dccde517dcb5c82d3848dbc431e7479ebc",
+                "RestApiId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditor"
+                },
+                "StageName": "Stage"
+            }
+        },
+        "RestApiIfIntrinsicAndNoSwaggerEditorprodStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditorDeployment2f0411dccd"
+                },
+                "RestApiId": {
+                    "Ref": "RestApiIfIntrinsicAndNoSwaggerEditor"
+                },
+                "StageName": "prod"
+            }
+        },
+        "HttpApiIfIntrinsicAndNoOpenApiEditorprodStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "HttpApiIfIntrinsicAndNoOpenApiEditor"
+                },
+                "StageName": "prod",
+                "AutoDeploy": true
+            }
+        },
+        "RestApiIfIntrinsicAndNoSwaggerEditor": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "Fn::If": [
+                        "FalseCondition",
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.alphavantage.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "swagger": "2.0"
+                        },
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.otheruri.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "swagger": "2.0"
+                        }
+                    ]
+                }
+            }
+        },
+        "HttpApiIfIntrinsicAndNoOpenApiEditor": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "Fn::If": [
+                        "FalseCondition",
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.alphavantage.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "openapi": "3.0"
+                        },
+                        {
+                            "info": {
+                                "title": {
+                                    "Fn::Sub": "${AWS::StackName}-Api"
+                                }
+                            },
+                            "paths": {
+                                "/post": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": "https://www.otheruri.co/",
+                                            "payloadFormatVersion": "1.0"
+                                        }
+                                    }
+                                }
+                            },
+                            "openapi": "3.0"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -484,6 +484,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "function_with_function_url_config_with_iam_authorization_type",
                 "function_with_function_url_config_without_cors_config",
                 "function_with_function_url_config_and_autopublishalias",
+                "definition_body_intrinsics_support",
             ],
             [
                 ("aws", "ap-southeast-1"),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding missing end-to-end test to make sure we keep supporting intrinsics where we currently support them in DefinitionBody.

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [x] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
