### PR TITLE
Hardcoded partition name causes cfn-lint Info message

### DIFF
--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -310,7 +310,7 @@ class ApiGatewayAuthorizer(object):
 
         elif authorizer_type == "LAMBDA":
             swagger[APIGATEWAY_AUTHORIZER_KEY] = Py27Dict({"type": self._get_swagger_authorizer_type()})
-            partition = ArnGenerator.get_partition_name()
+            partition = "{AWS::Partition}"
             resource = "lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations"
             authorizer_uri = fnSub(
                 ArnGenerator.generate_arn(

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -216,7 +216,7 @@ class ApiGatewayV2Authorizer(object):
             openapi[APIGATEWAY_AUTHORIZER_KEY] = {"type": "request"}
 
             # Generate the lambda arn
-            partition = ArnGenerator.get_partition_name()
+            partition = "{AWS::Partition}"
             resource = "lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations"
             authorizer_uri = fnSub(
                 ArnGenerator.generate_arn(


### PR DESCRIPTION
*Description of changes:*

In API Gateway v1 & v2, for Lambda authorizers, replaced hardcoded partition name with pseudo parameter {AWS::Partition}. 

This will fix a cfn-lint Info message ("I3042 ARN in Resource <<Resource name>> contains hardcoded Partition in ARN or incorrectly placed Pseudo Parameters") for any Lambda authorizer config in API Gateway.

*Description of how you validated changes:*

Ran cfn-lint (0.66.1) from command line against sample template. With code changes, the Info message no longer appears.

*Checklist:*

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [x] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Basic template used to test/verify is:

AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31
Resources:
    ServerlessHttpApi1:
        Type: AWS::Serverless::HttpApi
        Properties:
            Auth:
                Authorizers:
                    LambdaAuthorizer1:
                        AuthorizerPayloadFormatVersion: '2.0'
                        EnableSimpleResponses: true
                        FunctionArn: !GetAtt ServerlessFunction1.Arn
                        Identity:
                            ReauthorizeEvery: 0
                DefaultAuthorizer: LambdaAuthorizer1
    ServerlessFunction1:
        Type: AWS::Serverless::Function
        Properties:
            Handler: test.main
            Runtime: python3.9
            CodeUri: src/test.py
            FunctionName: test
            Timeout: 300

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
