### PR TITLE
feat: automatically add `DependsOn` for Lambda to SQS DLQ on ESM

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -534,7 +534,7 @@ class ResourceResolver:
         """
         for logical_id, resource in self.resources.items():
             if resource.get("Type") == resource_type:
-                yield copy.deepcopy(resource.get("Properties") or {})
+                yield logical_id, copy.deepcopy(resource.get("Properties") or {})
 
     def get_resource_by_logical_id(self, input: str) -> Dict[str, Any]:
         """

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -1,7 +1,8 @@
 """ CloudFormation Resource serialization, deserialization, and validation """
+import copy
 import re
 import inspect
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Tuple, Iterator
 
 from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.plugins import LifeCycleEvents
@@ -527,9 +528,13 @@ class ResourceResolver:
 
         self.resources = resources
 
-    def get_all_resources(self) -> Dict[str, Any]:
-        """Return a dictionary of all resources from the SAM template."""
-        return self.resources
+    def get_resources_by_type(self, resource_type: str) -> Iterator[Tuple[str, Dict[str, Any]]]:
+        """
+        Return generator of (logical_id, properties) tuples of resources with specified type.
+        """
+        for logical_id, resource in self.resources.items():
+            if resource.get("Type") == resource_type:
+                yield copy.deepcopy(resource.get("Properties") or {})
 
     def get_resource_by_logical_id(self, input: str) -> Dict[str, Any]:
         """

--- a/samtranslator/model/connector_profiles/profiles.json
+++ b/samtranslator/model/connector_profiles/profiles.json
@@ -234,6 +234,7 @@
         "Type": "AWS_IAM_ROLE_MANAGED_POLICY",
         "Properties": {
           "SourcePolicy": true,
+          "DependedBy": "SOURCE_EVENT_SOURCE_MAPPING_DLQ",
           "AccessCategories": {
             "Read": {
               "Statement": [

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -7,6 +7,7 @@ from samtranslator.model.connector.connector import (
     ConnectorResourceError,
     add_depends_on,
     get_event_source_mappings,
+    get_event_source_mapping_dlqs,
     get_resource_reference,
 )
 from samtranslator.model.connector_profiles.profile import (
@@ -1757,6 +1758,14 @@ class SamConnector(SamResourceMacro):
                 # The dependency type assumes Destination is a AWS::Lambda::Function
                 esm_ids = list(get_event_source_mappings(source.logical_id, destination.logical_id, resource_resolver))
                 # There can only be a single ESM from a resource to function, otherwise deployment fails
+                if len(esm_ids) == 1:
+                    add_depends_on(esm_ids[0], policy.logical_id, resource_resolver)
+        if depended_by == "SOURCE_EVENT_SOURCE_MAPPING_DLQ":
+            if source.logical_id and destination.logical_id:
+                # The dependency type assumes Source is a AWS::Lambda::Function
+                esm_ids = list(
+                    get_event_source_mapping_dlqs(source.logical_id, destination.logical_id, resource_resolver)
+                )
                 if len(esm_ids) == 1:
                     add_depends_on(esm_ids[0], policy.logical_id, resource_resolver)
         if depended_by == "SOURCE":

--- a/samtranslator/utils/__init__.py
+++ b/samtranslator/utils/__init__.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+
+def dictfind(obj: Any, path: str, separator: str = ".") -> Any:
+    if not isinstance(obj, dict):
+        return None
+    keys = path.split(separator)
+    v = obj
+    for k in keys:
+        if k not in v:
+            return None
+        v = v[k]
+    return v

--- a/tests/translator/input/connector_esm_dlq.yaml
+++ b/tests/translator/input/connector_esm_dlq.yaml
@@ -1,0 +1,71 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      StreamSpecification:
+        StreamViewType: NEW_IMAGE
+
+  MyRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: lambda.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  MyFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: nodejs16.x
+      Handler: index.handler
+      Role: !GetAtt MyRole.Arn
+      Code:
+        ZipFile: |
+          exports.handler = async (event, context) => {
+            console.log(JSON.stringify(event));
+          };
+
+  MyQueue:
+    Type: AWS::SQS::Queue
+
+  MyEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      EventSourceArn: !GetAtt MyTable.StreamArn
+      FunctionName: !Ref MyFunction
+      StartingPosition: TRIM_HORIZON
+      DestinationConfig:
+        OnFailure:
+          Destination: !GetAtt MyQueue.Arn
+
+  MyConnector:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source: 
+        Id: MyTable
+      Destination: 
+        Id: MyFunction
+      Permissions:
+        - Read
+
+  LambdaToQueue:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source: 
+        Id: MyFunction
+      Destination: 
+        Id: MyQueue
+      Permissions:
+        - Write

--- a/tests/translator/output/aws-cn/connector_esm_dlq.json
+++ b/tests/translator/output/aws-cn/connector_esm_dlq.json
@@ -1,0 +1,187 @@
+{
+ "Resources": {
+  "MyTable": {
+   "Type": "AWS::DynamoDB::Table",
+   "Properties": {
+    "BillingMode": "PAY_PER_REQUEST",
+    "AttributeDefinitions": [
+     {
+      "AttributeName": "id",
+      "AttributeType": "S"
+     }
+    ],
+    "KeySchema": [
+     {
+      "AttributeName": "id",
+      "KeyType": "HASH"
+     }
+    ],
+    "StreamSpecification": {
+     "StreamViewType": "NEW_IMAGE"
+    }
+   }
+  },
+  "MyRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": "sts:AssumeRole",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ]
+    },
+    "ManagedPolicyArns": [
+     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    ]
+   }
+  },
+  "MyFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Runtime": "nodejs16.x",
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "MyRole",
+      "Arn"
+     ]
+    },
+    "Code": {
+     "ZipFile": "exports.handler = async (event, context) => {\n  console.log(JSON.stringify(event));\n};\n"
+    }
+   }
+  },
+  "MyQueue": {
+   "Type": "AWS::SQS::Queue"
+  },
+  "MyEventSourceMapping": {
+   "Type": "AWS::Lambda::EventSourceMapping",
+   "Properties": {
+    "EventSourceArn": {
+     "Fn::GetAtt": [
+      "MyTable",
+      "StreamArn"
+     ]
+    },
+    "FunctionName": {
+     "Ref": "MyFunction"
+    },
+    "StartingPosition": "TRIM_HORIZON",
+    "DestinationConfig": {
+     "OnFailure": {
+      "Destination": {
+       "Fn::GetAtt": [
+        "MyQueue",
+        "Arn"
+       ]
+      }
+     }
+    }
+   },
+   "DependsOn": [
+    "MyConnectorPolicy",
+    "LambdaToQueuePolicy"
+   ]
+  },
+  "MyConnectorPolicy": {
+   "Type": "AWS::IAM::ManagedPolicy",
+   "Metadata": {
+    "aws:sam:connectors": {
+     "MyConnector": {
+      "Source": {
+       "Type": "AWS::DynamoDB::Table"
+      },
+      "Destination": {
+       "Type": "AWS::Lambda::Function"
+      }
+     }
+    }
+   },
+   "Properties": {
+    "PolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": [
+        "dynamodb:DescribeStream",
+        "dynamodb:GetRecords",
+        "dynamodb:GetShardIterator",
+        "dynamodb:ListStreams"
+       ],
+       "Resource": [
+        {
+         "Fn::Sub": [
+          "${SourceArn}/stream/*",
+          {
+           "SourceArn": {
+            "Fn::GetAtt": [
+             "MyTable",
+             "Arn"
+            ]
+           }
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    "Roles": [
+     {
+      "Ref": "MyRole"
+     }
+    ]
+   }
+  },
+  "LambdaToQueuePolicy": {
+   "Type": "AWS::IAM::ManagedPolicy",
+   "Metadata": {
+    "aws:sam:connectors": {
+     "LambdaToQueue": {
+      "Source": {
+       "Type": "AWS::Lambda::Function"
+      },
+      "Destination": {
+       "Type": "AWS::SQS::Queue"
+      }
+     }
+    }
+   },
+   "Properties": {
+    "PolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": [
+        "sqs:DeleteMessage",
+        "sqs:SendMessage",
+        "sqs:ChangeMessageVisibility",
+        "sqs:PurgeQueue"
+       ],
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "MyQueue",
+          "Arn"
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    "Roles": [
+     {
+      "Ref": "MyRole"
+     }
+    ]
+   }
+  }
+ }
+}

--- a/tests/translator/output/aws-us-gov/connector_esm_dlq.json
+++ b/tests/translator/output/aws-us-gov/connector_esm_dlq.json
@@ -1,0 +1,187 @@
+{
+ "Resources": {
+  "MyTable": {
+   "Type": "AWS::DynamoDB::Table",
+   "Properties": {
+    "BillingMode": "PAY_PER_REQUEST",
+    "AttributeDefinitions": [
+     {
+      "AttributeName": "id",
+      "AttributeType": "S"
+     }
+    ],
+    "KeySchema": [
+     {
+      "AttributeName": "id",
+      "KeyType": "HASH"
+     }
+    ],
+    "StreamSpecification": {
+     "StreamViewType": "NEW_IMAGE"
+    }
+   }
+  },
+  "MyRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": "sts:AssumeRole",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ]
+    },
+    "ManagedPolicyArns": [
+     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    ]
+   }
+  },
+  "MyFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Runtime": "nodejs16.x",
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "MyRole",
+      "Arn"
+     ]
+    },
+    "Code": {
+     "ZipFile": "exports.handler = async (event, context) => {\n  console.log(JSON.stringify(event));\n};\n"
+    }
+   }
+  },
+  "MyQueue": {
+   "Type": "AWS::SQS::Queue"
+  },
+  "MyEventSourceMapping": {
+   "Type": "AWS::Lambda::EventSourceMapping",
+   "Properties": {
+    "EventSourceArn": {
+     "Fn::GetAtt": [
+      "MyTable",
+      "StreamArn"
+     ]
+    },
+    "FunctionName": {
+     "Ref": "MyFunction"
+    },
+    "StartingPosition": "TRIM_HORIZON",
+    "DestinationConfig": {
+     "OnFailure": {
+      "Destination": {
+       "Fn::GetAtt": [
+        "MyQueue",
+        "Arn"
+       ]
+      }
+     }
+    }
+   },
+   "DependsOn": [
+    "MyConnectorPolicy",
+    "LambdaToQueuePolicy"
+   ]
+  },
+  "MyConnectorPolicy": {
+   "Type": "AWS::IAM::ManagedPolicy",
+   "Metadata": {
+    "aws:sam:connectors": {
+     "MyConnector": {
+      "Source": {
+       "Type": "AWS::DynamoDB::Table"
+      },
+      "Destination": {
+       "Type": "AWS::Lambda::Function"
+      }
+     }
+    }
+   },
+   "Properties": {
+    "PolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": [
+        "dynamodb:DescribeStream",
+        "dynamodb:GetRecords",
+        "dynamodb:GetShardIterator",
+        "dynamodb:ListStreams"
+       ],
+       "Resource": [
+        {
+         "Fn::Sub": [
+          "${SourceArn}/stream/*",
+          {
+           "SourceArn": {
+            "Fn::GetAtt": [
+             "MyTable",
+             "Arn"
+            ]
+           }
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    "Roles": [
+     {
+      "Ref": "MyRole"
+     }
+    ]
+   }
+  },
+  "LambdaToQueuePolicy": {
+   "Type": "AWS::IAM::ManagedPolicy",
+   "Metadata": {
+    "aws:sam:connectors": {
+     "LambdaToQueue": {
+      "Source": {
+       "Type": "AWS::Lambda::Function"
+      },
+      "Destination": {
+       "Type": "AWS::SQS::Queue"
+      }
+     }
+    }
+   },
+   "Properties": {
+    "PolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": [
+        "sqs:DeleteMessage",
+        "sqs:SendMessage",
+        "sqs:ChangeMessageVisibility",
+        "sqs:PurgeQueue"
+       ],
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "MyQueue",
+          "Arn"
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    "Roles": [
+     {
+      "Ref": "MyRole"
+     }
+    ]
+   }
+  }
+ }
+}

--- a/tests/translator/output/connector_esm_dlq.json
+++ b/tests/translator/output/connector_esm_dlq.json
@@ -1,0 +1,187 @@
+{
+ "Resources": {
+  "MyTable": {
+   "Type": "AWS::DynamoDB::Table",
+   "Properties": {
+    "BillingMode": "PAY_PER_REQUEST",
+    "AttributeDefinitions": [
+     {
+      "AttributeName": "id",
+      "AttributeType": "S"
+     }
+    ],
+    "KeySchema": [
+     {
+      "AttributeName": "id",
+      "KeyType": "HASH"
+     }
+    ],
+    "StreamSpecification": {
+     "StreamViewType": "NEW_IMAGE"
+    }
+   }
+  },
+  "MyRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": "sts:AssumeRole",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ]
+    },
+    "ManagedPolicyArns": [
+     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    ]
+   }
+  },
+  "MyFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Runtime": "nodejs16.x",
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "MyRole",
+      "Arn"
+     ]
+    },
+    "Code": {
+     "ZipFile": "exports.handler = async (event, context) => {\n  console.log(JSON.stringify(event));\n};\n"
+    }
+   }
+  },
+  "MyQueue": {
+   "Type": "AWS::SQS::Queue"
+  },
+  "MyEventSourceMapping": {
+   "Type": "AWS::Lambda::EventSourceMapping",
+   "Properties": {
+    "EventSourceArn": {
+     "Fn::GetAtt": [
+      "MyTable",
+      "StreamArn"
+     ]
+    },
+    "FunctionName": {
+     "Ref": "MyFunction"
+    },
+    "StartingPosition": "TRIM_HORIZON",
+    "DestinationConfig": {
+     "OnFailure": {
+      "Destination": {
+       "Fn::GetAtt": [
+        "MyQueue",
+        "Arn"
+       ]
+      }
+     }
+    }
+   },
+   "DependsOn": [
+    "MyConnectorPolicy",
+    "LambdaToQueuePolicy"
+   ]
+  },
+  "MyConnectorPolicy": {
+   "Type": "AWS::IAM::ManagedPolicy",
+   "Metadata": {
+    "aws:sam:connectors": {
+     "MyConnector": {
+      "Source": {
+       "Type": "AWS::DynamoDB::Table"
+      },
+      "Destination": {
+       "Type": "AWS::Lambda::Function"
+      }
+     }
+    }
+   },
+   "Properties": {
+    "PolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": [
+        "dynamodb:DescribeStream",
+        "dynamodb:GetRecords",
+        "dynamodb:GetShardIterator",
+        "dynamodb:ListStreams"
+       ],
+       "Resource": [
+        {
+         "Fn::Sub": [
+          "${SourceArn}/stream/*",
+          {
+           "SourceArn": {
+            "Fn::GetAtt": [
+             "MyTable",
+             "Arn"
+            ]
+           }
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    "Roles": [
+     {
+      "Ref": "MyRole"
+     }
+    ]
+   }
+  },
+  "LambdaToQueuePolicy": {
+   "Type": "AWS::IAM::ManagedPolicy",
+   "Metadata": {
+    "aws:sam:connectors": {
+     "LambdaToQueue": {
+      "Source": {
+       "Type": "AWS::Lambda::Function"
+      },
+      "Destination": {
+       "Type": "AWS::SQS::Queue"
+      }
+     }
+    }
+   },
+   "Properties": {
+    "PolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Effect": "Allow",
+       "Action": [
+        "sqs:DeleteMessage",
+        "sqs:SendMessage",
+        "sqs:ChangeMessageVisibility",
+        "sqs:PurgeQueue"
+       ],
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "MyQueue",
+          "Arn"
+         ]
+        }
+       ]
+      }
+     ]
+    },
+    "Roles": [
+     {
+      "Ref": "MyRole"
+     }
+    ]
+   }
+  }
+ }
+}


### PR DESCRIPTION
### Issue #, if available

https://github.com/aws/serverless-application-model/issues/2534

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
