### PR TITLE
Add ability to set State of EventBridge Rule

### DIFF
--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -170,6 +170,7 @@ class CloudWatchEvent(EventSource):
         "InputPath": PropertyType(False, is_str()),
         "DeadLetterConfig": PropertyType(False, is_type(dict)),
         "RetryPolicy": PropertyType(False, is_type(dict)),
+        "State": PropertyType(False, is_str()),
     }
 
     @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)
@@ -189,6 +190,9 @@ class CloudWatchEvent(EventSource):
         events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)
         events_rule.EventBusName = self.EventBusName
         events_rule.EventPattern = self.Pattern
+
+        if self.State:
+            events_rule.State = self.State
 
         resources.append(events_rule)
 

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -371,6 +371,9 @@
         "Pattern": {
           "type": "object"
         },
+        "State": {
+          "type": "string"
+        },
         "DeadLetterConfig": {
           "additionalProperties": false,
           "properties": {

--- a/tests/model/eventsources/test_eventbridge_rule_source.py
+++ b/tests/model/eventsources/test_eventbridge_rule_source.py
@@ -27,10 +27,10 @@ class EventBridgeRuleSourceTests(TestCase):
         self.assertEqual(target_id, "MyTargetId")
 
     def test_state_when_provided(self):
-        self.eb_event_source.State = "Disabled"
+        self.eb_event_source.State = "DISABLED"
         cfn = self.eb_event_source.to_cloudformation(function=self.func)
         state = cfn[0].State
-        self.assertEqual(state, "Disabled")
+        self.assertEqual(state, "DISABLED")
 
     def test_to_cloudformation_with_retry_policy(self):
         retry_policy = {"MaximumRetryAttempts": "10", "MaximumEventAgeInSeconds": "300"}

--- a/tests/model/eventsources/test_eventbridge_rule_source.py
+++ b/tests/model/eventsources/test_eventbridge_rule_source.py
@@ -26,6 +26,12 @@ class EventBridgeRuleSourceTests(TestCase):
         target_id = cfn[0].Targets[0]["Id"]
         self.assertEqual(target_id, "MyTargetId")
 
+    def test_state_when_provided(self):
+        self.eb_event_source.State = "Disabled"
+        cfn = self.eb_event_source.to_cloudformation(function=self.func)
+        state = cfn[0].State
+        self.assertEqual(state, "Disabled")
+
     def test_to_cloudformation_with_retry_policy(self):
         retry_policy = {"MaximumRetryAttempts": "10", "MaximumEventAgeInSeconds": "300"}
         self.eb_event_source.RetryPolicy = retry_policy

--- a/tests/model/stepfunctions/test_eventbridge_rule_source.py
+++ b/tests/model/stepfunctions/test_eventbridge_rule_source.py
@@ -33,3 +33,9 @@ class EventBridgeRuleSourceTests(TestCase):
         self.eb_event_source.DeadLetterConfig = dead_letter_config
         with self.assertRaises(InvalidEventException):
             self.eb_event_source.to_cloudformation(resource=self.state_machine)
+
+    def test_to_cloudformation_with_state(self):
+        self.eb_event_source.State = "DISABLED"
+        resources = self.eb_event_source.to_cloudformation(resource=self.state_machine)
+        state = resources[0].State
+        self.assertEqual(state, "DISABLED")

--- a/tests/translator/input/eventbridgerule_with_dlq.yaml
+++ b/tests/translator/input/eventbridgerule_with_dlq.yaml
@@ -10,6 +10,7 @@ Resources:
           Type: Schedule
           Properties:
             Schedule: 'rate(1 minute)'
+            State: ENABLED
             DeadLetterConfig:
               Type: SQS
   TriggeredFunction:
@@ -23,6 +24,7 @@ Resources:
           Type: EventBridgeRule
           Properties:
             EventBusName: ExternalEventBridge
+            State: ENABLED
             Pattern:
               detail:
                 state:

--- a/tests/translator/input/state_machine_with_cwe.yaml
+++ b/tests/translator/input/state_machine_with_cwe.yaml
@@ -8,6 +8,7 @@ Resources:
         CWEvent:
           Type: CloudWatchEvent
           Properties:
+            State: ENABLED
             Pattern:
               detail:
                 state:

--- a/tests/translator/output/aws-cn/eventbridgerule_with_dlq.json
+++ b/tests/translator/output/aws-cn/eventbridgerule_with_dlq.json
@@ -79,6 +79,7 @@
           }
         }, 
         "EventBusName": "ExternalEventBridge", 
+        "State" : "ENABLED", 
         "Targets": [
           {
             "DeadLetterConfig": {
@@ -213,6 +214,7 @@
       "Type": "AWS::Events::Rule", 
       "Properties": {
         "ScheduleExpression": "rate(1 minute)", 
+        "State" : "ENABLED",
         "Targets": [
           {
             "DeadLetterConfig": {

--- a/tests/translator/output/aws-cn/state_machine_with_cwe.json
+++ b/tests/translator/output/aws-cn/state_machine_with_cwe.json
@@ -10,6 +10,7 @@
             ]
           }
         }, 
+        "State": "ENABLED",
         "Targets": [
           {
             "RoleArn": {

--- a/tests/translator/output/aws-us-gov/eventbridgerule_with_dlq.json
+++ b/tests/translator/output/aws-us-gov/eventbridgerule_with_dlq.json
@@ -79,6 +79,7 @@
           }
         }, 
         "EventBusName": "ExternalEventBridge", 
+        "State" : "ENABLED", 
         "Targets": [
           {
             "DeadLetterConfig": {
@@ -213,6 +214,7 @@
       "Type": "AWS::Events::Rule", 
       "Properties": {
         "ScheduleExpression": "rate(1 minute)", 
+        "State" : "ENABLED",
         "Targets": [
           {
             "DeadLetterConfig": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_cwe.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_cwe.json
@@ -10,6 +10,7 @@
             ]
           }
         }, 
+        "State": "ENABLED",
         "Targets": [
           {
             "RoleArn": {

--- a/tests/translator/output/eventbridgerule_with_dlq.json
+++ b/tests/translator/output/eventbridgerule_with_dlq.json
@@ -78,7 +78,8 @@
             ]
           }
         }, 
-        "EventBusName": "ExternalEventBridge", 
+        "EventBusName": "ExternalEventBridge",
+        "State" : "ENABLED", 
         "Targets": [
           {
             "DeadLetterConfig": {
@@ -213,6 +214,7 @@
       "Type": "AWS::Events::Rule", 
       "Properties": {
         "ScheduleExpression": "rate(1 minute)", 
+        "State" : "ENABLED",
         "Targets": [
           {
             "DeadLetterConfig": {

--- a/tests/translator/output/state_machine_with_cwe.json
+++ b/tests/translator/output/state_machine_with_cwe.json
@@ -10,6 +10,7 @@
             ]
           }
         }, 
+        "State": "ENABLED",
         "Targets": [
           {
             "RoleArn": {


### PR DESCRIPTION
*Issue #, if available:*
#2509 

*Description of changes:*

- Added a schema and test to support `State` property of `AWS::Events::Rule` in SAM

*Description of how you validated changes:*
Used `bin/sam-translate.py` to generate a CFN template from SAM template which I then successfully deployed in my AWS account with desired changes taking effect.

*Checklist:*

- [X] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [X] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [X] `make pr` passes
- [ ] Update documentation
- [X] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
