### PR TITLE
Fix route53 record set groups

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -22,7 +22,7 @@ from samtranslator.region_configuration import RegionConfiguration
 from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.model.intrinsics import is_intrinsic, fnSub
 from samtranslator.model.lambda_ import LambdaPermission
-from samtranslator.translator import logical_id_generator
+from samtranslator.translator.logical_id_generator import LogicalIdGenerator
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.model.tags.resource_tagging import get_tag_list
 from samtranslator.utils.py27hash_fix import Py27Dict, Py27UniStr
@@ -388,7 +388,7 @@ class ApiGenerator(object):
         if stage_name_prefix.isalnum():
             stage_logical_id = self.logical_id + stage_name_prefix + "Stage"
         else:
-            generator = logical_id_generator.LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)
+            generator = LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)
             stage_logical_id = generator.gen()
         stage = ApiGatewayStage(stage_logical_id, attributes=self.passthrough_resource_attributes)
         stage.RestApiId = ref(self.logical_id)
@@ -425,7 +425,7 @@ class ApiGenerator(object):
             )
 
         self.domain["ApiDomainName"] = "{}{}".format(
-            "ApiGatewayDomainName", logical_id_generator.LogicalIdGenerator("", self.domain.get("DomainName")).gen()
+            "ApiGatewayDomainName", LogicalIdGenerator("", self.domain.get("DomainName")).gen()
         )
 
         domain = ApiGatewayDomainName(self.domain.get("ApiDomainName"), attributes=self.passthrough_resource_attributes)
@@ -529,12 +529,11 @@ class ApiGenerator(object):
                     self.logical_id,
                     "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
                 )
-            logical_id = (
-                "RecordSetGroup"
-                + logical_id_generator.LogicalIdGenerator(
-                    "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
-                ).gen()
-            )
+
+            logical_id_suffix = LogicalIdGenerator(
+                "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
+            ).gen()
+            logical_id = "RecordSetGroup" + logical_id_suffix
 
             record_set_group = route53_record_set_groups.get(logical_id)
             if not record_set_group:

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -13,7 +13,7 @@ from samtranslator.model.apigatewayv2 import (
 from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.model.s3_utils.uri_parser import parse_s3_uri
 from samtranslator.open_api.open_api import OpenApiEditor
-from samtranslator.translator import logical_id_generator
+from samtranslator.translator.logical_id_generator import LogicalIdGenerator
 from samtranslator.model.tags.resource_tagging import get_tag_list
 from samtranslator.model.intrinsics import is_intrinsic, is_intrinsic_no_value
 from samtranslator.model.route53 import Route53RecordSetGroup
@@ -231,7 +231,7 @@ class HttpApiGenerator(object):
             )
 
         self.domain["ApiDomainName"] = "{}{}".format(
-            "ApiGatewayDomainNameV2", logical_id_generator.LogicalIdGenerator("", self.domain.get("DomainName")).gen()
+            "ApiGatewayDomainNameV2", LogicalIdGenerator("", self.domain.get("DomainName")).gen()
         )
 
         domain = ApiGatewayV2DomainName(
@@ -321,12 +321,9 @@ class HttpApiGenerator(object):
                 self.logical_id,
                 "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
             )
-        logical_id = (
-            "RecordSetGroup"
-            + logical_id_generator.LogicalIdGenerator(
-                "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
-            ).gen()
-        )
+
+        logical_id_suffix = LogicalIdGenerator("", route53.get("HostedZoneId") or route53.get("HostedZoneName")).gen()
+        logical_id = "RecordSetGroup" + logical_id_suffix
 
         record_set_group = route53_record_set_groups.get(logical_id)
         if not record_set_group:
@@ -604,7 +601,7 @@ class HttpApiGenerator(object):
         elif stage_name_prefix == DefaultStageName:
             stage_logical_id = self.logical_id + "ApiGatewayDefaultStage"
         else:
-            generator = logical_id_generator.LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)
+            generator = LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)
             stage_logical_id = generator.gen()
         stage = ApiGatewayV2Stage(stage_logical_id, attributes=self.passthrough_resource_attributes)
         stage.ApiId = ref(self.logical_id)

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1106,6 +1106,7 @@ class SamApi(SamResourceMacro):
         redeploy_restapi_parameters = kwargs.get("redeploy_restapi_parameters")
         shared_api_usage_plan = kwargs.get("shared_api_usage_plan")
         template_conditions = kwargs.get("conditions")
+        route53_record_set_groups = kwargs.get("route53_record_set_groups", {})
 
         api_generator = ApiGenerator(
             self.logical_id,
@@ -1150,7 +1151,7 @@ class SamApi(SamResourceMacro):
             basepath_mapping,
             route53,
             usage_plan_resources,
-        ) = api_generator.to_cloudformation(redeploy_restapi_parameters)
+        ) = api_generator.to_cloudformation(redeploy_restapi_parameters, route53_record_set_groups)
 
         resources.extend([rest_api, deployment, stage])
         resources.extend(permissions)

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1211,8 +1211,6 @@ class SamHttpApi(SamResourceMacro):
         resources = []
         intrinsics_resolver = kwargs["intrinsics_resolver"]
         self.CorsConfiguration = intrinsics_resolver.resolve_parameter_refs(self.CorsConfiguration)
-
-        intrinsics_resolver = kwargs["intrinsics_resolver"]
         self.Domain = intrinsics_resolver.resolve_parameter_refs(self.Domain)
 
         api_generator = HttpApiGenerator(
@@ -1242,7 +1240,7 @@ class SamHttpApi(SamResourceMacro):
             domain,
             basepath_mapping,
             route53,
-        ) = api_generator.to_cloudformation()
+        ) = api_generator.to_cloudformation(kwargs.get("route53_record_set_groups", {}))
 
         resources.append(http_api)
         if domain:

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -125,6 +125,7 @@ class Translator:
         shared_api_usage_plan = SharedApiUsagePlan()
         document_errors = []
         changed_logical_ids = {}
+        route53_record_set_groups = {}
         for logical_id, resource_dict in self._get_resources_to_iterate(sam_template, macro_resolver):
             try:
                 macro = macro_resolver.resolve_resource_type(resource_dict).from_dict(
@@ -144,6 +145,7 @@ class Translator:
                 kwargs["redeploy_restapi_parameters"] = self.redeploy_restapi_parameters
                 kwargs["shared_api_usage_plan"] = shared_api_usage_plan
                 kwargs["feature_toggle"] = self.feature_toggle
+                kwargs["route53_record_set_groups"] = route53_record_set_groups
                 translated = macro.to_cloudformation(**kwargs)
 
                 supported_resource_refs = macro.get_resource_references(translated, supported_resource_refs)

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -216,11 +216,14 @@ class TestCustomDomains(TestCase):
         "passthrough_resource_attributes": None,
         "domain": None,
     }
+    route53_record_set_groups = {}
 
     def test_no_domain(self):
         self.kwargs["domain"] = None
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
-        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(
+            http_api, self.route53_record_set_groups
+        )
         self.assertIsNone(domain)
         self.assertIsNone(basepath)
         self.assertIsNone(route)
@@ -229,7 +232,7 @@ class TestCustomDomains(TestCase):
         self.kwargs["domain"] = {"CertificateArn": "someurl"}
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
         with pytest.raises(InvalidResourceException) as e:
