### PR TITLE
Add validation for swagger security when ApiKeyRequired is true

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -647,7 +647,10 @@ class SwaggerEditor(object):
             # We want to ensure only a single Authorizer security entry exists while keeping everything else
             for security in existing_security:
                 SwaggerEditor.validate_is_dict(
-                    security, "{} in Security for path {} is not a valid dictionary.".format(security, path)
+                    security,
+                    "{} in Security for path {} method {} is not a valid dictionary.".format(
+                        security, path, method_name
+                    ),
                 )
                 if authorizer_names.isdisjoint(security.keys()):
                     existing_non_authorizer_security.append(security)
@@ -703,7 +706,7 @@ class SwaggerEditor(object):
         :param string path: Path name
         """
 
-        for _, method_definition in self.iter_on_all_methods_for_path(path):
+        for method_name, method_definition in self.iter_on_all_methods_for_path(path):
             existing_security = method_definition.get("security", [])
             apikey_security_names = set(["api_key", "api_key_false"])
             existing_non_apikey_security = []
@@ -714,6 +717,12 @@ class SwaggerEditor(object):
             # (e.g. sigv4 (AWS_IAM), authorizers, NONE (marker for ignoring default authorizer))
             # We want to ensure only a single ApiKey security entry exists while keeping everything else
             for security in existing_security:
+                SwaggerEditor.validate_is_dict(
+                    security,
+                    "{} in Security for path {} method {} is not a valid dictionary.".format(
+                        security, path, method_name
+                    ),
+                )
                 if apikey_security_names.isdisjoint(security.keys()):
                     existing_non_apikey_security.append(security)
                 else:

--- a/tests/translator/input/error_swagger_security_not_dict_with_api_key_required.yaml
+++ b/tests/translator/input/error_swagger_security_not_dict_with_api_key_required.yaml
@@ -1,0 +1,45 @@
+transformId: AWS::Serverless-2016-10-31
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  AuthFunction:
+    Type: AWS::Serverless::Function
+  AccessingPartyAPI:
+    Type: AWS::Serverless::Api
+    Properties:
+      EndpointConfiguration: REGIONAL
+      StageName: demo
+      Auth:
+        ApiKeyRequired: true
+
+      DefinitionBody:
+        paths:
+          "/path":
+            put:
+              responses:
+                '201':
+                  content:
+                    application/json:
+                      schema:
+                        "$ref": "abcd"
+              x-amazon-apigateway-integration:
+                contentHandling: CONVERT_TO_TEXT
+                responses:
+                  default:
+                    statusCode: '200'
+                uri:
+                  Fn::Sub: foobar
+                httpMethod: POST
+                passthroughBehavior: when_no_match
+                type: aws_proxy
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      required:
+                      - readoutId
+                      - status
+                      type: object
+              security:
+                - []
+
+        openapi: 3.0.3

--- a/tests/translator/output/error_swagger_security_not_dict.json
+++ b/tests/translator/output/error_swagger_security_not_dict.json
@@ -1,3 +1,3 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. CustomAuthorizer in Security for path /path is not a valid dictionary."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. CustomAuthorizer in Security for path /path method put is not a valid dictionary."
 }

--- a/tests/translator/output/error_swagger_security_not_dict_with_api_key_required.json
+++ b/tests/translator/output/error_swagger_security_not_dict_with_api_key_required.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. [] in Security for path /path method put is not a valid dictionary."
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding a validation to confirm security is a dict in swagger when ApiKeyRequired is set to true

*Description of how you validated changes:*

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
