### PR TITLE
feat: Add State Property to EventBridgeRule EventSource in Function

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -186,6 +186,8 @@ class CloudWatchEvent(PushEventSource):
         "Input": PropertyType(False, is_str()),
         "InputPath": PropertyType(False, is_str()),
         "Target": PropertyType(False, is_type(dict)),
+        "Enabled": PropertyType(False, is_type(bool)),
+        "State": PropertyType(False, is_str()),
     }
 
     @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
@@ -217,6 +219,15 @@ class CloudWatchEvent(PushEventSource):
                 self, source_arn, passthrough_resource_attributes
             )
             resources.extend(dlq_resources)
+
+        if self.State and self.Enabled is not None:
+            raise InvalidEventException(self.relative_id, "State and Enabled Properties cannot both be specified.")
+
+        if self.State:
+            events_rule.State = self.State
+
+        if self.Enabled is not None:
+            events_rule.State = "ENABLED" if self.Enabled else "DISABLED"
 
         events_rule.Targets = [self._construct_target(function, dlq_queue_arn)]
 

--- a/tests/translator/input/error_function_with_invalid_event_bridge_rule.yaml
+++ b/tests/translator/input/error_function_with_invalid_event_bridge_rule.yaml
@@ -1,0 +1,35 @@
+Transform: "AWS::Serverless-2016-10-31"
+
+Resources:
+  TestBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: test-bucket
+  TestFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      FunctionName: test-function
+      InlineCode: |
+        exports.handler = async (event) => {
+          return 'Hello from Lambda!';
+        };
+      Handler: index.handler
+      Runtime: nodejs16.x
+      Events:
+        TestEventBridgeRule:
+          Type: EventBridgeRule
+          Properties:
+            State: ENABLED
+            Enabled: true
+            Pattern:
+              source:
+                - aws.s3
+              detail-type:
+                - Object Created
+              detail:
+                bucket:
+                  name:
+                    - "test-bucket"
+                object:
+                  key:
+                    - prefix: "/"

--- a/tests/translator/input/function_with_event_bridge_rule_state.yaml
+++ b/tests/translator/input/function_with_event_bridge_rule_state.yaml
@@ -1,0 +1,34 @@
+Transform: "AWS::Serverless-2016-10-31"
+
+Resources:
+  TestBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: test-bucket
+  TestFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      FunctionName: test-function
+      InlineCode: |
+        exports.handler = async (event) => {
+          return 'Hello from Lambda!';
+        };
+      Handler: index.handler
+      Runtime: nodejs16.x
+      Events:
+        TestEventBridgeRule:
+          Type: EventBridgeRule
+          Properties:
+            State: ENABLED
+            Pattern:
+              source:
+                - aws.s3
+              detail-type:
+                - Object Created
+              detail:
+                bucket:
+                  name:
+                    - "test-bucket"
+                object:
+                  key:
+                    - prefix: "/"

--- a/tests/translator/output/aws-cn/function_with_event_bridge_rule_state.json
+++ b/tests/translator/output/aws-cn/function_with_event_bridge_rule_state.json
@@ -1,0 +1,118 @@
+{
+ "Resources": {
+  "TestBucket": {
+   "Type": "AWS::S3::Bucket",
+   "Properties": {
+    "BucketName": "test-bucket"
+   }
+  },
+  "TestFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "exports.handler = async (event) => {\n  return 'Hello from Lambda!';\n};\n"
+    },
+    "FunctionName": "test-function",
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "TestFunctionRole",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs16.x",
+    "Tags": [
+     {
+      "Key": "lambda:createdBy",
+      "Value": "SAM"
+     }
+    ]
+   }
+  },
+  "TestFunctionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Action": [
+        "sts:AssumeRole"
+       ],
+       "Effect": "Allow",
+       "Principal": {
+        "Service": [
+         "lambda.amazonaws.com"
+        ]
+       }
+      }
+     ]
+    },
+    "ManagedPolicyArns": [
+     "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    ],
+    "Tags": [
+     {
+      "Key": "lambda:createdBy",
+      "Value": "SAM"
+     }
+    ]
+   }
+  },
+  "TestFunctionTestEventBridgeRule": {
+   "Type": "AWS::Events::Rule",
+   "Properties": {
+    "EventPattern": {
+     "source": [
+      "aws.s3"
+     ],
+     "detail-type": [
+      "Object Created"
+     ],
+     "detail": {
+      "bucket": {
+       "name": [
+        "test-bucket"
+       ]
+      },
+      "object": {
+       "key": [
+        {
+         "prefix": "/"
+        }
+       ]
+      }
+     }
+    },
+    "State": "ENABLED",
+    "Targets": [
+     {
+      "Arn": {
+       "Fn::GetAtt": [
+        "TestFunction",
+        "Arn"
+       ]
+      },
+      "Id": "TestFunctionTestEventBridgeRuleLambdaTarget"
+     }
+    ]
+   }
+  },
+  "TestFunctionTestEventBridgeRulePermission": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Ref": "TestFunction"
+    },
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "TestFunctionTestEventBridgeRule",
+      "Arn"
+     ]
+    }
+   }
+  }
+ }
+}