-            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api, self.route53_record_set_groups)
         self.assertEqual(
             e.value.message,
             "Resource with id [HttpApiId] is invalid. "
@@ -240,7 +243,7 @@ class TestCustomDomains(TestCase):
         self.kwargs["domain"] = {"DomainName": "example.com"}
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
         with pytest.raises(InvalidResourceException) as e:
-            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api, self.route53_record_set_groups)
         self.assertEqual(
             e.value.message,
             "Resource with id [HttpApiId] is invalid. "
@@ -250,7 +253,9 @@ class TestCustomDomains(TestCase):
     def test_basic_domain_default_endpoint(self):
         self.kwargs["domain"] = {"DomainName": "example.com", "CertificateArn": "some-url"}
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
-        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(
+            http_api, self.route53_record_set_groups
+        )
         self.assertIsNotNone(domain, None)
         self.assertIsNotNone(basepath, None)
         self.assertEqual(len(basepath), 1)
@@ -264,7 +269,9 @@ class TestCustomDomains(TestCase):
             "EndpointConfiguration": "REGIONAL",
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
-        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(
+            http_api, self.route53_record_set_groups
+        )
         self.assertIsNotNone(domain, None)
         self.assertIsNotNone(basepath, None)
         self.assertEqual(len(basepath), 1)
@@ -279,7 +286,7 @@ class TestCustomDomains(TestCase):
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
         with pytest.raises(InvalidResourceException) as e:
-            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api, self.route53_record_set_groups)
         self.assertEqual(
             e.value.message,
             "Resource with id [HttpApiId] is invalid. EndpointConfiguration for Custom Domains must be one of ['REGIONAL'].",
@@ -293,7 +300,7 @@ class TestCustomDomains(TestCase):
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
         with pytest.raises(InvalidResourceException) as e:
-            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api, self.route53_record_set_groups)
         self.assertEqual(
             e.value.message,
             "Resource with id [HttpApiId] is invalid. "
@@ -307,7 +314,9 @@ class TestCustomDomains(TestCase):
             "Route53": {"HostedZoneId": "xyz"},
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
-        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(
+            http_api, self.route53_record_set_groups
+        )
         self.assertIsNotNone(domain, None)
         self.assertIsNotNone(basepath, None)
         self.assertEqual(len(basepath), 1)
@@ -322,7 +331,9 @@ class TestCustomDomains(TestCase):
             "Route53": {"HostedZoneId": "xyz"},
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
-        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(
+            http_api, self.route53_record_set_groups
+        )
         self.assertIsNotNone(domain, None)
         self.assertIsNotNone(basepath, None)
         self.assertEqual(len(basepath), 3)
@@ -338,7 +349,7 @@ class TestCustomDomains(TestCase):
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
         with pytest.raises(InvalidResourceException) as e:
-            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+            HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api, self.route53_record_set_groups)
         self.assertEqual(
             e.value.message, "Resource with id [HttpApiId] is invalid. " + "Invalid Basepath name provided."
         )
@@ -351,7 +362,9 @@ class TestCustomDomains(TestCase):
             "Route53": {"HostedZoneId": "xyz", "HostedZoneName": "abc", "IpV6": True},
         }
         http_api = HttpApiGenerator(**self.kwargs)._construct_http_api()
-        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(http_api)
+        domain, basepath, route = HttpApiGenerator(**self.kwargs)._construct_api_domain(
+            http_api, self.route53_record_set_groups
+        )
         self.assertIsNotNone(domain, None)
         self.assertIsNotNone(basepath, None)
         self.assertEqual(len(basepath), 8)

--- a/tests/translator/input/api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_multiple.yaml
@@ -1,0 +1,67 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  apigateway-2402
+
+  Sample SAM Template for apigateway-2402
+
+Resources:
+            
+  ApiGatewayAdminOne:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: App-Prod-Web
+      StageName: Prod
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: Info
+          ResourcePath: '/*'
+          HttpMethod: '*'
+      Domain:
+        DomainName: admin.one.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: "abc123456"
+      EndpointConfiguration:
+        Type: REGIONAL
+
+            
+  ApiGatewayAdminTwo:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: App-Prod-Web
+      StageName: Prod
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: Info
+          ResourcePath: '/*'
+          HttpMethod: '*'
+      Domain:
+        DomainName: admin.two.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: "abc123456"
+      EndpointConfiguration:
+        Type: REGIONAL
+        
+            
+  ApiGatewayAdminThree:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: App-Prod-Web
+      StageName: Prod
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: Info
+          ResourcePath: '/*'
+          HttpMethod: '*'
+      Domain:
+        DomainName: admin.three.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: "abc123456"
+      EndpointConfiguration:
+        Type: REGIONAL

--- a/tests/translator/input/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.yaml
@@ -1,0 +1,71 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  apigateway-2402
+
+  Sample SAM Template for apigateway-2402
+
+Parameters:
+  MyHostedZoneId:
+    Type: String
+
+Resources:
+            
+  ApiGatewayAdminOne:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: App-Prod-Web
+      StageName: Prod
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: Info
+          ResourcePath: '/*'
+          HttpMethod: '*'
+      Domain:
+        DomainName: admin.one.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: !Ref MyHostedZoneId
+      EndpointConfiguration:
+        Type: REGIONAL
+
+            
+  ApiGatewayAdminTwo:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: App-Prod-Web
+      StageName: Prod
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: Info
+          ResourcePath: '/*'
+          HttpMethod: '*'
+      Domain:
+        DomainName: admin.two.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: !Sub "{{MyHostedZoneId}}"
+      EndpointConfiguration:
+        Type: REGIONAL
+        
+            
+  ApiGatewayAdminThree:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: App-Prod-Web
+      StageName: Prod
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: Info
+          ResourcePath: '/*'
+          HttpMethod: '*'
+      Domain:
+        DomainName: admin.three.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: !Ref MyHostedZoneId
+      EndpointConfiguration:
+        Type: REGIONAL

--- a/tests/translator/input/http_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/http_api_with_custom_domain_route53_multiple.yaml
@@ -1,0 +1,32 @@
+# This test-case tests what happens when an AWS_IAM authorizer is defined on an HttpApi and also enabled locally.
+# In this case the defined authorizer should NOT be overwritten.
+Resources:
+  MyApi1:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Domain:
+        DomainName: admin.one.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: "abc123456"
+
+  MyApi2:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Domain:
+        DomainName: admin.two.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: "abc123456"
+
+  MyApi3:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Domain:
+        DomainName: admin.three.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: "abc123456"

--- a/tests/translator/input/http_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/http_api_with_custom_domain_route53_multiple.yaml
@@ -1,5 +1,3 @@
-# This test-case tests what happens when an AWS_IAM authorizer is defined on an HttpApi and also enabled locally.
-# In this case the defined authorizer should NOT be overwritten.
 Resources:
   MyApi1:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/mixed_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/mixed_api_with_custom_domain_route53_multiple.yaml
@@ -27,7 +27,7 @@ Resources:
           ResourcePath: '/*'
           HttpMethod: '*'
       Domain:
-        DomainName: admin.one.amazon.com
+        DomainName: admin.two.amazon.com
         CertificateArn: arn::cert::abc
         EndpointConfiguration: REGIONAL
         Route53:

--- a/tests/translator/input/mixed_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/mixed_api_with_custom_domain_route53_multiple.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  apigateway-2402
+
+  Sample SAM Template for apigateway-2402
+
+Resources:
+  MyHttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Domain:
+        DomainName: admin.one.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: "abc123456"
+
+  MyRestApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: App-Prod-Web
+      StageName: Prod
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: Info
+          ResourcePath: '/*'
+          HttpMethod: '*'
+      Domain:
+        DomainName: admin.one.amazon.com
+        CertificateArn: arn::cert::abc
+        EndpointConfiguration: REGIONAL
+        Route53:
+          HostedZoneId: "abc123456"
+      EndpointConfiguration:
+        Type: REGIONAL

