### PR TITLE
chore: Change FeatureToggleAppConfigConfigProvider to accept AppConfig client, so SAM-T can send a monitored client.

### DIFF
--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -129,7 +129,7 @@ class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
     """Feature toggle config provider which loads config from AppConfig."""
 
     @cw_timer(prefix="External", name="AppConfig")
-    def __init__(self, application_id, environment_id, configuration_profile_id):
+    def __init__(self, application_id, environment_id, configuration_profile_id, app_config_client=None):
         FeatureToggleConfigProvider.__init__(self)
         try:
             LOG.info("Loading feature toggle config from AppConfig...")
@@ -137,7 +137,9 @@ class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
             # (5 + 5) * 2, 20 seconds maximum timeout duration
             # In case of high latency from AppConfig, we can always fall back to use an empty config and continue transform
             client_config = Config(connect_timeout=5, read_timeout=5, retries={"total_max_attempts": 2})
-            self.app_config_client = boto3.client("appconfig", config=client_config)
+            self.app_config_client = (
+                boto3.client("appconfig", config=client_config) if not app_config_client else app_config_client
+            )
             response = self.app_config_client.get_configuration(
                 Application=application_id,
                 Environment=environment_id,

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -105,16 +105,49 @@ class TestFeatureToggleAppConfig(TestCase):
         ]
     )
     @patch("samtranslator.feature_toggle.feature_toggle.boto3")
+    @patch("samtranslator.feature_toggle.feature_toggle.Config")
     def test_feature_toggle_with_appconfig_provider(
-        self, feature_name, stage, region, account_id, expected, boto3_mock
+        self, feature_name, stage, region, account_id, expected, config_mock, boto3_mock
     ):
         boto3_mock.client.return_value = self.app_config_mock
+        config_object_mock = Mock()
+        config_mock.return_value = config_object_mock
         feature_toggle_config_provider = FeatureToggleAppConfigConfigProvider(
             "test_app_id", "test_env_id", "test_conf_id"
         )
         feature_toggle = FeatureToggle(
             feature_toggle_config_provider, stage=stage, region=region, account_id=account_id
         )
+        boto3_mock.client.assert_called_once_with("appconfig", config=config_object_mock)
+        self.assertEqual(feature_toggle.is_enabled(feature_name), expected)
+
+    @parameterized.expand(
+        [
+            param("feature-1", "beta", "default", "123456789123", False),
+            param("feature-1", "beta", "us-west-2", "123456789123", True),
+            param("feature-2", "beta", "us-west-2", "123456789123", False),  # because feature is missing
+            param("feature-1", "beta", "ap-south-1", "123456789124", False),  # because default is used
+            param("feature-1", "alpha", "us-east-1", "123456789123", False),  # non-exist stage
+            param("feature-1", "beta", "us-east-1", "123456789100", True),
+            param("feature-1", "beta", "us-east-1", "123456789123", False),
+            # any None for stage, region and account_id returns False
+            param("feature-1", None, None, None, False),
+            param("feature-1", "beta", None, None, False),
+            param("feature-1", "beta", "us-west-2", None, False),
+            param("feature-1", "beta", None, "123456789123", False),
+        ]
+    )
+    @patch("samtranslator.feature_toggle.feature_toggle.boto3")
+    def test_feature_toggle_with_appconfig_provider_and_app_config_client(
+        self, feature_name, stage, region, account_id, expected, boto3_mock
+    ):
+        feature_toggle_config_provider = FeatureToggleAppConfigConfigProvider(
+            "test_app_id", "test_env_id", "test_conf_id", self.app_config_mock
+        )
+        feature_toggle = FeatureToggle(
+            feature_toggle_config_provider, stage=stage, region=region, account_id=account_id
+        )
+        boto3_mock.client.assert_not_called()
         self.assertEqual(feature_toggle.is_enabled(feature_name), expected)
 
 


### PR DESCRIPTION
We need to monitor all SAM Translator dependencies usage and failures, and this change to allow SAM Translator service to send a monitored APP Config client to the FeatureToggleAppConfigConfigProvider class to be used instead of creating a new client. 

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
