### PR TITLE
Add validation for S3 NotificationConfiguration in Serverless Functin…

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -313,7 +313,7 @@ class S3(PushEventSource):
         #   merging is literally "last one wins", which works fine because we linearly loop through the template once.
         #   The de-dupe happens inside `samtranslator.translator.Translator.translate` method when merging results of
         #   to_cloudformation() to output template.
-        self._inject_notification_configuration(function, bucket)
+        self._inject_notification_configuration(function, bucket, bucket_id)
         resources.append(S3Bucket.from_dict(bucket_id, bucket))
 
         return resources
@@ -378,7 +378,7 @@ class S3(PushEventSource):
         properties["Tags"] = tags + get_tag_list(dep_tag)
         return bucket
 
-    def _inject_notification_configuration(self, function, bucket):
+    def _inject_notification_configuration(self, function, bucket, bucket_id):
         base_event_mapping = {"Function": function.get_runtime_attr("arn")}
 
         if self.Filter is not None:
@@ -407,13 +407,16 @@ class S3(PushEventSource):
             notification_config = {}
             properties["NotificationConfiguration"] = notification_config
 
+        if not isinstance(notification_config, dict):
+            raise InvalidResourceException(bucket_id, "Invalid type for NotificationConfiguration. Must be a dict.")
+
         lambda_notifications = notification_config.get("LambdaConfigurations", None)
         if lambda_notifications is None:
             lambda_notifications = []
             notification_config["LambdaConfigurations"] = lambda_notifications
 
         if not isinstance(lambda_notifications, list):
-            raise InvalidResourceException(self.logical_id, "Invalid type for LambdaConfigurations. Must be a list.")
+            raise InvalidResourceException(bucket_id, "Invalid type for LambdaConfigurations. Must be a list.")
 
         for event_mapping in event_mappings:
             if event_mapping not in lambda_notifications:

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -408,7 +408,7 @@ class S3(PushEventSource):
             properties["NotificationConfiguration"] = notification_config
 
         if not isinstance(notification_config, dict):
-            raise InvalidResourceException(bucket_id, "Invalid type for NotificationConfiguration. Must be a dict.")
+            raise InvalidResourceException(bucket_id, "Invalid type for NotificationConfiguration.")
 
         lambda_notifications = notification_config.get("LambdaConfigurations", None)
         if lambda_notifications is None:

--- a/tests/translator/input/error_s3_lambda_configuration_invalid_type.yaml
+++ b/tests/translator/input/error_s3_lambda_configuration_invalid_type.yaml
@@ -22,3 +22,30 @@ Resources:
         LambdaConfigurations:
           Event: s3:ObjectCreated:Put
           Function: arn:aws:iam::...
+
+  AnotherFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: app.lambdaHandler
+      Runtime: nodejs14.x
+      Architectures:
+        - x86_64
+      Events:
+        S3Event:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: AnotherBucket
+            Events: s3:ObjectCreated:*
+
+  AnotherBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      NotificationConfiguration:
+      - Event: s3:ObjectCreated:*
+        Function:
+          Fn::GetAtt:
+          - AnotherFunction
+          - Arn
+        

--- a/tests/translator/output/error_s3_lambda_configuration_invalid_type.json
+++ b/tests/translator/output/error_s3_lambda_configuration_invalid_type.json
@@ -4,5 +4,5 @@
       "errorMessage": "Resource with id [AppFunctionS3Event] is invalid. Invalid type for LambdaConfigurations. Must be a list."
     }
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [AppFunctionS3Event] is invalid. Invalid type for LambdaConfigurations. Must be a list."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [AnotherBucket] is invalid. Invalid type for NotificationConfiguration. Must be a dict. Resource with id [RandomBucket] is invalid. Invalid type for LambdaConfigurations. Must be a list."
 } 

--- a/tests/translator/output/error_s3_lambda_configuration_invalid_type.json
+++ b/tests/translator/output/error_s3_lambda_configuration_invalid_type.json
@@ -4,5 +4,5 @@
       "errorMessage": "Resource with id [AppFunctionS3Event] is invalid. Invalid type for LambdaConfigurations. Must be a list."
     }
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [AnotherBucket] is invalid. Invalid type for NotificationConfiguration. Must be a dict. Resource with id [RandomBucket] is invalid. Invalid type for LambdaConfigurations. Must be a list."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [AnotherBucket] is invalid. Invalid type for NotificationConfiguration. Resource with id [RandomBucket] is invalid. Invalid type for LambdaConfigurations. Must be a list."
 } 


### PR DESCRIPTION
*Issue #, if available:*
N/A/

*Description of changes:*
Add Validation for `NotifcationConfiguration` in a S3 Bucket if it is used in a Serverless Function as an event source.

*Description of how you validated changes:*
Updated test to catch this error.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