--- a/tests/translator/output/api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,308 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+  "Resources": {
+    "ApiGatewayAdminTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminTwoDeployment61887a4eed"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOneBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName5fe29fe649"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminOneProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminThreeDeployment7541e97159": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 7541e971598cffe7cafab030d3fccc687d508f59",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminOneDeploymentdd3f545183": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayDomainName3fd2dbd8f8": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.two.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminTwoDeployment61887a4eed": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName5fe29fe649": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.one.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminTwoBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminTwoProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName41bfc7f9c4": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.three.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminThreeDeployment7541e97159"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminThreeBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName41bfc7f9c4"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminThreeProdStage"
+        }
+      }
+    },
+    "RecordSetGroup370194ff6e": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": "abc123456",
+        "RecordSets": [
+          {
+            "Name": "admin.two.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.three.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.one.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
+++ b/tests/translator/output/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
@@ -1,0 +1,325 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+  "Parameters": {
+    "MyHostedZoneId": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "RecordSetGroupd9cb5a3e02": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": {
+          "Fn::Sub": "{{MyHostedZoneId}}"
+        },
+        "RecordSets": [
+          {
+            "Name": "admin.two.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminTwoDeploymentca2a75b5dd"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayDomainName5fe29fe649": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.one.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminOneDeployment066bb1ceae"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayDomainName3fd2dbd8f8": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.two.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName41bfc7f9c4"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminThreeProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminOneBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName5fe29fe649"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminOneProdStage"
+        }
+      }
+    },
+    "RecordSetGroupd28e0e19d0": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": {
+          "Ref": "MyHostedZoneId"
+        },
+        "RecordSets": [
+          {
+            "Name": "admin.three.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.one.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOneDeployment066bb1ceae": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 066bb1ceaebd0cafae99258bbe7130af8b676372",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminTwoBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminTwoProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName41bfc7f9c4": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.three.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminThreeDeployment169349c1e9"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminTwoDeploymentca2a75b5dd": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: ca2a75b5dd3713c71543e80f2b6f5aac9538ea9c",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeDeployment169349c1e9": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 169349c1e96a0f130ee35f7bb9d83b042c386d6f",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,308 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+  "Resources": {
+    "ApiGatewayAdminTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminTwoDeployment61887a4eed"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOneBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName5fe29fe649"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminOneProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminThreeDeployment7541e97159": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 7541e971598cffe7cafab030d3fccc687d508f59",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminOneDeploymentdd3f545183": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayDomainName3fd2dbd8f8": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.two.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminTwoDeployment61887a4eed": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName5fe29fe649": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.one.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminTwoBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminTwoProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName41bfc7f9c4": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.three.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminThreeDeployment7541e97159"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminThreeBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName41bfc7f9c4"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminThreeProdStage"
+        }
+      }
+    },
+    "RecordSetGroup370194ff6e": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": "abc123456",
+        "RecordSets": [
+          {
+            "Name": "admin.two.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.three.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.one.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
@@ -1,0 +1,325 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+  "Parameters": {
+    "MyHostedZoneId": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "RecordSetGroupd9cb5a3e02": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": {
+          "Fn::Sub": "{{MyHostedZoneId}}"
+        },
+        "RecordSets": [
+          {
+            "Name": "admin.two.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminTwoDeploymentca2a75b5dd"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayDomainName5fe29fe649": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.one.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminOneDeployment066bb1ceae"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayDomainName3fd2dbd8f8": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.two.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName41bfc7f9c4"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminThreeProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminOneBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName5fe29fe649"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminOneProdStage"
+        }
+      }
+    },
+    "RecordSetGroupd28e0e19d0": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": {
+          "Ref": "MyHostedZoneId"
+        },
+        "RecordSets": [
+          {
+            "Name": "admin.three.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.one.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOneDeployment066bb1ceae": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 066bb1ceaebd0cafae99258bbe7130af8b676372",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminTwoBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminTwoProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName41bfc7f9c4": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.three.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminThreeDeployment169349c1e9"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminTwoDeploymentca2a75b5dd": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: ca2a75b5dd3713c71543e80f2b6f5aac9538ea9c",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeDeployment169349c1e9": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 169349c1e96a0f130ee35f7bb9d83b042c386d6f",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/http_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-cn/http_api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,255 @@
+{
+    "Resources": {
+        "MyApi1": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV25fe29fe649": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.one.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi1ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi1"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV25fe29fe649"
+                },
+                "Stage": {
+                    "Ref": "MyApi1ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "RecordSetGroup370194ff6e": {
+            "Type": "AWS::Route53::RecordSetGroup",
+            "Properties": {
+                "HostedZoneId": "abc123456",
+                "RecordSets": [
+                    {
+                        "Name": "admin.one.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.two.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV23fd2dbd8f8",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV23fd2dbd8f8",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.three.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV241bfc7f9c4",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV241bfc7f9c4",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "MyApi1ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi1"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyApi2": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV23fd2dbd8f8": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.two.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi2ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi2"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV23fd2dbd8f8"
+                },
+                "Stage": {
+                    "Ref": "MyApi2ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyApi2ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi2"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyApi3": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV241bfc7f9c4": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.three.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi3ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi3"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV241bfc7f9c4"
+                },
+                "Stage": {
+                    "Ref": "MyApi3ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyApi3ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi3"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        }
+    }
+}

--- a/tests/translator/output/aws-cn/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-cn/mixed_api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,193 @@
+{
+ "AWSTemplateFormatVersion": "2010-09-09",
+ "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+ "Resources": {
+  "MyRestApi": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Body": {
+     "info": {
+      "version": "1.0",
+      "title": {
+       "Ref": "AWS::StackName"
+      }
+     },
+     "paths": {},
+     "swagger": "2.0"
+    },
+    "Name": "App-Prod-Web",
+    "Parameters": {
+     "endpointConfigurationTypes": "REGIONAL"
+    },
+    "EndpointConfiguration": {
+     "Types": [
+      "REGIONAL"
+     ]
+    }
+   }
+  },
+  "MyHttpApiApiMapping": {
+   "Type": "AWS::ApiGatewayV2::ApiMapping",
+   "Properties": {
+    "ApiId": {
+     "Ref": "MyHttpApi"
+    },
+    "DomainName": {
+     "Ref": "ApiGatewayDomainNameV25fe29fe649"
+    },
+    "Stage": {
+     "Ref": "MyHttpApiApiGatewayDefaultStage"
+    }
+   }
+  },
+  "ApiGatewayDomainName5fe29fe649": {
+   "Type": "AWS::ApiGateway::DomainName",
+   "Properties": {
+    "RegionalCertificateArn": "arn::cert::abc",
+    "DomainName": "admin.one.amazon.com",
+    "EndpointConfiguration": {
+     "Types": [
+      "REGIONAL"
+     ]
+    }
+   }
+  },
+  "MyRestApiDeploymentdd3f545183": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "StageName": "Stage"
+   }
+  },
+  "ApiGatewayDomainNameV25fe29fe649": {
+   "Type": "AWS::ApiGatewayV2::DomainName",
+   "Properties": {
+    "DomainName": "admin.one.amazon.com",
+    "DomainNameConfigurations": [
+     {
+      "EndpointType": "REGIONAL",
+      "CertificateArn": "arn::cert::abc"
+     }
+    ],
+    "Tags": {
+     "httpapi:createdBy": "SAM"
+    }
+   }
+  },
+  "MyHttpApi": {
+   "Type": "AWS::ApiGatewayV2::Api",
+   "Properties": {
+    "Body": {
+     "info": {
+      "version": "1.0",
+      "title": {
+       "Ref": "AWS::StackName"
+      }
+     },
+     "paths": {},
+     "openapi": "3.0.1",
+     "tags": [
+      {
+       "name": "httpapi:createdBy",
+       "x-amazon-apigateway-tag-value": "SAM"
+      }
+     ]
+    }
+   }
+  },
+  "MyHttpApiApiGatewayDefaultStage": {
+   "Type": "AWS::ApiGatewayV2::Stage",
+   "Properties": {
+    "ApiId": {
+     "Ref": "MyHttpApi"
+    },
+    "StageName": "$default",
+    "Tags": {
+     "httpapi:createdBy": "SAM"
+    },
+    "AutoDeploy": true
+   }
+  },
+  "MyRestApiProdStage": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "DeploymentId": {
+     "Ref": "MyRestApiDeploymentdd3f545183"
+    },
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "StageName": "Prod",
+    "TracingEnabled": true,
+    "MethodSettings": [
+     {
+      "HttpMethod": "*",
+      "ResourcePath": "/*",
+      "LoggingLevel": "Info"
+     }
+    ]
+   }
+  },
+  "MyRestApiBasePathMapping": {
+   "Type": "AWS::ApiGateway::BasePathMapping",
+   "Properties": {
+    "DomainName": {
+     "Ref": "ApiGatewayDomainName5fe29fe649"
+    },
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "Stage": {
+     "Ref": "MyRestApiProdStage"
+    }
+   }
+  },
+  "RecordSetGroup370194ff6e": {
+   "Type": "AWS::Route53::RecordSetGroup",
+   "Properties": {
+    "HostedZoneId": "abc123456",
+    "RecordSets": [
+     {
+      "Name": "admin.one.amazon.com",
+      "Type": "A",
+      "AliasTarget": {
+       "HostedZoneId": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainName5fe29fe649",
+         "RegionalHostedZoneId"
+        ]
+       },
+       "DNSName": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainName5fe29fe649",
+         "RegionalDomainName"
+        ]
+       }
+      }
+     },
+     {
+      "Name": "admin.one.amazon.com",
+      "Type": "A",
+      "AliasTarget": {
+       "HostedZoneId": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainNameV25fe29fe649",
+         "RegionalHostedZoneId"
+        ]
+       },
+       "DNSName": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainNameV25fe29fe649",
+         "RegionalDomainName"
+        ]
+       }
+      }
+     }
+    ]
+   }
+  }
+ }
+}

