### PR TITLE
chore: increase test retry delay

### DIFF
--- a/integration/combination/test_api_with_authorizer_apikey.py
+++ b/integration/combination/test_api_with_authorizer_apikey.py
@@ -71,7 +71,7 @@ class TestApiWithAuthorizerApiKey(BaseTest):
         # ApiKeySourceType is AUTHORIZER. Passing api key via x-api-key will not get authorized
         self.verify_authorized_request(base_url + "lambda-token-api-key", 401, "x-api-key", key["value"])
 
-    @retry(StatusCodeError, 10)
+    @retry(StatusCodeError, 10, 0.25)
     def verify_authorized_request(
         self,
         url,

--- a/integration/combination/test_api_with_authorizers.py
+++ b/integration/combination/test_api_with_authorizers.py
@@ -427,7 +427,7 @@ class TestApiWithAuthorizers(BaseTest):
         auth_type_for_api_event_without_auth = api_event_with_out_auth["authorizationType"]
         self.assertEqual(auth_type_for_api_event_without_auth, "NONE")
 
-    @retry(StatusCodeError, 10)
+    @retry(StatusCodeError, 10, 0.25)
     def verify_authorized_request(
         self,
         url,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently it uses 10 attempts with 0.05 seconds delay, or `sum((2 ** x) * 0.05 for x in range(1, 11))` or about 1 minute 40 seconds in total.

Now it uses 0.25 seconds delay, or about 5 minutes in total.

Guessing it's IAM propagation, see e.g. https://stackoverflow.com/questions/20156043/how-long-should-i-wait-after-applying-an-aws-iam-policy-before-it-is-valid

*Description of how you validated changes:*

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
