### PR TITLE
feat: Add State Property to Schedule EventSource in StateMachine

### DIFF
--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -4,15 +4,13 @@ from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import PropertyType, ResourceMacro
 from samtranslator.model.events import EventsRule
 from samtranslator.model.iam import IAMRole, IAMRolePolicies
-from samtranslator.model.types import dict_of, is_str, is_type, list_of, one_of
+from samtranslator.model.types import is_str, is_type
 from samtranslator.model.intrinsics import fnSub
 from samtranslator.translator import logical_id_generator
-from samtranslator.model.exceptions import InvalidEventException, InvalidResourceException
+from samtranslator.model.exceptions import InvalidEventException
 from samtranslator.model.eventbridge_utils import EventBridgeRuleUtils
 from samtranslator.model.eventsources.push import Api as PushApi
-from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.swagger.swagger import SwaggerEditor
-from samtranslator.open_api.open_api import OpenApiEditor
 
 CONDITION = "Condition"
 SFN_EVETSOURCE_METRIC_PREFIX = "SFNEventSource"
@@ -82,6 +80,7 @@ class Schedule(EventSource):
         "Schedule": PropertyType(True, is_str()),
         "Input": PropertyType(False, is_str()),
         "Enabled": PropertyType(False, is_type(bool)),
+        "State": PropertyType(False, is_str()),
         "Name": PropertyType(False, is_str()),
         "Description": PropertyType(False, is_str()),
         "DeadLetterConfig": PropertyType(False, is_type(dict)),
@@ -105,8 +104,16 @@ class Schedule(EventSource):
         resources.append(events_rule)
 
         events_rule.ScheduleExpression = self.Schedule
+
+        if self.State and self.Enabled is not None:
+            raise InvalidEventException(self.relative_id, "State and Enabled Properties cannot both be specified.")
+
+        if self.State:
+            events_rule.State = self.State
+
         if self.Enabled is not None:
             events_rule.State = "ENABLED" if self.Enabled else "DISABLED"
+
         events_rule.Name = self.Name
         events_rule.Description = self.Description
 

--- a/tests/translator/input/error_state_machine_with_invalid_schedule_event.yaml
+++ b/tests/translator/input/error_state_machine_with_invalid_schedule_event.yaml
@@ -1,0 +1,17 @@
+Transform: "AWS::Serverless-2016-10-31"
+
+Resources:
+  ScheduledStateMachine:
+    Type: 'AWS::Serverless::StateMachine'
+    Properties:
+      DefinitionUri: s3://sam-demo-bucket/my_state_machine.asl.json
+      Role: arn:aws:iam::123456123456:role/service-role/SampleRole
+      Events:
+        Schedule1:
+          Type: Schedule
+          Properties:
+            Schedule: 'rate(1 minute)'
+            Name: TestSchedule
+            Description: test schedule
+            State: "Enabled"
+            Enabled: True

--- a/tests/translator/input/state_machine_with_event_schedule_state.yaml
+++ b/tests/translator/input/state_machine_with_event_schedule_state.yaml
@@ -1,0 +1,30 @@
+Transform: "AWS::Serverless-2016-10-31"
+
+Resources:
+  ScheduledStateMachine:
+    Type: 'AWS::Serverless::StateMachine'
+    Properties:
+      DefinitionUri: s3://sam-demo-bucket/my_state_machine.asl.json
+      Role: arn:aws:iam::123456123456:role/service-role/SampleRole
+      Events:
+        Schedule1:
+          Type: Schedule
+          Properties:
+            Schedule: 'rate(1 minute)'
+            Name: test-schedule
+            Description: Test Schedule
+            State: "Enabled"
+        Schedule2:
+          Type: Schedule
+          Properties:
+            Schedule: 'rate(1 minute)'
+            Name: test-schedule
+            Description: Test Schedule
+            State: !Sub "Enabled"
+        Schedule3:
+          Type: Schedule
+          Properties:
+            Schedule: 'rate(1 minute)'
+            Name: test-schedule
+            Description: Test Schedule
+            State: !Ref ScheduleState

--- a/tests/translator/output/aws-cn/state_machine_with_event_schedule_state.json
+++ b/tests/translator/output/aws-cn/state_machine_with_event_schedule_state.json
@@ -1,0 +1,204 @@
+{
+  "Resources": {
+    "ScheduledStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my_state_machine.asl.json"
+        },
+        "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule1": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "Enabled",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule1StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule1Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule1Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule1RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule2": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": {
+          "Fn::Sub": "Enabled"
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule2StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule2Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule2Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule2RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule3": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": {
+          "Ref": "ScheduleState"
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule3StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule3Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule3Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule3RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/state_machine_with_event_schedule_state.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_event_schedule_state.json
@@ -1,0 +1,204 @@
+{
+  "Resources": {
+    "ScheduledStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my_state_machine.asl.json"
+        },
+        "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule1": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "Enabled",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule1StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule1Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule1Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule1RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule2": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": {
+          "Fn::Sub": "Enabled"
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule2StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule2Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule2Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule2RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule3": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": {
+          "Ref": "ScheduleState"
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule3StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule3Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule3Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule3RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/error_state_machine_with_invalid_schedule_event.json
+++ b/tests/translator/output/error_state_machine_with_invalid_schedule_event.json
@@ -1,0 +1,8 @@
+{
+    "errors": [
+      {
+        "errorMessage": "Resource with id [ScheduledStateMachine] is invalid. Event with id [Schedule1] is invalid. State and Enabled Properties cannot both be specified."
+      }
+    ], 
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Event with id [Schedule1] is invalid. State and Enabled Properties cannot both be specified."
+}

--- a/tests/translator/output/state_machine_with_event_schedule_state.json
+++ b/tests/translator/output/state_machine_with_event_schedule_state.json
@@ -1,0 +1,204 @@
+{
+  "Resources": {
+    "ScheduledStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my_state_machine.asl.json"
+        },
+        "RoleArn": "arn:aws:iam::123456123456:role/service-role/SampleRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule1": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "Enabled",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule1StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule1Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule1Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule1RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule2": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": {
+          "Fn::Sub": "Enabled"
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule2StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule2Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule2Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule2RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule3": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Test Schedule",
+        "Name": "test-schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": {
+          "Ref": "ScheduleState"
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "ScheduledStateMachine"
+            },
+            "Id": "ScheduledStateMachineSchedule3StepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "ScheduledStateMachineSchedule3Role",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ScheduledStateMachineSchedule3Role": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "ScheduledStateMachineSchedule3RoleStartExecutionPolicy",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "ScheduledStateMachine"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
#2467 

*Description of changes:*

add State property to Schedule EventSource for AWS::Serverless::StateMachine.

*Description of how you validated changes:*

added invalid input and transform tests

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [x] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