--- a/tests/translator/output/aws-cn/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-cn/mixed_api_with_custom_domain_route53_multiple.json
@@ -1,193 +1,193 @@
 {
- "AWSTemplateFormatVersion": "2010-09-09",
- "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
- "Resources": {
-  "MyRestApi": {
-   "Type": "AWS::ApiGateway::RestApi",
-   "Properties": {
-    "Body": {
-     "info": {
-      "version": "1.0",
-      "title": {
-       "Ref": "AWS::StackName"
-      }
-     },
-     "paths": {},
-     "swagger": "2.0"
-    },
-    "Name": "App-Prod-Web",
-    "Parameters": {
-     "endpointConfigurationTypes": "REGIONAL"
-    },
-    "EndpointConfiguration": {
-     "Types": [
-      "REGIONAL"
-     ]
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+    "Resources": {
+        "MyRestApi": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "swagger": "2.0"
+                },
+                "Name": "App-Prod-Web",
+                "Parameters": {
+                    "endpointConfigurationTypes": "REGIONAL"
+                },
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }
+        },
+        "MyHttpApiApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyHttpApi"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV25fe29fe649"
+                },
+                "Stage": {
+                    "Ref": "MyHttpApiApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyRestApiDeployment61887a4eed": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "StageName": "Stage"
+            }
+        },
+        "ApiGatewayDomainName3fd2dbd8f8": {
+            "Type": "AWS::ApiGateway::DomainName",
+            "Properties": {
+                "RegionalCertificateArn": "arn::cert::abc",
+                "DomainName": "admin.two.amazon.com",
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV25fe29fe649": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.one.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyHttpApi": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "MyHttpApiApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyHttpApi"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyRestApiProdStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "MyRestApiDeployment61887a4eed"
+                },
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "StageName": "Prod",
+                "TracingEnabled": true,
+                "MethodSettings": [
+                    {
+                        "HttpMethod": "*",
+                        "ResourcePath": "/*",
+                        "LoggingLevel": "Info"
+                    }
+                ]
+            }
+        },
+        "MyRestApiBasePathMapping": {
+            "Type": "AWS::ApiGateway::BasePathMapping",
+            "Properties": {
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+                },
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "Stage": {
+                    "Ref": "MyRestApiProdStage"
+                }
+            }
+        },
+        "RecordSetGroup370194ff6e": {
+            "Type": "AWS::Route53::RecordSetGroup",
+            "Properties": {
+                "HostedZoneId": "abc123456",
+                "RecordSets": [
+                    {
+                        "Name": "admin.two.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainName3fd2dbd8f8",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainName3fd2dbd8f8",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.one.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        }
     }
-   }
-  },
-  "MyHttpApiApiMapping": {
-   "Type": "AWS::ApiGatewayV2::ApiMapping",
-   "Properties": {
-    "ApiId": {
-     "Ref": "MyHttpApi"
-    },
-    "DomainName": {
-     "Ref": "ApiGatewayDomainNameV25fe29fe649"
-    },
-    "Stage": {
-     "Ref": "MyHttpApiApiGatewayDefaultStage"
-    }
-   }
-  },
-  "ApiGatewayDomainName5fe29fe649": {
-   "Type": "AWS::ApiGateway::DomainName",
-   "Properties": {
-    "RegionalCertificateArn": "arn::cert::abc",
-    "DomainName": "admin.one.amazon.com",
-    "EndpointConfiguration": {
-     "Types": [
-      "REGIONAL"
-     ]
-    }
-   }
-  },
-  "MyRestApiDeploymentdd3f545183": {
-   "Type": "AWS::ApiGateway::Deployment",
-   "Properties": {
-    "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "StageName": "Stage"
-   }
-  },
-  "ApiGatewayDomainNameV25fe29fe649": {
-   "Type": "AWS::ApiGatewayV2::DomainName",
-   "Properties": {
-    "DomainName": "admin.one.amazon.com",
-    "DomainNameConfigurations": [
-     {
-      "EndpointType": "REGIONAL",
-      "CertificateArn": "arn::cert::abc"
-     }
-    ],
-    "Tags": {
-     "httpapi:createdBy": "SAM"
-    }
-   }
-  },
-  "MyHttpApi": {
-   "Type": "AWS::ApiGatewayV2::Api",
-   "Properties": {
-    "Body": {
-     "info": {
-      "version": "1.0",
-      "title": {
-       "Ref": "AWS::StackName"
-      }
-     },
-     "paths": {},
-     "openapi": "3.0.1",
-     "tags": [
-      {
-       "name": "httpapi:createdBy",
-       "x-amazon-apigateway-tag-value": "SAM"
-      }
-     ]
-    }
-   }
-  },
-  "MyHttpApiApiGatewayDefaultStage": {
-   "Type": "AWS::ApiGatewayV2::Stage",
-   "Properties": {
-    "ApiId": {
-     "Ref": "MyHttpApi"
-    },
-    "StageName": "$default",
-    "Tags": {
-     "httpapi:createdBy": "SAM"
-    },
-    "AutoDeploy": true
-   }
-  },
-  "MyRestApiProdStage": {
-   "Type": "AWS::ApiGateway::Stage",
-   "Properties": {
-    "DeploymentId": {
-     "Ref": "MyRestApiDeploymentdd3f545183"
-    },
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "StageName": "Prod",
-    "TracingEnabled": true,
-    "MethodSettings": [
-     {
-      "HttpMethod": "*",
-      "ResourcePath": "/*",
-      "LoggingLevel": "Info"
-     }
-    ]
-   }
-  },
-  "MyRestApiBasePathMapping": {
-   "Type": "AWS::ApiGateway::BasePathMapping",
-   "Properties": {
-    "DomainName": {
-     "Ref": "ApiGatewayDomainName5fe29fe649"
-    },
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "Stage": {
-     "Ref": "MyRestApiProdStage"
-    }
-   }
-  },
-  "RecordSetGroup370194ff6e": {
-   "Type": "AWS::Route53::RecordSetGroup",
-   "Properties": {
-    "HostedZoneId": "abc123456",
-    "RecordSets": [
-     {
-      "Name": "admin.one.amazon.com",
-      "Type": "A",
-      "AliasTarget": {
-       "HostedZoneId": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainName5fe29fe649",
-         "RegionalHostedZoneId"
-        ]
-       },
-       "DNSName": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainName5fe29fe649",
-         "RegionalDomainName"
-        ]
-       }
-      }
-     },
-     {
-      "Name": "admin.one.amazon.com",
-      "Type": "A",
-      "AliasTarget": {
-       "HostedZoneId": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainNameV25fe29fe649",
-         "RegionalHostedZoneId"
-        ]
-       },
-       "DNSName": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainNameV25fe29fe649",
-         "RegionalDomainName"
-        ]
-       }
-      }
-     }
-    ]
-   }
-  }
- }
 }

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,308 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+  "Resources": {
+    "ApiGatewayAdminTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminTwoDeployment61887a4eed"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOneBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName5fe29fe649"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminOneProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminThreeDeployment7541e97159": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 7541e971598cffe7cafab030d3fccc687d508f59",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminOneDeploymentdd3f545183": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayDomainName3fd2dbd8f8": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.two.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminTwoDeployment61887a4eed": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName5fe29fe649": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.one.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminTwoBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminTwoProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName41bfc7f9c4": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.three.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminThreeDeployment7541e97159"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminThreeBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName41bfc7f9c4"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminThreeProdStage"
+        }
+      }
+    },
+    "RecordSetGroup370194ff6e": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": "abc123456",
+        "RecordSets": [
+          {
+            "Name": "admin.two.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.three.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.one.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
@@ -1,0 +1,325 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+  "Parameters": {
+    "MyHostedZoneId": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "RecordSetGroupd9cb5a3e02": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": {
+          "Fn::Sub": "{{MyHostedZoneId}}"
+        },
+        "RecordSets": [
+          {
+            "Name": "admin.two.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName3fd2dbd8f8",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminTwoProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminTwoDeploymentca2a75b5dd"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayDomainName5fe29fe649": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.one.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminOneProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminOneDeployment066bb1ceae"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayDomainName3fd2dbd8f8": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.two.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName41bfc7f9c4"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminThreeProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminOneBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName5fe29fe649"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminOneProdStage"
+        }
+      }
+    },
+    "RecordSetGroupd28e0e19d0": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneId": {
+          "Ref": "MyHostedZoneId"
+        },
+        "RecordSets": [
+          {
+            "Name": "admin.three.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName41bfc7f9c4",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          },
+          {
+            "Name": "admin.one.amazon.com",
+            "Type": "A",
+            "AliasTarget": {
+              "HostedZoneId": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalHostedZoneId"
+                ]
+              },
+              "DNSName": {
+                "Fn::GetAtt": [
+                  "ApiGatewayDomainName5fe29fe649",
+                  "RegionalDomainName"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminOneDeployment066bb1ceae": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 066bb1ceaebd0cafae99258bbe7130af8b676372",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminOne"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminTwoBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "Stage": {
+          "Ref": "ApiGatewayAdminTwoProdStage"
+        }
+      }
+    },
+    "ApiGatewayAdminTwo": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayDomainName41bfc7f9c4": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "RegionalCertificateArn": "arn::cert::abc",
+        "DomainName": "admin.three.amazon.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ApiGatewayAdminThreeDeployment169349c1e9"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true,
+        "MethodSettings": [
+          {
+            "HttpMethod": "*",
+            "ResourcePath": "/*",
+            "LoggingLevel": "Info"
+          }
+        ]
+      }
+    },
+    "ApiGatewayAdminTwoDeploymentca2a75b5dd": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: ca2a75b5dd3713c71543e80f2b6f5aac9538ea9c",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminTwo"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminThree": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    },
+    "ApiGatewayAdminThreeDeployment169349c1e9": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 169349c1e96a0f130ee35f7bb9d83b042c386d6f",
+        "RestApiId": {
+          "Ref": "ApiGatewayAdminThree"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "ApiGatewayAdminOne": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "Name": "App-Prod-Web",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/http_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-us-gov/http_api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,255 @@
+{
+    "Resources": {
+        "MyApi1": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV25fe29fe649": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.one.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi1ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi1"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV25fe29fe649"
+                },
+                "Stage": {
+                    "Ref": "MyApi1ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "RecordSetGroup370194ff6e": {
+            "Type": "AWS::Route53::RecordSetGroup",
+            "Properties": {
+                "HostedZoneId": "abc123456",
+                "RecordSets": [
+                    {
+                        "Name": "admin.one.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.two.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV23fd2dbd8f8",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV23fd2dbd8f8",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.three.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV241bfc7f9c4",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV241bfc7f9c4",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "MyApi1ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi1"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyApi2": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV23fd2dbd8f8": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.two.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi2ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi2"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV23fd2dbd8f8"
+                },
+                "Stage": {
+                    "Ref": "MyApi2ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyApi2ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi2"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyApi3": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV241bfc7f9c4": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.three.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi3ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi3"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV241bfc7f9c4"
+                },
+                "Stage": {
+                    "Ref": "MyApi3ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyApi3ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi3"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        }
+    }
+}

--- a/tests/translator/output/aws-us-gov/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-us-gov/mixed_api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,193 @@
+{
+ "AWSTemplateFormatVersion": "2010-09-09",
+ "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+ "Resources": {
+  "MyRestApi": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Body": {
+     "info": {
+      "version": "1.0",
+      "title": {
+       "Ref": "AWS::StackName"
+      }
+     },
+     "paths": {},
+     "swagger": "2.0"
+    },
+    "Name": "App-Prod-Web",
+    "Parameters": {
+     "endpointConfigurationTypes": "REGIONAL"
+    },
+    "EndpointConfiguration": {
+     "Types": [
+      "REGIONAL"
+     ]
+    }
+   }
+  },
+  "MyHttpApiApiMapping": {
+   "Type": "AWS::ApiGatewayV2::ApiMapping",
+   "Properties": {
+    "ApiId": {
+     "Ref": "MyHttpApi"
+    },
+    "DomainName": {
+     "Ref": "ApiGatewayDomainNameV25fe29fe649"
+    },
+    "Stage": {
+     "Ref": "MyHttpApiApiGatewayDefaultStage"
+    }
+   }
+  },
+  "ApiGatewayDomainName5fe29fe649": {
+   "Type": "AWS::ApiGateway::DomainName",
+   "Properties": {
+    "RegionalCertificateArn": "arn::cert::abc",
+    "DomainName": "admin.one.amazon.com",
+    "EndpointConfiguration": {
+     "Types": [
+      "REGIONAL"
+     ]
+    }
+   }
+  },
+  "MyRestApiDeploymentdd3f545183": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "StageName": "Stage"
+   }
+  },
+  "ApiGatewayDomainNameV25fe29fe649": {
+   "Type": "AWS::ApiGatewayV2::DomainName",
+   "Properties": {
+    "DomainName": "admin.one.amazon.com",
+    "DomainNameConfigurations": [
+     {
+      "EndpointType": "REGIONAL",
+      "CertificateArn": "arn::cert::abc"
+     }
+    ],
+    "Tags": {
+     "httpapi:createdBy": "SAM"
+    }
+   }
+  },
+  "MyHttpApi": {
+   "Type": "AWS::ApiGatewayV2::Api",
+   "Properties": {
+    "Body": {
+     "info": {
+      "version": "1.0",
+      "title": {
+       "Ref": "AWS::StackName"
+      }
+     },
+     "paths": {},
+     "openapi": "3.0.1",
+     "tags": [
+      {
+       "name": "httpapi:createdBy",
+       "x-amazon-apigateway-tag-value": "SAM"
+      }
+     ]
+    }
+   }
+  },
+  "MyHttpApiApiGatewayDefaultStage": {
+   "Type": "AWS::ApiGatewayV2::Stage",
+   "Properties": {
+    "ApiId": {
+     "Ref": "MyHttpApi"
+    },
+    "StageName": "$default",
+    "Tags": {
+     "httpapi:createdBy": "SAM"
+    },
+    "AutoDeploy": true
+   }
+  },
+  "MyRestApiProdStage": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "DeploymentId": {
+     "Ref": "MyRestApiDeploymentdd3f545183"
+    },
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "StageName": "Prod",
+    "TracingEnabled": true,
+    "MethodSettings": [
+     {
+      "HttpMethod": "*",
+      "ResourcePath": "/*",
+      "LoggingLevel": "Info"
+     }
+    ]
+   }
+  },
+  "MyRestApiBasePathMapping": {
+   "Type": "AWS::ApiGateway::BasePathMapping",
+   "Properties": {
+    "DomainName": {
+     "Ref": "ApiGatewayDomainName5fe29fe649"
+    },
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "Stage": {
+     "Ref": "MyRestApiProdStage"
+    }
+   }
+  },
+  "RecordSetGroup370194ff6e": {
+   "Type": "AWS::Route53::RecordSetGroup",
+   "Properties": {
+    "HostedZoneId": "abc123456",
+    "RecordSets": [
+     {
+      "Name": "admin.one.amazon.com",
+      "Type": "A",
+      "AliasTarget": {
+       "HostedZoneId": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainName5fe29fe649",
+         "RegionalHostedZoneId"
+        ]
+       },
+       "DNSName": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainName5fe29fe649",
+         "RegionalDomainName"
+        ]
+       }
+      }
+     },
+     {
+      "Name": "admin.one.amazon.com",
+      "Type": "A",
+      "AliasTarget": {
+       "HostedZoneId": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainNameV25fe29fe649",
+         "RegionalHostedZoneId"
+        ]
+       },
+       "DNSName": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainNameV25fe29fe649",
+         "RegionalDomainName"
+        ]
+       }
+      }
+     }
+    ]
+   }
+  }
+ }
+}

