### PR TITLE
Bump jsonschema version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
 boto3>=1.19.5,==1.*
-jsonschema~=3.2
+jsonschema~=4.6

--- a/tests/validator/output/api/error_definitionuri.json
+++ b/tests/validator/output/api/error_definitionuri.json
@@ -3,7 +3,9 @@
   "[Resources.ApiDefinitionUriBucketMissing.Properties.DefinitionUri] 'Bucket' is a required property",
   "[Resources.ApiDefinitionUriBucketNotIntrinsic.Properties.DefinitionUri.Bucket] {'Not': 'Intrinsic'} is not of type 'string', 'intrinsic'",
   "[Resources.ApiDefinitionUriBucketNotString.Properties.DefinitionUri.Bucket] 3 is not of type 'string', 'intrinsic'",
+  "[Resources.ApiDefinitionUriEmpty.Properties.DefinitionUri] Must not be empty",
   "[Resources.ApiDefinitionUriKeyEmpty.Properties.DefinitionUri.Key] Must not be empty",
   "[Resources.ApiDefinitionUriKeyMissing.Properties.DefinitionUri] 'Key' is a required property",
-  "[Resources.ApiDefinitionUriKeyNotString.Properties.DefinitionUri.Key] {'Not': 'Intrinsic'} is not of type 'string', 'intrinsic'"
+  "[Resources.ApiDefinitionUriKeyNotString.Properties.DefinitionUri.Key] {'Not': 'Intrinsic'} is not of type 'string', 'intrinsic'",
+  "[Resources.ApiDefinitionUriNotStringOrObject.Properties.DefinitionUri] 3 is not of type 'string', 'object'"
 ]


### PR DESCRIPTION
*Issue #, if available:*
#2426 

*Description of changes:*
Bump jsonschema to v4.6. Added two validation errors that should caught in test.

*Description of how you validated changes:*
`make pr` passed

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
