### PR TITLE
fix: Fail gracefully when AutoPublishAlias is an empty string

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -878,7 +878,7 @@ class SamFunction(SamResourceMacro):
         )
 
         if deployment_preference_collection.get(self.logical_id).enabled:
-            if self.AutoPublishAlias is None:
+            if not self.AutoPublishAlias:
                 raise InvalidResourceException(
                     self.logical_id, "'DeploymentPreference' requires AutoPublishAlias property to be specified."
                 )

--- a/tests/translator/input/error_auto_publish_alias_empty_string.yaml
+++ b/tests/translator/input/error_auto_publish_alias_empty_string.yaml
@@ -1,0 +1,10 @@
+Resources:
+  MinimalFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: hello.handler
+      Runtime: python2.7
+      AutoPublishAlias: ''
+      DeploymentPreference:
+        Type: AllAtOnce

--- a/tests/translator/output/error_auto_publish_alias_empty_string.json
+++ b/tests/translator/output/error_auto_publish_alias_empty_string.json
@@ -1,0 +1,3 @@
+{
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MinimalFunction] is invalid. 'DeploymentPreference' requires AutoPublishAlias property to be specified."
+}


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Check if AutoPublishAlias is "truthy", which matches what we do elsewhere in the code. 

*Description of how you validated changes:*
Added the test first, which failed and after patching the test passed. 

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