--- a/tests/translator/output/aws-us-gov/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-us-gov/mixed_api_with_custom_domain_route53_multiple.json
@@ -1,193 +1,193 @@
 {
- "AWSTemplateFormatVersion": "2010-09-09",
- "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
- "Resources": {
-  "MyRestApi": {
-   "Type": "AWS::ApiGateway::RestApi",
-   "Properties": {
-    "Body": {
-     "info": {
-      "version": "1.0",
-      "title": {
-       "Ref": "AWS::StackName"
-      }
-     },
-     "paths": {},
-     "swagger": "2.0"
-    },
-    "Name": "App-Prod-Web",
-    "Parameters": {
-     "endpointConfigurationTypes": "REGIONAL"
-    },
-    "EndpointConfiguration": {
-     "Types": [
-      "REGIONAL"
-     ]
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+    "Resources": {
+        "MyRestApi": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "swagger": "2.0"
+                },
+                "Name": "App-Prod-Web",
+                "Parameters": {
+                    "endpointConfigurationTypes": "REGIONAL"
+                },
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }
+        },
+        "MyHttpApiApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyHttpApi"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV25fe29fe649"
+                },
+                "Stage": {
+                    "Ref": "MyHttpApiApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyRestApiDeployment61887a4eed": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "StageName": "Stage"
+            }
+        },
+        "ApiGatewayDomainName3fd2dbd8f8": {
+            "Type": "AWS::ApiGateway::DomainName",
+            "Properties": {
+                "RegionalCertificateArn": "arn::cert::abc",
+                "DomainName": "admin.two.amazon.com",
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV25fe29fe649": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.one.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyHttpApi": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "MyHttpApiApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyHttpApi"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyRestApiProdStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "MyRestApiDeployment61887a4eed"
+                },
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "StageName": "Prod",
+                "TracingEnabled": true,
+                "MethodSettings": [
+                    {
+                        "HttpMethod": "*",
+                        "ResourcePath": "/*",
+                        "LoggingLevel": "Info"
+                    }
+                ]
+            }
+        },
+        "MyRestApiBasePathMapping": {
+            "Type": "AWS::ApiGateway::BasePathMapping",
+            "Properties": {
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+                },
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "Stage": {
+                    "Ref": "MyRestApiProdStage"
+                }
+            }
+        },
+        "RecordSetGroup370194ff6e": {
+            "Type": "AWS::Route53::RecordSetGroup",
+            "Properties": {
+                "HostedZoneId": "abc123456",
+                "RecordSets": [
+                    {
+                        "Name": "admin.two.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainName3fd2dbd8f8",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainName3fd2dbd8f8",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.one.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        }
     }
-   }
-  },
-  "MyHttpApiApiMapping": {
-   "Type": "AWS::ApiGatewayV2::ApiMapping",
-   "Properties": {
-    "ApiId": {
-     "Ref": "MyHttpApi"
-    },
-    "DomainName": {
-     "Ref": "ApiGatewayDomainNameV25fe29fe649"
-    },
-    "Stage": {
-     "Ref": "MyHttpApiApiGatewayDefaultStage"
-    }
-   }
-  },
-  "ApiGatewayDomainName5fe29fe649": {
-   "Type": "AWS::ApiGateway::DomainName",
-   "Properties": {
-    "RegionalCertificateArn": "arn::cert::abc",
-    "DomainName": "admin.one.amazon.com",
-    "EndpointConfiguration": {
-     "Types": [
-      "REGIONAL"
-     ]
-    }
-   }
-  },
-  "MyRestApiDeploymentdd3f545183": {
-   "Type": "AWS::ApiGateway::Deployment",
-   "Properties": {
-    "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "StageName": "Stage"
-   }
-  },
-  "ApiGatewayDomainNameV25fe29fe649": {
-   "Type": "AWS::ApiGatewayV2::DomainName",
-   "Properties": {
-    "DomainName": "admin.one.amazon.com",
-    "DomainNameConfigurations": [
-     {
-      "EndpointType": "REGIONAL",
-      "CertificateArn": "arn::cert::abc"
-     }
-    ],
-    "Tags": {
-     "httpapi:createdBy": "SAM"
-    }
-   }
-  },
-  "MyHttpApi": {
-   "Type": "AWS::ApiGatewayV2::Api",
-   "Properties": {
-    "Body": {
-     "info": {
-      "version": "1.0",
-      "title": {
-       "Ref": "AWS::StackName"
-      }
-     },
-     "paths": {},
-     "openapi": "3.0.1",
-     "tags": [
-      {
-       "name": "httpapi:createdBy",
-       "x-amazon-apigateway-tag-value": "SAM"
-      }
-     ]
-    }
-   }
-  },
-  "MyHttpApiApiGatewayDefaultStage": {
-   "Type": "AWS::ApiGatewayV2::Stage",
-   "Properties": {
-    "ApiId": {
-     "Ref": "MyHttpApi"
-    },
-    "StageName": "$default",
-    "Tags": {
-     "httpapi:createdBy": "SAM"
-    },
-    "AutoDeploy": true
-   }
-  },
-  "MyRestApiProdStage": {
-   "Type": "AWS::ApiGateway::Stage",
-   "Properties": {
-    "DeploymentId": {
-     "Ref": "MyRestApiDeploymentdd3f545183"
-    },
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "StageName": "Prod",
-    "TracingEnabled": true,
-    "MethodSettings": [
-     {
-      "HttpMethod": "*",
-      "ResourcePath": "/*",
-      "LoggingLevel": "Info"
-     }
-    ]
-   }
-  },
-  "MyRestApiBasePathMapping": {
-   "Type": "AWS::ApiGateway::BasePathMapping",
-   "Properties": {
-    "DomainName": {
-     "Ref": "ApiGatewayDomainName5fe29fe649"
-    },
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "Stage": {
-     "Ref": "MyRestApiProdStage"
-    }
-   }
-  },
-  "RecordSetGroup370194ff6e": {
-   "Type": "AWS::Route53::RecordSetGroup",
-   "Properties": {
-    "HostedZoneId": "abc123456",
-    "RecordSets": [
-     {
-      "Name": "admin.one.amazon.com",
-      "Type": "A",
-      "AliasTarget": {
-       "HostedZoneId": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainName5fe29fe649",
-         "RegionalHostedZoneId"
-        ]
-       },
-       "DNSName": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainName5fe29fe649",
-         "RegionalDomainName"
-        ]
-       }
-      }
-     },
-     {
-      "Name": "admin.one.amazon.com",
-      "Type": "A",
-      "AliasTarget": {
-       "HostedZoneId": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainNameV25fe29fe649",
-         "RegionalHostedZoneId"
-        ]
-       },
-       "DNSName": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainNameV25fe29fe649",
-         "RegionalDomainName"
-        ]
-       }
-      }
-     }
-    ]
-   }
-  }
- }
 }

