### PR TITLE
Update methods in Metrics class to accept timestamp

### DIFF
--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -93,6 +93,7 @@ class MetricDatum:
         :param value: value of metric
         :param unit: unit of metric (try using values from Unit class)
         :param dimensions: array of dimensions applied to the metric
+        :param timestamp: timestamp of metric (datetime.datetime object)
         """
         self.name = name
         self.value = value
@@ -130,7 +131,7 @@ class Metrics:
             )
             self.publish()
 
-    def _record_metric(self, name, value, unit, dimensions=None):
+    def _record_metric(self, name, value, unit, dimensions=None, timestamp=None):
         """
         Create and save metric object in internal cache.
 
@@ -138,10 +139,11 @@ class Metrics:
         :param value: value of metric
         :param unit: unit of metric (try using values from Unit class)
         :param dimensions: array of dimensions applied to the metric
+        :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self.metrics_cache.setdefault(name, []).append(MetricDatum(name, value, unit, dimensions))
+        self.metrics_cache.setdefault(name, []).append(MetricDatum(name, value, unit, dimensions, timestamp))
 
-    def record_count(self, name, value, dimensions=None):
+    def record_count(self, name, value, dimensions=None, timestamp=None):
         """
         Create metric with unit Count.
 
@@ -149,10 +151,11 @@ class Metrics:
         :param value: value of metric
         :param unit: unit of metric (try using values from Unit class)
         :param dimensions: array of dimensions applied to the metric
+        :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self._record_metric(name, value, Unit.Count, dimensions)
+        self._record_metric(name, value, Unit.Count, dimensions, timestamp)
 
-    def record_latency(self, name, value, dimensions=None):
+    def record_latency(self, name, value, dimensions=None, timestamp=None):
         """
         Create metric with unit Milliseconds.
 
@@ -160,8 +163,9 @@ class Metrics:
         :param value: value of metric
         :param unit: unit of metric (try using values from Unit class)
         :param dimensions: array of dimensions applied to the metric
+        :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self._record_metric(name, value, Unit.Milliseconds, dimensions)
+        self._record_metric(name, value, Unit.Milliseconds, dimensions, timestamp)
 
     def publish(self):
         """Calls publish method from the configured metrics publisher to publish metrics"""


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Allow customized timestamp when recording metrics.

*Description of how you validated changes:*
Updated existing tests to include test cases with customized timestamp

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
