### PR TITLE
fix: check null method for open api

### DIFF
--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -397,6 +397,11 @@ class OpenApiEditor(object):
                             ]
                         )
                     for method_definition in self.get_conditional_contents(method):
+                        # check if there is any method_definition given by customer
+                        if not method_definition:
+                            raise InvalidDocumentException(
+                                [InvalidTemplateException(f"Invalid method definition ({method}) for path: {path}")]
+                            )
                         # If no integration given, then we don't need to process this definition (could be AWS::NoValue)
                         if not self.method_definition_has_integration(method_definition):
                             continue

--- a/tests/translator/input/error_http_api_null_method.yaml
+++ b/tests/translator/input/error_http_api_null_method.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyHttpApiGateway:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Auth:
+        Authorizers:
+          MyAuthorizer:
+            IdentitySource: $request.header.Authorization
+            JwtConfiguration:
+              issuer:
+                Ref: MyOAuth2Issuer
+        DefaultAuthorizer: MyAuthorizer
+      DefinitionBody:
+        openapi: 3.0.1
+        paths:
+          /test:
+            post: null

--- a/tests/translator/output/error_http_api_null_method.json
+++ b/tests/translator/output/error_http_api_null_method.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Invalid method definition (None) for path: /test"
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Checks if method is not `None` before proceeding to work on it.

*Description of how you validated changes:*
Adding a new test case and verifying the older ones.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