--- a/tests/translator/output/http_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/http_api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,255 @@
+{
+    "Resources": {
+        "MyApi1": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV25fe29fe649": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.one.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi1ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi1"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV25fe29fe649"
+                },
+                "Stage": {
+                    "Ref": "MyApi1ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "RecordSetGroup370194ff6e": {
+            "Type": "AWS::Route53::RecordSetGroup",
+            "Properties": {
+                "HostedZoneId": "abc123456",
+                "RecordSets": [
+                    {
+                        "Name": "admin.one.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.two.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV23fd2dbd8f8",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV23fd2dbd8f8",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.three.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV241bfc7f9c4",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV241bfc7f9c4",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "MyApi1ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi1"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyApi2": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV23fd2dbd8f8": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.two.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi2ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi2"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV23fd2dbd8f8"
+                },
+                "Stage": {
+                    "Ref": "MyApi2ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyApi2ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi2"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyApi3": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV241bfc7f9c4": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.three.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyApi3ApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi3"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV241bfc7f9c4"
+                },
+                "Stage": {
+                    "Ref": "MyApi3ApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyApi3ApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyApi3"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        }
+    }
+}

--- a/tests/translator/output/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/mixed_api_with_custom_domain_route53_multiple.json
@@ -1,0 +1,193 @@
+{
+ "AWSTemplateFormatVersion": "2010-09-09",
+ "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+ "Resources": {
+  "MyRestApi": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Body": {
+     "info": {
+      "version": "1.0",
+      "title": {
+       "Ref": "AWS::StackName"
+      }
+     },
+     "paths": {},
+     "swagger": "2.0"
+    },
+    "Name": "App-Prod-Web",
+    "Parameters": {
+     "endpointConfigurationTypes": "REGIONAL"
+    },
+    "EndpointConfiguration": {
+     "Types": [
+      "REGIONAL"
+     ]
+    }
+   }
+  },
+  "MyHttpApiApiMapping": {
+   "Type": "AWS::ApiGatewayV2::ApiMapping",
+   "Properties": {
+    "ApiId": {
+     "Ref": "MyHttpApi"
+    },
+    "DomainName": {
+     "Ref": "ApiGatewayDomainNameV25fe29fe649"
+    },
+    "Stage": {
+     "Ref": "MyHttpApiApiGatewayDefaultStage"
+    }
+   }
+  },
+  "ApiGatewayDomainName5fe29fe649": {
+   "Type": "AWS::ApiGateway::DomainName",
+   "Properties": {
+    "RegionalCertificateArn": "arn::cert::abc",
+    "DomainName": "admin.one.amazon.com",
+    "EndpointConfiguration": {
+     "Types": [
+      "REGIONAL"
+     ]
+    }
+   }
+  },
+  "MyRestApiDeploymentdd3f545183": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "StageName": "Stage"
+   }
+  },
+  "ApiGatewayDomainNameV25fe29fe649": {
+   "Type": "AWS::ApiGatewayV2::DomainName",
+   "Properties": {
+    "DomainName": "admin.one.amazon.com",
+    "DomainNameConfigurations": [
+     {
+      "EndpointType": "REGIONAL",
+      "CertificateArn": "arn::cert::abc"
+     }
+    ],
+    "Tags": {
+     "httpapi:createdBy": "SAM"
+    }
+   }
+  },
+  "MyHttpApi": {
+   "Type": "AWS::ApiGatewayV2::Api",
+   "Properties": {
+    "Body": {
+     "info": {
+      "version": "1.0",
+      "title": {
+       "Ref": "AWS::StackName"
+      }
+     },
+     "paths": {},
+     "openapi": "3.0.1",
+     "tags": [
+      {
+       "name": "httpapi:createdBy",
+       "x-amazon-apigateway-tag-value": "SAM"
+      }
+     ]
+    }
+   }
+  },
+  "MyHttpApiApiGatewayDefaultStage": {
+   "Type": "AWS::ApiGatewayV2::Stage",
+   "Properties": {
+    "ApiId": {
+     "Ref": "MyHttpApi"
+    },
+    "StageName": "$default",
+    "Tags": {
+     "httpapi:createdBy": "SAM"
+    },
+    "AutoDeploy": true
+   }
+  },
+  "MyRestApiProdStage": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "DeploymentId": {
+     "Ref": "MyRestApiDeploymentdd3f545183"
+    },
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "StageName": "Prod",
+    "TracingEnabled": true,
+    "MethodSettings": [
+     {
+      "HttpMethod": "*",
+      "ResourcePath": "/*",
+      "LoggingLevel": "Info"
+     }
+    ]
+   }
+  },
+  "MyRestApiBasePathMapping": {
+   "Type": "AWS::ApiGateway::BasePathMapping",
+   "Properties": {
+    "DomainName": {
+     "Ref": "ApiGatewayDomainName5fe29fe649"
+    },
+    "RestApiId": {
+     "Ref": "MyRestApi"
+    },
+    "Stage": {
+     "Ref": "MyRestApiProdStage"
+    }
+   }
+  },
+  "RecordSetGroup370194ff6e": {
+   "Type": "AWS::Route53::RecordSetGroup",
+   "Properties": {
+    "HostedZoneId": "abc123456",
+    "RecordSets": [
+     {
+      "Name": "admin.one.amazon.com",
+      "Type": "A",
+      "AliasTarget": {
+       "HostedZoneId": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainName5fe29fe649",
+         "RegionalHostedZoneId"
+        ]
+       },
+       "DNSName": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainName5fe29fe649",
+         "RegionalDomainName"
+        ]
+       }
+      }
+     },
+     {
+      "Name": "admin.one.amazon.com",
+      "Type": "A",
+      "AliasTarget": {
+       "HostedZoneId": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainNameV25fe29fe649",
+         "RegionalHostedZoneId"
+        ]
+       },
+       "DNSName": {
+        "Fn::GetAtt": [
+         "ApiGatewayDomainNameV25fe29fe649",
+         "RegionalDomainName"
+        ]
+       }
+      }
+     }
+    ]
+   }
+  }
+ }
+}