--- a/tests/translator/output/aws-us-gov/function_with_event_bridge_rule_state.json
+++ b/tests/translator/output/aws-us-gov/function_with_event_bridge_rule_state.json
@@ -1,0 +1,118 @@
+{
+ "Resources": {
+  "TestBucket": {
+   "Type": "AWS::S3::Bucket",
+   "Properties": {
+    "BucketName": "test-bucket"
+   }
+  },
+  "TestFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "exports.handler = async (event) => {\n  return 'Hello from Lambda!';\n};\n"
+    },
+    "FunctionName": "test-function",
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "TestFunctionRole",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs16.x",
+    "Tags": [
+     {
+      "Key": "lambda:createdBy",
+      "Value": "SAM"
+     }
+    ]
+   }
+  },
+  "TestFunctionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Action": [
+        "sts:AssumeRole"
+       ],
+       "Effect": "Allow",
+       "Principal": {
+        "Service": [
+         "lambda.amazonaws.com"
+        ]
+       }
+      }
+     ]
+    },
+    "ManagedPolicyArns": [
+     "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    ],
+    "Tags": [
+     {
+      "Key": "lambda:createdBy",
+      "Value": "SAM"
+     }
+    ]
+   }
+  },
+  "TestFunctionTestEventBridgeRule": {
+   "Type": "AWS::Events::Rule",
+   "Properties": {
+    "EventPattern": {
+     "source": [
+      "aws.s3"
+     ],
+     "detail-type": [
+      "Object Created"
+     ],
+     "detail": {
+      "bucket": {
+       "name": [
+        "test-bucket"
+       ]
+      },
+      "object": {
+       "key": [
+        {
+         "prefix": "/"
+        }
+       ]
+      }
+     }
+    },
+    "State": "ENABLED",
+    "Targets": [
+     {
+      "Arn": {
+       "Fn::GetAtt": [
+        "TestFunction",
+        "Arn"
+       ]
+      },
+      "Id": "TestFunctionTestEventBridgeRuleLambdaTarget"
+     }
+    ]
+   }
+  },
+  "TestFunctionTestEventBridgeRulePermission": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Ref": "TestFunction"
+    },
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "TestFunctionTestEventBridgeRule",
+      "Arn"
+     ]
+    }
+   }
+  }
+ }
+}

--- a/tests/translator/output/error_function_with_invalid_event_bridge_rule.json
+++ b/tests/translator/output/error_function_with_invalid_event_bridge_rule.json
@@ -1,0 +1,1 @@
+{"errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [TestFunction] is invalid. Event with id [TestEventBridgeRule] is invalid. State and Enabled Properties cannot both be specified."}

--- a/tests/translator/output/function_with_event_bridge_rule_state.json
+++ b/tests/translator/output/function_with_event_bridge_rule_state.json
@@ -1,0 +1,118 @@
+{
+ "Resources": {
+  "TestBucket": {
+   "Type": "AWS::S3::Bucket",
+   "Properties": {
+    "BucketName": "test-bucket"
+   }
+  },
+  "TestFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "exports.handler = async (event) => {\n  return 'Hello from Lambda!';\n};\n"
+    },
+    "FunctionName": "test-function",
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "TestFunctionRole",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs16.x",
+    "Tags": [
+     {
+      "Key": "lambda:createdBy",
+      "Value": "SAM"
+     }
+    ]
+   }
+  },
+  "TestFunctionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Action": [
+        "sts:AssumeRole"
+       ],
+       "Effect": "Allow",
+       "Principal": {
+        "Service": [
+         "lambda.amazonaws.com"
+        ]
+       }
+      }
+     ]
+    },
+    "ManagedPolicyArns": [
+     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    ],
+    "Tags": [
+     {
+      "Key": "lambda:createdBy",
+      "Value": "SAM"
+     }
+    ]
+   }
+  },
+  "TestFunctionTestEventBridgeRule": {
+   "Type": "AWS::Events::Rule",
+   "Properties": {
+    "EventPattern": {
+     "source": [
+      "aws.s3"
+     ],
+     "detail-type": [
+      "Object Created"
+     ],
+     "detail": {
+      "bucket": {
+       "name": [
+        "test-bucket"
+       ]
+      },
+      "object": {
+       "key": [
+        {
+         "prefix": "/"
+        }
+       ]
+      }
+     }
+    },
+    "State": "ENABLED",
+    "Targets": [
+     {
+      "Arn": {
+       "Fn::GetAtt": [
+        "TestFunction",
+        "Arn"
+       ]
+      },
+      "Id": "TestFunctionTestEventBridgeRuleLambdaTarget"
+     }
+    ]
+   }
+  },
+  "TestFunctionTestEventBridgeRulePermission": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Ref": "TestFunction"
+    },
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "TestFunctionTestEventBridgeRule",
+      "Arn"
+     ]
+    }
+   }
+  }
+ }
+}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Add state property to EventBridgeRule EventSource for AWS::Serverless::Function.

*Description of how you validated changes:*

Added invalid input and transform tests.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [x] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
