### PR TITLE
fix: use array of exceptions instead of str for InvalidDocumentException

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -1121,7 +1121,7 @@ class HttpApi(PushEventSource):
                 editor = OpenApiEditor(resources_to_link["explicit_api"].get("DefinitionBody"))
             except InvalidDocumentException as e:
                 api_logical_id = self.ApiId.get("Ref") if isinstance(self.ApiId, dict) else self.ApiId
-                raise InvalidResourceException(api_logical_id, e)
+                raise InvalidResourceException(api_logical_id, " ".join(ex.message for ex in e.causes))
 
         # If this is using the new $default path, keep path blank and add a * permission
         if path == OpenApiEditor._DEFAULT_PATH:

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -41,8 +41,11 @@ class OpenApiEditor(object):
         """
         if not OpenApiEditor.is_valid(doc):
             raise InvalidDocumentException(
-                "Invalid OpenApi document. "
-                "Invalid values or missing keys for 'openapi' or 'paths' in 'DefinitionBody'."
+                [
+                    InvalidTemplateException(
+                        "Invalid OpenApi document. Invalid values or missing keys for 'openapi' or 'paths' in 'DefinitionBody'."
+                    )
+                ]
             )
 
         self._doc = copy.deepcopy(doc)

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -48,7 +48,7 @@ class SwaggerEditor(object):
         """
 
         if not SwaggerEditor.is_valid(doc):
-            raise InvalidDocumentException("Invalid Swagger document")
+            raise InvalidDocumentException([InvalidTemplateException("Invalid Swagger document")])
 
         self._doc = copy.deepcopy(doc)
         self.paths = self._doc["paths"]
@@ -187,7 +187,11 @@ class SwaggerEditor(object):
         method = self._normalize_method_name(method)
         if self.has_integration(path, method):
             raise InvalidDocumentException(
-                "Lambda integration already exists on Path={}, Method={}".format(path, method)
+                [
+                    InvalidTemplateException(
+                        "Lambda integration already exists on Path={}, Method={}".format(path, method)
+                    )
+                ]
             )
 
         self.add_path(path, method)
@@ -252,7 +256,9 @@ class SwaggerEditor(object):
 
         method = self._normalize_method_name(method)
         if self.has_integration(path, method):
-            raise InvalidDocumentException("Integration already exists on Path={}, Method={}".format(path, method))
+            raise InvalidDocumentException(
+                [InvalidTemplateException("Integration already exists on Path={}, Method={}".format(path, method))]
+            )
 
         self.add_path(path, method)
 
@@ -1029,7 +1035,9 @@ class SwaggerEditor(object):
             return
 
         if effect not in ["Allow", "Deny"]:
-            raise InvalidDocumentException("Effect must be one of {}".format(["Allow", "Deny"]))
+            raise InvalidDocumentException(
+                [InvalidTemplateException("Effect must be one of {}".format(["Allow", "Deny"]))]
+            )
 
         if not isinstance(policy_list, (dict, list)):
             raise InvalidDocumentException(
@@ -1091,7 +1099,9 @@ class SwaggerEditor(object):
             ip_list = [ip_list]
 
         if conditional not in ["IpAddress", "NotIpAddress"]:
-            raise InvalidDocumentException("Conditional must be one of {}".format(["IpAddress", "NotIpAddress"]))
+            raise InvalidDocumentException(
+                [InvalidTemplateException("Conditional must be one of {}".format(["IpAddress", "NotIpAddress"]))]
+            )
 
         self.resource_policy["Version"] = "2012-10-17"
         allow_statement = Py27Dict()
@@ -1127,7 +1137,9 @@ class SwaggerEditor(object):
         """
 
         if conditional not in ["StringNotEquals", "StringEquals"]:
-            raise InvalidDocumentException("Conditional must be one of {}".format(["StringNotEquals", "StringEquals"]))
+            raise InvalidDocumentException(
+                [InvalidTemplateException("Conditional must be one of {}".format(["StringNotEquals", "StringEquals"]))]
+            )
 
         condition = Py27Dict()
         string_endpoint_list = endpoint_dict.get("StringEndpointList")

--- a/tests/translator/output/error_http_api_invalid_openapi.json
+++ b/tests/translator/output/error_http_api_invalid_openapi.json
@@ -4,5 +4,5 @@
       "errorMessage": "Resource with id [Api] is invalid. Invalid OpenApi document. Invalid values or missing keys for 'openapi' or 'paths' in 'DefinitionBody'."
     }
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Api] is invalid. Invalid OpenApi document. Invalid values or missing keys for 'openapi' or 'paths' in 'DefinitionBody'."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Api] is invalid. Structure of the SAM template is invalid. Invalid OpenApi document. Invalid values or missing keys for 'openapi' or 'paths' in 'DefinitionBody'."
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Replace `str` parameters with array of exceptions for `InvalidDocumentException` constructor call.

*Description of how you validated changes:*
By running existing test cases.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