--- a/tests/translator/output/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/mixed_api_with_custom_domain_route53_multiple.json
@@ -1,193 +1,193 @@
 {
- "AWSTemplateFormatVersion": "2010-09-09",
- "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
- "Resources": {
-  "MyRestApi": {
-   "Type": "AWS::ApiGateway::RestApi",
-   "Properties": {
-    "Body": {
-     "info": {
-      "version": "1.0",
-      "title": {
-       "Ref": "AWS::StackName"
-      }
-     },
-     "paths": {},
-     "swagger": "2.0"
-    },
-    "Name": "App-Prod-Web",
-    "Parameters": {
-     "endpointConfigurationTypes": "REGIONAL"
-    },
-    "EndpointConfiguration": {
-     "Types": [
-      "REGIONAL"
-     ]
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "apigateway-2402\nSample SAM Template for apigateway-2402\n",
+    "Resources": {
+        "MyRestApi": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "swagger": "2.0"
+                },
+                "Name": "App-Prod-Web",
+                "Parameters": {
+                    "endpointConfigurationTypes": "REGIONAL"
+                },
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }
+        },
+        "MyHttpApiApiMapping": {
+            "Type": "AWS::ApiGatewayV2::ApiMapping",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyHttpApi"
+                },
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainNameV25fe29fe649"
+                },
+                "Stage": {
+                    "Ref": "MyHttpApiApiGatewayDefaultStage"
+                }
+            }
+        },
+        "MyRestApiDeployment61887a4eed": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Properties": {
+                "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "StageName": "Stage"
+            }
+        },
+        "ApiGatewayDomainName3fd2dbd8f8": {
+            "Type": "AWS::ApiGateway::DomainName",
+            "Properties": {
+                "RegionalCertificateArn": "arn::cert::abc",
+                "DomainName": "admin.two.amazon.com",
+                "EndpointConfiguration": {
+                    "Types": [
+                        "REGIONAL"
+                    ]
+                }
+            }
+        },
+        "ApiGatewayDomainNameV25fe29fe649": {
+            "Type": "AWS::ApiGatewayV2::DomainName",
+            "Properties": {
+                "DomainName": "admin.one.amazon.com",
+                "DomainNameConfigurations": [
+                    {
+                        "EndpointType": "REGIONAL",
+                        "CertificateArn": "arn::cert::abc"
+                    }
+                ],
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                }
+            }
+        },
+        "MyHttpApi": {
+            "Type": "AWS::ApiGatewayV2::Api",
+            "Properties": {
+                "Body": {
+                    "info": {
+                        "version": "1.0",
+                        "title": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    "paths": {},
+                    "openapi": "3.0.1",
+                    "tags": [
+                        {
+                            "name": "httpapi:createdBy",
+                            "x-amazon-apigateway-tag-value": "SAM"
+                        }
+                    ]
+                }
+            }
+        },
+        "MyHttpApiApiGatewayDefaultStage": {
+            "Type": "AWS::ApiGatewayV2::Stage",
+            "Properties": {
+                "ApiId": {
+                    "Ref": "MyHttpApi"
+                },
+                "StageName": "$default",
+                "Tags": {
+                    "httpapi:createdBy": "SAM"
+                },
+                "AutoDeploy": true
+            }
+        },
+        "MyRestApiProdStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "MyRestApiDeployment61887a4eed"
+                },
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "StageName": "Prod",
+                "TracingEnabled": true,
+                "MethodSettings": [
+                    {
+                        "HttpMethod": "*",
+                        "ResourcePath": "/*",
+                        "LoggingLevel": "Info"
+                    }
+                ]
+            }
+        },
+        "MyRestApiBasePathMapping": {
+            "Type": "AWS::ApiGateway::BasePathMapping",
+            "Properties": {
+                "DomainName": {
+                    "Ref": "ApiGatewayDomainName3fd2dbd8f8"
+                },
+                "RestApiId": {
+                    "Ref": "MyRestApi"
+                },
+                "Stage": {
+                    "Ref": "MyRestApiProdStage"
+                }
+            }
+        },
+        "RecordSetGroup370194ff6e": {
+            "Type": "AWS::Route53::RecordSetGroup",
+            "Properties": {
+                "HostedZoneId": "abc123456",
+                "RecordSets": [
+                    {
+                        "Name": "admin.two.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainName3fd2dbd8f8",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainName3fd2dbd8f8",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Name": "admin.one.amazon.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalHostedZoneId"
+                                ]
+                            },
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "ApiGatewayDomainNameV25fe29fe649",
+                                    "RegionalDomainName"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        }
     }
