### PR TITLE
chore: Only do request logging when internal flag is provided

### DIFF
--- a/integration/combination/test_api_with_authorizers.py
+++ b/integration/combination/test_api_with_authorizers.py
@@ -439,7 +439,7 @@ class TestApiWithAuthorizers(BaseTest):
             response = self.do_get_request_with_logging(url)
         else:
             headers = {header_key: header_value}
-            response = self.Test.do_get_request_with_logging(url, headers)
+            response = self.do_get_request_with_logging(url, headers)
         status = response.status_code
 
         if status != expected_status_code:

--- a/integration/combination/test_api_with_authorizers.py
+++ b/integration/combination/test_api_with_authorizers.py
@@ -436,10 +436,10 @@ class TestApiWithAuthorizers(BaseTest):
         header_value=None,
     ):
         if not header_key or not header_value:
-            response = BaseTest.do_get_request_with_logging(url)
+            response = self.do_get_request_with_logging(url)
         else:
             headers = {header_key: header_value}
-            response = BaseTest.do_get_request_with_logging(url, headers)
+            response = self.Test.do_get_request_with_logging(url, headers)
         status = response.status_code
 
         if status != expected_status_code:

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -69,7 +69,9 @@ class BaseTest(TestCase):
         self.internal = check_internal
 
     @classmethod
-    @pytest.mark.usefixtures("get_prefix", "get_stage", "check_internal", "parameter_values", "get_s3", "check_internal")
+    @pytest.mark.usefixtures(
+        "get_prefix", "get_stage", "check_internal", "parameter_values", "get_s3", "check_internal"
+    )
     def setUpClass(cls):
         cls.FUNCTION_OUTPUT = "hello"
         cls.tests_integ_dir = Path(__file__).resolve().parents[1]

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -64,8 +64,12 @@ class BaseTest(TestCase):
     def case_name(self, request):
         self.testcase = request.node.name
 
+    @pytest.fixture(autouse=True)
+    def internal_check(self, check_internal):
+        self.internal = check_internal
+
     @classmethod
-    @pytest.mark.usefixtures("get_prefix", "get_stage", "check_internal", "parameter_values", "get_s3")
+    @pytest.mark.usefixtures("get_prefix", "get_stage", "check_internal", "parameter_values", "get_s3", "check_internal")
     def setUpClass(cls):
         cls.FUNCTION_OUTPUT = "hello"
         cls.tests_integ_dir = Path(__file__).resolve().parents[1]
@@ -560,10 +564,11 @@ class BaseTest(TestCase):
         """
         response = requests.get(url, headers=headers) if headers else requests.get(url)
         amazon_headers = RequestUtils(response).get_amazon_headers()
-        REQUEST_LOGGER.info(
-            "Request made to " + url,
-            extra={"test": self.testcase, "status": response.status_code, "headers": amazon_headers},
-        )
+        if self.internal:
+            REQUEST_LOGGER.info(
+                "Request made to " + url,
+                extra={"test": self.testcase, "status": response.status_code, "headers": amazon_headers},
+            )
         return response
 
     def do_options_request_with_logging(self, url, headers=None):
@@ -578,8 +583,9 @@ class BaseTest(TestCase):
         """
         response = requests.options(url, headers=headers) if headers else requests.options(url)
         amazon_headers = RequestUtils(response).get_amazon_headers()
-        REQUEST_LOGGER.info(
-            "Request made to " + url,
-            extra={"test": self.testcase, "status": response.status_code, "headers": amazon_headers},
-        )
+        if self.internal:
+            REQUEST_LOGGER.info(
+                "Request made to " + url,
+                extra={"test": self.testcase, "status": response.status_code, "headers": amazon_headers},
+            )
         return response


### PR DESCRIPTION
*Issue #, if available:*
N.A.

*Description of changes:*
To clean up integration test run experience for non-internal test runs

*Description of how you validated changes:*
Tested outputs locally with and without --internal

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
