### PR TITLE
feat: Added UserAttributeUpdateSettings to Cognito

### DIFF
--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -22,6 +22,7 @@ class CognitoUserPool(Resource):
         "SmsAuthenticationMessage": PropertyType(False, is_str()),
         "SmsConfiguration": PropertyType(False, is_type(dict)),
         "SmsVerificationMessage": PropertyType(False, is_str()),
+        "UserAttributeUpdateSettings": PropertyType(False, is_type(dict)),
         "UsernameAttributes": PropertyType(False, list_of(is_str())),
         "UsernameConfiguration": PropertyType(False, is_type(dict)),
         "UserPoolAddOns": PropertyType(False, list_of(dict)),

--- a/tests/translator/input/cognito_userpool_with_event.yaml
+++ b/tests/translator/input/cognito_userpool_with_event.yaml
@@ -12,6 +12,9 @@ Resources:
         - AttributeDataType: String
           Name: email
           Required: false
+      UserAttributeUpdateSettings:
+        AttributesRequireVerificationBeforeUpdate: 
+          - email
   ImplicitApiFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/tests/translator/output/aws-cn/cognito_userpool_with_event.json
+++ b/tests/translator/output/aws-cn/cognito_userpool_with_event.json
@@ -35,6 +35,11 @@
             "Required": false
           }
         ],
+        "UserAttributeUpdateSettings": {
+         "AttributesRequireVerificationBeforeUpdate": [
+          "email"
+         ]
+        },
         "UsernameAttributes": [
           "email"
         ],

--- a/tests/translator/output/aws-us-gov/cognito_userpool_with_event.json
+++ b/tests/translator/output/aws-us-gov/cognito_userpool_with_event.json
@@ -35,6 +35,11 @@
             "Required": false
           }
         ],
+        "UserAttributeUpdateSettings": {
+         "AttributesRequireVerificationBeforeUpdate": [
+          "email"
+         ]
+        },
         "UsernameAttributes": [
           "email"
         ],

--- a/tests/translator/output/cognito_userpool_with_event.json
+++ b/tests/translator/output/cognito_userpool_with_event.json
@@ -35,6 +35,11 @@
             "Required": false
           }
         ],
+        "UserAttributeUpdateSettings": {
+         "AttributesRequireVerificationBeforeUpdate": [
+          "email"
+         ]
+        },
         "UsernameAttributes": [
           "email"
         ],


### PR DESCRIPTION
*Issue #, if available:*
#2496

*Description of changes:*
Added `UserAttributeUpdateSettings` to Cognito model.

*Description of how you validated changes:*
A sample template that contained the `UserAttributeUpdateSettings` property was run with `bin/sam-translate.py` before and after the changes to validate the property was picked up by the reference to the `AWS::Cognito::UserPool` in the function's events.

*Checklist:*

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
