### PR TITLE
fix: clean the DeploymentGroup alarms configuration in case of updating the DeploymentPreference and removing the alarms attribute.

### DIFF
--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -226,7 +226,13 @@ class DeploymentPreferenceCollection(object):
             If Alarms is in the wrong format
         """
         if not preference_alarms or is_intrinsic_no_value(preference_alarms):
-            return None
+            # return the empty alarms configuration in case if there is no alarms at all defined in the
+            # DeploymentPreference to force CFN to update the deployment group and remove the alarms values from the
+            # created DeploymentGroup. Check issue https://github.com/aws/serverless-application-model/issues/2452
+            return {
+                "Enabled": False,
+                "Alarms": [],
+            }
 
         if is_intrinsic_if(preference_alarms):
             processed_alarms = copy.deepcopy(preference_alarms)

--- a/tests/translator/model/preferences/test_deployment_preference_collection.py
+++ b/tests/translator/model/preferences/test_deployment_preference_collection.py
@@ -272,7 +272,7 @@ class TestDeploymentPreferenceCollection(TestCase):
 
         self.assertIsNotNone(deployment_group.AlarmConfiguration)
         self.assertFalse(deployment_group.AlarmConfiguration.get("Enabled"))
-        self.assertTrue(len(deployment_group.AlarmConfiguration.get("Alarms")), 0)
+        self.assertEqual(len(deployment_group.AlarmConfiguration.get("Alarms")), 0)
 
     @patch("boto3.session.Session.region_name", "ap-southeast-1")
     def test_deployment_preference_with_alarms_empty(self):
@@ -286,7 +286,7 @@ class TestDeploymentPreferenceCollection(TestCase):
 
         self.assertIsNotNone(deployment_group.AlarmConfiguration)
         self.assertFalse(deployment_group.AlarmConfiguration.get("Enabled"))
-        self.assertTrue(len(deployment_group.AlarmConfiguration.get("Alarms")), 0)
+        self.assertEqual(len(deployment_group.AlarmConfiguration.get("Alarms")), 0)
 
     @patch("boto3.session.Session.region_name", "ap-southeast-1")
     def test_deployment_preference_with_alarms_not_list(self):

--- a/tests/translator/model/preferences/test_deployment_preference_collection.py
+++ b/tests/translator/model/preferences/test_deployment_preference_collection.py
@@ -67,6 +67,10 @@ class TestDeploymentPreferenceCollection(TestCase):
     def test_deployment_group_with_minimal_parameters(self):
         expected_deployment_group = CodeDeployDeploymentGroup(self.function_logical_id + "DeploymentGroup")
         expected_deployment_group.ApplicationName = {"Ref": CODEDEPLOY_APPLICATION_LOGICAL_ID}
+        expected_deployment_group.AlarmConfiguration = {
+            "Enabled": False,
+            "Alarms": []
+        }
         expected_deployment_group.AutoRollbackConfiguration = {
             "Enabled": True,
             "Events": ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM", "DEPLOYMENT_STOP_ON_REQUEST"],
@@ -269,7 +273,9 @@ class TestDeploymentPreferenceCollection(TestCase):
         deployment_preference_collection.add(self.function_logical_id, deployment_preference)
         deployment_group = deployment_preference_collection.deployment_group(self.function_logical_id)
 
-        self.assertIsNone(deployment_group.AlarmConfiguration)
+        self.assertIsNotNone(deployment_group.AlarmConfiguration)
+        self.assertFalse(deployment_group.AlarmConfiguration.get("Enabled"))
+        self.assertTrue(len(deployment_group.AlarmConfiguration.get("Alarms")), 0)
 
     @patch("boto3.session.Session.region_name", "ap-southeast-1")
     def test_deployment_preference_with_alarms_empty(self):
@@ -281,7 +287,9 @@ class TestDeploymentPreferenceCollection(TestCase):
         deployment_preference_collection.add(self.function_logical_id, deployment_preference)
         deployment_group = deployment_preference_collection.deployment_group(self.function_logical_id)
 
-        self.assertIsNone(deployment_group.AlarmConfiguration)
+        self.assertIsNotNone(deployment_group.AlarmConfiguration)
+        self.assertFalse(deployment_group.AlarmConfiguration.get("Enabled"))
+        self.assertTrue(len(deployment_group.AlarmConfiguration.get("Alarms")), 0)
 
     @patch("boto3.session.Session.region_name", "ap-southeast-1")
     def test_deployment_preference_with_alarms_not_list(self):

--- a/tests/translator/model/preferences/test_deployment_preference_collection.py
+++ b/tests/translator/model/preferences/test_deployment_preference_collection.py
@@ -67,10 +67,7 @@ class TestDeploymentPreferenceCollection(TestCase):
     def test_deployment_group_with_minimal_parameters(self):
         expected_deployment_group = CodeDeployDeploymentGroup(self.function_logical_id + "DeploymentGroup")
         expected_deployment_group.ApplicationName = {"Ref": CODEDEPLOY_APPLICATION_LOGICAL_ID}
-        expected_deployment_group.AlarmConfiguration = {
-            "Enabled": False,
-            "Alarms": []
-        }
+        expected_deployment_group.AlarmConfiguration = {"Enabled": False, "Alarms": []}
         expected_deployment_group.AutoRollbackConfiguration = {
             "Enabled": True,
             "Events": ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM", "DEPLOYMENT_STOP_ON_REQUEST"],

--- a/tests/translator/output/aws-cn/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_custom_codedeploy_deployment_preference.json
@@ -69,6 +69,10 @@
     "CustomWithCondition2DeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -214,6 +218,10 @@
     "CustomWithSubDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -313,6 +321,10 @@
     "NormalWithSubDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -371,6 +383,10 @@
     "NormalWithRefDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -499,6 +515,10 @@
     "CustomWithConditionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -702,6 +722,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -823,6 +847,10 @@
     "CustomWithFindInMapDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-cn/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -88,6 +88,10 @@
     "HelloWorldFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-cn/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_and_custom_role.json
@@ -112,6 +112,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -146,6 +150,10 @@
     "FunctionWithRoleDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-cn/function_with_deployment_no_service_role_with_passthrough.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_no_service_role_with_passthrough.json
@@ -11,6 +11,10 @@
     "OtherFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -161,6 +165,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-cn/function_with_deployment_no_service_role_without_passthrough.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_no_service_role_without_passthrough.json
@@ -11,6 +11,10 @@
     "OtherFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -160,6 +164,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-cn/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference.json
@@ -30,6 +30,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_all_parameters.json
@@ -97,6 +97,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_condition_with_passthrough.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_condition_with_passthrough.json
@@ -36,6 +36,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_condition_without_passthrough.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_condition_without_passthrough.json
@@ -36,6 +36,10 @@
       "MinimalFunctionDeploymentGroup": {
         "Type": "AWS::CodeDeploy::DeploymentGroup",
         "Properties": {
+          "AlarmConfiguration": {
+            "Enabled": false,
+            "Alarms": []
+          },
           "ApplicationName": {
             "Ref": "ServerlessDeploymentApplication"
           },

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_from_parameters.json
@@ -111,6 +111,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations.json
@@ -145,6 +145,10 @@
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -343,6 +347,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations_conditions_with_passthrough.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations_conditions_with_passthrough.json
@@ -122,6 +122,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -192,6 +196,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -382,6 +390,10 @@
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations_conditions_without_passthrough.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations_conditions_without_passthrough.json
@@ -457,6 +457,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -491,6 +495,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_passthrough_condition_with_supported_intrinsics.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_passthrough_condition_with_supported_intrinsics.json
@@ -511,6 +511,10 @@
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Condition": "FunctionCondition",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -545,6 +549,10 @@
         "FalseRefDeploymentGroup": {
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -580,6 +588,10 @@
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Condition": "FunctionCondition",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -614,6 +626,10 @@
         "FalseFindInMapDeploymentGroup": {
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },

--- a/tests/translator/output/aws-cn/function_with_disabled_traffic_hook.json
+++ b/tests/translator/output/aws-cn/function_with_disabled_traffic_hook.json
@@ -121,6 +121,10 @@
     "FunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-us-gov/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_custom_codedeploy_deployment_preference.json
@@ -69,6 +69,10 @@
     "CustomWithCondition2DeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -214,6 +218,10 @@
     "CustomWithSubDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -313,6 +321,10 @@
     "NormalWithSubDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -371,6 +383,10 @@
     "NormalWithRefDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -499,6 +515,10 @@
     "CustomWithConditionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -702,6 +722,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -823,6 +847,10 @@
     "CustomWithFindInMapDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-us-gov/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -88,6 +88,10 @@
     "HelloWorldFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_and_custom_role.json
@@ -112,6 +112,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -146,6 +150,10 @@
     "FunctionWithRoleDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_no_service_role_with_passthrough.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_no_service_role_with_passthrough.json
@@ -11,6 +11,10 @@
     "OtherFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -161,6 +165,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-us-gov/function_with_deployment_no_service_role_without_passthrough.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_no_service_role_without_passthrough.json
@@ -11,6 +11,10 @@
     "OtherFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -160,6 +164,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
@@ -30,6 +30,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_all_parameters.json
@@ -97,6 +97,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_condition_with_passthrough.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_condition_with_passthrough.json
@@ -36,6 +36,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_condition_without_passthrough.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_condition_without_passthrough.json
@@ -36,6 +36,10 @@
       "MinimalFunctionDeploymentGroup": {
         "Type": "AWS::CodeDeploy::DeploymentGroup",
         "Properties": {
+          "AlarmConfiguration": {
+            "Enabled": false,
+            "Alarms": []
+          },
           "ApplicationName": {
             "Ref": "ServerlessDeploymentApplication"
           },

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_from_parameters.json
@@ -111,6 +111,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations.json
@@ -145,6 +145,10 @@
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -343,6 +347,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations_conditions_with_passthrough.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations_conditions_with_passthrough.json
@@ -122,6 +122,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -192,6 +196,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -382,6 +390,10 @@
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations_conditions_without_passthrough.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations_conditions_without_passthrough.json
@@ -457,6 +457,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -491,6 +495,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_passthrough_condition_with_supported_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_passthrough_condition_with_supported_intrinsics.json
@@ -511,6 +511,10 @@
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Condition": "FunctionCondition",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -545,6 +549,10 @@
         "FalseRefDeploymentGroup": {
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -580,6 +588,10 @@
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Condition": "FunctionCondition",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -614,6 +626,10 @@
         "FalseFindInMapDeploymentGroup": {
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },

--- a/tests/translator/output/aws-us-gov/function_with_disabled_traffic_hook.json
+++ b/tests/translator/output/aws-us-gov/function_with_disabled_traffic_hook.json
@@ -121,6 +121,10 @@
     "FunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/function_with_custom_codedeploy_deployment_preference.json
@@ -69,9 +69,13 @@
     "CustomWithCondition2DeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
-        }, 
+        },
         "AutoRollbackConfiguration": {
           "Enabled": true, 
           "Events": [
@@ -214,6 +218,10 @@
     "CustomWithSubDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -313,6 +321,10 @@
     "NormalWithSubDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -371,6 +383,10 @@
     "NormalWithRefDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -499,6 +515,10 @@
     "CustomWithConditionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -702,6 +722,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -823,6 +847,10 @@
     "CustomWithFindInMapDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -88,6 +88,10 @@
     "HelloWorldFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/function_with_deployment_and_custom_role.json
@@ -112,6 +112,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -146,6 +150,10 @@
     "FunctionWithRoleDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/function_with_deployment_no_service_role_with_passthrough.json
+++ b/tests/translator/output/function_with_deployment_no_service_role_with_passthrough.json
@@ -11,6 +11,10 @@
     "OtherFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -161,6 +165,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/function_with_deployment_no_service_role_without_passthrough.json
+++ b/tests/translator/output/function_with_deployment_no_service_role_without_passthrough.json
@@ -11,6 +11,10 @@
     "OtherFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -160,6 +164,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/function_with_deployment_preference.json
+++ b/tests/translator/output/function_with_deployment_preference.json
@@ -30,6 +30,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/function_with_deployment_preference_all_parameters.json
@@ -97,6 +97,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/function_with_deployment_preference_condition_with_passthrough.json
+++ b/tests/translator/output/function_with_deployment_preference_condition_with_passthrough.json
@@ -36,6 +36,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/function_with_deployment_preference_condition_without_passthrough.json
+++ b/tests/translator/output/function_with_deployment_preference_condition_without_passthrough.json
@@ -36,6 +36,10 @@
       "MinimalFunctionDeploymentGroup": {
         "Type": "AWS::CodeDeploy::DeploymentGroup",
         "Properties": {
+          "AlarmConfiguration": {
+            "Enabled": false,
+            "Alarms": []
+          },
           "ApplicationName": {
             "Ref": "ServerlessDeploymentApplication"
           },

--- a/tests/translator/output/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/function_with_deployment_preference_from_parameters.json
@@ -111,6 +111,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/function_with_deployment_preference_multiple_combinations.json
@@ -145,6 +145,10 @@
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 
@@ -343,6 +347,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup", 
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         }, 

--- a/tests/translator/output/function_with_deployment_preference_multiple_combinations_conditions_with_passthrough.json
+++ b/tests/translator/output/function_with_deployment_preference_multiple_combinations_conditions_with_passthrough.json
@@ -122,6 +122,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -192,6 +196,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -382,6 +390,10 @@
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/function_with_deployment_preference_multiple_combinations_conditions_without_passthrough.json
+++ b/tests/translator/output/function_with_deployment_preference_multiple_combinations_conditions_without_passthrough.json
@@ -457,6 +457,10 @@
     "MinimalFunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },
@@ -491,6 +495,10 @@
     "MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },

--- a/tests/translator/output/function_with_deployment_preference_passthrough_condition_with_supported_intrinsics.json
+++ b/tests/translator/output/function_with_deployment_preference_passthrough_condition_with_supported_intrinsics.json
@@ -511,6 +511,10 @@
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Condition": "FunctionCondition",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -545,6 +549,10 @@
         "FalseRefDeploymentGroup": {
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -580,6 +588,10 @@
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Condition": "FunctionCondition",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },
@@ -614,6 +626,10 @@
         "FalseFindInMapDeploymentGroup": {
             "Type": "AWS::CodeDeploy::DeploymentGroup",
             "Properties": {
+                "AlarmConfiguration": {
+                  "Enabled": false,
+                  "Alarms": []
+                },
                 "ApplicationName": {
                     "Ref": "ServerlessDeploymentApplication"
                 },

--- a/tests/translator/output/function_with_disabled_traffic_hook.json
+++ b/tests/translator/output/function_with_disabled_traffic_hook.json
@@ -121,6 +121,10 @@
     "FunctionDeploymentGroup": {
       "Type": "AWS::CodeDeploy::DeploymentGroup",
       "Properties": {
+        "AlarmConfiguration": {
+          "Enabled": false,
+          "Alarms": []
+        },
         "ApplicationName": {
           "Ref": "ServerlessDeploymentApplication"
         },


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/serverless-application-model/issues/2452

*Description of changes:*
If the Alarms property in Deployment preference is not provided, update the generated DeploymentGroup resource to contain an empty AlarmsConfiguration. So in case of updating the DeploymentGroup resource, the empty AlarmsConfiguration will force cleaning the alarms value from the DeploymentGroup resource.



*Checklist:*

- [X] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [X] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
