### PR TITLE
Do not change input file and exit if hardcoded partition used

### DIFF
--- a/bin/add_transform_test.py
+++ b/bin/add_transform_test.py
@@ -28,6 +28,7 @@ def read_json_file(file_path: str) -> Dict[str, Any]:
     template: Dict[str, Any] = json.loads(Path(file_path).read_text(encoding="utf-8"))
     return template
 
+
 def write_json_file(obj: Dict[str, Any], file_path: str) -> None:
     with open(file_path, "w", encoding="utf-8") as f:
         json.dump(obj, f, indent=2)

--- a/bin/add_transform_test.py
+++ b/bin/add_transform_test.py
@@ -106,7 +106,7 @@ def verify_input_template(input_file_path: str):
 
     if "arn:aws:" in template:
         print("ERROR: hardcoded partition name detected. Consider replace it with pseudo parameter {AWS::Partition}")
-        sys.exit(0)
+        sys.exit(1)
 
 
 def main() -> None:

--- a/bin/add_transform_test.py
+++ b/bin/add_transform_test.py
@@ -25,8 +25,8 @@ CLI_OPTIONS = docopt(__doc__)
 
 
 def read_json_file(file_path: str) -> Dict[str, Any]:
-    return json.loads(Path(file_path).read_text(encoding="utf-8"))
-
+    template: Dict[str, Any] = json.loads(Path(file_path).read_text(encoding="utf-8"))
+    return template
 
 def write_json_file(obj: Dict[str, Any], file_path: str) -> None:
     with open(file_path, "w", encoding="utf-8") as f:

--- a/bin/add_transform_test.py
+++ b/bin/add_transform_test.py
@@ -28,38 +28,6 @@ TRANSFORM_TEST_DIR = os.path.join(SCRIPT_DIR, "..", "tests", "translator")
 CLI_OPTIONS = docopt(__doc__)
 
 
-def map_nested(obj: Any, fn) -> Any:
-    if isinstance(obj, dict):
-        return {k: map_nested(v, fn) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [map_nested(v, fn) for v in obj]
-    return fn(obj)
-
-
-def replace_arn(s: Any) -> Any:
-    if not isinstance(s, str):
-        return s
-
-    pattern = "arn:aws:"
-    replaced_pattern = "arn:${AWS::Partition}"
-    if pattern in s:
-        # pattern is substring of s, use Fn::Sub to replace part of s
-        s = s.replace(pattern, replaced_pattern)
-    if re.search(r"\${.+}", s):
-        return {"Fn::Sub": s}
-    return s
-
-
-def replace_arn_partitions(input_file_path: str) -> None:
-    with open(input_file_path, "r") as f:
-        sam_template = yaml_parse(f)
-
-    replaced_template = map_nested(sam_template, lambda v: replace_arn(v))
-
-    with open(input_file_path, "w") as f:
-        yaml.dump(replaced_template, f, default_flow_style=False)
-
-
 def read_json_file(file_path: str) -> Dict[str, Any]:
     with open(file_path, "r") as f:
         sam_template: Dict[str, Any] = json.load(f)
@@ -129,14 +97,23 @@ def get_input_file_path() -> str:
 
 def copy_input_file_to_transform_test_dir(input_file_path: str, transform_test_input_path: str) -> None:
     shutil.copyfile(input_file_path, transform_test_input_path)
-
-    replace_arn_partitions(transform_test_input_path)
     print(f"Transform Test input file generated {transform_test_input_path}")
+
+
+def verify_input_template(input_file_path: str):
+    with open(input_file_path, "r") as f:
+        template = f.read()
+
+    if "arn:aws:" in template:
+        print("ERROR: hardcoded partition name detected. Consider replace it with pseudo parameter {AWS::Partition}")
+        sys.exit(0)
 
 
 def main() -> None:
     input_file_path = get_input_file_path()
     file_basename = Path(input_file_path).stem
+
+    verify_input_template(input_file_path)
 
     transform_test_input_path = os.path.join(TRANSFORM_TEST_DIR, "input", file_basename + ".yaml")
     copy_input_file_to_transform_test_dir(input_file_path, transform_test_input_path)

--- a/bin/add_transform_test.py
+++ b/bin/add_transform_test.py
@@ -25,13 +25,11 @@ CLI_OPTIONS = docopt(__doc__)
 
 
 def read_json_file(file_path: str) -> Dict[str, Any]:
-    with open(file_path, "r") as f:
-        sam_template: Dict[str, Any] = json.load(f)
-    return sam_template
+    return json.loads(Path(file_path).read_text(encoding="utf-8"))
 
 
 def write_json_file(obj: Dict[str, Any], file_path: str) -> None:
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         json.dump(obj, f, indent=2)
 
 
@@ -97,10 +95,7 @@ def copy_input_file_to_transform_test_dir(input_file_path: str, transform_test_i
 
 
 def verify_input_template(input_file_path: str):
-    with open(input_file_path, "r") as f:
-        template = f.read()
-
-    if "arn:aws:" in template:
+    if "arn:aws:" in Path(input_file_path).read_text(encoding="utf-8"):
         print("ERROR: hardcoded partition name detected. Consider replace it with pseudo parameter {AWS::Partition}")
         sys.exit(1)
 

--- a/bin/add_transform_test.py
+++ b/bin/add_transform_test.py
@@ -11,17 +11,13 @@ Options:
 """
 import json
 import subprocess
-import re
 import os
 import shutil
 import sys
-import yaml
 import tempfile
 from docopt import docopt  # type: ignore
 from pathlib import Path
 from typing import Any, Dict
-
-from samtranslator.yaml_helper import yaml_parse
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 TRANSFORM_TEST_DIR = os.path.join(SCRIPT_DIR, "..", "tests", "translator")


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
