### PR TITLE
chore: Add test name to request logging and remove default region from pytest.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ venv.bak/
 
 # PyCharm
 .idea
+
+# Companion stack config
+integration/config/file_to_s3_map_modified.json

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ init:
 	pip install -e '.[dev]'
 
 test:
-	pytest --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/*
+	AWS_DEFAULT_REGION=us-east-1 pytest --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/*
 
 test-fast:
 	pytest -x --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/*

--- a/integration/combination/test_api_settings.py
+++ b/integration/combination/test_api_settings.py
@@ -162,7 +162,7 @@ class TestApiSettings(BaseTest):
 
     def verify_binary_media_request(self, url, expected_status_code):
         headers = {"accept": "image/png"}
-        response = BaseTest.do_get_request_with_logging(url, headers)
+        response = self.do_get_request_with_logging(url, headers)
 
         status = response.status_code
         expected_file_path = str(Path(self.code_dir, "AWS_logo_RGB.png"))

--- a/integration/combination/test_api_with_authorizer_apikey.py
+++ b/integration/combination/test_api_with_authorizer_apikey.py
@@ -80,10 +80,10 @@ class TestApiWithAuthorizerApiKey(BaseTest):
         header_value=None,
     ):
         if not header_key or not header_value:
-            response = BaseTest.do_get_request_with_logging(url)
+            response = self.do_get_request_with_logging(url)
         else:
             headers = {header_key: header_value}
-            response = BaseTest.do_get_request_with_logging(url, headers)
+            response = self.do_get_request_with_logging(url, headers)
         status = response.status_code
         if status != expected_status_code:
             raise StatusCodeError(

--- a/integration/config/logger_configurations.py
+++ b/integration/config/logger_configurations.py
@@ -8,7 +8,9 @@ class LoggingConfiguration:
         console_handler = logging.StreamHandler()
         console_handler.setLevel(logging.INFO)
         console_handler.setFormatter(
-            logging.Formatter("%(asctime)s %(message)s | Status: %(status)s | Headers: %(headers)s ")
+            logging.Formatter(
+                "\nREQUEST LOG [%(test)s] | Time: %(asctime)s %(message)s | Status: %(status)s | Headers: %(headers)s"
+            )
         )
         logger.addHandler(console_handler)
         logger.propagate = False

--- a/integration/single/test_function_with_http_api_and_auth.py
+++ b/integration/single/test_function_with_http_api_and_auth.py
@@ -1,6 +1,7 @@
 from unittest.case import skipIf
 
 import pytest
+import time
 
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
@@ -21,23 +22,22 @@ class TestFunctionWithHttpApiAndAuth(BaseTest):
 
         self.create_and_verify_stack("single/function_with_http_api_events_and_auth")
 
+        # This will be changed according to APIGW suggested wait time
+        time.sleep(10)
+
         implicitEndpoint = self.get_api_v2_endpoint("ServerlessHttpApi")
         self.assertEqual(
-            BaseTest.do_get_request_with_logging(implicitEndpoint + "/default-auth").text, self.FUNCTION_OUTPUT
+            self.do_get_request_with_logging(implicitEndpoint + "/default-auth").text, self.FUNCTION_OUTPUT
         )
-        self.assertEqual(BaseTest.do_get_request_with_logging(implicitEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
+        self.assertEqual(self.do_get_request_with_logging(implicitEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
 
         defaultIamEndpoint = self.get_api_v2_endpoint("MyDefaultIamAuthHttpApi")
-        self.assertEqual(
-            BaseTest.do_get_request_with_logging(defaultIamEndpoint + "/no-auth").text, self.FUNCTION_OUTPUT
-        )
-        self.assertEqual(
-            BaseTest.do_get_request_with_logging(defaultIamEndpoint + "/default-auth").text, IAM_AUTH_OUTPUT
-        )
-        self.assertEqual(BaseTest.do_get_request_with_logging(defaultIamEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
+        self.assertEqual(self.do_get_request_with_logging(defaultIamEndpoint + "/no-auth").text, self.FUNCTION_OUTPUT)
+        self.assertEqual(self.do_get_request_with_logging(defaultIamEndpoint + "/default-auth").text, IAM_AUTH_OUTPUT)
+        self.assertEqual(self.do_get_request_with_logging(defaultIamEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
 
         iamEnabledEndpoint = self.get_api_v2_endpoint("MyIamAuthEnabledHttpApi")
         self.assertEqual(
-            BaseTest.do_get_request_with_logging(iamEnabledEndpoint + "/default-auth").text, self.FUNCTION_OUTPUT
+            self.do_get_request_with_logging(iamEnabledEndpoint + "/default-auth").text, self.FUNCTION_OUTPUT
         )
-        self.assertEqual(BaseTest.do_get_request_with_logging(iamEnabledEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)
+        self.assertEqual(self.do_get_request_with_logging(iamEnabledEndpoint + "/iam-auth").text, IAM_AUTH_OUTPUT)

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,8 +3,6 @@
 # NOTE: If debug breakpoints aren't working, comment out the code coverage line below
 addopts = --cov samtranslator --cov-report term-missing --cov-fail-under 95
 testpaths = tests
-env =
-    AWS_DEFAULT_REGION = ap-southeast-1
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
 log_cli = 1


### PR DESCRIPTION
*Issue #, if available:*
N.A.

*Description of changes:*
In the integration test logging, when tests are running in parallel, the position of the logging messages does not follow the exact test it belongs to. Therefore a header is added to indicate the test case each request belongs to.

*Description of how you validated changes:*
Ran locally to see the logs:
REQUEST LOG [test_cors_1_combination_api_with_cors_openapi] | Time: 2022-09-22 22:28:08,487 Request made to https://* | Status: 200 | Headers: {*}

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
