### PR TITLE
Add Integration Test Deployer Logging Improvements

### DIFF
--- a/integration/helpers/deployer/deployer.py
+++ b/integration/helpers/deployer/deployer.py
@@ -266,9 +266,11 @@ class Deployer:
             waiter.wait(ChangeSetName=changeset_id, StackName=stack_name, WaiterConfig=waiter_config)
         except botocore.exceptions.WaiterError as ex:
 
+            LOG.error("Waiter exception waiting for changeset", exc_info=ex)
+
             resp = ex.last_response
-            status = resp["Status"]
-            reason = resp["StatusReason"]
+            status = resp.get("Status", "")
+            reason = resp.get("StatusReason", "")
 
             if (
                 status == "FAILED"


### PR DESCRIPTION
Dealing with cases where integration tests fail and produce no useful logging feedback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
