### PR TITLE
chore: Add region skip condition and retry for http test

### DIFF
--- a/integration/single/test_function_with_http_api_and_auth.py
+++ b/integration/single/test_function_with_http_api_and_auth.py
@@ -14,6 +14,7 @@ class TestFunctionWithHttpApiAndAuth(BaseTest):
     """
     AWS::Lambda::Function tests with http api events and auth
     """
+
     @retry(
         stop=stop_after_attempt(5),
         wait=wait_exponential(multiplier=1, min=4, max=10) + wait_random(0, 1),

--- a/integration/single/test_function_with_http_api_and_auth.py
+++ b/integration/single/test_function_with_http_api_and_auth.py
@@ -1,11 +1,26 @@
+import logging
+from unittest.case import skipIf
+
+from tenacity import stop_after_attempt, retry_if_exception_type, after_log, wait_exponential, retry, wait_random
+
 from integration.helpers.base_test import BaseTest
+from integration.helpers.resource import current_region_does_not_support
+
+LOG = logging.getLogger(__name__)
 
 
+@skipIf(current_region_does_not_support(["HttpApi"]), "HttpApi is not supported in this testing region")
 class TestFunctionWithHttpApiAndAuth(BaseTest):
     """
     AWS::Lambda::Function tests with http api events and auth
     """
-
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_exponential(multiplier=1, min=4, max=10) + wait_random(0, 1),
+        retry=retry_if_exception_type(AssertionError),
+        after=after_log(LOG, logging.WARNING),
+        reraise=True,
+    )
     def test_function_with_http_api_and_auth(self):
         # If the request is not signed, which none of the below are, IAM will respond with a "Forbidden" message.
         # We are not testing that IAM auth works here, we are simply testing if it was applied.


### PR DESCRIPTION
*Issue #, if available:*
N.A.

*Description of changes:*
To exclude regions for http tests so it does not get tested in regions not supporting http api

*Description of how you validated changes:*
This change uses the same decorator used in other http api tests

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
