### PR TITLE
fix: Correct kafka property names in generated event source mapping

### DIFF
--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -119,9 +119,9 @@ class PullEventSource(ResourceMacro):
         if self.ConsumerGroupId:
             consumer_group_id_structure = {"ConsumerGroupId": self.ConsumerGroupId}
             if self.resource_type == "MSK":
-                lambda_eventsourcemapping.AmazonManagedKafkaConfig = consumer_group_id_structure
+                lambda_eventsourcemapping.AmazonManagedKafkaEventSourceConfig = consumer_group_id_structure
             elif self.resource_type == "SelfManagedKafka":
-                lambda_eventsourcemapping.SelfManagedKafkaConfig = consumer_group_id_structure
+                lambda_eventsourcemapping.SelfManagedKafkaEventSourceConfig = consumer_group_id_structure
             else:
                 raise InvalidEventException(
                     self.logical_id,

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -81,8 +81,8 @@ class LambdaEventSourceMapping(Resource):
         "FunctionResponseTypes": PropertyType(False, is_type(list)),
         "SelfManagedEventSource": PropertyType(False, is_type(dict)),
         "FilterCriteria": PropertyType(False, is_type(dict)),
-        "AmazonManagedKafkaConfig": PropertyType(False, is_type(dict)),
-        "SelfManagedKafkaConfig": PropertyType(False, is_type(dict)),
+        "AmazonManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),
+        "SelfManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}

--- a/tests/translator/output/aws-cn/function_with_msk.json
+++ b/tests/translator/output/aws-cn/function_with_msk.json
@@ -69,7 +69,7 @@
         "Topics": [
           "MyDummyTestTopic"
         ],
-        "AmazonManagedKafkaConfig": {
+        "AmazonManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": "consumergroup1"
         }
       }

--- a/tests/translator/output/aws-cn/function_with_msk_with_intrinsics.json
+++ b/tests/translator/output/aws-cn/function_with_msk_with_intrinsics.json
@@ -88,7 +88,7 @@
         "Topics": {
           "Ref": "TopicsValue"
         },
-        "AmazonManagedKafkaConfig": {
+        "AmazonManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": {
             "Ref": "ConsumerGroupValue"
           }

--- a/tests/translator/output/aws-cn/function_with_self_managed_kafka.json
+++ b/tests/translator/output/aws-cn/function_with_self_managed_kafka.json
@@ -115,7 +115,7 @@
             ]
           }
         },
-        "SelfManagedKafkaConfig": {
+        "SelfManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": "consumergroup1"
         }
       }

--- a/tests/translator/output/aws-cn/self_managed_kafka_with_intrinsics.json
+++ b/tests/translator/output/aws-cn/self_managed_kafka_with_intrinsics.json
@@ -153,7 +153,7 @@
             }
           }
         },
-        "SelfManagedKafkaConfig": {
+        "SelfManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": {
             "Ref": "ConsumerGroupValue"
           }

--- a/tests/translator/output/aws-us-gov/function_with_msk.json
+++ b/tests/translator/output/aws-us-gov/function_with_msk.json
@@ -69,7 +69,7 @@
         "Topics": [
           "MyDummyTestTopic"
         ],
-        "AmazonManagedKafkaConfig": {
+        "AmazonManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": "consumergroup1"
         }
       }

--- a/tests/translator/output/aws-us-gov/function_with_msk_with_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/function_with_msk_with_intrinsics.json
@@ -88,7 +88,7 @@
         "Topics": {
           "Ref": "TopicsValue"
         },
-        "AmazonManagedKafkaConfig": {
+        "AmazonManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": {
             "Ref": "ConsumerGroupValue"
           }

--- a/tests/translator/output/aws-us-gov/function_with_self_managed_kafka.json
+++ b/tests/translator/output/aws-us-gov/function_with_self_managed_kafka.json
@@ -115,7 +115,7 @@
             ]
           }
         },
-        "SelfManagedKafkaConfig": {
+        "SelfManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": "consumergroup1"
         }
       }

--- a/tests/translator/output/aws-us-gov/self_managed_kafka_with_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/self_managed_kafka_with_intrinsics.json
@@ -153,7 +153,7 @@
             }
           }
         },
-        "SelfManagedKafkaConfig": {
+        "SelfManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": {
             "Ref": "ConsumerGroupValue"
           }

--- a/tests/translator/output/function_with_msk.json
+++ b/tests/translator/output/function_with_msk.json
@@ -69,7 +69,7 @@
         "Topics": [
           "MyDummyTestTopic"
         ],
-        "AmazonManagedKafkaConfig": {
+        "AmazonManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": "consumergroup1"
         }
       }

--- a/tests/translator/output/function_with_msk_with_intrinsics.json
+++ b/tests/translator/output/function_with_msk_with_intrinsics.json
@@ -88,7 +88,7 @@
         "Topics": {
           "Ref": "TopicsValue"
         },
-        "AmazonManagedKafkaConfig": {
+        "AmazonManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": {
             "Ref": "ConsumerGroupValue"
           }

--- a/tests/translator/output/function_with_self_managed_kafka.json
+++ b/tests/translator/output/function_with_self_managed_kafka.json
@@ -115,7 +115,7 @@
             ]
           }
         },
-          "SelfManagedKafkaConfig": {
+          "SelfManagedKafkaEventSourceConfig": {
             "ConsumerGroupId": "consumergroup1"
         }
       }

--- a/tests/translator/output/self_managed_kafka_with_intrinsics.json
+++ b/tests/translator/output/self_managed_kafka_with_intrinsics.json
@@ -153,7 +153,7 @@
             }
           }
         },
-        "SelfManagedKafkaConfig": {
+        "SelfManagedKafkaEventSourceConfig": {
           "ConsumerGroupId": {
             "Ref": "ConsumerGroupValue"
           }


### PR DESCRIPTION
### Issue #, if available

#2546

### Description of changes

Fix property names according to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#aws-resource-lambda-eventsourcemapping-properties

### Description of how you validated changes

### Checklist

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
