### PR TITLE
fix: update error message to contain the normalized method rather than the method dict

### DIFF
--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -400,7 +400,11 @@ class OpenApiEditor(object):
                         # check if there is any method_definition given by customer
                         if not method_definition:
                             raise InvalidDocumentException(
-                                [InvalidTemplateException(f"Invalid method definition ({method}) for path: {path}")]
+                                [
+                                    InvalidTemplateException(
+                                        f"Invalid method definition ({normalized_method_name}) for path: {path}"
+                                    )
+                                ]
                             )
                         # If no integration given, then we don't need to process this definition (could be AWS::NoValue)
                         if not self.method_definition_has_integration(method_definition):

--- a/tests/translator/output/error_http_api_null_method.json
+++ b/tests/translator/output/error_http_api_null_method.json
@@ -1,3 +1,3 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Invalid method definition (None) for path: /test"
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Invalid method definition (post) for path: /test"
 }


### PR DESCRIPTION
*Issue #, if available:*
Follow up for #2409

*Description of changes:*
Changed error message to contain normalized method name rather than method object

*Description of how you validated changes:*
Re-running unit tests which contains example use case

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