-   }
-  },
-  "MyHttpApiApiMapping": {
-   "Type": "AWS::ApiGatewayV2::ApiMapping",
-   "Properties": {
-    "ApiId": {
-     "Ref": "MyHttpApi"
-    },
-    "DomainName": {
-     "Ref": "ApiGatewayDomainNameV25fe29fe649"
-    },
-    "Stage": {
-     "Ref": "MyHttpApiApiGatewayDefaultStage"
-    }
-   }
-  },
-  "ApiGatewayDomainName5fe29fe649": {
-   "Type": "AWS::ApiGateway::DomainName",
-   "Properties": {
-    "RegionalCertificateArn": "arn::cert::abc",
-    "DomainName": "admin.one.amazon.com",
-    "EndpointConfiguration": {
-     "Types": [
-      "REGIONAL"
-     ]
-    }
-   }
-  },
-  "MyRestApiDeploymentdd3f545183": {
-   "Type": "AWS::ApiGateway::Deployment",
-   "Properties": {
-    "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "StageName": "Stage"
-   }
-  },
-  "ApiGatewayDomainNameV25fe29fe649": {
-   "Type": "AWS::ApiGatewayV2::DomainName",
-   "Properties": {
-    "DomainName": "admin.one.amazon.com",
-    "DomainNameConfigurations": [
-     {
-      "EndpointType": "REGIONAL",
-      "CertificateArn": "arn::cert::abc"
-     }
-    ],
-    "Tags": {
-     "httpapi:createdBy": "SAM"
-    }
-   }
-  },
-  "MyHttpApi": {
-   "Type": "AWS::ApiGatewayV2::Api",
-   "Properties": {
-    "Body": {
-     "info": {
-      "version": "1.0",
-      "title": {
-       "Ref": "AWS::StackName"
-      }
-     },
-     "paths": {},
-     "openapi": "3.0.1",
-     "tags": [
-      {
-       "name": "httpapi:createdBy",
-       "x-amazon-apigateway-tag-value": "SAM"
-      }
-     ]
-    }
-   }
-  },
-  "MyHttpApiApiGatewayDefaultStage": {
-   "Type": "AWS::ApiGatewayV2::Stage",
-   "Properties": {
-    "ApiId": {
-     "Ref": "MyHttpApi"
-    },
-    "StageName": "$default",
-    "Tags": {
-     "httpapi:createdBy": "SAM"
-    },
-    "AutoDeploy": true
-   }
-  },
-  "MyRestApiProdStage": {
-   "Type": "AWS::ApiGateway::Stage",
-   "Properties": {
-    "DeploymentId": {
-     "Ref": "MyRestApiDeploymentdd3f545183"
-    },
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "StageName": "Prod",
-    "TracingEnabled": true,
-    "MethodSettings": [
-     {
-      "HttpMethod": "*",
-      "ResourcePath": "/*",
-      "LoggingLevel": "Info"
-     }
-    ]
-   }
-  },
-  "MyRestApiBasePathMapping": {
-   "Type": "AWS::ApiGateway::BasePathMapping",
-   "Properties": {
-    "DomainName": {
-     "Ref": "ApiGatewayDomainName5fe29fe649"
-    },
-    "RestApiId": {
-     "Ref": "MyRestApi"
-    },
-    "Stage": {
-     "Ref": "MyRestApiProdStage"
-    }
-   }
-  },
-  "RecordSetGroup370194ff6e": {
-   "Type": "AWS::Route53::RecordSetGroup",
-   "Properties": {
-    "HostedZoneId": "abc123456",
-    "RecordSets": [
-     {
-      "Name": "admin.one.amazon.com",
-      "Type": "A",
-      "AliasTarget": {
-       "HostedZoneId": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainName5fe29fe649",
-         "RegionalHostedZoneId"
-        ]
-       },
-       "DNSName": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainName5fe29fe649",
-         "RegionalDomainName"
-        ]
-       }
-      }
-     },
-     {
-      "Name": "admin.one.amazon.com",
-      "Type": "A",
-      "AliasTarget": {
-       "HostedZoneId": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainNameV25fe29fe649",
-         "RegionalHostedZoneId"
-        ]
-       },
-       "DNSName": {
-        "Fn::GetAtt": [
-         "ApiGatewayDomainNameV25fe29fe649",
-         "RegionalDomainName"
-        ]
-       }
-      }
-     }
-    ]
-   }
-  }
- }
 }

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -525,6 +525,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "api_with_basic_custom_domain_intrinsics",
                 "api_with_custom_domain_route53",
                 "api_with_custom_domain_route53_hosted_zone_name",
+                "api_with_custom_domain_route53_multiple",
                 "api_with_basic_custom_domain_http",
                 "api_with_basic_custom_domain_intrinsics_http",
                 "api_with_custom_domain_route53_http",

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -550,6 +550,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "http_api_local_iam_auth_enabled",
                 "http_api_multiple_authorizers",
                 "http_api_with_custom_domain_route53_multiple",
+                "mixed_api_with_custom_domain_route53_multiple",
             ],
             [
                 ("aws", "ap-southeast-1"),

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -549,6 +549,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "http_api_local_iam_auth_enabled_with_existing_conflicting_authorizer",
                 "http_api_local_iam_auth_enabled",
                 "http_api_multiple_authorizers",
+                "http_api_with_custom_domain_route53_multiple",
             ],
             [
                 ("aws", "ap-southeast-1"),

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -526,6 +526,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
                 "api_with_custom_domain_route53",
                 "api_with_custom_domain_route53_hosted_zone_name",
                 "api_with_custom_domain_route53_multiple",
+                "api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid",
                 "api_with_basic_custom_domain_http",
                 "api_with_basic_custom_domain_intrinsics_http",
                 "api_with_custom_domain_route53_http",


### PR DESCRIPTION
*Issue #, if available:*
#1829 

*Description of changes:*
Keep track of created `AWS::Route53::RecordSetGroup` resources in a cache. If a logical ID is already contained in the cache, use the created one and append a record set into it. Otherwise, create a new `AWS::Route53::RecordSetGroup` for that logical ID and keep it in the cache.

*Description of how you validated changes:*
- Added e2e test (`tests/translator/input/api_with_custom_domain_route53_multiple.yaml`) to confirm the template is transformed as expected

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
