### PR TITLE
Enable mypy --strict for future code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint:
 	# Linter performs static analysis to catch latent bugs
 	pylint --rcfile .pylintrc samtranslator
 	# mypy performs type check
-	mypy samtranslator bin/add_transform_test.py bin/json-format.py
+	mypy --strict samtranslator bin
 
 prepare-companion-stack:
 	pytest -v --no-cov integration/setup -m setup

--- a/bin/add_transform_test.py
+++ b/bin/add_transform_test.py
@@ -95,7 +95,7 @@ def copy_input_file_to_transform_test_dir(input_file_path: str, transform_test_i
     print(f"Transform Test input file generated {transform_test_input_path}")
 
 
-def verify_input_template(input_file_path: str):
+def verify_input_template(input_file_path: str):  # type: ignore[no-untyped-def]
     if "arn:aws:" in Path(input_file_path).read_text(encoding="utf-8"):
         print("ERROR: hardcoded partition name detected. Consider replace it with pseudo parameter {AWS::Partition}")
         sys.exit(1)

--- a/bin/json-format.py
+++ b/bin/json-format.py
@@ -52,7 +52,7 @@ class JSONFormatter:
                     continue
                 self.process_file(file_path)
 
-    def output_summary(self):
+    def output_summary(self):  # type: ignore[no-untyped-def]
         print(f"{self.scanned_file_found} file(s) scanned.")
         if self.write:
             print(f"{self.unformatted_file_count} file(s) reformatted.")
@@ -98,7 +98,7 @@ def main() -> None:
         else:
             raise ValueError(f"{path}: Unsupported path")
 
-    formatter.output_summary()
+    formatter.output_summary()  # type: ignore[no-untyped-call]
 
 
 if __name__ == "__main__":

--- a/bin/sam-translate.py
+++ b/bin/sam-translate.py
@@ -27,13 +27,13 @@ import sys
 
 import boto3
 
-from docopt import docopt
+from docopt import docopt  # type: ignore[import]
 from functools import reduce
 
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, my_path + "/..")
 
-from samtranslator.public.translator import ManagedPolicyLoader
+from samtranslator.public.translator import ManagedPolicyLoader  # type: ignore[attr-defined]
 from samtranslator.translator.transform import transform
 from samtranslator.yaml_helper import yaml_parse
 from samtranslator.model.exceptions import InvalidDocumentException
@@ -49,7 +49,7 @@ else:
     logging.basicConfig()
 
 
-def execute_command(command, args):
+def execute_command(command, args):  # type: ignore[no-untyped-def]
     try:
         aws_cmd = "aws" if platform.system().lower() != "windows" else "aws.cmd"
         command_with_args = [aws_cmd, "cloudformation", command] + list(args)
@@ -65,7 +65,7 @@ def execute_command(command, args):
         sys.exit(e.returncode)
 
 
-def get_input_output_file_paths():
+def get_input_output_file_paths():  # type: ignore[no-untyped-def]
     input_file_option = cli_options.get("--template-file")
     output_file_option = cli_options.get("--output-template")
     input_file_path = os.path.join(cwd, input_file_option)
@@ -74,7 +74,7 @@ def get_input_output_file_paths():
     return input_file_path, output_file_path
 
 
-def package(input_file_path, output_file_path):
+def package(input_file_path, output_file_path):  # type: ignore[no-untyped-def]
     template_file = input_file_path
     package_output_template_file = input_file_path + "._sam_packaged_.yaml"
     s3_bucket = cli_options.get("--s3-bucket")
@@ -87,17 +87,17 @@ def package(input_file_path, output_file_path):
         s3_bucket,
     ]
 
-    execute_command("package", args)
+    execute_command("package", args)  # type: ignore[no-untyped-call]
 
     return package_output_template_file
 
 
-def transform_template(input_file_path, output_file_path):
+def transform_template(input_file_path, output_file_path):  # type: ignore[no-untyped-def]
     with open(input_file_path, "r") as f:
-        sam_template = yaml_parse(f)
+        sam_template = yaml_parse(f)  # type: ignore[no-untyped-call]
 
     try:
-        cloud_formation_template = transform(sam_template, {}, ManagedPolicyLoader(iam_client))
+        cloud_formation_template = transform(sam_template, {}, ManagedPolicyLoader(iam_client))  # type: ignore[no-untyped-call]
         cloud_formation_template_prettified = json.dumps(cloud_formation_template, indent=1)
 
         with open(output_file_path, "w") as f:
@@ -107,29 +107,29 @@ def transform_template(input_file_path, output_file_path):
     except InvalidDocumentException as e:
         errorMessage = reduce(lambda message, error: message + " " + error.message, e.causes, e.message)
         LOG.error(errorMessage)
-        errors = map(lambda cause: cause.message, e.causes)
+        errors = map(lambda cause: cause.message, e.causes)  # type: ignore[no-any-return]
         LOG.error(errors)
 
 
-def deploy(template_file):
+def deploy(template_file):  # type: ignore[no-untyped-def]
     capabilities = cli_options.get("--capabilities")
     stack_name = cli_options.get("--stack-name")
     args = ["--template-file", template_file, "--capabilities", capabilities, "--stack-name", stack_name]
 
-    execute_command("deploy", args)
+    execute_command("deploy", args)  # type: ignore[no-untyped-call]
 
     return package_output_template_file
 
 
 if __name__ == "__main__":
-    input_file_path, output_file_path = get_input_output_file_paths()
+    input_file_path, output_file_path = get_input_output_file_paths()  # type: ignore[no-untyped-call]
 
     if cli_options.get("package"):
-        package_output_template_file = package(input_file_path, output_file_path)
-        transform_template(package_output_template_file, output_file_path)
+        package_output_template_file = package(input_file_path, output_file_path)  # type: ignore[no-untyped-call]
+        transform_template(package_output_template_file, output_file_path)  # type: ignore[no-untyped-call]
     elif cli_options.get("deploy"):
-        package_output_template_file = package(input_file_path, output_file_path)
-        transform_template(package_output_template_file, output_file_path)
-        deploy(output_file_path)
+        package_output_template_file = package(input_file_path, output_file_path)  # type: ignore[no-untyped-call]
+        transform_template(package_output_template_file, output_file_path)  # type: ignore[no-untyped-call]
+        deploy(output_file_path)  # type: ignore[no-untyped-call]
     else:
-        transform_template(input_file_path, output_file_path)
+        transform_template(input_file_path, output_file_path)  # type: ignore[no-untyped-call]

--- a/samtranslator/feature_toggle/dialup.py
+++ b/samtranslator/feature_toggle/dialup.py
@@ -4,16 +4,16 @@ import hashlib
 class BaseDialup(object):
     """BaseDialup class to provide an interface for all dialup classes"""
 
-    def __init__(self, region_config, **kwargs):
+    def __init__(self, region_config, **kwargs):  # type: ignore[no-untyped-def]
         self.region_config = region_config
 
-    def is_enabled(self):
+    def is_enabled(self):  # type: ignore[no-untyped-def]
         """
         Returns a bool on whether this dialup is enabled or not
         """
         raise NotImplementedError
 
-    def __str__(self):
+    def __str__(self):  # type: ignore[no-untyped-def]
         return self.__class__.__name__
 
 
@@ -22,10 +22,10 @@ class DisabledDialup(BaseDialup):
     A dialup that is never enabled
     """
 
-    def __init__(self, region_config, **kwargs):
-        super(DisabledDialup, self).__init__(region_config)
+    def __init__(self, region_config, **kwargs):  # type: ignore[no-untyped-def]
+        super(DisabledDialup, self).__init__(region_config)  # type: ignore[no-untyped-call]
 
-    def is_enabled(self):
+    def is_enabled(self):  # type: ignore[no-untyped-def]
         return False
 
 
@@ -35,11 +35,11 @@ class ToggleDialup(BaseDialup):
     Example of region_config: { "type": "toggle", "enabled": True }
     """
 
-    def __init__(self, region_config, **kwargs):
-        super(ToggleDialup, self).__init__(region_config)
+    def __init__(self, region_config, **kwargs):  # type: ignore[no-untyped-def]
+        super(ToggleDialup, self).__init__(region_config)  # type: ignore[no-untyped-call]
         self.region_config = region_config
 
-    def is_enabled(self):
+    def is_enabled(self):  # type: ignore[no-untyped-def]
         return self.region_config.get("enabled", False)
 
 
@@ -49,12 +49,12 @@ class SimpleAccountPercentileDialup(BaseDialup):
     Example of region_config: { "type": "account-percentile", "enabled-%": 20 }
     """
 
-    def __init__(self, region_config, account_id, feature_name, **kwargs):
-        super(SimpleAccountPercentileDialup, self).__init__(region_config)
+    def __init__(self, region_config, account_id, feature_name, **kwargs):  # type: ignore[no-untyped-def]
+        super(SimpleAccountPercentileDialup, self).__init__(region_config)  # type: ignore[no-untyped-call]
         self.account_id = account_id
         self.feature_name = feature_name
 
-    def _get_account_percentile(self):
+    def _get_account_percentile(self):  # type: ignore[no-untyped-def]
         """
         Get account percentile based on sha256 hash of account ID and feature_name
 
@@ -65,10 +65,10 @@ class SimpleAccountPercentileDialup(BaseDialup):
         m.update(self.feature_name.encode())
         return int(m.hexdigest(), 16) % 100
 
-    def is_enabled(self):
+    def is_enabled(self):  # type: ignore[no-untyped-def]
         """
         Enable when account_percentile falls within target_percentile
         Meaning only (target_percentile)% of accounts will be enabled
         """
         target_percentile = self.region_config.get("enabled-%", 0)
-        return self._get_account_percentile() < target_percentile
+        return self._get_account_percentile() < target_percentile  # type: ignore[no-untyped-call]

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -24,13 +24,13 @@ class FeatureToggle:
         "account-percentile": SimpleAccountPercentileDialup,
     }
 
-    def __init__(self, config_provider, stage, account_id, region):
+    def __init__(self, config_provider, stage, account_id, region):  # type: ignore[no-untyped-def]
         self.feature_config = config_provider.config
         self.stage = stage
         self.account_id = account_id
         self.region = region
 
-    def _get_dialup(self, region_config, feature_name):
+    def _get_dialup(self, region_config, feature_name):  # type: ignore[no-untyped-def]
         """
         get the right dialup instance
         if no dialup type is provided or the specified dialup is not supported,
@@ -46,9 +46,9 @@ class FeatureToggle:
                 region_config, account_id=self.account_id, feature_name=feature_name
             )
         LOG.warning("Dialup type '{}' is None or is not supported.".format(dialup_type))
-        return DisabledDialup(region_config)
+        return DisabledDialup(region_config)  # type: ignore[no-untyped-call]
 
-    def is_enabled(self, feature_name):
+    def is_enabled(self, feature_name):  # type: ignore[no-untyped-def]
         """
         To check if feature is available
 
@@ -78,7 +78,7 @@ class FeatureToggle:
         else:
             region_config = stage_config[region] if region in stage_config else stage_config.get("default", {})
 
-        dialup = self._get_dialup(region_config, feature_name=feature_name)
+        dialup = self._get_dialup(region_config, feature_name=feature_name)  # type: ignore[no-untyped-call]
         LOG.info("Using Dialip {}".format(dialup))
         is_enabled = dialup.is_enabled()
 
@@ -89,45 +89,45 @@ class FeatureToggle:
 class FeatureToggleConfigProvider:
     """Interface for all FeatureToggle config providers"""
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         pass
 
     @property
-    def config(self):
+    def config(self):  # type: ignore[no-untyped-def]
         raise NotImplementedError
 
 
 class FeatureToggleDefaultConfigProvider(FeatureToggleConfigProvider):
     """Default config provider, always return False for every query."""
 
-    def __init__(self):
-        FeatureToggleConfigProvider.__init__(self)
+    def __init__(self):  # type: ignore[no-untyped-def]
+        FeatureToggleConfigProvider.__init__(self)  # type: ignore[no-untyped-call]
 
     @property
-    def config(self):
+    def config(self):  # type: ignore[no-untyped-def]
         return {}
 
 
 class FeatureToggleLocalConfigProvider(FeatureToggleConfigProvider):
     """Feature toggle config provider which uses a local file. This is to facilitate local testing."""
 
-    def __init__(self, local_config_path):
-        FeatureToggleConfigProvider.__init__(self)
+    def __init__(self, local_config_path):  # type: ignore[no-untyped-def]
+        FeatureToggleConfigProvider.__init__(self)  # type: ignore[no-untyped-call]
         with open(local_config_path, "r", encoding="utf-8") as f:
             config_json = f.read()
         self.feature_toggle_config = json.loads(config_json)
 
     @property
-    def config(self):
+    def config(self):  # type: ignore[no-untyped-def]
         return self.feature_toggle_config
 
 
 class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
     """Feature toggle config provider which loads config from AppConfig."""
 
-    @cw_timer(prefix="External", name="AppConfig")
-    def __init__(self, application_id, environment_id, configuration_profile_id, app_config_client=None):
-        FeatureToggleConfigProvider.__init__(self)
+    @cw_timer(prefix="External", name="AppConfig")  # type: ignore[no-untyped-call]
+    def __init__(self, application_id, environment_id, configuration_profile_id, app_config_client=None):  # type: ignore[no-untyped-def]
+        FeatureToggleConfigProvider.__init__(self)  # type: ignore[no-untyped-call]
         try:
             LOG.info("Loading feature toggle config from AppConfig...")
             # Lambda function has 120 seconds limit
@@ -152,5 +152,5 @@ class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
             self.feature_toggle_config = json.loads("{}")
 
     @property
-    def config(self):
+    def config(self):  # type: ignore[no-untyped-def]
         return self.feature_toggle_config

--- a/samtranslator/intrinsics/actions.py
+++ b/samtranslator/intrinsics/actions.py
@@ -19,29 +19,29 @@ class Action(object):
     # TODO: Make `Action` an abstract class and not giving `intrinsic_name` initial value.
     intrinsic_name: str = None  # type: ignore
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         if not self.intrinsic_name:
             raise TypeError("Subclass must provide a intrinsic_name")
 
-    def resolve_parameter_refs(self, input_dict, parameters):
+    def resolve_parameter_refs(self, input_dict, parameters):  # type: ignore[no-untyped-def]
         """
         Subclass must implement this method to resolve the intrinsic function
         """
         raise NotImplementedError("Subclass must implement this method")
 
-    def resolve_resource_refs(self, input_dict, supported_resource_refs):
+    def resolve_resource_refs(self, input_dict, supported_resource_refs):  # type: ignore[no-untyped-def]
         """
         Subclass must implement this method to resolve resource references
         """
         raise NotImplementedError("Subclass must implement this method")
 
-    def resolve_resource_id_refs(self, input_dict, supported_resource_id_refs):
+    def resolve_resource_id_refs(self, input_dict, supported_resource_id_refs):  # type: ignore[no-untyped-def]
         """
         Subclass must implement this method to resolve resource references
         """
         raise NotImplementedError("Subclass must implement this method")
 
-    def can_handle(self, input_dict):
+    def can_handle(self, input_dict):  # type: ignore[no-untyped-def]
         """
         Validates that the input dictionary contains only one key and is of the given intrinsic_name
 
@@ -57,7 +57,7 @@ class Action(object):
         )
 
     @classmethod
-    def _parse_resource_reference(cls, ref_value):
+    def _parse_resource_reference(cls, ref_value):  # type: ignore[no-untyped-def]
         """
         Splits a resource reference of structure "LogicalId.Property" and returns the "LogicalId" and "Property"
         separately.
@@ -84,7 +84,7 @@ class Action(object):
 class RefAction(Action):
     intrinsic_name = "Ref"
 
-    def resolve_parameter_refs(self, input_dict, parameters):
+    def resolve_parameter_refs(self, input_dict, parameters):  # type: ignore[no-untyped-def]
         """
         Resolves references that are present in the parameters and returns the value. If it is not in parameters,
         this method simply returns the input unchanged.
@@ -95,7 +95,7 @@ class RefAction(Action):
         :param parameters: Dictionary of parameter values for resolution
         :return:
         """
-        if not self.can_handle(input_dict):
+        if not self.can_handle(input_dict):  # type: ignore[no-untyped-call]
             return input_dict
 
         param_name = input_dict[self.intrinsic_name]
@@ -107,7 +107,7 @@ class RefAction(Action):
             return parameters[param_name]
         return input_dict
 
-    def resolve_resource_refs(self, input_dict, supported_resource_refs):
+    def resolve_resource_refs(self, input_dict, supported_resource_refs):  # type: ignore[no-untyped-def]
         """
         Resolves references to some property of a resource. These are runtime properties which can't be converted
         to a value here. Instead we output another reference that will more actually resolve to the value when
@@ -122,11 +122,11 @@ class RefAction(Action):
         :return dict: Dictionary with resource references resolved.
         """
 
-        if not self.can_handle(input_dict):
+        if not self.can_handle(input_dict):  # type: ignore[no-untyped-call]
             return input_dict
 
         ref_value = input_dict[self.intrinsic_name]
-        logical_id, property = self._parse_resource_reference(ref_value)
+        logical_id, property = self._parse_resource_reference(ref_value)  # type: ignore[no-untyped-call]
 
         # ref_value could not be parsed
         if not logical_id:
@@ -138,7 +138,7 @@ class RefAction(Action):
 
         return {self.intrinsic_name: resolved_value}
 
-    def resolve_resource_id_refs(self, input_dict, supported_resource_id_refs):
+    def resolve_resource_id_refs(self, input_dict, supported_resource_id_refs):  # type: ignore[no-untyped-def]
         """
         Updates references to the old logical id of a resource to the new (generated) logical id.
 
@@ -150,7 +150,7 @@ class RefAction(Action):
         :return dict: Dictionary with resource references resolved.
         """
 
-        if not self.can_handle(input_dict):
+        if not self.can_handle(input_dict):  # type: ignore[no-untyped-call]
             return input_dict
 
         ref_value = input_dict[self.intrinsic_name]
@@ -169,7 +169,7 @@ class RefAction(Action):
 class SubAction(Action):
     intrinsic_name = "Fn::Sub"
 
-    def resolve_parameter_refs(self, input_dict, parameters):
+    def resolve_parameter_refs(self, input_dict, parameters):  # type: ignore[no-untyped-def]
         """
         Substitute references found within the string of `Fn::Sub` intrinsic function
 
@@ -180,7 +180,7 @@ class SubAction(Action):
         :return: Resolved
         """
 
-        def do_replacement(full_ref, prop_name):
+        def do_replacement(full_ref, prop_name):  # type: ignore[no-untyped-def]
             """
             Replace parameter references with actual value. Return value of this method is directly replaces the
             reference structure
@@ -191,9 +191,9 @@ class SubAction(Action):
             """
             return parameters.get(prop_name, full_ref)
 
-        return self._handle_sub_action(input_dict, do_replacement)
+        return self._handle_sub_action(input_dict, do_replacement)  # type: ignore[no-untyped-call]
 
-    def resolve_resource_refs(self, input_dict, supported_resource_refs):
+    def resolve_resource_refs(self, input_dict, supported_resource_refs):  # type: ignore[no-untyped-def]
         """
         Resolves reference to some property of a resource. Inside string to be substituted, there could be either a
         "Ref" or a "GetAtt" usage of this property. They have to be handled differently.
@@ -219,7 +219,7 @@ class SubAction(Action):
         :return: Resolved dictionary
         """
 
-        def do_replacement(full_ref, ref_value):
+        def do_replacement(full_ref, ref_value):  # type: ignore[no-untyped-def]
             """
             Perform the appropriate replacement to handle ${LogicalId.Property} type references inside a Sub.
             This method is called to get the replacement string for each reference within Sub's value
@@ -250,9 +250,9 @@ class SubAction(Action):
             replacement = self._resource_ref_separator.join([logical_id, property])
             return full_ref.replace(replacement, resolved_value)
 
-        return self._handle_sub_action(input_dict, do_replacement)
+        return self._handle_sub_action(input_dict, do_replacement)  # type: ignore[no-untyped-call]
 
-    def resolve_resource_id_refs(self, input_dict, supported_resource_id_refs):
+    def resolve_resource_id_refs(self, input_dict, supported_resource_id_refs):  # type: ignore[no-untyped-def]
         """
         Resolves reference to some property of a resource. Inside string to be substituted, there could be either a
         "Ref" or a "GetAtt" usage of this property. They have to be handled differently.
@@ -277,7 +277,7 @@ class SubAction(Action):
         :return: Resolved dictionary
         """
 
-        def do_replacement(full_ref, ref_value):
+        def do_replacement(full_ref, ref_value):  # type: ignore[no-untyped-def]
             """
             Perform the appropriate replacement to handle ${LogicalId} type references inside a Sub.
             This method is called to get the replacement string for each reference within Sub's value
@@ -306,9 +306,9 @@ class SubAction(Action):
             # syntax and retain other attributes. Ex: ${LogicalId.Property.Arn} => ${SomeOtherLogicalId.Arn}
             return full_ref.replace(logical_id, resolved_value)
 
-        return self._handle_sub_action(input_dict, do_replacement)
+        return self._handle_sub_action(input_dict, do_replacement)  # type: ignore[no-untyped-call]
 
-    def _handle_sub_action(self, input_dict, handler):
+    def _handle_sub_action(self, input_dict, handler):  # type: ignore[no-untyped-def]
         """
         Handles resolving replacements in the Sub action based on the handler that is passed as an input.
 
@@ -318,17 +318,17 @@ class SubAction(Action):
         :param handler: handler that is specific to each implementation.
         :return: Resolved value of the Sub dictionary
         """
-        if not self.can_handle(input_dict):
+        if not self.can_handle(input_dict):  # type: ignore[no-untyped-call]
             return input_dict
 
         key = self.intrinsic_name
         sub_value = input_dict[key]
 
-        input_dict[key] = self._handle_sub_value(sub_value, handler)
+        input_dict[key] = self._handle_sub_value(sub_value, handler)  # type: ignore[no-untyped-call]
 
         return input_dict
 
-    def _handle_sub_value(self, sub_value, handler_method):
+    def _handle_sub_value(self, sub_value, handler_method):  # type: ignore[no-untyped-def]
         """
         Generic method to handle value to Fn::Sub key. We are interested in parsing the ${} syntaxes inside
         the string portion of the value.
@@ -343,15 +343,15 @@ class SubAction(Action):
         # because that's the best we can do here.
         if isinstance(sub_value, str):
             # Ex: {Fn::Sub: "some string"}
-            sub_value = self._sub_all_refs(sub_value, handler_method)
+            sub_value = self._sub_all_refs(sub_value, handler_method)  # type: ignore[no-untyped-call]
 
         elif isinstance(sub_value, list) and len(sub_value) > 0 and isinstance(sub_value[0], str):
             # Ex: {Fn::Sub: ["some string", {a:b}] }
-            sub_value[0] = self._sub_all_refs(sub_value[0], handler_method)
+            sub_value[0] = self._sub_all_refs(sub_value[0], handler_method)  # type: ignore[no-untyped-call]
 
         return sub_value
 
-    def _sub_all_refs(self, text, handler_method):
+    def _sub_all_refs(self, text, handler_method):  # type: ignore[no-untyped-def]
         """
         Substitute references within a string that is using ${key} syntax by calling the `handler_method` on every
         occurrence of this structure. The value returned by this method directly replaces the reference structure.
@@ -389,11 +389,11 @@ class SubAction(Action):
 class GetAttAction(Action):
     intrinsic_name = "Fn::GetAtt"
 
-    def resolve_parameter_refs(self, input_dict, parameters):
+    def resolve_parameter_refs(self, input_dict, parameters):  # type: ignore[no-untyped-def]
         # Parameters can never be referenced within GetAtt value
         return input_dict
 
-    def resolve_resource_refs(self, input_dict, supported_resource_refs):
+    def resolve_resource_refs(self, input_dict, supported_resource_refs):  # type: ignore[no-untyped-def]
         """
         Resolve resource references within a GetAtt dict.
 
@@ -418,13 +418,13 @@ class GetAttAction(Action):
         :return: Resolved dictionary
         """
 
-        if not self.can_handle(input_dict):
+        if not self.can_handle(input_dict):  # type: ignore[no-untyped-call]
             return input_dict
 
         key = self.intrinsic_name
         value = input_dict[key]
 
-        if not self._check_input_value(value):
+        if not self._check_input_value(value):  # type: ignore[no-untyped-call]
             return input_dict
 
         # Value of GetAtt is an array. It can contain any number of elements, with first being the LogicalId of
@@ -444,9 +444,9 @@ class GetAttAction(Action):
         remaining = splits[2:]  # if any
 
         resolved_value = supported_resource_refs.get(logical_id, property)
-        return self._get_resolved_dictionary(input_dict, key, resolved_value, remaining)
+        return self._get_resolved_dictionary(input_dict, key, resolved_value, remaining)  # type: ignore[no-untyped-call]
 
-    def resolve_resource_id_refs(self, input_dict, supported_resource_id_refs):
+    def resolve_resource_id_refs(self, input_dict, supported_resource_id_refs):  # type: ignore[no-untyped-def]
         """
         Resolve resource references within a GetAtt dict.
 
@@ -470,13 +470,13 @@ class GetAttAction(Action):
         :return: Resolved dictionary
         """
 
-        if not self.can_handle(input_dict):
+        if not self.can_handle(input_dict):  # type: ignore[no-untyped-call]
             return input_dict
 
         key = self.intrinsic_name
         value = input_dict[key]
 
-        if not self._check_input_value(value):
+        if not self._check_input_value(value):  # type: ignore[no-untyped-call]
             return input_dict
 
         value_str = self._resource_ref_separator.join(value)
@@ -485,9 +485,9 @@ class GetAttAction(Action):
         remaining = splits[1:]  # if any
 
         resolved_value = supported_resource_id_refs.get(logical_id)
-        return self._get_resolved_dictionary(input_dict, key, resolved_value, remaining)
+        return self._get_resolved_dictionary(input_dict, key, resolved_value, remaining)  # type: ignore[no-untyped-call]
 
-    def _check_input_value(self, value):
+    def _check_input_value(self, value):  # type: ignore[no-untyped-def]
         # Value must be an array with *at least* two elements. If not, this is invalid GetAtt syntax. We just pass along
         # the input to CFN for it to do the "official" validation.
         if not isinstance(value, list) or len(value) < 2:
@@ -501,7 +501,7 @@ class GetAttAction(Action):
 
         return True
 
-    def _get_resolved_dictionary(self, input_dict, key, resolved_value, remaining):
+    def _get_resolved_dictionary(self, input_dict, key, resolved_value, remaining):  # type: ignore[no-untyped-def]
         """
         Resolves the function and returns the updated dictionary
 
@@ -525,7 +525,7 @@ class FindInMapAction(Action):
 
     intrinsic_name = "Fn::FindInMap"
 
-    def resolve_parameter_refs(self, input_dict, parameters):
+    def resolve_parameter_refs(self, input_dict, parameters):  # type: ignore[no-untyped-def]
         """
         Recursively resolves "Fn::FindInMap"references that are present in the mappings and returns the value.
         If it is not in mappings, this method simply returns the input unchanged.
@@ -535,24 +535,24 @@ class FindInMapAction(Action):
 
         :param parameters: Dictionary of mappings from the SAM template
         """
-        if not self.can_handle(input_dict):
+        if not self.can_handle(input_dict):  # type: ignore[no-untyped-call]
             return input_dict
 
         value = input_dict[self.intrinsic_name]
 
         # FindInMap expects an array with 3 values
         if not isinstance(value, list) or len(value) != 3:
-            raise InvalidDocumentException(
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                 [
-                    InvalidTemplateException(
+                    InvalidTemplateException(  # type: ignore[no-untyped-call]
                         f"Invalid FindInMap value {value}. FindInMap expects an array with 3 values."
                     )
                 ]
             )
 
-        map_name = self.resolve_parameter_refs(value[0], parameters)
-        top_level_key = self.resolve_parameter_refs(value[1], parameters)
-        second_level_key = self.resolve_parameter_refs(value[2], parameters)
+        map_name = self.resolve_parameter_refs(value[0], parameters)  # type: ignore[no-untyped-call]
+        top_level_key = self.resolve_parameter_refs(value[1], parameters)  # type: ignore[no-untyped-call]
+        second_level_key = self.resolve_parameter_refs(value[2], parameters)  # type: ignore[no-untyped-call]
 
         if not isinstance(map_name, str) or not isinstance(top_level_key, str) or not isinstance(second_level_key, str):
             return input_dict

--- a/samtranslator/intrinsics/resolver.py
+++ b/samtranslator/intrinsics/resolver.py
@@ -4,11 +4,11 @@ from samtranslator.intrinsics.actions import Action, SubAction, RefAction, GetAt
 from samtranslator.model.exceptions import InvalidTemplateException, InvalidDocumentException
 
 # All intrinsics are supported by default
-DEFAULT_SUPPORTED_INTRINSICS = {action.intrinsic_name: action() for action in [RefAction, SubAction, GetAttAction]}
+DEFAULT_SUPPORTED_INTRINSICS = {action.intrinsic_name: action() for action in [RefAction, SubAction, GetAttAction]}  # type: ignore[no-untyped-call]
 
 
 class IntrinsicsResolver(object):
-    def __init__(self, parameters, supported_intrinsics=None):
+    def __init__(self, parameters, supported_intrinsics=None):  # type: ignore[no-untyped-def]
         """
         Instantiate the resolver
         :param dict parameters: Map of parameter names to their values
@@ -20,8 +20,8 @@ class IntrinsicsResolver(object):
         if supported_intrinsics is None:
             supported_intrinsics = DEFAULT_SUPPORTED_INTRINSICS
         if parameters is None or not isinstance(parameters, dict):
-            raise InvalidDocumentException(
-                [InvalidTemplateException("'Mappings' or 'Parameters' is either null or not a valid dictionary.")]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                [InvalidTemplateException("'Mappings' or 'Parameters' is either null or not a valid dictionary.")]  # type: ignore[no-untyped-call]
             )
 
         if not isinstance(supported_intrinsics, dict) or not all(
@@ -32,7 +32,7 @@ class IntrinsicsResolver(object):
         self.supported_intrinsics = supported_intrinsics
         self.parameters = parameters
 
-    def resolve_parameter_refs(self, input):
+    def resolve_parameter_refs(self, input):  # type: ignore[no-untyped-def]
         """
         Resolves references to parameters within the given dictionary recursively. Other intrinsic functions such as
         !GetAtt, !Sub or !Ref to non-parameters will be left untouched.
@@ -43,9 +43,9 @@ class IntrinsicsResolver(object):
         :param input: Any primitive type (dict, array, string etc) whose values might contain intrinsic functions
         :return: A copy of a dictionary with parameter references replaced by actual value.
         """
-        return self._traverse(input, self.parameters, self._try_resolve_parameter_refs)
+        return self._traverse(input, self.parameters, self._try_resolve_parameter_refs)  # type: ignore[no-untyped-call]
 
-    def resolve_sam_resource_refs(self, input, supported_resource_refs):
+    def resolve_sam_resource_refs(self, input, supported_resource_refs):  # type: ignore[no-untyped-def]
         """
         Customers can provide a reference to a "derived" SAM resource such as Alias of a Function or Stage of an API
         resource. This method recursively walks the tree, converting all derived references to the real resource name,
@@ -67,9 +67,9 @@ class IntrinsicsResolver(object):
             references supported in this SAM template, along with the value they should resolve to.
         :return list errors: List of dictionary containing information about invalid reference. Empty list otherwise
         """
-        return self._traverse(input, supported_resource_refs, self._try_resolve_sam_resource_refs)
+        return self._traverse(input, supported_resource_refs, self._try_resolve_sam_resource_refs)  # type: ignore[no-untyped-call]
 
-    def resolve_sam_resource_id_refs(self, input, supported_resource_id_refs):
+    def resolve_sam_resource_id_refs(self, input, supported_resource_id_refs):  # type: ignore[no-untyped-def]
         """
         Some SAM resources have their logical ids mutated from the original id that the customer writes in the
         template. This method recursively walks the tree and updates these logical ids from the old value
@@ -90,9 +90,9 @@ class IntrinsicsResolver(object):
         :param dict supported_resource_id_refs: Dictionary that maps old logical ids to new ones.
         :return list errors: List of dictionary containing information about invalid reference. Empty list otherwise
         """
-        return self._traverse(input, supported_resource_id_refs, self._try_resolve_sam_resource_id_refs)
+        return self._traverse(input, supported_resource_id_refs, self._try_resolve_sam_resource_id_refs)  # type: ignore[no-untyped-call]
 
-    def _traverse(self, input, resolution_data, resolver_method):
+    def _traverse(self, input, resolution_data, resolver_method):  # type: ignore[no-untyped-def]
         """
         Driver method that performs the actual traversal of input and calls the appropriate `resolver_method` when
         to perform the resolution.
@@ -129,13 +129,13 @@ class IntrinsicsResolver(object):
         input = resolver_method(input, resolution_data)
 
         if isinstance(input, dict):
-            return self._traverse_dict(input, resolution_data, resolver_method)
+            return self._traverse_dict(input, resolution_data, resolver_method)  # type: ignore[no-untyped-call]
         if isinstance(input, list):
-            return self._traverse_list(input, resolution_data, resolver_method)
+            return self._traverse_list(input, resolution_data, resolver_method)  # type: ignore[no-untyped-call]
         # We can iterate only over dict or list types. Primitive types are terminals
         return input
 
-    def _traverse_dict(self, input_dict, resolution_data, resolver_method):
+    def _traverse_dict(self, input_dict, resolution_data, resolver_method):  # type: ignore[no-untyped-def]
         """
         Traverse a dictionary to resolve intrinsic functions on every value
 
@@ -145,11 +145,11 @@ class IntrinsicsResolver(object):
         :return: Modified dictionary with values resolved
         """
         for key, value in input_dict.items():
-            input_dict[key] = self._traverse(value, resolution_data, resolver_method)
+            input_dict[key] = self._traverse(value, resolution_data, resolver_method)  # type: ignore[no-untyped-call]
 
         return input_dict
 
-    def _traverse_list(self, input_list, resolution_data, resolver_method):
+    def _traverse_list(self, input_list, resolution_data, resolver_method):  # type: ignore[no-untyped-def]
         """
         Traverse a list to resolve intrinsic functions on every element
 
@@ -159,11 +159,11 @@ class IntrinsicsResolver(object):
         :return: Modified list with intrinsic functions resolved
         """
         for index, value in enumerate(input_list):
-            input_list[index] = self._traverse(value, resolution_data, resolver_method)
+            input_list[index] = self._traverse(value, resolution_data, resolver_method)  # type: ignore[no-untyped-call]
 
         return input_list
 
-    def _try_resolve_parameter_refs(self, input, parameters):
+    def _try_resolve_parameter_refs(self, input, parameters):  # type: ignore[no-untyped-def]
         """
         Try to resolve parameter references on the given input object. The object could be of any type.
         If the input is not in the format used by intrinsics (ie. dictionary with one key), input is returned
@@ -174,13 +174,13 @@ class IntrinsicsResolver(object):
         :param parameters: Parameter values used to for ref substitution
         :return:
         """
-        if not self._is_intrinsic_dict(input):
+        if not self._is_intrinsic_dict(input):  # type: ignore[no-untyped-call]
             return input
 
         function_type = list(input.keys())[0]
         return self.supported_intrinsics[function_type].resolve_parameter_refs(input, parameters)
 
-    def _try_resolve_sam_resource_refs(self, input, supported_resource_refs):
+    def _try_resolve_sam_resource_refs(self, input, supported_resource_refs):  # type: ignore[no-untyped-def]
         """
         Try to resolve SAM resource references on the given template. If the given object looks like one of the
         supported intrinsics, it calls the appropriate resolution on it. If not, this method returns the original input
@@ -191,13 +191,13 @@ class IntrinsicsResolver(object):
             resource references and the values they resolve to.
         :return: Modified input dictionary with references resolved
         """
-        if not self._is_intrinsic_dict(input):
+        if not self._is_intrinsic_dict(input):  # type: ignore[no-untyped-call]
             return input
 
         function_type = list(input.keys())[0]
         return self.supported_intrinsics[function_type].resolve_resource_refs(input, supported_resource_refs)
 
-    def _try_resolve_sam_resource_id_refs(self, input, supported_resource_id_refs):
+    def _try_resolve_sam_resource_id_refs(self, input, supported_resource_id_refs):  # type: ignore[no-untyped-def]
         """
         Try to resolve SAM resource id references on the given template. If the given object looks like one of the
         supported intrinsics, it calls the appropriate resolution on it. If not, this method returns the original input
@@ -207,13 +207,13 @@ class IntrinsicsResolver(object):
         :param dict supported_resource_id_refs: Dictionary that maps old logical ids to new ones.
         :return: Modified input dictionary with id references resolved
         """
-        if not self._is_intrinsic_dict(input):
+        if not self._is_intrinsic_dict(input):  # type: ignore[no-untyped-call]
             return input
 
         function_type = list(input.keys())[0]
         return self.supported_intrinsics[function_type].resolve_resource_id_refs(input, supported_resource_id_refs)
 
-    def _is_intrinsic_dict(self, input):
+    def _is_intrinsic_dict(self, input):  # type: ignore[no-untyped-def]
         """
         Can the input represent an intrinsic function in it?
 

--- a/samtranslator/intrinsics/resource_refs.py
+++ b/samtranslator/intrinsics/resource_refs.py
@@ -5,13 +5,13 @@ class SupportedResourceReferences(object):
     collection which is finally used to resolve all the references in output CFN template.
     """
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
 
         # This is a two level map like:
         # { "LogicalId": {"Property": "Value"} }
         self._refs = {}
 
-    def add(self, logical_id, property, value):
+    def add(self, logical_id, property, value):  # type: ignore[no-untyped-def]
         """
         Add the information that resource with given `logical_id` supports the given `property`, and that a reference
         to `logical_id.property` resolves to given `value.
@@ -40,7 +40,7 @@ class SupportedResourceReferences(object):
 
         self._refs[logical_id][property] = value
 
-    def get(self, logical_id, property):
+    def get(self, logical_id, property):  # type: ignore[no-untyped-def]
         """
         Returns the value of the reference for given logical_id at given property. Ex: MyFunction.Alias
 
@@ -50,12 +50,12 @@ class SupportedResourceReferences(object):
         """
 
         # By defaulting to empty dictionary, we can handle the case where logical_id is not in map without if statements
-        prop_values = self.get_all(logical_id)
+        prop_values = self.get_all(logical_id)  # type: ignore[no-untyped-call]
         if prop_values:
             return prop_values.get(property, None)
         return None
 
-    def get_all(self, logical_id):
+    def get_all(self, logical_id):  # type: ignore[no-untyped-def]
         """
         Get all properties and their values supported by the resource with given logical ID
 
@@ -64,12 +64,12 @@ class SupportedResourceReferences(object):
         """
         return self._refs.get(logical_id, None)
 
-    def __len__(self):
+    def __len__(self):  # type: ignore[no-untyped-def]
         """
         To make len(this_object) work
         :return: Number of resource references available
         """
         return len(self._refs)
 
-    def __str__(self):
+    def __str__(self):  # type: ignore[no-untyped-def]
         return str(self._refs)

--- a/samtranslator/metrics/method_decorator.py
+++ b/samtranslator/metrics/method_decorator.py
@@ -16,22 +16,22 @@ class MetricsMethodWrapperSingleton:
     This singleton will be alive until lambda receives shutdown event
     """
 
-    _DUMMY_INSTANCE = Metrics("ServerlessTransform", DummyMetricsPublisher())
+    _DUMMY_INSTANCE = Metrics("ServerlessTransform", DummyMetricsPublisher())  # type: ignore[no-untyped-call, no-untyped-call]
     _METRICS_INSTANCE = _DUMMY_INSTANCE
 
     @staticmethod
-    def set_instance(metrics):
+    def set_instance(metrics):  # type: ignore[no-untyped-def]
         MetricsMethodWrapperSingleton._METRICS_INSTANCE = metrics
 
     @staticmethod
-    def get_instance():
+    def get_instance():  # type: ignore[no-untyped-def]
         """
         Return the instance, if nothing is set return a dummy one
         """
         return MetricsMethodWrapperSingleton._METRICS_INSTANCE
 
 
-def _get_metric_name(prefix, name, func, args):
+def _get_metric_name(prefix, name, func, args):  # type: ignore[no-untyped-def]
     """
     Returns the metric name depending on the parameters
 
@@ -61,20 +61,20 @@ def _get_metric_name(prefix, name, func, args):
     return metric_name
 
 
-def _send_cw_metric(prefix, name, execution_time_ms, func, args):
+def _send_cw_metric(prefix, name, execution_time_ms, func, args):  # type: ignore[no-untyped-def]
     """
     Gets metric name from 'prefix', 'name', 'func' and 'args' parameters, then calls metrics instance from its
     singleton object to record the latency.
     """
     try:
-        metric_name = _get_metric_name(prefix, name, func, args)
+        metric_name = _get_metric_name(prefix, name, func, args)  # type: ignore[no-untyped-call]
         LOG.debug("Execution took %sms for %s", execution_time_ms, metric_name)
-        MetricsMethodWrapperSingleton.get_instance().record_latency(metric_name, execution_time_ms)
+        MetricsMethodWrapperSingleton.get_instance().record_latency(metric_name, execution_time_ms)  # type: ignore[no-untyped-call]
     except Exception as e:
         LOG.warning("Failed to add metrics", exc_info=e)
 
 
-def cw_timer(_func=None, name=None, prefix=None):
+def cw_timer(_func=None, name=None, prefix=None):  # type: ignore[no-untyped-def]
     """
     A method decorator, that will calculate execution time of the decorated method, and store this information as a
     metric in CloudWatch by calling the metrics singleton instance.
@@ -87,19 +87,19 @@ def cw_timer(_func=None, name=None, prefix=None):
     If prefix is defined, it will be added in the beginning of what is been generated above
     """
 
-    def cw_timer_decorator(func):
+    def cw_timer_decorator(func):  # type: ignore[no-untyped-def]
         @functools.wraps(func)
-        def wrapper_cw_timer(*args, **kwargs):
+        def wrapper_cw_timer(*args, **kwargs):  # type: ignore[no-untyped-def]
             start_time = datetime.now()
 
             exec_result = func(*args, **kwargs)
 
             execution_time = datetime.now() - start_time
             execution_time_ms = execution_time.total_seconds() * 1000
-            _send_cw_metric(prefix, name, execution_time_ms, func, args)
+            _send_cw_metric(prefix, name, execution_time_ms, func, args)  # type: ignore[no-untyped-call]
 
             return exec_result
 
         return wrapper_cw_timer
 
-    return cw_timer_decorator if _func is None else cw_timer_decorator(_func)
+    return cw_timer_decorator if _func is None else cw_timer_decorator(_func)  # type: ignore[no-untyped-call]

--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -10,26 +10,26 @@ LOG = logging.getLogger(__name__)
 class MetricsPublisher:
     """Interface for all MetricPublishers"""
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         pass
 
-    def publish(self, namespace, metrics):
+    def publish(self, namespace, metrics):  # type: ignore[no-untyped-def]
         raise NotImplementedError
 
 
 class CWMetricsPublisher(MetricsPublisher):
     BATCH_SIZE = 20
 
-    def __init__(self, cloudwatch_client):
+    def __init__(self, cloudwatch_client):  # type: ignore[no-untyped-def]
         """
         Constructor
 
         :param cloudwatch_client: cloudwatch client required to publish metrics to cloudwatch
         """
-        MetricsPublisher.__init__(self)
+        MetricsPublisher.__init__(self)  # type: ignore[no-untyped-call]
         self.cloudwatch_client = cloudwatch_client
 
-    def publish(self, namespace, metrics):
+    def publish(self, namespace, metrics):  # type: ignore[no-untyped-def]
         """
         Method to publish all metrics to Cloudwatch.
 
@@ -41,15 +41,15 @@ class CWMetricsPublisher(MetricsPublisher):
             batch.append(metric)
             # Cloudwatch recommends not to send more than 20 metrics at a time
             if len(batch) == self.BATCH_SIZE:
-                self._flush_metrics(namespace, batch)
+                self._flush_metrics(namespace, batch)  # type: ignore[no-untyped-call]
                 batch = []
-        self._flush_metrics(namespace, batch)
+        self._flush_metrics(namespace, batch)  # type: ignore[no-untyped-call]
 
-    def _flush_metrics(self, namespace, metrics):
+    def _flush_metrics(self, namespace, metrics):  # type: ignore[no-untyped-def]
         """
         Internal method to publish all provided metrics to cloudwatch, please make sure that array size of metrics is <= 20.
         """
-        metric_data = list(map(lambda m: m.get_metric_data(), metrics))
+        metric_data = list(map(lambda m: m.get_metric_data(), metrics))  # type: ignore[no-any-return]
         try:
             if metric_data:
                 self.cloudwatch_client.put_metric_data(Namespace=namespace, MetricData=metric_data)
@@ -58,10 +58,10 @@ class CWMetricsPublisher(MetricsPublisher):
 
 
 class DummyMetricsPublisher(MetricsPublisher):
-    def __init__(self):
-        MetricsPublisher.__init__(self)
+    def __init__(self):  # type: ignore[no-untyped-def]
+        MetricsPublisher.__init__(self)  # type: ignore[no-untyped-call]
 
-    def publish(self, namespace, metrics):
+    def publish(self, namespace, metrics):  # type: ignore[no-untyped-def]
         """Do not publish any metric, this is a dummy publisher used for offline use."""
         LOG.debug("Dummy publisher ignoring {} metrices".format(len(metrics)))
 
@@ -85,7 +85,7 @@ class MetricDatum:
     Class to hold Metric data.
     """
 
-    def __init__(self, name, value, unit, dimensions=None, timestamp=None):
+    def __init__(self, name, value, unit, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
         """
         Constructor
 
@@ -101,7 +101,7 @@ class MetricDatum:
         self.dimensions = dimensions if dimensions else []
         self.timestamp = timestamp if timestamp else datetime.utcnow()
 
-    def get_metric_data(self):
+    def get_metric_data(self):  # type: ignore[no-untyped-def]
         return {
             "MetricName": self.name,
             "Value": self.value,
@@ -112,26 +112,26 @@ class MetricDatum:
 
 
 class Metrics:
-    def __init__(self, namespace="ServerlessTransform", metrics_publisher=None):
+    def __init__(self, namespace="ServerlessTransform", metrics_publisher=None):  # type: ignore[no-untyped-def]
         """
         Constructor
 
         :param namespace: namespace under which all metrics will be published
         :param metrics_publisher: publisher to publish all metrics
         """
-        self.metrics_publisher = metrics_publisher if metrics_publisher else DummyMetricsPublisher()
+        self.metrics_publisher = metrics_publisher if metrics_publisher else DummyMetricsPublisher()  # type: ignore[no-untyped-call]
         self.metrics_cache = {}
         self.namespace = namespace
 
-    def __del__(self):
+    def __del__(self):  # type: ignore[no-untyped-def]
         if len(self.metrics_cache) > 0:
             # attempting to publish if user forgot to call publish in code
             LOG.warning(
                 "There are unpublished metrics. Please make sure you call publish after you record all metrics."
             )
-            self.publish()
+            self.publish()  # type: ignore[no-untyped-call]
 
-    def _record_metric(self, name, value, unit, dimensions=None, timestamp=None):
+    def _record_metric(self, name, value, unit, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
         """
         Create and save metric object in internal cache.
 
@@ -141,9 +141,9 @@ class Metrics:
         :param dimensions: array of dimensions applied to the metric
         :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self.metrics_cache.setdefault(name, []).append(MetricDatum(name, value, unit, dimensions, timestamp))
+        self.metrics_cache.setdefault(name, []).append(MetricDatum(name, value, unit, dimensions, timestamp))  # type: ignore[no-untyped-call]
 
-    def record_count(self, name, value, dimensions=None, timestamp=None):
+    def record_count(self, name, value, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
         """
         Create metric with unit Count.
 
@@ -153,9 +153,9 @@ class Metrics:
         :param dimensions: array of dimensions applied to the metric
         :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self._record_metric(name, value, Unit.Count, dimensions, timestamp)
+        self._record_metric(name, value, Unit.Count, dimensions, timestamp)  # type: ignore[no-untyped-call]
 
-    def record_latency(self, name, value, dimensions=None, timestamp=None):
+    def record_latency(self, name, value, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
         """
         Create metric with unit Milliseconds.
 
@@ -165,9 +165,9 @@ class Metrics:
         :param dimensions: array of dimensions applied to the metric
         :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self._record_metric(name, value, Unit.Milliseconds, dimensions, timestamp)
+        self._record_metric(name, value, Unit.Milliseconds, dimensions, timestamp)  # type: ignore[no-untyped-call]
 
-    def publish(self):
+    def publish(self):  # type: ignore[no-untyped-def]
         """Calls publish method from the configured metrics publisher to publish metrics"""
         # flatten the key->list dict into a flat list; we don't care about the key as it's
         # the metric name which is also in the MetricDatum object
@@ -177,7 +177,7 @@ class Metrics:
         self.metrics_publisher.publish(self.namespace, all_metrics)
         self.metrics_cache = {}
 
-    def get_metric(self, name):
+    def get_metric(self, name):  # type: ignore[no-untyped-def]
         """
         Returns a list of metrics from the internal cache for a metric name
 

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -18,7 +18,7 @@ class PropertyType(object):
         raise an error when intrinsic function dictionary is supplied as value
     """
 
-    def __init__(self, required, validate=lambda value: True, supports_intrinsics=True):
+    def __init__(self, required, validate=lambda value: True, supports_intrinsics=True):  # type: ignore[no-untyped-def]
         self.required = required
         self.validate = validate
         self.supports_intrinsics = supports_intrinsics
@@ -61,7 +61,7 @@ class Resource(object):
     # }
     runtime_attrs: Dict[str, Callable[["Resource"], Any]] = {}  # TODO: replace Any with something more explicit
 
-    def __init__(self, logical_id, relative_id=None, depends_on=None, attributes=None):
+    def __init__(self, logical_id, relative_id=None, depends_on=None, attributes=None):  # type: ignore[no-untyped-def]
         """Initializes a Resource object with the given logical id.
 
         :param str logical_id: The logical id of this Resource
@@ -70,7 +70,7 @@ class Resource(object):
         :param depends_on Value of DependsOn resource attribute
         :param attributes Dictionary of resource attributes and their values
         """
-        self._validate_logical_id(logical_id)
+        self._validate_logical_id(logical_id)  # type: ignore[no-untyped-call]
         self.logical_id = logical_id
         self.relative_id = relative_id
         self.depends_on = depends_on
@@ -81,10 +81,10 @@ class Resource(object):
         self.resource_attributes = {}
         if attributes is not None:
             for attr, value in attributes.items():
-                self.set_resource_attribute(attr, value)
+                self.set_resource_attribute(attr, value)  # type: ignore[no-untyped-call]
 
     @classmethod
-    def get_supported_resource_attributes(cls):
+    def get_supported_resource_attributes(cls):  # type: ignore[no-untyped-def]
         """
         A getter method for the supported resource attributes
         returns: a tuple that contains the name of all supported resource attributes
@@ -92,7 +92,7 @@ class Resource(object):
         return tuple(cls._supported_resource_attributes)
 
     @classmethod
-    def get_pass_through_attributes(cls):
+    def get_pass_through_attributes(cls):  # type: ignore[no-untyped-def]
         """
         A getter method for the resource attributes to be passed to auto-generated resources
         returns: a tuple that contains the name of all pass through attributes
@@ -100,7 +100,7 @@ class Resource(object):
         return tuple(cls._pass_through_attributes)
 
     @classmethod
-    def from_dict(cls, logical_id, resource_dict, relative_id=None, sam_plugins=None):
+    def from_dict(cls, logical_id, resource_dict, relative_id=None, sam_plugins=None):  # type: ignore[no-untyped-def]
         """Constructs a Resource object with the given logical id, based on the given resource dict. The resource dict
         is the value associated with the logical id in a CloudFormation template's Resources section, and takes the
         following format. ::
@@ -126,7 +126,7 @@ class Resource(object):
 
         resource = cls(logical_id, relative_id=relative_id)
 
-        resource._validate_resource_dict(logical_id, resource_dict)
+        resource._validate_resource_dict(logical_id, resource_dict)  # type: ignore[no-untyped-call]
 
         # Default to empty properties dictionary. If customers skip the Properties section, an empty dictionary
         # accurately captures the intent.
@@ -145,13 +145,13 @@ class Resource(object):
         # all resource attributes ie. all attributes were unsupported before
         for attr in resource._supported_resource_attributes:
             if attr in resource_dict:
-                resource.set_resource_attribute(attr, resource_dict[attr])
+                resource.set_resource_attribute(attr, resource_dict[attr])  # type: ignore[no-untyped-call]
 
-        resource.validate_properties()
+        resource.validate_properties()  # type: ignore[no-untyped-call]
         return resource
 
     @classmethod
-    def _validate_logical_id(cls, logical_id):
+    def _validate_logical_id(cls, logical_id):  # type: ignore[no-untyped-def]
         """Validates that the provided logical id is an alphanumeric string.
 
         :param str logical_id: the logical id to validate
@@ -162,10 +162,10 @@ class Resource(object):
         pattern = re.compile(r"^[A-Za-z0-9]+$")
         if logical_id is not None and pattern.match(logical_id):
             return True
-        raise InvalidResourceException(logical_id, "Logical ids must be alphanumeric.")
+        raise InvalidResourceException(logical_id, "Logical ids must be alphanumeric.")  # type: ignore[no-untyped-call]
 
     @classmethod
-    def _validate_resource_dict(cls, logical_id, resource_dict):
+    def _validate_resource_dict(cls, logical_id, resource_dict):  # type: ignore[no-untyped-def]
         """Validates that the provided resource dict contains the correct Type string, and the required Properties dict.
 
         :param dict resource_dict: the resource dict to validate
@@ -174,18 +174,18 @@ class Resource(object):
         :raises InvalidResourceException: if the resource dict has an invalid format
         """
         if "Type" not in resource_dict:
-            raise InvalidResourceException(logical_id, "Resource dict missing key 'Type'.")
+            raise InvalidResourceException(logical_id, "Resource dict missing key 'Type'.")  # type: ignore[no-untyped-call]
         if resource_dict["Type"] != cls.resource_type:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 logical_id,
                 "Resource has incorrect Type; expected '{expected}', "
                 "got '{actual}'".format(expected=cls.resource_type, actual=resource_dict["Type"]),
             )
 
         if "Properties" in resource_dict and not isinstance(resource_dict["Properties"], dict):
-            raise InvalidResourceException(logical_id, "Properties of a resource must be an object.")
+            raise InvalidResourceException(logical_id, "Properties of a resource must be an object.")  # type: ignore[no-untyped-call]
 
-    def to_dict(self):
+    def to_dict(self):  # type: ignore[no-untyped-def]
         """Validates that the required properties for this Resource have been provided, then returns a dict
         corresponding to the given Resource object. This dict will take the format of a single entry in the Resources
         section of a CloudFormation template, and will take the following format. ::
@@ -206,13 +206,13 @@ class Resource(object):
         :rtype: dict
         :raises TypeError: if a required property is missing from this Resource
         """
-        self.validate_properties()
+        self.validate_properties()  # type: ignore[no-untyped-call]
 
-        resource_dict = self._generate_resource_dict()
+        resource_dict = self._generate_resource_dict()  # type: ignore[no-untyped-call]
 
         return {self.logical_id: resource_dict}
 
-    def _generate_resource_dict(self):
+    def _generate_resource_dict(self):  # type: ignore[no-untyped-def]
         """Generates the resource dict for this Resource, the value associated with the logical id in a CloudFormation
         template's Resources section.
 
@@ -234,11 +234,11 @@ class Resource(object):
             if value is not None:
                 properties_dict[name] = value
 
-        resource_dict["Properties"] = properties_dict
+        resource_dict["Properties"] = properties_dict  # type: ignore[assignment]
 
         return resource_dict
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value):  # type: ignore[no-untyped-def]
         """Allows an attribute of this resource to be set only if it is a keyword or a property of the Resource with a
         valid value.
 
@@ -249,14 +249,14 @@ class Resource(object):
         if name in self._keywords or name in self.property_types.keys():
             return super(Resource, self).__setattr__(name, value)
 
-        raise InvalidResourceException(
+        raise InvalidResourceException(  # type: ignore[no-untyped-call]
             self.logical_id,
             "property {property_name} not defined for resource of type {resource_type}".format(
                 resource_type=self.resource_type, property_name=name
             ),
         )
 
-    def validate_properties(self):
+    def validate_properties(self):  # type: ignore[no-untyped-def]
         """Validates that the required properties for this Resource have been populated, and that all properties have
         valid values.
 
@@ -268,22 +268,22 @@ class Resource(object):
             value = getattr(self, name)
 
             # If the property value is an intrinsic function, any remaining validation has to be left to CloudFormation
-            if property_type.supports_intrinsics and self._is_intrinsic_function(value):
+            if property_type.supports_intrinsics and self._is_intrinsic_function(value):  # type: ignore[no-untyped-call]
                 continue
 
             # If the property value has not been set, verify that the property is not required.
             if value is None:
                 if property_type.required:
-                    raise InvalidResourceException(
+                    raise InvalidResourceException(  # type: ignore[no-untyped-call]
                         self.logical_id, "Missing required property '{property_name}'.".format(property_name=name)
                     )
             # Otherwise, validate the value of the property.
             elif not property_type.validate(value, should_raise=False):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "Type of property '{property_name}' is invalid.".format(property_name=name)
                 )
 
-    def set_resource_attribute(self, attr, value):
+    def set_resource_attribute(self, attr, value):  # type: ignore[no-untyped-def]
         """Sets attributes on resource. Resource attributes are top-level entries of a CloudFormation resource
         that exist outside of the Properties dictionary
 
@@ -298,7 +298,7 @@ class Resource(object):
 
         self.resource_attributes[attr] = value
 
-    def get_resource_attribute(self, attr):
+    def get_resource_attribute(self, attr):  # type: ignore[no-untyped-def]
         """Gets the resource attribute if available
 
         :param attr: Name of the attribute
@@ -310,7 +310,7 @@ class Resource(object):
         return self.resource_attributes[attr]
 
     @classmethod
-    def _is_intrinsic_function(cls, value):
+    def _is_intrinsic_function(cls, value):  # type: ignore[no-untyped-def]
         """Checks whether the Property value provided has the format of an intrinsic function, that is ::
 
             { "<operation>": <parameter> }
@@ -321,7 +321,7 @@ class Resource(object):
         """
         return isinstance(value, dict) and len(value) == 1
 
-    def get_runtime_attr(self, attr_name):
+    def get_runtime_attr(self, attr_name):  # type: ignore[no-untyped-def]
         """
         Returns a CloudFormation construct that provides value for this attribute. If the resource does not provide
         this attribute, then this method raises an exception
@@ -333,7 +333,7 @@ class Resource(object):
             return self.runtime_attrs[attr_name](self)
         raise NotImplementedError(f"{attr_name} attribute is not implemented for resource {self.resource_type}")
 
-    def get_passthrough_resource_attributes(self):
+    def get_passthrough_resource_attributes(self):  # type: ignore[no-untyped-def]
         """
         Returns a dictionary of resource attributes of the ResourceMacro that should be passed through from the main
         vanilla CloudFormation resource to its children. Currently only Condition is copied.
@@ -341,7 +341,7 @@ class Resource(object):
         :return: Dictionary of resource attributes.
         """
         attributes = {}
-        for resource_attribute in self.get_pass_through_attributes():
+        for resource_attribute in self.get_pass_through_attributes():  # type: ignore[no-untyped-call]
             if resource_attribute in self.resource_attributes:
                 attributes[resource_attribute] = self.resource_attributes.get(resource_attribute)
         return attributes
@@ -357,7 +357,7 @@ class ResourceMacro(Resource):
     Resources to which this macro should expand.
     """
 
-    def resources_to_link(self, resources):
+    def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
         """Returns a dictionary of resources which will need to be modified when this is turned into CloudFormation.
         The result of this will be passed to :func: `to_cloudformation`.
 
@@ -366,7 +366,7 @@ class ResourceMacro(Resource):
         """
         return {}
 
-    def to_cloudformation(self, **kwargs):
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns a list of Resource instances, representing vanilla CloudFormation resources, to which this macro
         expands. The caller should be able to update their template with the expanded resources by calling
         :func:`to_dict` on each resource returned, then updating their "Resources" mapping with the results.
@@ -404,7 +404,7 @@ class SamResourceMacro(ResourceMacro):
     # Aggregate list of all reserved tags
     _RESERVED_TAGS = [_SAM_KEY, _SAR_APP_KEY, _SAR_SEMVER_KEY]
 
-    def get_resource_references(self, generated_cfn_resources, supported_resource_refs):
+    def get_resource_references(self, generated_cfn_resources, supported_resource_refs):  # type: ignore[no-untyped-def]
         """
         Constructs the list of supported resource references by going through the list of CFN resources generated
         by to_cloudformation() on this SAM resource. Each SAM resource must provide a map of properties that it
@@ -429,7 +429,7 @@ class SamResourceMacro(ResourceMacro):
 
         return supported_resource_refs
 
-    def _construct_tag_list(self, tags, additional_tags=None):
+    def _construct_tag_list(self, tags, additional_tags=None):  # type: ignore[no-untyped-def]
         if not bool(tags):
             tags = {}
 
@@ -437,7 +437,7 @@ class SamResourceMacro(ResourceMacro):
             additional_tags = {}
 
         for tag in self._RESERVED_TAGS:
-            self._check_tag(tag, tags)
+            self._check_tag(tag, tags)  # type: ignore[no-untyped-call]
 
         sam_tag = {self._SAM_KEY: self._SAM_VALUE}
 
@@ -445,11 +445,11 @@ class SamResourceMacro(ResourceMacro):
         # tags list. Changing this ordering will trigger a update on Lambda Function resource. Even though this
         # does not change the actual content of the tags, we don't want to trigger update of a resource without
         # customer's knowledge.
-        return get_tag_list(sam_tag) + get_tag_list(additional_tags) + get_tag_list(tags)
+        return get_tag_list(sam_tag) + get_tag_list(additional_tags) + get_tag_list(tags)  # type: ignore[no-untyped-call]
 
-    def _check_tag(self, reserved_tag_name, tags):
+    def _check_tag(self, reserved_tag_name, tags):  # type: ignore[no-untyped-def]
         if reserved_tag_name in tags:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 f"{reserved_tag_name} is a reserved Tag key name and "
                 "cannot be set on your resource. "
@@ -457,13 +457,13 @@ class SamResourceMacro(ResourceMacro):
                 "input.",
             )
 
-    def _resolve_string_parameter(self, intrinsics_resolver, parameter_value, parameter_name):
+    def _resolve_string_parameter(self, intrinsics_resolver, parameter_value, parameter_name):  # type: ignore[no-untyped-def]
         if not parameter_value:
             return parameter_value
         value = intrinsics_resolver.resolve_parameter_refs(parameter_value)
 
         if not isinstance(value, str) and not isinstance(value, dict):
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Could not resolve parameter for '{}' or parameter is not a String.".format(parameter_name),
             )
@@ -474,7 +474,7 @@ class ResourceTypeResolver(object):
     """ResourceTypeResolver maps Resource Types to Resource classes, e.g. AWS::Serverless::Function to
     samtranslator.model.sam_resources.SamFunction."""
 
-    def __init__(self, *modules):
+    def __init__(self, *modules):  # type: ignore[no-untyped-def]
         """Initializes the ResourceTypeResolver from the given modules.
 
         :param modules: one or more Python modules containing Resource definitions
@@ -490,20 +490,20 @@ class ResourceTypeResolver(object):
             ):
                 self.resource_types[resource_class.resource_type] = resource_class
 
-    def can_resolve(self, resource_dict):
+    def can_resolve(self, resource_dict):  # type: ignore[no-untyped-def]
         if not isinstance(resource_dict, dict) or not isinstance(resource_dict.get("Type"), str):
             return False
 
         return resource_dict["Type"] in self.resource_types
 
-    def resolve_resource_type(self, resource_dict):
+    def resolve_resource_type(self, resource_dict):  # type: ignore[no-untyped-def]
         """Returns the Resource class corresponding to the 'Type' key in the given resource dict.
 
         :param dict resource_dict: the resource dict to resolve
         :returns: the resolved Resource class
         :rtype: class
         """
-        if not self.can_resolve(resource_dict):
+        if not self.can_resolve(resource_dict):  # type: ignore[no-untyped-call]
             raise TypeError(
                 "Resource dict has missing or invalid value for key Type. Event Type is: {}.".format(
                     resource_dict.get("Type")

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -65,7 +65,7 @@ class SharedApiUsagePlan(object):
 
     SHARED_USAGE_PLAN_CONDITION_NAME = "SharedUsagePlanCondition"
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         self.usage_plan_shared = False
         self.stage_keys_shared = []
         self.api_stages_shared = []
@@ -77,7 +77,7 @@ class SharedApiUsagePlan(object):
         self.deletion_policy = None
         self.update_replace_policy = None
 
-    def get_combined_resource_attributes(self, resource_attributes, conditions):
+    def get_combined_resource_attributes(self, resource_attributes, conditions):  # type: ignore[no-untyped-def]
         """
         This method returns a dictionary which combines 'DeletionPolicy', 'UpdateReplacePolicy' and 'Condition'
         values of API definitions that could be used in Shared Usage Plan resources.
@@ -89,9 +89,9 @@ class SharedApiUsagePlan(object):
         conditions: Dict[str]
             Conditions section of the template
         """
-        self._set_deletion_policy(resource_attributes.get("DeletionPolicy"))
-        self._set_update_replace_policy(resource_attributes.get("UpdateReplacePolicy"))
-        self._set_condition(resource_attributes.get("Condition"), conditions)
+        self._set_deletion_policy(resource_attributes.get("DeletionPolicy"))  # type: ignore[no-untyped-call]
+        self._set_update_replace_policy(resource_attributes.get("UpdateReplacePolicy"))  # type: ignore[no-untyped-call]
+        self._set_condition(resource_attributes.get("Condition"), conditions)  # type: ignore[no-untyped-call]
 
         combined_resource_attributes = {}
         if self.deletion_policy:
@@ -104,7 +104,7 @@ class SharedApiUsagePlan(object):
 
         return combined_resource_attributes
 
-    def _set_deletion_policy(self, deletion_policy):
+    def _set_deletion_policy(self, deletion_policy):  # type: ignore[no-untyped-def]
         if deletion_policy:
             if self.deletion_policy:
                 # update only if new deletion policy is Retain
@@ -113,7 +113,7 @@ class SharedApiUsagePlan(object):
             else:
                 self.deletion_policy = deletion_policy
 
-    def _set_update_replace_policy(self, update_replace_policy):
+    def _set_update_replace_policy(self, update_replace_policy):  # type: ignore[no-untyped-def]
         if update_replace_policy:
             if self.update_replace_policy:
                 # if new value is Retain or
@@ -125,7 +125,7 @@ class SharedApiUsagePlan(object):
             else:
                 self.update_replace_policy = update_replace_policy
 
-    def _set_condition(self, condition, template_conditions):
+    def _set_condition(self, condition, template_conditions):  # type: ignore[no-untyped-def]
         # if there are any API without condition, then skip
         if self.any_api_without_condition:
             return
@@ -133,13 +133,13 @@ class SharedApiUsagePlan(object):
         if condition and condition not in self.conditions:
 
             if template_conditions is None:
-                raise InvalidTemplateException(
+                raise InvalidTemplateException(  # type: ignore[no-untyped-call]
                     "Can't have condition without having 'Conditions' section in the template"
                 )
 
             if self.conditions:
                 self.conditions.add(condition)
-                or_condition = make_or_condition(self.conditions)
+                or_condition = make_or_condition(self.conditions)  # type: ignore[no-untyped-call]
                 template_conditions[SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME] = or_condition
             else:
                 self.conditions.add(condition)
@@ -151,7 +151,7 @@ class SharedApiUsagePlan(object):
 
 
 class ApiGenerator(object):
-    def __init__(
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         logical_id,
         cache_cluster_enabled,
@@ -240,56 +240,56 @@ class ApiGenerator(object):
         self.mode = mode
         self.api_key_source_type = api_key_source_type
 
-    def _construct_rest_api(self):
+    def _construct_rest_api(self):  # type: ignore[no-untyped-def]
         """Constructs and returns the ApiGateway RestApi.
 
         :returns: the RestApi to which this SAM Api corresponds
         :rtype: model.apigateway.ApiGatewayRestApi
         """
-        rest_api = ApiGatewayRestApi(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)
+        rest_api = ApiGatewayRestApi(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)  # type: ignore[no-untyped-call]
         # NOTE: For backwards compatibility we need to retain BinaryMediaTypes on the CloudFormation Property
         # Removing this and only setting x-amazon-apigateway-binary-media-types results in other issues.
         rest_api.BinaryMediaTypes = self.binary_media
         rest_api.MinimumCompressionSize = self.minimum_compression_size
 
         if self.endpoint_configuration:
-            self._set_endpoint_configuration(rest_api, self.endpoint_configuration)
+            self._set_endpoint_configuration(rest_api, self.endpoint_configuration)  # type: ignore[no-untyped-call]
 
-        elif not RegionConfiguration.is_apigw_edge_configuration_supported():
+        elif not RegionConfiguration.is_apigw_edge_configuration_supported():  # type: ignore[no-untyped-call]
             # Since this region does not support EDGE configuration, we explicitly set the endpoint type
             # to Regional which is the only supported config.
-            self._set_endpoint_configuration(rest_api, "REGIONAL")
+            self._set_endpoint_configuration(rest_api, "REGIONAL")  # type: ignore[no-untyped-call]
 
         if self.definition_uri and self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Specify either 'DefinitionUri' or 'DefinitionBody' property and not both."
             )
 
         if self.open_api_version:
-            if not SwaggerEditor.safe_compare_regex_with_string(
-                SwaggerEditor.get_openapi_versions_supported_regex(), self.open_api_version
+            if not SwaggerEditor.safe_compare_regex_with_string(  # type: ignore[no-untyped-call]
+                SwaggerEditor.get_openapi_versions_supported_regex(), self.open_api_version  # type: ignore[no-untyped-call]
             ):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "The OpenApiVersion value must be of the format '3.0.0'."
                 )
 
-        self._add_cors()
-        self._add_auth()
-        self._add_gateway_responses()
-        self._add_binary_media_types()
-        self._add_models()
+        self._add_cors()  # type: ignore[no-untyped-call]
+        self._add_auth()  # type: ignore[no-untyped-call]
+        self._add_gateway_responses()  # type: ignore[no-untyped-call]
+        self._add_binary_media_types()  # type: ignore[no-untyped-call]
+        self._add_models()  # type: ignore[no-untyped-call]
 
         if self.fail_on_warnings:
             rest_api.FailOnWarnings = self.fail_on_warnings
 
         if self.disable_execute_api_endpoint is not None:
-            self._add_endpoint_extension()
+            self._add_endpoint_extension()  # type: ignore[no-untyped-call]
 
         if self.definition_uri:
-            rest_api.BodyS3Location = self._construct_body_s3_dict()
+            rest_api.BodyS3Location = self._construct_body_s3_dict()  # type: ignore[no-untyped-call]
         elif self.definition_body:
             # # Post Process OpenApi Auth Settings
-            self.definition_body = self._openapi_postprocess(self.definition_body)
+            self.definition_body = self._openapi_postprocess(self.definition_body)  # type: ignore[no-untyped-call]
             rest_api.Body = self.definition_body
 
         if self.name:
@@ -306,7 +306,7 @@ class ApiGenerator(object):
 
         return rest_api
 
-    def _add_endpoint_extension(self):
+    def _add_endpoint_extension(self):  # type: ignore[no-untyped-def]
         """Add disableExecuteApiEndpoint if it is set in SAM
         Note:
         If neither DefinitionUri nor DefinitionBody are specified,
@@ -315,14 +315,14 @@ class ApiGenerator(object):
         For this reason, we always put DisableExecuteApiEndpoint into openapi object irrespective of origin of DefinitionBody.
         """
         if self.disable_execute_api_endpoint is not None and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "DisableExecuteApiEndpoint works only within 'DefinitionBody' property."
             )
-        editor = SwaggerEditor(self.definition_body)
-        editor.add_disable_execute_api_endpoint_extension(self.disable_execute_api_endpoint)
+        editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        editor.add_disable_execute_api_endpoint_extension(self.disable_execute_api_endpoint)  # type: ignore[no-untyped-call]
         self.definition_body = editor.swagger
 
-    def _construct_body_s3_dict(self):
+    def _construct_body_s3_dict(self):  # type: ignore[no-untyped-def]
         """Constructs the RestApi's `BodyS3Location property`_, from the SAM Api's DefinitionUri property.
 
         :returns: a BodyS3Location dict, containing the S3 Bucket, Key, and Version of the Swagger definition
@@ -331,7 +331,7 @@ class ApiGenerator(object):
         if isinstance(self.definition_uri, dict):
             if not self.definition_uri.get("Bucket", None) or not self.definition_uri.get("Key", None):
                 # DefinitionUri is a dictionary but does not contain Bucket or Key property
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "'DefinitionUri' requires Bucket and Key properties to be specified."
                 )
             s3_pointer = self.definition_uri
@@ -339,7 +339,7 @@ class ApiGenerator(object):
         else:
 
             # DefinitionUri is a string
-            s3_pointer = parse_s3_uri(self.definition_uri)
+            s3_pointer = parse_s3_uri(self.definition_uri)  # type: ignore[no-untyped-call]
             if s3_pointer is None:
                 raise InvalidResourceException(
                     self.logical_id,
@@ -356,21 +356,21 @@ class ApiGenerator(object):
                     s3_pointer["Version"] = Py27UniStr(s3_pointer["Version"])
 
         # Construct body_s3 as py27 dict
-        body_s3 = Py27Dict()
+        body_s3 = Py27Dict()  # type: ignore[no-untyped-call]
         body_s3["Bucket"] = s3_pointer["Bucket"]
         body_s3["Key"] = s3_pointer["Key"]
         if "Version" in s3_pointer:
             body_s3["Version"] = s3_pointer["Version"]
         return body_s3
 
-    def _construct_deployment(self, rest_api):
+    def _construct_deployment(self, rest_api):  # type: ignore[no-untyped-def]
         """Constructs and returns the ApiGateway Deployment.
 
         :param model.apigateway.ApiGatewayRestApi rest_api: the RestApi for this Deployment
         :returns: the Deployment to which this SAM Api corresponds
         :rtype: model.apigateway.ApiGatewayDeployment
         """
-        deployment = ApiGatewayDeployment(
+        deployment = ApiGatewayDeployment(  # type: ignore[no-untyped-call]
             self.logical_id + "Deployment", attributes=self.passthrough_resource_attributes
         )
         deployment.RestApiId = rest_api.get_runtime_attr("rest_api_id")
@@ -379,7 +379,7 @@ class ApiGenerator(object):
 
         return deployment
 
-    def _construct_stage(self, deployment, swagger, redeploy_restapi_parameters):
+    def _construct_stage(self, deployment, swagger, redeploy_restapi_parameters):  # type: ignore[no-untyped-def]
         """Constructs and returns the ApiGateway Stage.
 
         :param model.apigateway.ApiGatewayDeployment deployment: the Deployment for this Stage
@@ -393,11 +393,11 @@ class ApiGenerator(object):
         if stage_name_prefix.isalnum():
             stage_logical_id = self.logical_id + stage_name_prefix + "Stage"
         else:
-            generator = LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)
-            stage_logical_id = generator.gen()
-        stage = ApiGatewayStage(stage_logical_id, attributes=self.passthrough_resource_attributes)
-        stage.RestApiId = ref(self.logical_id)
-        stage.update_deployment_ref(deployment.logical_id)
+            generator = LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)  # type: ignore[no-untyped-call]
+            stage_logical_id = generator.gen()  # type: ignore[no-untyped-call]
+        stage = ApiGatewayStage(stage_logical_id, attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
+        stage.RestApiId = ref(self.logical_id)  # type: ignore[no-untyped-call]
+        stage.update_deployment_ref(deployment.logical_id)  # type: ignore[no-untyped-call]
         stage.StageName = self.stage_name
         stage.CacheClusterEnabled = self.cache_cluster_enabled
         stage.CacheClusterSize = self.cache_cluster_size
@@ -413,11 +413,11 @@ class ApiGenerator(object):
             )
 
         if self.tags is not None:
-            stage.Tags = get_tag_list(self.tags)
+            stage.Tags = get_tag_list(self.tags)  # type: ignore[no-untyped-call]
 
         return stage
 
-    def _construct_api_domain(self, rest_api, route53_record_set_groups):
+    def _construct_api_domain(self, rest_api, route53_record_set_groups):  # type: ignore[no-untyped-def]
         # pylint: disable=duplicate-code
         """
         Constructs and returns the ApiGateway Domain and BasepathMapping
@@ -426,15 +426,15 @@ class ApiGenerator(object):
             return None, None, None
 
         if self.domain.get("DomainName") is None or self.domain.get("CertificateArn") is None:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Custom Domains only works if both DomainName and CertificateArn are provided."
             )
 
         self.domain["ApiDomainName"] = "{}{}".format(
-            "ApiGatewayDomainName", LogicalIdGenerator("", self.domain.get("DomainName")).gen()
+            "ApiGatewayDomainName", LogicalIdGenerator("", self.domain.get("DomainName")).gen()  # type: ignore[no-untyped-call, no-untyped-call]
         )
 
-        domain = ApiGatewayDomainName(self.domain.get("ApiDomainName"), attributes=self.passthrough_resource_attributes)
+        domain = ApiGatewayDomainName(self.domain.get("ApiDomainName"), attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
         domain.DomainName = self.domain.get("DomainName")
         endpoint = self.domain.get("EndpointConfiguration")
 
@@ -442,7 +442,7 @@ class ApiGenerator(object):
             endpoint = "REGIONAL"
             self.domain["EndpointConfiguration"] = "REGIONAL"
         elif endpoint not in ["EDGE", "REGIONAL", "PRIVATE"]:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "EndpointConfiguration for Custom Domains must be"
                 " one of {}.".format(["EDGE", "REGIONAL", "PRIVATE"]),
@@ -464,7 +464,7 @@ class ApiGenerator(object):
                         if not key in {"TruststoreUri", "TruststoreVersion"}:
                             invalid_keys.append(key)
                     invalid_keys.sort()
-                    raise InvalidResourceException(
+                    raise InvalidResourceException(  # type: ignore[no-untyped-call]
                         ",".join(invalid_keys),
                         "Available MutualTlsAuthentication fields are {}.".format(
                             ["TruststoreUri", "TruststoreVersion"]
@@ -472,11 +472,11 @@ class ApiGenerator(object):
                     )
                 domain.MutualTlsAuthentication = {}
                 if mutual_tls_auth.get("TruststoreUri", None):
-                    domain.MutualTlsAuthentication["TruststoreUri"] = mutual_tls_auth["TruststoreUri"]
+                    domain.MutualTlsAuthentication["TruststoreUri"] = mutual_tls_auth["TruststoreUri"]  # type: ignore[attr-defined]
                 if mutual_tls_auth.get("TruststoreVersion", None):
-                    domain.MutualTlsAuthentication["TruststoreVersion"] = mutual_tls_auth["TruststoreVersion"]
+                    domain.MutualTlsAuthentication["TruststoreVersion"] = mutual_tls_auth["TruststoreVersion"]  # type: ignore[attr-defined]
             else:
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     mutual_tls_auth,
                     "MutualTlsAuthentication must be a map with at least one of the following fields {}.".format(
                         ["TruststoreUri", "TruststoreVersion"]
@@ -500,23 +500,23 @@ class ApiGenerator(object):
         basepath_resource_list = []
 
         if basepaths is None:
-            basepath_mapping = ApiGatewayBasePathMapping(
+            basepath_mapping = ApiGatewayBasePathMapping(  # type: ignore[no-untyped-call]
                 self.logical_id + "BasePathMapping", attributes=self.passthrough_resource_attributes
             )
-            basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
-            basepath_mapping.RestApiId = ref(rest_api.logical_id)
-            basepath_mapping.Stage = ref(rest_api.logical_id + ".Stage")
+            basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))  # type: ignore[no-untyped-call]
+            basepath_mapping.RestApiId = ref(rest_api.logical_id)  # type: ignore[no-untyped-call]
+            basepath_mapping.Stage = ref(rest_api.logical_id + ".Stage")  # type: ignore[no-untyped-call]
             basepath_resource_list.extend([basepath_mapping])
         else:
             for path in basepaths:
                 path = "".join(e for e in path if e.isalnum())
                 logical_id = "{}{}{}".format(self.logical_id, path, "BasePathMapping")
-                basepath_mapping = ApiGatewayBasePathMapping(
+                basepath_mapping = ApiGatewayBasePathMapping(  # type: ignore[no-untyped-call]
                     logical_id, attributes=self.passthrough_resource_attributes
                 )
-                basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
-                basepath_mapping.RestApiId = ref(rest_api.logical_id)
-                basepath_mapping.Stage = ref(rest_api.logical_id + ".Stage")
+                basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))  # type: ignore[no-untyped-call]
+                basepath_mapping.RestApiId = ref(rest_api.logical_id)  # type: ignore[no-untyped-call]
+                basepath_mapping.Stage = ref(rest_api.logical_id + ".Stage")  # type: ignore[no-untyped-call]
                 basepath_mapping.BasePath = path
                 basepath_resource_list.extend([basepath_mapping])
 
@@ -525,25 +525,25 @@ class ApiGenerator(object):
         if self.domain.get("Route53") is not None:
             route53 = self.domain.get("Route53")
             if not isinstance(route53, dict):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     "Invalid property type '{}' for Route53. "
                     "Expected a map defines an Amazon Route 53 configuration'.".format(type(route53).__name__),
                 )
             if route53.get("HostedZoneId") is None and route53.get("HostedZoneName") is None:
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
                 )
 
-            logical_id_suffix = LogicalIdGenerator(
+            logical_id_suffix = LogicalIdGenerator(  # type: ignore[no-untyped-call, no-untyped-call]
                 "", route53.get("HostedZoneId") or route53.get("HostedZoneName")
             ).gen()
             logical_id = "RecordSetGroup" + logical_id_suffix
 
             record_set_group = route53_record_set_groups.get(logical_id)
             if not record_set_group:
-                record_set_group = Route53RecordSetGroup(logical_id, attributes=self.passthrough_resource_attributes)
+                record_set_group = Route53RecordSetGroup(logical_id, attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
                 if "HostedZoneId" in route53:
                     record_set_group.HostedZoneId = route53.get("HostedZoneId")
                 if "HostedZoneName" in route53:
@@ -551,30 +551,30 @@ class ApiGenerator(object):
                 record_set_group.RecordSets = []
                 route53_record_set_groups[logical_id] = record_set_group
 
-            record_set_group.RecordSets += self._construct_record_sets_for_domain(self.domain)
+            record_set_group.RecordSets += self._construct_record_sets_for_domain(self.domain)  # type: ignore[no-untyped-call]
 
         return domain, basepath_resource_list, record_set_group
 
-    def _construct_record_sets_for_domain(self, domain):
+    def _construct_record_sets_for_domain(self, domain):  # type: ignore[no-untyped-def]
         recordset_list = []
         recordset = {}
         route53 = domain.get("Route53")
 
         recordset["Name"] = domain.get("DomainName")
         recordset["Type"] = "A"
-        recordset["AliasTarget"] = self._construct_alias_target(self.domain)
+        recordset["AliasTarget"] = self._construct_alias_target(self.domain)  # type: ignore[no-untyped-call]
         recordset_list.extend([recordset])
 
         recordset_ipv6 = {}
         if route53.get("IpV6") is not None and route53.get("IpV6") is True:
             recordset_ipv6["Name"] = domain.get("DomainName")
             recordset_ipv6["Type"] = "AAAA"
-            recordset_ipv6["AliasTarget"] = self._construct_alias_target(self.domain)
+            recordset_ipv6["AliasTarget"] = self._construct_alias_target(self.domain)  # type: ignore[no-untyped-call]
             recordset_list.extend([recordset_ipv6])
 
         return recordset_list
 
-    def _construct_alias_target(self, domain):
+    def _construct_alias_target(self, domain):  # type: ignore[no-untyped-def]
         # pylint: disable=duplicate-code
         alias_target = {}
         route53 = domain.get("Route53")
@@ -583,25 +583,25 @@ class ApiGenerator(object):
         if target_health is not None:
             alias_target["EvaluateTargetHealth"] = target_health
         if domain.get("EndpointConfiguration") == "REGIONAL":
-            alias_target["HostedZoneId"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalHostedZoneId")
-            alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")
+            alias_target["HostedZoneId"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalHostedZoneId")  # type: ignore[no-untyped-call]
+            alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")  # type: ignore[no-untyped-call]
         else:
             if route53.get("DistributionDomainName") is None:
-                route53["DistributionDomainName"] = fnGetAtt(self.domain.get("ApiDomainName"), "DistributionDomainName")
+                route53["DistributionDomainName"] = fnGetAtt(self.domain.get("ApiDomainName"), "DistributionDomainName")  # type: ignore[no-untyped-call]
             alias_target["HostedZoneId"] = "Z2FDTNDATAQYW2"
             alias_target["DNSName"] = route53.get("DistributionDomainName")
         return alias_target
 
-    @cw_timer(prefix="Generator", name="Api")
-    def to_cloudformation(self, redeploy_restapi_parameters, route53_record_set_groups):
+    @cw_timer(prefix="Generator", name="Api")  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, redeploy_restapi_parameters, route53_record_set_groups):  # type: ignore[no-untyped-def]
         """Generates CloudFormation resources from a SAM API resource
 
         :returns: a tuple containing the RestApi, Deployment, and Stage for an empty Api.
         :rtype: tuple
         """
-        rest_api = self._construct_rest_api()
-        domain, basepath_mapping, route53 = self._construct_api_domain(rest_api, route53_record_set_groups)
-        deployment = self._construct_deployment(rest_api)
+        rest_api = self._construct_rest_api()  # type: ignore[no-untyped-call]
+        domain, basepath_mapping, route53 = self._construct_api_domain(rest_api, route53_record_set_groups)  # type: ignore[no-untyped-call]
+        deployment = self._construct_deployment(rest_api)  # type: ignore[no-untyped-call]
 
         swagger = None
         if rest_api.Body is not None:
@@ -609,13 +609,13 @@ class ApiGenerator(object):
         elif rest_api.BodyS3Location is not None:
             swagger = rest_api.BodyS3Location
 
-        stage = self._construct_stage(deployment, swagger, redeploy_restapi_parameters)
-        permissions = self._construct_authorizer_lambda_permission()
-        usage_plan = self._construct_usage_plan(rest_api_stage=stage)
+        stage = self._construct_stage(deployment, swagger, redeploy_restapi_parameters)  # type: ignore[no-untyped-call]
+        permissions = self._construct_authorizer_lambda_permission()  # type: ignore[no-untyped-call]
+        usage_plan = self._construct_usage_plan(rest_api_stage=stage)  # type: ignore[no-untyped-call]
 
         return rest_api, deployment, stage, permissions, domain, basepath_mapping, route53, usage_plan
 
-    def _add_cors(self):
+    def _add_cors(self):  # type: ignore[no-untyped-def]
         """
         Add CORS configuration to the Swagger file, if necessary
         """
@@ -626,43 +626,43 @@ class ApiGenerator(object):
             return
 
         if self.cors and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Cors works only with inline Swagger specified in 'DefinitionBody' property."
             )
 
-        if isinstance(self.cors, str) or is_intrinsic(self.cors):
+        if isinstance(self.cors, str) or is_intrinsic(self.cors):  # type: ignore[no-untyped-call]
             # Just set Origin property. Others will be defaults
-            properties = CorsProperties(AllowOrigin=self.cors)
+            properties = CorsProperties(AllowOrigin=self.cors)  # type: ignore[call-arg]
         elif isinstance(self.cors, dict):
 
             # Make sure keys in the dict are recognized
             if not all(key in CorsProperties._fields for key in self.cors.keys()):
-                raise InvalidResourceException(self.logical_id, INVALID_ERROR)
+                raise InvalidResourceException(self.logical_id, INVALID_ERROR)  # type: ignore[no-untyped-call]
 
             properties = CorsProperties(**self.cors)
 
         else:
-            raise InvalidResourceException(self.logical_id, INVALID_ERROR)
+            raise InvalidResourceException(self.logical_id, INVALID_ERROR)  # type: ignore[no-untyped-call]
 
-        if not SwaggerEditor.is_valid(self.definition_body):
-            raise InvalidResourceException(
+        if not SwaggerEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add Cors configuration because "
                 "'DefinitionBody' does not contain a valid Swagger definition.",
             )
 
         if properties.AllowCredentials is True and properties.AllowOrigin == _CORS_WILDCARD:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add Cors configuration because "
                 "'AllowCredentials' can not be true when "
                 "'AllowOrigin' is \"'*'\" or not set",
             )
 
-        editor = SwaggerEditor(self.definition_body)
-        for path in editor.iter_on_path():
+        editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        for path in editor.iter_on_path():  # type: ignore[no-untyped-call]
             try:
-                editor.add_cors(
+                editor.add_cors(  # type: ignore[no-untyped-call]
                     path,
                     properties.AllowOrigin,
                     properties.AllowHeaders,
@@ -671,12 +671,12 @@ class ApiGenerator(object):
                     allow_credentials=properties.AllowCredentials,
                 )
             except InvalidTemplateException as ex:
-                raise InvalidResourceException(self.logical_id, ex.message)
+                raise InvalidResourceException(self.logical_id, ex.message)  # type: ignore[no-untyped-call]
 
         # Assign the Swagger back to template
         self.definition_body = editor.swagger
 
-    def _add_binary_media_types(self):
+    def _add_binary_media_types(self):  # type: ignore[no-untyped-def]
         """
         Add binary media types to Swagger
         """
@@ -688,13 +688,13 @@ class ApiGenerator(object):
         if self.binary_media and not self.definition_body:
             return
 
-        editor = SwaggerEditor(self.definition_body)
-        editor.add_binary_media_types(self.binary_media)
+        editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        editor.add_binary_media_types(self.binary_media)  # type: ignore[no-untyped-call]
 
         # Assign the Swagger back to template
         self.definition_body = editor.swagger
 
-    def _add_auth(self):
+    def _add_auth(self):  # type: ignore[no-untyped-def]
         """
         Add Auth configuration to the Swagger file, if necessary
         """
@@ -703,27 +703,27 @@ class ApiGenerator(object):
             return
 
         if self.auth and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Auth works only with inline Swagger specified in 'DefinitionBody' property."
             )
 
         # Make sure keys in the dict are recognized
         if not all(key in AuthProperties._fields for key in self.auth.keys()):
-            raise InvalidResourceException(self.logical_id, "Invalid value for 'Auth' property")
+            raise InvalidResourceException(self.logical_id, "Invalid value for 'Auth' property")  # type: ignore[no-untyped-call]
 
-        if not SwaggerEditor.is_valid(self.definition_body):
-            raise InvalidResourceException(
+        if not SwaggerEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add Auth configuration because "
                 "'DefinitionBody' does not contain a valid Swagger definition.",
             )
-        swagger_editor = SwaggerEditor(self.definition_body)
+        swagger_editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
         auth_properties = AuthProperties(**self.auth)
-        authorizers = self._get_authorizers(auth_properties.Authorizers, auth_properties.DefaultAuthorizer)
+        authorizers = self._get_authorizers(auth_properties.Authorizers, auth_properties.DefaultAuthorizer)  # type: ignore[no-untyped-call]
 
         if authorizers:
-            swagger_editor.add_authorizers_security_definitions(authorizers)
-            self._set_default_authorizer(
+            swagger_editor.add_authorizers_security_definitions(authorizers)  # type: ignore[no-untyped-call]
+            self._set_default_authorizer(  # type: ignore[no-untyped-call]
                 swagger_editor,
                 authorizers,
                 auth_properties.DefaultAuthorizer,
@@ -732,21 +732,21 @@ class ApiGenerator(object):
             )
 
         if auth_properties.ApiKeyRequired:
-            swagger_editor.add_apikey_security_definition()
-            self._set_default_apikey_required(swagger_editor)
+            swagger_editor.add_apikey_security_definition()  # type: ignore[no-untyped-call]
+            self._set_default_apikey_required(swagger_editor)  # type: ignore[no-untyped-call]
 
         if auth_properties.ResourcePolicy:
-            SwaggerEditor.validate_is_dict(
+            SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
                 auth_properties.ResourcePolicy, "ResourcePolicy must be a map (ResourcePolicyStatement)."
             )
-            for path in swagger_editor.iter_on_path():
-                swagger_editor.add_resource_policy(auth_properties.ResourcePolicy, path, self.stage_name)
+            for path in swagger_editor.iter_on_path():  # type: ignore[no-untyped-call]
+                swagger_editor.add_resource_policy(auth_properties.ResourcePolicy, path, self.stage_name)  # type: ignore[no-untyped-call]
             if auth_properties.ResourcePolicy.get("CustomStatements"):
-                swagger_editor.add_custom_statements(auth_properties.ResourcePolicy.get("CustomStatements"))
+                swagger_editor.add_custom_statements(auth_properties.ResourcePolicy.get("CustomStatements"))  # type: ignore[no-untyped-call]
 
-        self.definition_body = self._openapi_postprocess(swagger_editor.swagger)
+        self.definition_body = self._openapi_postprocess(swagger_editor.swagger)  # type: ignore[no-untyped-call]
 
-    def _construct_usage_plan(self, rest_api_stage=None):
+    def _construct_usage_plan(self, rest_api_stage=None):  # type: ignore[no-untyped-def]
         """Constructs and returns the ApiGateway UsagePlan, ApiGateway UsagePlanKey, ApiGateway ApiKey for Auth.
 
         :param model.apigateway.ApiGatewayStage stage: the stage of rest api
@@ -763,10 +763,10 @@ class ApiGenerator(object):
         usage_plan_properties = auth_properties.UsagePlan
         # throws error if UsagePlan is not a dict
         if not isinstance(usage_plan_properties, dict):
-            raise InvalidResourceException(self.logical_id, "'UsagePlan' must be a dictionary")
+            raise InvalidResourceException(self.logical_id, "'UsagePlan' must be a dictionary")  # type: ignore[no-untyped-call]
         # throws error if the property invalid/ unsupported for UsagePlan
         if not all(key in UsagePlanProperties._fields for key in usage_plan_properties.keys()):
-            raise InvalidResourceException(self.logical_id, "Invalid property for 'UsagePlan'")
+            raise InvalidResourceException(self.logical_id, "Invalid property for 'UsagePlan'")  # type: ignore[no-untyped-call]
 
         create_usage_plan = usage_plan_properties.get("CreateUsagePlan")
         usage_plan = None
@@ -774,9 +774,9 @@ class ApiGenerator(object):
         usage_plan_key = None
 
         if create_usage_plan is None:
-            raise InvalidResourceException(self.logical_id, "'CreateUsagePlan' is a required field for UsagePlan.")
+            raise InvalidResourceException(self.logical_id, "'CreateUsagePlan' is a required field for UsagePlan.")  # type: ignore[no-untyped-call]
         if create_usage_plan not in create_usage_plans_accepted_values:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "'CreateUsagePlan' accepts one of {}.".format(create_usage_plans_accepted_values)
             )
 
@@ -786,20 +786,20 @@ class ApiGenerator(object):
         # create usage plan for this api only
         if usage_plan_properties.get("CreateUsagePlan") == "PER_API":
             usage_plan_logical_id = self.logical_id + "UsagePlan"
-            usage_plan = ApiGatewayUsagePlan(
+            usage_plan = ApiGatewayUsagePlan(  # type: ignore[no-untyped-call]
                 logical_id=usage_plan_logical_id,
                 depends_on=[self.logical_id],
                 attributes=self.passthrough_resource_attributes,
             )
             api_stages = []
             api_stage = {}
-            api_stage["ApiId"] = ref(self.logical_id)
-            api_stage["Stage"] = ref(rest_api_stage.logical_id)
+            api_stage["ApiId"] = ref(self.logical_id)  # type: ignore[no-untyped-call]
+            api_stage["Stage"] = ref(rest_api_stage.logical_id)  # type: ignore[no-untyped-call]
             api_stages.append(api_stage)
             usage_plan.ApiStages = api_stages
 
-            api_key = self._construct_api_key(usage_plan_logical_id, create_usage_plan, rest_api_stage)
-            usage_plan_key = self._construct_usage_plan_key(usage_plan_logical_id, create_usage_plan, api_key)
+            api_key = self._construct_api_key(usage_plan_logical_id, create_usage_plan, rest_api_stage)  # type: ignore[no-untyped-call]
+            usage_plan_key = self._construct_usage_plan_key(usage_plan_logical_id, create_usage_plan, api_key)  # type: ignore[no-untyped-call]
 
         # create a usage plan for all the Apis
         elif create_usage_plan == "SHARED":
@@ -807,7 +807,7 @@ class ApiGenerator(object):
             usage_plan_logical_id = "ServerlessUsagePlan"
             if self.logical_id not in self.shared_api_usage_plan.depends_on_shared:
                 self.shared_api_usage_plan.depends_on_shared.append(self.logical_id)
-            usage_plan = ApiGatewayUsagePlan(
+            usage_plan = ApiGatewayUsagePlan(  # type: ignore[no-untyped-call]
                 logical_id=usage_plan_logical_id,
                 depends_on=self.shared_api_usage_plan.depends_on_shared,
                 attributes=self.shared_api_usage_plan.get_combined_resource_attributes(
@@ -815,28 +815,28 @@ class ApiGenerator(object):
                 ),
             )
             api_stage = {}
-            api_stage["ApiId"] = ref(self.logical_id)
-            api_stage["Stage"] = ref(rest_api_stage.logical_id)
+            api_stage["ApiId"] = ref(self.logical_id)  # type: ignore[no-untyped-call]
+            api_stage["Stage"] = ref(rest_api_stage.logical_id)  # type: ignore[no-untyped-call]
             if api_stage not in self.shared_api_usage_plan.api_stages_shared:
                 self.shared_api_usage_plan.api_stages_shared.append(api_stage)
             usage_plan.ApiStages = self.shared_api_usage_plan.api_stages_shared
 
-            api_key = self._construct_api_key(usage_plan_logical_id, create_usage_plan, rest_api_stage)
-            usage_plan_key = self._construct_usage_plan_key(usage_plan_logical_id, create_usage_plan, api_key)
+            api_key = self._construct_api_key(usage_plan_logical_id, create_usage_plan, rest_api_stage)  # type: ignore[no-untyped-call]
+            usage_plan_key = self._construct_usage_plan_key(usage_plan_logical_id, create_usage_plan, api_key)  # type: ignore[no-untyped-call]
 
         if usage_plan_properties.get("UsagePlanName"):
-            usage_plan.UsagePlanName = usage_plan_properties.get("UsagePlanName")
+            usage_plan.UsagePlanName = usage_plan_properties.get("UsagePlanName")  # type: ignore[union-attr]
         if usage_plan_properties.get("Description"):
-            usage_plan.Description = usage_plan_properties.get("Description")
+            usage_plan.Description = usage_plan_properties.get("Description")  # type: ignore[union-attr]
         if usage_plan_properties.get("Quota"):
-            usage_plan.Quota = usage_plan_properties.get("Quota")
+            usage_plan.Quota = usage_plan_properties.get("Quota")  # type: ignore[union-attr]
         if usage_plan_properties.get("Tags"):
-            usage_plan.Tags = usage_plan_properties.get("Tags")
+            usage_plan.Tags = usage_plan_properties.get("Tags")  # type: ignore[union-attr]
         if usage_plan_properties.get("Throttle"):
-            usage_plan.Throttle = usage_plan_properties.get("Throttle")
+            usage_plan.Throttle = usage_plan_properties.get("Throttle")  # type: ignore[union-attr]
         return usage_plan, api_key, usage_plan_key
 
-    def _construct_api_key(self, usage_plan_logical_id, create_usage_plan, rest_api_stage):
+    def _construct_api_key(self, usage_plan_logical_id, create_usage_plan, rest_api_stage):  # type: ignore[no-untyped-def]
         """
         :param usage_plan_logical_id: String
         :param create_usage_plan: String
@@ -847,7 +847,7 @@ class ApiGenerator(object):
             # create an api key resource for all the apis
             LOG.info("Creating api key resource for all the Apis from SHARED usage plan")
             api_key_logical_id = "ServerlessApiKey"
-            api_key = ApiGatewayApiKey(
+            api_key = ApiGatewayApiKey(  # type: ignore[no-untyped-call]
                 logical_id=api_key_logical_id,
                 depends_on=[usage_plan_logical_id],
                 attributes=self.shared_api_usage_plan.get_combined_resource_attributes(
@@ -856,8 +856,8 @@ class ApiGenerator(object):
             )
             api_key.Enabled = True
             stage_key = {}
-            stage_key["RestApiId"] = ref(self.logical_id)
-            stage_key["StageName"] = ref(rest_api_stage.logical_id)
+            stage_key["RestApiId"] = ref(self.logical_id)  # type: ignore[no-untyped-call]
+            stage_key["StageName"] = ref(rest_api_stage.logical_id)  # type: ignore[no-untyped-call]
             if stage_key not in self.shared_api_usage_plan.stage_keys_shared:
                 self.shared_api_usage_plan.stage_keys_shared.append(stage_key)
             api_key.StageKeys = self.shared_api_usage_plan.stage_keys_shared
@@ -865,7 +865,7 @@ class ApiGenerator(object):
         else:
             # create an api key resource for this api
             api_key_logical_id = self.logical_id + "ApiKey"
-            api_key = ApiGatewayApiKey(
+            api_key = ApiGatewayApiKey(  # type: ignore[no-untyped-call]
                 logical_id=api_key_logical_id,
                 depends_on=[usage_plan_logical_id],
                 attributes=self.passthrough_resource_attributes,
@@ -873,13 +873,13 @@ class ApiGenerator(object):
             api_key.Enabled = True
             stage_keys = []
             stage_key = {}
-            stage_key["RestApiId"] = ref(self.logical_id)
-            stage_key["StageName"] = ref(rest_api_stage.logical_id)
+            stage_key["RestApiId"] = ref(self.logical_id)  # type: ignore[no-untyped-call]
+            stage_key["StageName"] = ref(rest_api_stage.logical_id)  # type: ignore[no-untyped-call]
             stage_keys.append(stage_key)
             api_key.StageKeys = stage_keys
         return api_key
 
-    def _construct_usage_plan_key(self, usage_plan_logical_id, create_usage_plan, api_key):
+    def _construct_usage_plan_key(self, usage_plan_logical_id, create_usage_plan, api_key):  # type: ignore[no-untyped-def]
         """
         :param usage_plan_logical_id: String
         :param create_usage_plan: String
@@ -898,18 +898,18 @@ class ApiGenerator(object):
             usage_plan_key_logical_id = self.logical_id + "UsagePlanKey"
             resource_attributes = self.passthrough_resource_attributes
 
-        usage_plan_key = ApiGatewayUsagePlanKey(
+        usage_plan_key = ApiGatewayUsagePlanKey(  # type: ignore[no-untyped-call]
             logical_id=usage_plan_key_logical_id,
             depends_on=[api_key.logical_id],
             attributes=resource_attributes,
         )
-        usage_plan_key.KeyId = ref(api_key.logical_id)
+        usage_plan_key.KeyId = ref(api_key.logical_id)  # type: ignore[no-untyped-call]
         usage_plan_key.KeyType = "API_KEY"
-        usage_plan_key.UsagePlanId = ref(usage_plan_logical_id)
+        usage_plan_key.UsagePlanId = ref(usage_plan_logical_id)  # type: ignore[no-untyped-call]
 
         return usage_plan_key
 
-    def _add_gateway_responses(self):
+    def _add_gateway_responses(self):  # type: ignore[no-untyped-def]
         """
         Add Gateway Response configuration to the Swagger file, if necessary
         """
@@ -918,61 +918,61 @@ class ApiGenerator(object):
             return
 
         if self.gateway_responses and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "GatewayResponses works only with inline Swagger specified in 'DefinitionBody' property.",
             )
 
         # Make sure keys in the dict are recognized
         for responses_key, responses_value in self.gateway_responses.items():
-            if is_intrinsic(responses_value):
+            if is_intrinsic(responses_value):  # type: ignore[no-untyped-call]
                 # TODO: Add intrinsic support for this field.
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     "Unable to set GatewayResponses attribute because "
                     "intrinsic functions are not supported for this field.",
                 )
             if not isinstance(responses_value, dict):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     "Invalid property type '{}' for GatewayResponses. "
                     "Expected an object of type 'GatewayResponse'.".format(type(responses_value).__name__),
                 )
             for response_key in responses_value.keys():
                 if response_key not in GatewayResponseProperties:
-                    raise InvalidResourceException(
+                    raise InvalidResourceException(  # type: ignore[no-untyped-call]
                         self.logical_id,
                         "Invalid property '{}' in 'GatewayResponses' property '{}'.".format(
                             response_key, responses_key
                         ),
                     )
 
-        if not SwaggerEditor.is_valid(self.definition_body):
-            raise InvalidResourceException(
+        if not SwaggerEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add Auth configuration because "
                 "'DefinitionBody' does not contain a valid Swagger definition.",
             )
 
-        swagger_editor = SwaggerEditor(self.definition_body)
+        swagger_editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
 
         # The dicts below will eventually become part of swagger/openapi definition, thus requires using Py27Dict()
-        gateway_responses = Py27Dict()
+        gateway_responses = Py27Dict()  # type: ignore[no-untyped-call]
         for response_type, response in self.gateway_responses.items():
-            gateway_responses[response_type] = ApiGatewayResponse(
+            gateway_responses[response_type] = ApiGatewayResponse(  # type: ignore[no-untyped-call]
                 api_logical_id=self.logical_id,
-                response_parameters=response.get("ResponseParameters", Py27Dict()),
-                response_templates=response.get("ResponseTemplates", Py27Dict()),
+                response_parameters=response.get("ResponseParameters", Py27Dict()),  # type: ignore[no-untyped-call]
+                response_templates=response.get("ResponseTemplates", Py27Dict()),  # type: ignore[no-untyped-call]
                 status_code=response.get("StatusCode", None),
             )
 
         if gateway_responses:
-            swagger_editor.add_gateway_responses(gateway_responses)
+            swagger_editor.add_gateway_responses(gateway_responses)  # type: ignore[no-untyped-call]
 
         # Assign the Swagger back to template
         self.definition_body = swagger_editor.swagger
 
-    def _add_models(self):
+    def _add_models(self):  # type: ignore[no-untyped-def]
         """
         Add Model definitions to the Swagger file, if necessary
         :return:
@@ -982,28 +982,28 @@ class ApiGenerator(object):
             return
 
         if self.models and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Models works only with inline Swagger specified in 'DefinitionBody' property."
             )
 
-        if not SwaggerEditor.is_valid(self.definition_body):
-            raise InvalidResourceException(
+        if not SwaggerEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add Models definitions because "
                 "'DefinitionBody' does not contain a valid Swagger definition.",
             )
 
         if not all(isinstance(model, dict) for model in self.models.values()):
-            raise InvalidResourceException(self.logical_id, "Invalid value for 'Models' property")
+            raise InvalidResourceException(self.logical_id, "Invalid value for 'Models' property")  # type: ignore[no-untyped-call]
 
-        swagger_editor = SwaggerEditor(self.definition_body)
-        swagger_editor.add_models(self.models)
+        swagger_editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        swagger_editor.add_models(self.models)  # type: ignore[no-untyped-call]
 
         # Assign the Swagger back to template
 
-        self.definition_body = self._openapi_postprocess(swagger_editor.swagger)
+        self.definition_body = self._openapi_postprocess(swagger_editor.swagger)  # type: ignore[no-untyped-call]
 
-    def _openapi_postprocess(self, definition_body):
+    def _openapi_postprocess(self, definition_body):  # type: ignore[no-untyped-def]
         """
         Convert definitions to openapi 3 in definition body if OpenApiVersion flag is specified.
 
@@ -1016,20 +1016,20 @@ class ApiGenerator(object):
         if definition_body.get("openapi") is not None and self.open_api_version is None:
             self.open_api_version = definition_body.get("openapi")
 
-        if self.open_api_version and SwaggerEditor.safe_compare_regex_with_string(
-            SwaggerEditor.get_openapi_version_3_regex(), self.open_api_version
+        if self.open_api_version and SwaggerEditor.safe_compare_regex_with_string(  # type: ignore[no-untyped-call]
+            SwaggerEditor.get_openapi_version_3_regex(), self.open_api_version  # type: ignore[no-untyped-call]
         ):
             if definition_body.get("securityDefinitions"):
-                components = definition_body.get("components", Py27Dict())
+                components = definition_body.get("components", Py27Dict())  # type: ignore[no-untyped-call]
                 # In the previous line, the default value `Py27Dict()` will be only returned only if `components`
                 # property is not in definition_body dict, but if it exist, and its value is None, so None will be
                 # returned and not the default value. That is why the below line is required.
-                components = components if components else Py27Dict()
+                components = components if components else Py27Dict()  # type: ignore[no-untyped-call]
                 components["securitySchemes"] = definition_body["securityDefinitions"]
                 definition_body["components"] = components
                 del definition_body["securityDefinitions"]
             if definition_body.get("definitions"):
-                components = definition_body.get("components", Py27Dict())
+                components = definition_body.get("components", Py27Dict())  # type: ignore[no-untyped-call]
                 components["schemas"] = definition_body["definitions"]
                 definition_body["components"] = components
                 del definition_body["definitions"]
@@ -1038,7 +1038,7 @@ class ApiGenerator(object):
             paths = definition_body.get("paths")
             if paths:
                 for path, path_item in paths.items():
-                    SwaggerEditor.validate_path_item_is_dict(path_item, path)
+                    SwaggerEditor.validate_path_item_is_dict(path_item, path)  # type: ignore[no-untyped-call]
                     if path_item.get("options"):
                         options = path_item.get("options").copy()
                         for field, field_val in options.items():
@@ -1047,7 +1047,7 @@ class ApiGenerator(object):
                                 del definition_body["paths"][path]["options"][field]
                             # add schema for the headers in options section for openapi3
                             if field in ["responses"]:
-                                SwaggerEditor.validate_is_dict(
+                                SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
                                     field_val,
                                     "Value of responses in options method for path {} must be a "
                                     "dictionary according to Swagger spec.".format(path),
@@ -1055,7 +1055,7 @@ class ApiGenerator(object):
                                 if field_val.get("200") and field_val.get("200").get("headers"):
                                     headers = field_val["200"]["headers"]
                                     for header, header_val in headers.items():
-                                        new_header_val_with_schema = Py27Dict()
+                                        new_header_val_with_schema = Py27Dict()  # type: ignore[no-untyped-call]
                                         new_header_val_with_schema["schema"] = header_val
                                         definition_body["paths"][path]["options"][field]["200"]["headers"][
                                             header
@@ -1063,11 +1063,11 @@ class ApiGenerator(object):
 
         return definition_body
 
-    def _get_authorizers(self, authorizers_config, default_authorizer=None):
+    def _get_authorizers(self, authorizers_config, default_authorizer=None):  # type: ignore[no-untyped-def]
         # The dict below will eventually become part of swagger/openapi definition, thus requires using Py27Dict()
-        authorizers = Py27Dict()
+        authorizers = Py27Dict()  # type: ignore[no-untyped-call]
         if default_authorizer == "AWS_IAM":
-            authorizers[default_authorizer] = ApiGatewayAuthorizer(
+            authorizers[default_authorizer] = ApiGatewayAuthorizer(  # type: ignore[no-untyped-call]
                 api_logical_id=self.logical_id, name=default_authorizer, is_aws_iam_authorizer=True
             )
 
@@ -1077,15 +1077,15 @@ class ApiGenerator(object):
             return None
 
         if not isinstance(authorizers_config, dict):
-            raise InvalidResourceException(self.logical_id, "Authorizers must be a dictionary.")
+            raise InvalidResourceException(self.logical_id, "Authorizers must be a dictionary.")  # type: ignore[no-untyped-call]
 
         for authorizer_name, authorizer in authorizers_config.items():
             if not isinstance(authorizer, dict):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "Authorizer %s must be a dictionary." % (authorizer_name)
                 )
 
-            authorizers[authorizer_name] = ApiGatewayAuthorizer(
+            authorizers[authorizer_name] = ApiGatewayAuthorizer(  # type: ignore[no-untyped-call]
                 api_logical_id=self.logical_id,
                 name=authorizer_name,
                 user_pool_arn=authorizer.get("UserPoolArn"),
@@ -1097,23 +1097,23 @@ class ApiGenerator(object):
             )
         return authorizers
 
-    def _get_permission(self, authorizer_name, authorizer_lambda_function_arn):
+    def _get_permission(self, authorizer_name, authorizer_lambda_function_arn):  # type: ignore[no-untyped-def]
         """Constructs and returns the Lambda Permission resource allowing the Authorizer to invoke the function.
 
         :returns: the permission resource
         :rtype: model.lambda_.LambdaPermission
         """
-        rest_api = ApiGatewayRestApi(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)
-        api_id = rest_api.get_runtime_attr("rest_api_id")
+        rest_api = ApiGatewayRestApi(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)  # type: ignore[no-untyped-call]
+        api_id = rest_api.get_runtime_attr("rest_api_id")  # type: ignore[no-untyped-call]
 
-        partition = ArnGenerator.get_partition_name()
+        partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
         resource = "${__ApiId__}/authorizers/*"
-        source_arn = fnSub(
-            ArnGenerator.generate_arn(partition=partition, service="execute-api", resource=resource),
+        source_arn = fnSub(  # type: ignore[no-untyped-call]
+            ArnGenerator.generate_arn(partition=partition, service="execute-api", resource=resource),  # type: ignore[no-untyped-call]
             {"__ApiId__": api_id},
         )
 
-        lambda_permission = LambdaPermission(
+        lambda_permission = LambdaPermission(  # type: ignore[no-untyped-call]
             self.logical_id + authorizer_name + "AuthorizerPermission", attributes=self.passthrough_resource_attributes
         )
         lambda_permission.Action = "lambda:InvokeFunction"
@@ -1123,12 +1123,12 @@ class ApiGenerator(object):
 
         return lambda_permission
 
-    def _construct_authorizer_lambda_permission(self):
+    def _construct_authorizer_lambda_permission(self):  # type: ignore[no-untyped-def]
         if not self.auth:
             return []
 
         auth_properties = AuthProperties(**self.auth)
-        authorizers = self._get_authorizers(auth_properties.Authorizers)
+        authorizers = self._get_authorizers(auth_properties.Authorizers)  # type: ignore[no-untyped-call]
 
         if not authorizers:
             return []
@@ -1140,25 +1140,25 @@ class ApiGenerator(object):
             if not authorizer.function_arn:
                 continue
 
-            permission = self._get_permission(authorizer_name, authorizer.function_arn)
+            permission = self._get_permission(authorizer_name, authorizer.function_arn)  # type: ignore[no-untyped-call]
             permissions.append(permission)
 
         return permissions
 
-    def _set_default_authorizer(
+    def _set_default_authorizer(  # type: ignore[no-untyped-def]
         self, swagger_editor, authorizers, default_authorizer, add_default_auth_to_preflight=True, api_authorizers=None
     ):
         if not default_authorizer:
             return
 
         if not isinstance(default_authorizer, str):
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "DefaultAuthorizer is not a string.",
             )
 
         if not authorizers.get(default_authorizer) and default_authorizer != "AWS_IAM":
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to set DefaultAuthorizer because '"
                 + default_authorizer
@@ -1174,11 +1174,11 @@ class ApiGenerator(object):
                 api_authorizers=api_authorizers,
             )
 
-    def _set_default_apikey_required(self, swagger_editor):
+    def _set_default_apikey_required(self, swagger_editor):  # type: ignore[no-untyped-def]
         for path in swagger_editor.iter_on_path():
             swagger_editor.set_path_default_apikey_required(path)
 
-    def _set_endpoint_configuration(self, rest_api, value):
+    def _set_endpoint_configuration(self, rest_api, value):  # type: ignore[no-untyped-def]
         """
         Sets endpoint configuration property of AWS::ApiGateway::RestApi resource
         :param rest_api: RestApi resource

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -30,7 +30,7 @@ HttpApiTagName = "httpapi:createdBy"
 
 
 class HttpApiGenerator(object):
-    def __init__(
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         logical_id,
         stage_variables,
@@ -87,39 +87,39 @@ class HttpApiGenerator(object):
         self.description = description
         self.disable_execute_api_endpoint = disable_execute_api_endpoint
 
-    def _construct_http_api(self):
+    def _construct_http_api(self):  # type: ignore[no-untyped-def]
         """Constructs and returns the ApiGatewayV2 HttpApi.
 
         :returns: the HttpApi to which this SAM Api corresponds
         :rtype: model.apigatewayv2.ApiGatewayHttpApi
         """
-        http_api = ApiGatewayV2HttpApi(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)
+        http_api = ApiGatewayV2HttpApi(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)  # type: ignore[no-untyped-call]
 
         if self.definition_uri and self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Specify either 'DefinitionUri' or 'DefinitionBody' property and not both."
             )
         if self.cors_configuration:
             # call this method to add cors in open api
-            self._add_cors()
+            self._add_cors()  # type: ignore[no-untyped-call]
 
-        self._add_auth()
-        self._add_tags()
+        self._add_auth()  # type: ignore[no-untyped-call]
+        self._add_tags()  # type: ignore[no-untyped-call]
 
         if self.fail_on_warnings:
             http_api.FailOnWarnings = self.fail_on_warnings
 
         if self.disable_execute_api_endpoint is not None:
-            self._add_endpoint_configuration()
+            self._add_endpoint_configuration()  # type: ignore[no-untyped-call]
 
-        self._add_description()
+        self._add_description()  # type: ignore[no-untyped-call]
 
         if self.definition_uri:
-            http_api.BodyS3Location = self._construct_body_s3_dict()
+            http_api.BodyS3Location = self._construct_body_s3_dict()  # type: ignore[no-untyped-call]
         elif self.definition_body:
             http_api.Body = self.definition_body
         else:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "'DefinitionUri' or 'DefinitionBody' are required properties of an "
                 "'AWS::Serverless::HttpApi'. Add a value for one of these properties or "
@@ -128,7 +128,7 @@ class HttpApiGenerator(object):
 
         return http_api
 
-    def _add_endpoint_configuration(self):
+    def _add_endpoint_configuration(self):  # type: ignore[no-untyped-def]
         """Add disableExecuteApiEndpoint if it is set in SAM
         HttpApi doesn't have vpcEndpointIds
 
@@ -141,20 +141,20 @@ class HttpApiGenerator(object):
 
         """
         if self.disable_execute_api_endpoint is not None and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "DisableExecuteApiEndpoint works only within 'DefinitionBody' property."
             )
-        editor = OpenApiEditor(self.definition_body)
+        editor = OpenApiEditor(self.definition_body)  # type: ignore[no-untyped-call]
 
         # if DisableExecuteApiEndpoint is set in both definition_body and as a property,
         # SAM merges and overrides the disableExecuteApiEndpoint in definition_body with headers of
         # "x-amazon-apigateway-endpoint-configuration"
-        editor.add_endpoint_config(self.disable_execute_api_endpoint)
+        editor.add_endpoint_config(self.disable_execute_api_endpoint)  # type: ignore[no-untyped-call]
 
         # Assign the OpenApi back to template
         self.definition_body = editor.openapi
 
-    def _add_cors(self):
+    def _add_cors(self):  # type: ignore[no-untyped-def]
         """
         Add CORS configuration if CORSConfiguration property is set in SAM.
         Adds CORS configuration only if DefinitionBody is present and
@@ -162,7 +162,7 @@ class HttpApiGenerator(object):
         """
 
         if self.cors_configuration and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Cors works only with inline OpenApi specified in 'DefinitionBody' property."
             )
 
@@ -170,24 +170,24 @@ class HttpApiGenerator(object):
         # This also support referencing the value as a parameter
         if isinstance(self.cors_configuration, bool):
             # if cors config is true add Origins as "'*'"
-            properties = CorsProperties(AllowOrigins=[_CORS_WILDCARD])
+            properties = CorsProperties(AllowOrigins=[_CORS_WILDCARD])  # type: ignore[call-arg]
 
-        elif is_intrinsic(self.cors_configuration):
+        elif is_intrinsic(self.cors_configuration):  # type: ignore[no-untyped-call]
             # Just set Origin property. Intrinsics will be handledOthers will be defaults
-            properties = CorsProperties(AllowOrigins=self.cors_configuration)
+            properties = CorsProperties(AllowOrigins=self.cors_configuration)  # type: ignore[call-arg]
 
         elif isinstance(self.cors_configuration, dict):
             # Make sure keys in the dict are recognized
             if not all(key in CorsProperties._fields for key in self.cors_configuration.keys()):
-                raise InvalidResourceException(self.logical_id, "Invalid value for 'Cors' property.")
+                raise InvalidResourceException(self.logical_id, "Invalid value for 'Cors' property.")  # type: ignore[no-untyped-call]
 
             properties = CorsProperties(**self.cors_configuration)
 
         else:
-            raise InvalidResourceException(self.logical_id, "Invalid value for 'Cors' property.")
+            raise InvalidResourceException(self.logical_id, "Invalid value for 'Cors' property.")  # type: ignore[no-untyped-call]
 
-        if not OpenApiEditor.is_valid(self.definition_body):
-            raise InvalidResourceException(
+        if not OpenApiEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add Cors configuration because "
                 "'DefinitionBody' does not contain a valid "
@@ -195,17 +195,17 @@ class HttpApiGenerator(object):
             )
 
         if properties.AllowCredentials is True and properties.AllowOrigins == [_CORS_WILDCARD]:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add Cors configuration because "
                 "'AllowCredentials' can not be true when "
                 "'AllowOrigin' is \"'*'\" or not set.",
             )
 
-        editor = OpenApiEditor(self.definition_body)
+        editor = OpenApiEditor(self.definition_body)  # type: ignore[no-untyped-call]
         # if CORS is set in both definition_body and as a CorsConfiguration property,
         # SAM merges and overrides the cors headers in definition_body with headers of CorsConfiguration
-        editor.add_cors(
+        editor.add_cors(  # type: ignore[no-untyped-call]
             properties.AllowOrigins,
             properties.AllowHeaders,
             properties.AllowMethods,
@@ -217,7 +217,7 @@ class HttpApiGenerator(object):
         # Assign the OpenApi back to template
         self.definition_body = editor.openapi
 
-    def _construct_api_domain(self, http_api, route53_record_set_groups):
+    def _construct_api_domain(self, http_api, route53_record_set_groups):  # type: ignore[no-untyped-def]
         """
         Constructs and returns the ApiGateway Domain and BasepathMapping
         """
@@ -225,15 +225,15 @@ class HttpApiGenerator(object):
             return None, None, None
 
         if self.domain.get("DomainName") is None or self.domain.get("CertificateArn") is None:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Custom Domains only works if both DomainName and CertificateArn are provided."
             )
 
         self.domain["ApiDomainName"] = "{}{}".format(
-            "ApiGatewayDomainNameV2", LogicalIdGenerator("", self.domain.get("DomainName")).gen()
+            "ApiGatewayDomainNameV2", LogicalIdGenerator("", self.domain.get("DomainName")).gen()  # type: ignore[no-untyped-call, no-untyped-call]
         )
 
-        domain = ApiGatewayV2DomainName(
+        domain = ApiGatewayV2DomainName(  # type: ignore[no-untyped-call]
             self.domain.get("ApiDomainName"), attributes=self.passthrough_resource_attributes
         )
         domain_config = {}
@@ -246,7 +246,7 @@ class HttpApiGenerator(object):
             # to make sure that default is always REGIONAL
             self.domain["EndpointConfiguration"] = "REGIONAL"
         elif endpoint not in ["REGIONAL"]:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "EndpointConfiguration for Custom Domains must be one of {}.".format(["REGIONAL"]),
             )
@@ -272,7 +272,7 @@ class HttpApiGenerator(object):
                         if key not in {"TruststoreUri", "TruststoreVersion"}:
                             invalid_keys.append(key)
                     invalid_keys.sort()
-                    raise InvalidResourceException(
+                    raise InvalidResourceException(  # type: ignore[no-untyped-call]
                         ",".join(invalid_keys),
                         "Available MutualTlsAuthentication fields are {}.".format(
                             ["TruststoreUri", "TruststoreVersion"]
@@ -280,11 +280,11 @@ class HttpApiGenerator(object):
                     )
                 domain.MutualTlsAuthentication = {}
                 if mutual_tls_auth.get("TruststoreUri", None):
-                    domain.MutualTlsAuthentication["TruststoreUri"] = mutual_tls_auth["TruststoreUri"]
+                    domain.MutualTlsAuthentication["TruststoreUri"] = mutual_tls_auth["TruststoreUri"]  # type: ignore[attr-defined]
                 if mutual_tls_auth.get("TruststoreVersion", None):
-                    domain.MutualTlsAuthentication["TruststoreVersion"] = mutual_tls_auth["TruststoreVersion"]
+                    domain.MutualTlsAuthentication["TruststoreVersion"] = mutual_tls_auth["TruststoreVersion"]  # type: ignore[attr-defined]
             else:
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     mutual_tls_auth,
                     "MutualTlsAuthentication must be a map with at least one of the following fields {}.".format(
                         ["TruststoreUri", "TruststoreVersion"]
@@ -298,35 +298,35 @@ class HttpApiGenerator(object):
             basepaths = self.domain.get("BasePath")
         else:
             basepaths = None
-        basepath_resource_list = self._construct_basepath_mappings(basepaths, http_api)
+        basepath_resource_list = self._construct_basepath_mappings(basepaths, http_api)  # type: ignore[no-untyped-call]
 
         # Create the Route53 RecordSetGroup resource
-        record_set_group = self._construct_route53_recordsetgroup(route53_record_set_groups)
+        record_set_group = self._construct_route53_recordsetgroup(route53_record_set_groups)  # type: ignore[no-untyped-call]
 
         return domain, basepath_resource_list, record_set_group
 
-    def _construct_route53_recordsetgroup(self, route53_record_set_groups):
+    def _construct_route53_recordsetgroup(self, route53_record_set_groups):  # type: ignore[no-untyped-def]
         if self.domain.get("Route53") is None:
             return
         route53 = self.domain.get("Route53")
         if not isinstance(route53, dict):
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Invalid property type '{}' for Route53. "
                 "Expected a map defines an Amazon Route 53 configuration'.".format(type(route53).__name__),
             )
         if route53.get("HostedZoneId") is None and route53.get("HostedZoneName") is None:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "HostedZoneId or HostedZoneName is required to enable Route53 support on Custom Domains.",
             )
 
-        logical_id_suffix = LogicalIdGenerator("", route53.get("HostedZoneId") or route53.get("HostedZoneName")).gen()
+        logical_id_suffix = LogicalIdGenerator("", route53.get("HostedZoneId") or route53.get("HostedZoneName")).gen()  # type: ignore[no-untyped-call, no-untyped-call]
         logical_id = "RecordSetGroup" + logical_id_suffix
 
         record_set_group = route53_record_set_groups.get(logical_id)
         if not record_set_group:
-            record_set_group = Route53RecordSetGroup(logical_id, attributes=self.passthrough_resource_attributes)
+            record_set_group = Route53RecordSetGroup(logical_id, attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
             if "HostedZoneId" in route53:
                 record_set_group.HostedZoneId = route53.get("HostedZoneId")
             elif "HostedZoneName" in route53:
@@ -334,19 +334,19 @@ class HttpApiGenerator(object):
             record_set_group.RecordSets = []
             route53_record_set_groups[logical_id] = record_set_group
 
-        record_set_group.RecordSets += self._construct_record_sets_for_domain(self.domain)
+        record_set_group.RecordSets += self._construct_record_sets_for_domain(self.domain)  # type: ignore[no-untyped-call]
         return record_set_group
 
-    def _construct_basepath_mappings(self, basepaths, http_api):
+    def _construct_basepath_mappings(self, basepaths, http_api):  # type: ignore[no-untyped-def]
         basepath_resource_list = []
 
         if basepaths is None:
-            basepath_mapping = ApiGatewayV2ApiMapping(
+            basepath_mapping = ApiGatewayV2ApiMapping(  # type: ignore[no-untyped-call]
                 self.logical_id + "ApiMapping", attributes=self.passthrough_resource_attributes
             )
-            basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
-            basepath_mapping.ApiId = ref(http_api.logical_id)
-            basepath_mapping.Stage = ref(http_api.logical_id + ".Stage")
+            basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))  # type: ignore[no-untyped-call]
+            basepath_mapping.ApiId = ref(http_api.logical_id)  # type: ignore[no-untyped-call]
+            basepath_mapping.Stage = ref(http_api.logical_id + ".Stage")  # type: ignore[no-untyped-call]
             basepath_resource_list.extend([basepath_mapping])
         else:
             for path in basepaths:
@@ -354,43 +354,43 @@ class HttpApiGenerator(object):
                 invalid_regex = r"[^0-9a-zA-Z\/\-\_]+"
 
                 if not isinstance(path, str):
-                    raise InvalidResourceException(self.logical_id, "Basepath must be a string.")
+                    raise InvalidResourceException(self.logical_id, "Basepath must be a string.")  # type: ignore[no-untyped-call]
 
                 if re.search(invalid_regex, path) is not None:
-                    raise InvalidResourceException(self.logical_id, "Invalid Basepath name provided.")
+                    raise InvalidResourceException(self.logical_id, "Invalid Basepath name provided.")  # type: ignore[no-untyped-call]
 
                 # ignore leading and trailing `/` in the path name
                 path = path.strip("/")
 
                 logical_id = "{}{}{}".format(self.logical_id, re.sub(r"[\-_/]+", "", path), "ApiMapping")
-                basepath_mapping = ApiGatewayV2ApiMapping(logical_id, attributes=self.passthrough_resource_attributes)
-                basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
-                basepath_mapping.ApiId = ref(http_api.logical_id)
-                basepath_mapping.Stage = ref(http_api.logical_id + ".Stage")
+                basepath_mapping = ApiGatewayV2ApiMapping(logical_id, attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
+                basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))  # type: ignore[no-untyped-call]
+                basepath_mapping.ApiId = ref(http_api.logical_id)  # type: ignore[no-untyped-call]
+                basepath_mapping.Stage = ref(http_api.logical_id + ".Stage")  # type: ignore[no-untyped-call]
                 basepath_mapping.ApiMappingKey = path
                 basepath_resource_list.extend([basepath_mapping])
         return basepath_resource_list
 
-    def _construct_record_sets_for_domain(self, domain):
+    def _construct_record_sets_for_domain(self, domain):  # type: ignore[no-untyped-def]
         recordset_list = []
         recordset = {}
         route53 = domain.get("Route53")
 
         recordset["Name"] = domain.get("DomainName")
         recordset["Type"] = "A"
-        recordset["AliasTarget"] = self._construct_alias_target(self.domain)
+        recordset["AliasTarget"] = self._construct_alias_target(self.domain)  # type: ignore[no-untyped-call]
         recordset_list.extend([recordset])
 
         recordset_ipv6 = {}
         if route53.get("IpV6"):
             recordset_ipv6["Name"] = domain.get("DomainName")
             recordset_ipv6["Type"] = "AAAA"
-            recordset_ipv6["AliasTarget"] = self._construct_alias_target(self.domain)
+            recordset_ipv6["AliasTarget"] = self._construct_alias_target(self.domain)  # type: ignore[no-untyped-call]
             recordset_list.extend([recordset_ipv6])
 
         return recordset_list
 
-    def _construct_alias_target(self, domain):
+    def _construct_alias_target(self, domain):  # type: ignore[no-untyped-def]
         alias_target = {}
         route53 = domain.get("Route53")
         target_health = route53.get("EvaluateTargetHealth")
@@ -398,16 +398,16 @@ class HttpApiGenerator(object):
         if target_health is not None:
             alias_target["EvaluateTargetHealth"] = target_health
         if domain.get("EndpointConfiguration") == "REGIONAL":
-            alias_target["HostedZoneId"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalHostedZoneId")
-            alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")
+            alias_target["HostedZoneId"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalHostedZoneId")  # type: ignore[no-untyped-call]
+            alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")  # type: ignore[no-untyped-call]
         else:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Only REGIONAL endpoint is supported on HTTP APIs.",
             )
         return alias_target
 
-    def _add_auth(self):
+    def _add_auth(self):  # type: ignore[no-untyped-def]
         """
         Add Auth configuration to the OAS file, if necessary
         """
@@ -415,61 +415,61 @@ class HttpApiGenerator(object):
             return
 
         if self.auth and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Auth works only with inline OpenApi specified in the 'DefinitionBody' property."
             )
 
         # Make sure keys in the dict are recognized
         if not all(key in AuthProperties._fields for key in self.auth.keys()):
-            raise InvalidResourceException(self.logical_id, "Invalid value for 'Auth' property")
+            raise InvalidResourceException(self.logical_id, "Invalid value for 'Auth' property")  # type: ignore[no-untyped-call]
 
-        if not OpenApiEditor.is_valid(self.definition_body):
-            raise InvalidResourceException(
+        if not OpenApiEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add Auth configuration because 'DefinitionBody' does not contain a valid OpenApi definition.",
             )
-        open_api_editor = OpenApiEditor(self.definition_body)
+        open_api_editor = OpenApiEditor(self.definition_body)  # type: ignore[no-untyped-call]
         auth_properties = AuthProperties(**self.auth)
-        authorizers = self._get_authorizers(auth_properties.Authorizers, auth_properties.EnableIamAuthorizer)
+        authorizers = self._get_authorizers(auth_properties.Authorizers, auth_properties.EnableIamAuthorizer)  # type: ignore[no-untyped-call]
 
         # authorizers is guaranteed to return a value or raise an exception
-        open_api_editor.add_authorizers_security_definitions(authorizers)
-        self._set_default_authorizer(
+        open_api_editor.add_authorizers_security_definitions(authorizers)  # type: ignore[no-untyped-call]
+        self._set_default_authorizer(  # type: ignore[no-untyped-call]
             open_api_editor, authorizers, auth_properties.DefaultAuthorizer, auth_properties.Authorizers
         )
         self.definition_body = open_api_editor.openapi
 
-    def _add_tags(self):
+    def _add_tags(self):  # type: ignore[no-untyped-def]
         """
         Adds tags to the Http Api, including a default SAM tag.
         """
         if self.tags and not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Tags works only with inline OpenApi specified in the 'DefinitionBody' property."
             )
 
         if not self.definition_body:
             return
 
-        if self.tags and not OpenApiEditor.is_valid(self.definition_body):
-            raise InvalidResourceException(
+        if self.tags and not OpenApiEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to add `Tags` because 'DefinitionBody' does not contain a valid OpenApi definition.",
             )
-        if not OpenApiEditor.is_valid(self.definition_body):
+        if not OpenApiEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
             return
 
         if not self.tags:
             self.tags = {}
         self.tags[HttpApiTagName] = "SAM"
 
-        open_api_editor = OpenApiEditor(self.definition_body)
+        open_api_editor = OpenApiEditor(self.definition_body)  # type: ignore[no-untyped-call]
 
         # authorizers is guaranteed to return a value or raise an exception
-        open_api_editor.add_tags(self.tags)
+        open_api_editor.add_tags(self.tags)  # type: ignore[no-untyped-call]
         self.definition_body = open_api_editor.openapi
 
-    def _set_default_authorizer(self, open_api_editor, authorizers, default_authorizer, api_authorizers):
+    def _set_default_authorizer(self, open_api_editor, authorizers, default_authorizer, api_authorizers):  # type: ignore[no-untyped-def]
         """
         Sets the default authorizer if one is given in the template
         :param open_api_editor: editor object that contains the OpenApi definition
@@ -480,17 +480,17 @@ class HttpApiGenerator(object):
         if not default_authorizer:
             return
 
-        if is_intrinsic_no_value(default_authorizer):
+        if is_intrinsic_no_value(default_authorizer):  # type: ignore[no-untyped-call]
             return
 
-        if is_intrinsic(default_authorizer):
-            raise InvalidResourceException(
+        if is_intrinsic(default_authorizer):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to set DefaultAuthorizer because intrinsic functions are not supported for this field.",
             )
 
         if not authorizers.get(default_authorizer):
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to set DefaultAuthorizer because '"
                 + default_authorizer
@@ -502,7 +502,7 @@ class HttpApiGenerator(object):
                 path, default_authorizer, authorizers=authorizers, api_authorizers=api_authorizers
             )
 
-    def _get_authorizers(self, authorizers_config, enable_iam_authorizer=False):
+    def _get_authorizers(self, authorizers_config, enable_iam_authorizer=False):  # type: ignore[no-untyped-def]
         """
         Returns all authorizers for an API as an ApiGatewayV2Authorizer object
         :param authorizers_config: authorizer configuration from the API Auth section
@@ -511,28 +511,28 @@ class HttpApiGenerator(object):
         authorizers = {}
 
         if enable_iam_authorizer is True:
-            authorizers["AWS_IAM"] = ApiGatewayV2Authorizer(is_aws_iam_authorizer=True)
+            authorizers["AWS_IAM"] = ApiGatewayV2Authorizer(is_aws_iam_authorizer=True)  # type: ignore[no-untyped-call]
 
         # If all the customer wants to do is enable the IAM authorizer the authorizers_config will be None.
         if not authorizers_config:
             return authorizers
 
         if not isinstance(authorizers_config, dict):
-            raise InvalidResourceException(self.logical_id, "Authorizers must be a dictionary.")
+            raise InvalidResourceException(self.logical_id, "Authorizers must be a dictionary.")  # type: ignore[no-untyped-call]
 
         for authorizer_name, authorizer in authorizers_config.items():
             if not isinstance(authorizer, dict):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "Authorizer %s must be a dictionary." % (authorizer_name)
                 )
 
             if "OpenIdConnectUrl" in authorizer:
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     "'OpenIdConnectUrl' is no longer a supported property for authorizer '%s'. Please refer to the AWS SAM documentation."
                     % (authorizer_name),
                 )
-            authorizers[authorizer_name] = ApiGatewayV2Authorizer(
+            authorizers[authorizer_name] = ApiGatewayV2Authorizer(  # type: ignore[no-untyped-call]
                 api_logical_id=self.logical_id,
                 name=authorizer_name,
                 authorization_scopes=authorizer.get("AuthorizationScopes"),
@@ -546,7 +546,7 @@ class HttpApiGenerator(object):
             )
         return authorizers
 
-    def _construct_body_s3_dict(self):
+    def _construct_body_s3_dict(self):  # type: ignore[no-untyped-def]
         """
         Constructs the HttpApi's `BodyS3Location property`, from the SAM Api's DefinitionUri property.
         :returns: a BodyS3Location dict, containing the S3 Bucket, Key, and Version of the OpenApi definition
@@ -555,14 +555,14 @@ class HttpApiGenerator(object):
         if isinstance(self.definition_uri, dict):
             if not self.definition_uri.get("Bucket", None) or not self.definition_uri.get("Key", None):
                 # DefinitionUri is a dictionary but does not contain Bucket or Key property
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "'DefinitionUri' requires Bucket and Key properties to be specified."
                 )
             s3_pointer = self.definition_uri
 
         else:
             # DefinitionUri is a string
-            s3_pointer = parse_s3_uri(self.definition_uri)
+            s3_pointer = parse_s3_uri(self.definition_uri)  # type: ignore[no-untyped-call]
             if s3_pointer is None:
                 raise InvalidResourceException(
                     self.logical_id,
@@ -575,7 +575,7 @@ class HttpApiGenerator(object):
             body_s3["Version"] = s3_pointer["Version"]
         return body_s3
 
-    def _construct_stage(self):
+    def _construct_stage(self):  # type: ignore[no-untyped-def]
         """Constructs and returns the ApiGatewayV2 Stage.
 
         :returns: the Stage to which this SAM Api corresponds
@@ -600,10 +600,10 @@ class HttpApiGenerator(object):
         elif stage_name_prefix == DefaultStageName:
             stage_logical_id = self.logical_id + "ApiGatewayDefaultStage"
         else:
-            generator = LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)
-            stage_logical_id = generator.gen()
-        stage = ApiGatewayV2Stage(stage_logical_id, attributes=self.passthrough_resource_attributes)
-        stage.ApiId = ref(self.logical_id)
+            generator = LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)  # type: ignore[no-untyped-call]
+            stage_logical_id = generator.gen()  # type: ignore[no-untyped-call]
+        stage = ApiGatewayV2Stage(stage_logical_id, attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
+        stage.ApiId = ref(self.logical_id)  # type: ignore[no-untyped-call]
         stage.StageName = self.stage_name
         stage.StageVariables = self.stage_variables
         stage.AccessLogSettings = self.access_log_settings
@@ -614,36 +614,36 @@ class HttpApiGenerator(object):
 
         return stage
 
-    def _add_description(self):
+    def _add_description(self):  # type: ignore[no-untyped-def]
         """Add description to DefinitionBody if Description property is set in SAM"""
         if not self.description:
             return
 
         if not self.definition_body:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Description works only with inline OpenApi specified in the 'DefinitionBody' property.",
             )
         if self.definition_body.get("info", {}).get("description"):
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to set Description because it is already defined within inline OpenAPI specified in the "
                 "'DefinitionBody' property.",
             )
 
-        open_api_editor = OpenApiEditor(self.definition_body)
-        open_api_editor.add_description(self.description)
+        open_api_editor = OpenApiEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        open_api_editor.add_description(self.description)  # type: ignore[no-untyped-call]
         self.definition_body = open_api_editor.openapi
 
-    @cw_timer(prefix="Generator", name="HttpApi")
-    def to_cloudformation(self, route53_record_set_groups):
+    @cw_timer(prefix="Generator", name="HttpApi")  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, route53_record_set_groups):  # type: ignore[no-untyped-def]
         """Generates CloudFormation resources from a SAM HTTP API resource
 
         :returns: a tuple containing the HttpApi and Stage for an empty Api.
         :rtype: tuple
         """
-        http_api = self._construct_http_api()
-        domain, basepath_mapping, route53 = self._construct_api_domain(http_api, route53_record_set_groups)
-        stage = self._construct_stage()
+        http_api = self._construct_http_api()  # type: ignore[no-untyped-call]
+        domain, basepath_mapping, route53 = self._construct_api_domain(http_api, route53_record_set_groups)  # type: ignore[no-untyped-call]
+        stage = self._construct_stage()  # type: ignore[no-untyped-call]
 
         return http_api, stage, domain, basepath_mapping, route53

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -13,50 +13,50 @@ from samtranslator.utils.py27hash_fix import Py27Dict, Py27UniStr
 class ApiGatewayRestApi(Resource):
     resource_type = "AWS::ApiGateway::RestApi"
     property_types = {
-        "Body": PropertyType(False, is_type(dict)),
-        "BodyS3Location": PropertyType(False, is_type(dict)),
-        "CloneFrom": PropertyType(False, is_str()),
-        "Description": PropertyType(False, is_str()),
-        "FailOnWarnings": PropertyType(False, is_type(bool)),
-        "Name": PropertyType(False, is_str()),
-        "Parameters": PropertyType(False, is_type(dict)),
-        "EndpointConfiguration": PropertyType(False, is_type(dict)),
-        "BinaryMediaTypes": PropertyType(False, is_type(list)),
-        "MinimumCompressionSize": PropertyType(False, is_type(int)),
-        "Mode": PropertyType(False, is_str()),
-        "ApiKeySourceType": PropertyType(False, is_str()),
+        "Body": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BodyS3Location": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CloneFrom": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FailOnWarnings": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Parameters": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EndpointConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BinaryMediaTypes": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MinimumCompressionSize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Mode": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ApiKeySourceType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"rest_api_id": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"rest_api_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
 
 class ApiGatewayStage(Resource):
     resource_type = "AWS::ApiGateway::Stage"
     property_types = {
-        "AccessLogSetting": PropertyType(False, is_type(dict)),
-        "CacheClusterEnabled": PropertyType(False, is_type(bool)),
-        "CacheClusterSize": PropertyType(False, is_str()),
-        "CanarySetting": PropertyType(False, is_type(dict)),
-        "ClientCertificateId": PropertyType(False, is_str()),
-        "DeploymentId": PropertyType(True, is_str()),
-        "Description": PropertyType(False, is_str()),
-        "RestApiId": PropertyType(True, is_str()),
-        "StageName": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "Tags": PropertyType(False, list_of(is_type(dict))),
-        "TracingEnabled": PropertyType(False, is_type(bool)),
-        "Variables": PropertyType(False, is_type(dict)),
-        "MethodSettings": PropertyType(False, is_type(list)),
+        "AccessLogSetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CacheClusterEnabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CacheClusterSize": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CanarySetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ClientCertificateId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DeploymentId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RestApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StageName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "TracingEnabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Variables": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MethodSettings": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
-    def update_deployment_ref(self, deployment_logical_id):
-        self.DeploymentId = ref(deployment_logical_id)
+    def update_deployment_ref(self, deployment_logical_id):  # type: ignore[no-untyped-def]
+        self.DeploymentId = ref(deployment_logical_id)  # type: ignore[no-untyped-call]
 
 
 class ApiGatewayAccount(Resource):
     resource_type = "AWS::ApiGateway::Account"
-    property_types = {"CloudWatchRoleArn": PropertyType(False, one_of(is_str(), is_type(dict)))}
+    property_types = {"CloudWatchRoleArn": PropertyType(False, one_of(is_str(), is_type(dict)))}  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
 
 
 class ApiGatewayDeployment(Resource):
@@ -64,15 +64,15 @@ class ApiGatewayDeployment(Resource):
 
     resource_type = "AWS::ApiGateway::Deployment"
     property_types = {
-        "Description": PropertyType(False, is_str()),
-        "RestApiId": PropertyType(True, is_str()),
-        "StageDescription": PropertyType(False, is_type(dict)),
-        "StageName": PropertyType(False, is_str()),
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RestApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StageDescription": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StageName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"deployment_id": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"deployment_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
-    def make_auto_deployable(
+    def make_auto_deployable(  # type: ignore[no-untyped-def]
         self, stage, openapi_version=None, swagger=None, domain=None, redeploy_restapi_parameters=None
     ):
         """
@@ -107,9 +107,9 @@ class ApiGatewayDeployment(Resource):
         if function_names and function_names.get(self.logical_id[:-10], None):
             hash_input.append(function_names.get(self.logical_id[:-10], ""))
         data = self._X_HASH_DELIMITER.join(hash_input)
-        generator = logical_id_generator.LogicalIdGenerator(self.logical_id, data)
-        self.logical_id = generator.gen()
-        digest = generator.get_hash(length=40)  # Get the full hash
+        generator = logical_id_generator.LogicalIdGenerator(self.logical_id, data)  # type: ignore[no-untyped-call]
+        self.logical_id = generator.gen()  # type: ignore[no-untyped-call]
+        digest = generator.get_hash(length=40)  # type: ignore[no-untyped-call] # Get the full hash
         self.Description = "RestApi deployment id: {}".format(digest)
         stage.update_deployment_ref(self.logical_id)
 
@@ -117,29 +117,29 @@ class ApiGatewayDeployment(Resource):
 class ApiGatewayResponse(object):
     ResponseParameterProperties = ["Headers", "Paths", "QueryStrings"]
 
-    def __init__(self, api_logical_id=None, response_parameters=None, response_templates=None, status_code=None):
+    def __init__(self, api_logical_id=None, response_parameters=None, response_templates=None, status_code=None):  # type: ignore[no-untyped-def]
         if response_parameters:
             for response_parameter_key in response_parameters.keys():
                 if response_parameter_key not in ApiGatewayResponse.ResponseParameterProperties:
-                    raise InvalidResourceException(
+                    raise InvalidResourceException(  # type: ignore[no-untyped-call]
                         api_logical_id, "Invalid gateway response parameter '{}'".format(response_parameter_key)
                     )
 
-        status_code_str = self._status_code_string(status_code)
+        status_code_str = self._status_code_string(status_code)  # type: ignore[no-untyped-call]
         # status_code must look like a status code, if present. Let's not be judgmental; just check 0-999.
         if status_code and not match(r"^[0-9]{1,3}$", status_code_str):
-            raise InvalidResourceException(api_logical_id, "Property 'StatusCode' must be numeric")
+            raise InvalidResourceException(api_logical_id, "Property 'StatusCode' must be numeric")  # type: ignore[no-untyped-call]
 
         self.api_logical_id = api_logical_id
         # Defaults to Py27Dict() as these will go into swagger
-        self.response_parameters = response_parameters or Py27Dict()
-        self.response_templates = response_templates or Py27Dict()
+        self.response_parameters = response_parameters or Py27Dict()  # type: ignore[no-untyped-call]
+        self.response_templates = response_templates or Py27Dict()  # type: ignore[no-untyped-call]
         self.status_code = status_code_str
 
-    def generate_swagger(self):
+    def generate_swagger(self):  # type: ignore[no-untyped-def]
         # Applying Py27Dict here as this goes into swagger
-        swagger = Py27Dict()
-        swagger["responseParameters"] = self._add_prefixes(self.response_parameters)
+        swagger = Py27Dict()  # type: ignore[no-untyped-call]
+        swagger["responseParameters"] = self._add_prefixes(self.response_parameters)  # type: ignore[no-untyped-call]
         swagger["responseTemplates"] = self.response_templates
 
         # Prevent "null" being written.
@@ -148,10 +148,10 @@ class ApiGatewayResponse(object):
 
         return swagger
 
-    def _add_prefixes(self, response_parameters):
+    def _add_prefixes(self, response_parameters):  # type: ignore[no-untyped-def]
         GATEWAY_RESPONSE_PREFIX = "gatewayresponse."
         # applying Py27Dict as this is part of swagger
-        prefixed_parameters = Py27Dict()
+        prefixed_parameters = Py27Dict()  # type: ignore[no-untyped-call]
 
         parameter_prefix_pairs = [("Headers", "header."), ("Paths", "path."), ("QueryStrings", "querystring.")]
         for parameter, prefix in parameter_prefix_pairs:
@@ -164,74 +164,74 @@ class ApiGatewayResponse(object):
 
         return prefixed_parameters
 
-    def _status_code_string(self, status_code):
+    def _status_code_string(self, status_code):  # type: ignore[no-untyped-def]
         return None if status_code is None else str(status_code)
 
 
 class ApiGatewayDomainName(Resource):
     resource_type = "AWS::ApiGateway::DomainName"
     property_types = {
-        "RegionalCertificateArn": PropertyType(False, is_str()),
-        "DomainName": PropertyType(True, is_str()),
-        "EndpointConfiguration": PropertyType(False, is_type(dict)),
-        "MutualTlsAuthentication": PropertyType(False, is_type(dict)),
-        "SecurityPolicy": PropertyType(False, is_str()),
-        "CertificateArn": PropertyType(False, is_str()),
-        "OwnershipVerificationCertificateArn": PropertyType(False, is_str()),
+        "RegionalCertificateArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DomainName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EndpointConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MutualTlsAuthentication": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SecurityPolicy": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CertificateArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "OwnershipVerificationCertificateArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
 
 class ApiGatewayBasePathMapping(Resource):
     resource_type = "AWS::ApiGateway::BasePathMapping"
     property_types = {
-        "BasePath": PropertyType(False, is_str()),
-        "DomainName": PropertyType(True, is_str()),
-        "RestApiId": PropertyType(False, is_str()),
-        "Stage": PropertyType(False, is_str()),
+        "BasePath": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DomainName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RestApiId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Stage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
 
 class ApiGatewayUsagePlan(Resource):
     resource_type = "AWS::ApiGateway::UsagePlan"
     property_types = {
-        "ApiStages": PropertyType(False, is_type(list)),
-        "Description": PropertyType(False, is_str()),
-        "Quota": PropertyType(False, is_type(dict)),
-        "Tags": PropertyType(False, list_of(dict)),
-        "Throttle": PropertyType(False, is_type(dict)),
-        "UsagePlanName": PropertyType(False, is_str()),
+        "ApiStages": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Quota": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, list_of(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Throttle": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "UsagePlanName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
-    runtime_attrs = {"usage_plan_id": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"usage_plan_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
 
 class ApiGatewayUsagePlanKey(Resource):
     resource_type = "AWS::ApiGateway::UsagePlanKey"
     property_types = {
-        "KeyId": PropertyType(True, is_str()),
-        "KeyType": PropertyType(True, is_str()),
-        "UsagePlanId": PropertyType(True, is_str()),
+        "KeyId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "KeyType": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "UsagePlanId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
 
 class ApiGatewayApiKey(Resource):
     resource_type = "AWS::ApiGateway::ApiKey"
     property_types = {
-        "CustomerId": PropertyType(False, is_str()),
-        "Description": PropertyType(False, is_str()),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "GenerateDistinctId": PropertyType(False, is_type(bool)),
-        "Name": PropertyType(False, is_str()),
-        "StageKeys": PropertyType(False, is_type(list)),
-        "Value": PropertyType(False, is_str()),
+        "CustomerId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "GenerateDistinctId": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StageKeys": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Value": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"api_key_id": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"api_key_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
 
 class ApiGatewayAuthorizer(object):
     _VALID_FUNCTION_PAYLOAD_TYPES = [None, "TOKEN", "REQUEST"]
 
-    def __init__(
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         api_logical_id=None,
         name=None,
@@ -246,20 +246,20 @@ class ApiGatewayAuthorizer(object):
         if authorization_scopes is None:
             authorization_scopes = []
         if function_payload_type not in ApiGatewayAuthorizer._VALID_FUNCTION_PAYLOAD_TYPES:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 api_logical_id,
                 f"{name} Authorizer has invalid 'FunctionPayloadType': {function_payload_type}.",
             )
 
-        if function_payload_type == "REQUEST" and self._is_missing_identity_source(identity):
-            raise InvalidResourceException(
+        if function_payload_type == "REQUEST" and self._is_missing_identity_source(identity):  # type: ignore[no-untyped-call]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 api_logical_id,
                 f"{name} Authorizer must specify Identity with at least one "
                 "of Headers, QueryStrings, StageVariables, or Context.",
             )
 
         if authorization_scopes is not None and not isinstance(authorization_scopes, list):
-            raise InvalidResourceException(api_logical_id, "AuthorizationScopes must be a list.")
+            raise InvalidResourceException(api_logical_id, "AuthorizationScopes must be a list.")  # type: ignore[no-untyped-call]
 
         self.api_logical_id = api_logical_id
         self.name = name
@@ -271,7 +271,7 @@ class ApiGatewayAuthorizer(object):
         self.is_aws_iam_authorizer = is_aws_iam_authorizer
         self.authorization_scopes = authorization_scopes
 
-    def _is_missing_identity_source(self, identity):
+    def _is_missing_identity_source(self, identity):  # type: ignore[no-untyped-def]
         if not identity:
             return True
 
@@ -293,35 +293,35 @@ class ApiGatewayAuthorizer(object):
         # If we can resolve ttl, attempt to see if things are valid
         return ttl_int > 0 and required_properties_missing
 
-    def generate_swagger(self):
-        authorizer_type = self._get_type()
+    def generate_swagger(self):  # type: ignore[no-untyped-def]
+        authorizer_type = self._get_type()  # type: ignore[no-untyped-call]
         APIGATEWAY_AUTHORIZER_KEY = "x-amazon-apigateway-authorizer"
-        swagger = Py27Dict()
+        swagger = Py27Dict()  # type: ignore[no-untyped-call]
         swagger["type"] = "apiKey"
-        swagger["name"] = self._get_swagger_header_name()
+        swagger["name"] = self._get_swagger_header_name()  # type: ignore[no-untyped-call]
         swagger["in"] = "header"
-        swagger["x-amazon-apigateway-authtype"] = self._get_swagger_authtype()
+        swagger["x-amazon-apigateway-authtype"] = self._get_swagger_authtype()  # type: ignore[no-untyped-call]
 
         if authorizer_type == "COGNITO_USER_POOLS":
-            authorizer_dict = Py27Dict()
-            authorizer_dict["type"] = self._get_swagger_authorizer_type()
-            authorizer_dict["providerARNs"] = self._get_user_pool_arn_array()
+            authorizer_dict = Py27Dict()  # type: ignore[no-untyped-call]
+            authorizer_dict["type"] = self._get_swagger_authorizer_type()  # type: ignore[no-untyped-call]
+            authorizer_dict["providerARNs"] = self._get_user_pool_arn_array()  # type: ignore[no-untyped-call]
             swagger[APIGATEWAY_AUTHORIZER_KEY] = authorizer_dict
 
         elif authorizer_type == "LAMBDA":
-            swagger[APIGATEWAY_AUTHORIZER_KEY] = Py27Dict({"type": self._get_swagger_authorizer_type()})
-            partition = ArnGenerator.get_partition_name()
+            swagger[APIGATEWAY_AUTHORIZER_KEY] = Py27Dict({"type": self._get_swagger_authorizer_type()})  # type: ignore[no-untyped-call, no-untyped-call]
+            partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
             resource = "lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations"
-            authorizer_uri = fnSub(
-                ArnGenerator.generate_arn(
+            authorizer_uri = fnSub(  # type: ignore[no-untyped-call]
+                ArnGenerator.generate_arn(  # type: ignore[no-untyped-call]
                     partition=partition, service="apigateway", resource=resource, include_account_id=False
                 ),
                 {"__FunctionArn__": self.function_arn},
             )
 
             swagger[APIGATEWAY_AUTHORIZER_KEY]["authorizerUri"] = authorizer_uri
-            reauthorize_every = self._get_reauthorize_every()
-            function_invoke_role = self._get_function_invoke_role()
+            reauthorize_every = self._get_reauthorize_every()  # type: ignore[no-untyped-call]
+            function_invoke_role = self._get_function_invoke_role()  # type: ignore[no-untyped-call]
 
             if reauthorize_every is not None:
                 swagger[APIGATEWAY_AUTHORIZER_KEY]["authorizerResultTtlInSeconds"] = reauthorize_every
@@ -329,40 +329,40 @@ class ApiGatewayAuthorizer(object):
             if function_invoke_role:
                 swagger[APIGATEWAY_AUTHORIZER_KEY]["authorizerCredentials"] = function_invoke_role
 
-            if self._get_function_payload_type() == "REQUEST":
-                identity_source = self._get_identity_source()
+            if self._get_function_payload_type() == "REQUEST":  # type: ignore[no-untyped-call]
+                identity_source = self._get_identity_source()  # type: ignore[no-untyped-call]
                 if identity_source:
-                    swagger[APIGATEWAY_AUTHORIZER_KEY]["identitySource"] = self._get_identity_source()
+                    swagger[APIGATEWAY_AUTHORIZER_KEY]["identitySource"] = self._get_identity_source()  # type: ignore[no-untyped-call]
 
         # Authorizer Validation Expression is only allowed on COGNITO_USER_POOLS and LAMBDA_TOKEN
-        is_lambda_token_authorizer = authorizer_type == "LAMBDA" and self._get_function_payload_type() == "TOKEN"
+        is_lambda_token_authorizer = authorizer_type == "LAMBDA" and self._get_function_payload_type() == "TOKEN"  # type: ignore[no-untyped-call]
 
         if authorizer_type == "COGNITO_USER_POOLS" or is_lambda_token_authorizer:
-            identity_validation_expression = self._get_identity_validation_expression()
+            identity_validation_expression = self._get_identity_validation_expression()  # type: ignore[no-untyped-call]
 
             if identity_validation_expression:
                 swagger[APIGATEWAY_AUTHORIZER_KEY]["identityValidationExpression"] = identity_validation_expression
 
         return swagger
 
-    def _get_identity_validation_expression(self):
+    def _get_identity_validation_expression(self):  # type: ignore[no-untyped-def]
         return self.identity and self.identity.get("ValidationExpression")
 
-    def _build_identity_source_item(self, item_prefix, prop_value):
+    def _build_identity_source_item(self, item_prefix, prop_value):  # type: ignore[no-untyped-def]
         item = item_prefix + prop_value
         if isinstance(prop_value, Py27UniStr):
             item = Py27UniStr(item)
         return item
 
-    def _build_identity_source_item_array(self, prop_key, item_prefix):
+    def _build_identity_source_item_array(self, prop_key, item_prefix):  # type: ignore[no-untyped-def]
         arr = []
         if self.identity.get(prop_key):
             arr = [
-                self._build_identity_source_item(item_prefix, prop_value) for prop_value in self.identity.get(prop_key)
+                self._build_identity_source_item(item_prefix, prop_value) for prop_value in self.identity.get(prop_key)  # type: ignore[no-untyped-call]
             ]
         return arr
 
-    def _get_identity_source(self):
+    def _get_identity_source(self):  # type: ignore[no-untyped-def]
         key_prefix_pairs = [
             ("Headers", "method.request.header."),
             ("QueryStrings", "method.request.querystring."),
@@ -370,9 +370,9 @@ class ApiGatewayAuthorizer(object):
             ("Context", "context."),
         ]
 
-        identity_source_array = reduce(
-            lambda accumulator, key_prefix_pair: accumulator
-            + self._build_identity_source_item_array(key_prefix_pair[0], key_prefix_pair[1]),
+        identity_source_array = reduce(  # type: ignore[var-annotated]
+            lambda accumulator, key_prefix_pair: accumulator  # type: ignore[no-any-return]
+            + self._build_identity_source_item_array(key_prefix_pair[0], key_prefix_pair[1]),  # type: ignore[no-untyped-call]
             key_prefix_pairs,
             [],
         )
@@ -384,19 +384,19 @@ class ApiGatewayAuthorizer(object):
 
         return identity_source
 
-    def _get_user_pool_arn_array(self):
+    def _get_user_pool_arn_array(self):  # type: ignore[no-untyped-def]
         return self.user_pool_arn if isinstance(self.user_pool_arn, list) else [self.user_pool_arn]
 
-    def _get_swagger_header_name(self):
-        authorizer_type = self._get_type()
-        payload_type = self._get_function_payload_type()
+    def _get_swagger_header_name(self):  # type: ignore[no-untyped-def]
+        authorizer_type = self._get_type()  # type: ignore[no-untyped-call]
+        payload_type = self._get_function_payload_type()  # type: ignore[no-untyped-call]
 
         if authorizer_type == "LAMBDA" and payload_type == "REQUEST":
             return "Unused"
 
-        return self._get_identity_header()
+        return self._get_identity_header()  # type: ignore[no-untyped-call]
 
-    def _get_type(self):
+    def _get_type(self):  # type: ignore[no-untyped-def]
         if self.is_aws_iam_authorizer:
             return "AWS_IAM"
 
@@ -405,9 +405,9 @@ class ApiGatewayAuthorizer(object):
 
         return "LAMBDA"
 
-    def _get_identity_header(self):
+    def _get_identity_header(self):  # type: ignore[no-untyped-def]
         if self.identity and not isinstance(self.identity, dict):
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id,
                 "Auth.Authorizers.<Authorizer>.Identity must be a dict (LambdaTokenAuthorizationIdentity, "
                 "LambdaRequestAuthorizationIdentity or CognitoAuthorizationIdentity).",
@@ -418,20 +418,20 @@ class ApiGatewayAuthorizer(object):
 
         return self.identity.get("Header")
 
-    def _get_reauthorize_every(self):
+    def _get_reauthorize_every(self):  # type: ignore[no-untyped-def]
         if not self.identity:
             return None
 
         return self.identity.get("ReauthorizeEvery")
 
-    def _get_function_invoke_role(self):
+    def _get_function_invoke_role(self):  # type: ignore[no-untyped-def]
         if not self.function_invoke_role or self.function_invoke_role == "NONE":
             return None
 
         return self.function_invoke_role
 
-    def _get_swagger_authtype(self):
-        authorizer_type = self._get_type()
+    def _get_swagger_authtype(self):  # type: ignore[no-untyped-def]
+        authorizer_type = self._get_type()  # type: ignore[no-untyped-call]
         if authorizer_type == "AWS_IAM":
             return "awsSigv4"
 
@@ -440,16 +440,16 @@ class ApiGatewayAuthorizer(object):
 
         return "custom"
 
-    def _get_function_payload_type(self):
+    def _get_function_payload_type(self):  # type: ignore[no-untyped-def]
         return "TOKEN" if not self.function_payload_type else self.function_payload_type
 
-    def _get_swagger_authorizer_type(self):
-        authorizer_type = self._get_type()
+    def _get_swagger_authorizer_type(self):  # type: ignore[no-untyped-def]
+        authorizer_type = self._get_type()  # type: ignore[no-untyped-call]
 
         if authorizer_type == "COGNITO_USER_POOLS":
             return "cognito_user_pools"
 
-        payload_type = self._get_function_payload_type()
+        payload_type = self._get_function_payload_type()  # type: ignore[no-untyped-call]
 
         if payload_type == "REQUEST":
             return "request"

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -10,58 +10,58 @@ APIGATEWAY_AUTHORIZER_KEY = "x-amazon-apigateway-authorizer"
 class ApiGatewayV2HttpApi(Resource):
     resource_type = "AWS::ApiGatewayV2::Api"
     property_types = {
-        "Body": PropertyType(False, is_type(dict)),
-        "BodyS3Location": PropertyType(False, is_type(dict)),
-        "Description": PropertyType(False, is_str()),
-        "FailOnWarnings": PropertyType(False, is_type(bool)),
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
-        "BasePath": PropertyType(False, is_str()),
-        "CorsConfiguration": PropertyType(False, is_type(dict)),
+        "Body": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BodyS3Location": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FailOnWarnings": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BasePath": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CorsConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"http_api_id": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"http_api_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
 
 class ApiGatewayV2Stage(Resource):
     resource_type = "AWS::ApiGatewayV2::Stage"
     property_types = {
-        "AccessLogSettings": PropertyType(False, is_type(dict)),
-        "DefaultRouteSettings": PropertyType(False, is_type(dict)),
-        "RouteSettings": PropertyType(False, is_type(dict)),
-        "ClientCertificateId": PropertyType(False, is_str()),
-        "Description": PropertyType(False, is_str()),
-        "ApiId": PropertyType(True, is_str()),
-        "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "Tags": PropertyType(False, is_type(dict)),
-        "StageVariables": PropertyType(False, is_type(dict)),
-        "AutoDeploy": PropertyType(False, is_type(bool)),
+        "AccessLogSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefaultRouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ClientCertificateId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StageVariables": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AutoDeploy": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
 
 class ApiGatewayV2DomainName(Resource):
     resource_type = "AWS::ApiGatewayV2::DomainName"
     property_types = {
-        "DomainName": PropertyType(True, is_str()),
-        "DomainNameConfigurations": PropertyType(False, list_of(is_type(dict))),
-        "MutualTlsAuthentication": PropertyType(False, is_type(dict)),
-        "Tags": PropertyType(False, is_type(dict)),
+        "DomainName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DomainNameConfigurations": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "MutualTlsAuthentication": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
 
 class ApiGatewayV2ApiMapping(Resource):
     resource_type = "AWS::ApiGatewayV2::ApiMapping"
     property_types = {
-        "ApiId": PropertyType(True, is_str()),
-        "ApiMappingKey": PropertyType(False, is_str()),
-        "DomainName": PropertyType(True, is_str()),
-        "Stage": PropertyType(True, is_str()),
+        "ApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ApiMappingKey": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DomainName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Stage": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
 
 class ApiGatewayV2Authorizer(object):
-    def __init__(
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         api_logical_id=None,
         name=None,
@@ -90,106 +90,106 @@ class ApiGatewayV2Authorizer(object):
         self.enable_simple_responses = enable_simple_responses
         self.is_aws_iam_authorizer = is_aws_iam_authorizer
 
-        self._validate_input_parameters()
+        self._validate_input_parameters()  # type: ignore[no-untyped-call]
 
-        authorizer_type = self._get_auth_type()
+        authorizer_type = self._get_auth_type()  # type: ignore[no-untyped-call]
 
         # Validate necessary parameters exist
         if authorizer_type == "JWT":
-            self._validate_jwt_authorizer()
+            self._validate_jwt_authorizer()  # type: ignore[no-untyped-call]
 
         if authorizer_type == "REQUEST":
-            self._validate_lambda_authorizer()
+            self._validate_lambda_authorizer()  # type: ignore[no-untyped-call]
 
-    def _get_auth_type(self):
+    def _get_auth_type(self):  # type: ignore[no-untyped-def]
         if self.is_aws_iam_authorizer:
             return "AWS_IAM"
         if self.jwt_configuration:
             return "JWT"
         return "REQUEST"
 
-    def _validate_input_parameters(self):
-        authorizer_type = self._get_auth_type()
+    def _validate_input_parameters(self):  # type: ignore[no-untyped-def]
+        authorizer_type = self._get_auth_type()  # type: ignore[no-untyped-call]
 
         if self.authorization_scopes is not None and not isinstance(self.authorization_scopes, list):
-            raise InvalidResourceException(self.api_logical_id, "AuthorizationScopes must be a list.")
+            raise InvalidResourceException(self.api_logical_id, "AuthorizationScopes must be a list.")  # type: ignore[no-untyped-call]
 
         if self.authorization_scopes is not None and not authorizer_type == "JWT":
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, "AuthorizationScopes must be defined only for OAuth2 Authorizer."
             )
 
         if self.jwt_configuration is not None and not authorizer_type == "JWT":
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, "JwtConfiguration must be defined only for OAuth2 Authorizer."
             )
 
         if self.id_source is not None and not authorizer_type == "JWT":
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, "IdentitySource must be defined only for OAuth2 Authorizer."
             )
 
         if self.function_arn is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, "FunctionArn must be defined only for Lambda Authorizer."
             )
 
         if self.function_invoke_role is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, "FunctionInvokeRole must be defined only for Lambda Authorizer."
             )
 
         if self.identity is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(self.api_logical_id, "Identity must be defined only for Lambda Authorizer.")
+            raise InvalidResourceException(self.api_logical_id, "Identity must be defined only for Lambda Authorizer.")  # type: ignore[no-untyped-call]
 
         if self.authorizer_payload_format_version is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, "AuthorizerPayloadFormatVersion must be defined only for Lambda Authorizer."
             )
 
         if self.enable_simple_responses is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, "EnableSimpleResponses must be defined only for Lambda Authorizer."
             )
 
-    def _validate_jwt_authorizer(self):
+    def _validate_jwt_authorizer(self):  # type: ignore[no-untyped-def]
         if not self.jwt_configuration:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, f"{self.name} OAuth2 Authorizer must define 'JwtConfiguration'."
             )
         if not self.id_source:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, f"{self.name} OAuth2 Authorizer must define 'IdentitySource'."
             )
 
-    def _validate_lambda_authorizer(self):
+    def _validate_lambda_authorizer(self):  # type: ignore[no-untyped-def]
         if not self.function_arn:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, f"{self.name} Lambda Authorizer must define 'FunctionArn'."
             )
         if not self.authorizer_payload_format_version:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.api_logical_id, f"{self.name} Lambda Authorizer must define 'AuthorizerPayloadFormatVersion'."
             )
 
         if self.identity:
             if not isinstance(self.identity, dict):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.api_logical_id, self.name + " Lambda Authorizer property 'identity' is of invalid type."
                 )
             headers = self.identity.get("Headers")
             if headers:
                 if not isinstance(headers, list) or any((not isinstance(header, str) for header in headers)):
-                    raise InvalidResourceException(
+                    raise InvalidResourceException(  # type: ignore[no-untyped-call]
                         self.api_logical_id,
                         self.name + " Lambda Authorizer property identity's 'Headers' is of invalid type.",
                     )
 
-    def generate_openapi(self):
+    def generate_openapi(self):  # type: ignore[no-untyped-def]
         """
         Generates OAS for the securitySchemes section
         """
-        authorizer_type = self._get_auth_type()
+        authorizer_type = self._get_auth_type()  # type: ignore[no-untyped-call]
 
         if authorizer_type == "AWS_IAM":
             openapi = {
@@ -201,7 +201,7 @@ class ApiGatewayV2Authorizer(object):
 
         if authorizer_type == "JWT":
             openapi = {"type": "oauth2"}
-            openapi[APIGATEWAY_AUTHORIZER_KEY] = {
+            openapi[APIGATEWAY_AUTHORIZER_KEY] = {  # type: ignore[assignment]
                 "jwtConfiguration": self.jwt_configuration,
                 "identitySource": self.id_source,
                 "type": "jwt",
@@ -213,71 +213,71 @@ class ApiGatewayV2Authorizer(object):
                 "name": "Unused",
                 "in": "header",
             }
-            openapi[APIGATEWAY_AUTHORIZER_KEY] = {"type": "request"}
+            openapi[APIGATEWAY_AUTHORIZER_KEY] = {"type": "request"}  # type: ignore[assignment]
 
             # Generate the lambda arn
-            partition = ArnGenerator.get_partition_name()
+            partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
             resource = "lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations"
-            authorizer_uri = fnSub(
-                ArnGenerator.generate_arn(
+            authorizer_uri = fnSub(  # type: ignore[no-untyped-call]
+                ArnGenerator.generate_arn(  # type: ignore[no-untyped-call]
                     partition=partition, service="apigateway", resource=resource, include_account_id=False
                 ),
                 {"__FunctionArn__": self.function_arn},
             )
-            openapi[APIGATEWAY_AUTHORIZER_KEY]["authorizerUri"] = authorizer_uri
+            openapi[APIGATEWAY_AUTHORIZER_KEY]["authorizerUri"] = authorizer_uri  # type: ignore[index]
 
             # Set authorizerCredentials if present
-            function_invoke_role = self._get_function_invoke_role()
+            function_invoke_role = self._get_function_invoke_role()  # type: ignore[no-untyped-call]
             if function_invoke_role:
-                openapi[APIGATEWAY_AUTHORIZER_KEY]["authorizerCredentials"] = function_invoke_role
+                openapi[APIGATEWAY_AUTHORIZER_KEY]["authorizerCredentials"] = function_invoke_role  # type: ignore[index]
 
             # Set authorizerResultTtlInSeconds if present
-            reauthorize_every = self._get_reauthorize_every()
+            reauthorize_every = self._get_reauthorize_every()  # type: ignore[no-untyped-call]
             if reauthorize_every is not None:
-                openapi[APIGATEWAY_AUTHORIZER_KEY]["authorizerResultTtlInSeconds"] = reauthorize_every
+                openapi[APIGATEWAY_AUTHORIZER_KEY]["authorizerResultTtlInSeconds"] = reauthorize_every  # type: ignore[index]
 
             # Set identitySource if present
             if self.identity:
-                openapi[APIGATEWAY_AUTHORIZER_KEY]["identitySource"] = self._get_identity_source()
+                openapi[APIGATEWAY_AUTHORIZER_KEY]["identitySource"] = self._get_identity_source()  # type: ignore[no-untyped-call, index]
 
             # Set authorizerPayloadFormatVersion. It's a required parameter
-            openapi[APIGATEWAY_AUTHORIZER_KEY][
+            openapi[APIGATEWAY_AUTHORIZER_KEY][  # type: ignore[index]
                 "authorizerPayloadFormatVersion"
             ] = self.authorizer_payload_format_version
 
             # Set authorizerPayloadFormatVersion. It's a required parameter
             if self.enable_simple_responses:
-                openapi[APIGATEWAY_AUTHORIZER_KEY]["enableSimpleResponses"] = self.enable_simple_responses
+                openapi[APIGATEWAY_AUTHORIZER_KEY]["enableSimpleResponses"] = self.enable_simple_responses  # type: ignore[index]
 
         return openapi
 
-    def _get_function_invoke_role(self):
+    def _get_function_invoke_role(self):  # type: ignore[no-untyped-def]
         if not self.function_invoke_role or self.function_invoke_role == "NONE":
             return None
 
         return self.function_invoke_role
 
-    def _get_identity_source(self):
+    def _get_identity_source(self):  # type: ignore[no-untyped-def]
         identity_source_headers = []
         identity_source_query_strings = []
         identity_source_stage_variables = []
         identity_source_context = []
 
         if self.identity.get("Headers"):
-            identity_source_headers = list(map(lambda h: "$request.header." + h, self.identity.get("Headers")))
+            identity_source_headers = list(map(lambda h: "$request.header." + h, self.identity.get("Headers")))  # type: ignore[no-any-return]
 
         if self.identity.get("QueryStrings"):
             identity_source_query_strings = list(
-                map(lambda qs: "$request.querystring." + qs, self.identity.get("QueryStrings"))
+                map(lambda qs: "$request.querystring." + qs, self.identity.get("QueryStrings"))  # type: ignore[no-any-return]
             )
 
         if self.identity.get("StageVariables"):
             identity_source_stage_variables = list(
-                map(lambda sv: "$stageVariables." + sv, self.identity.get("StageVariables"))
+                map(lambda sv: "$stageVariables." + sv, self.identity.get("StageVariables"))  # type: ignore[no-any-return]
             )
 
         if self.identity.get("Context"):
-            identity_source_context = list(map(lambda c: "$context." + c, self.identity.get("Context")))
+            identity_source_context = list(map(lambda c: "$context." + c, self.identity.get("Context")))  # type: ignore[no-any-return]
 
         identity_source = (
             identity_source_headers
@@ -288,7 +288,7 @@ class ApiGatewayV2Authorizer(object):
 
         return identity_source
 
-    def _get_reauthorize_every(self):
+    def _get_reauthorize_every(self):  # type: ignore[no-untyped-def]
         if not self.identity:
             return None
 

--- a/samtranslator/model/cloudformation.py
+++ b/samtranslator/model/cloudformation.py
@@ -7,11 +7,11 @@ class NestedStack(Resource):
     resource_type = "AWS::CloudFormation::Stack"
     # TODO: support passthrough parameters for stacks (Conditions, etc)
     property_types = {
-        "TemplateURL": PropertyType(True, is_str()),
-        "Parameters": PropertyType(False, is_type(dict)),
-        "NotificationARNs": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "Tags": PropertyType(False, list_of(is_type(dict))),
-        "TimeoutInMinutes": PropertyType(False, is_type(int)),
+        "TemplateURL": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Parameters": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "NotificationARNs": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "TimeoutInMinutes": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"stack_id": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"stack_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]

--- a/samtranslator/model/codedeploy.py
+++ b/samtranslator/model/codedeploy.py
@@ -5,21 +5,21 @@ from samtranslator.model.types import is_type, one_of, is_str
 
 class CodeDeployApplication(Resource):
     resource_type = "AWS::CodeDeploy::Application"
-    property_types = {"ComputePlatform": PropertyType(False, one_of(is_str(), is_type(dict)))}
+    property_types = {"ComputePlatform": PropertyType(False, one_of(is_str(), is_type(dict)))}  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
 
 class CodeDeployDeploymentGroup(Resource):
     resource_type = "AWS::CodeDeploy::DeploymentGroup"
     property_types = {
-        "AlarmConfiguration": PropertyType(False, is_type(dict)),
-        "ApplicationName": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "AutoRollbackConfiguration": PropertyType(False, is_type(dict)),
-        "DeploymentConfigName": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "DeploymentStyle": PropertyType(False, is_type(dict)),
-        "ServiceRoleArn": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "TriggerConfigurations": PropertyType(False, is_type(list)),
+        "AlarmConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ApplicationName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "AutoRollbackConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DeploymentConfigName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "DeploymentStyle": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ServiceRoleArn": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "TriggerConfigurations": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]

--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -6,34 +6,34 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class CognitoUserPool(Resource):
     resource_type = "AWS::Cognito::UserPool"
     property_types = {
-        "AccountRecoverySetting": PropertyType(False, is_type(dict)),
-        "AdminCreateUserConfig": PropertyType(False, is_type(dict)),
-        "AliasAttributes": PropertyType(False, list_of(is_str())),
-        "AutoVerifiedAttributes": PropertyType(False, list_of(is_str())),
-        "DeviceConfiguration": PropertyType(False, is_type(dict)),
-        "EmailConfiguration": PropertyType(False, is_type(dict)),
-        "EmailVerificationMessage": PropertyType(False, is_str()),
-        "EmailVerificationSubject": PropertyType(False, is_str()),
-        "EnabledMfas": PropertyType(False, list_of(is_str())),
-        "LambdaConfig": PropertyType(False, is_type(dict)),
-        "MfaConfiguration": PropertyType(False, is_str()),
-        "Policies": PropertyType(False, is_type(dict)),
-        "Schema": PropertyType(False, list_of(dict)),
-        "SmsAuthenticationMessage": PropertyType(False, is_str()),
-        "SmsConfiguration": PropertyType(False, is_type(dict)),
-        "SmsVerificationMessage": PropertyType(False, is_str()),
-        "UserAttributeUpdateSettings": PropertyType(False, is_type(dict)),
-        "UsernameAttributes": PropertyType(False, list_of(is_str())),
-        "UsernameConfiguration": PropertyType(False, is_type(dict)),
-        "UserPoolAddOns": PropertyType(False, list_of(dict)),
-        "UserPoolName": PropertyType(False, is_str()),
-        "UserPoolTags": PropertyType(False, is_type(dict)),
-        "VerificationMessageTemplate": PropertyType(False, is_type(dict)),
+        "AccountRecoverySetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AdminCreateUserConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AliasAttributes": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "AutoVerifiedAttributes": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "DeviceConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EmailConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EmailVerificationMessage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EmailVerificationSubject": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EnabledMfas": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "LambdaConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MfaConfiguration": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Policies": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Schema": PropertyType(False, list_of(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SmsAuthenticationMessage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SmsConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SmsVerificationMessage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "UserAttributeUpdateSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "UsernameAttributes": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "UsernameConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "UserPoolAddOns": PropertyType(False, list_of(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "UserPoolName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "UserPoolTags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "VerificationMessageTemplate": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
     runtime_attrs = {
-        "name": lambda self: ref(self.logical_id),
-        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),
-        "provider_name": lambda self: fnGetAtt(self.logical_id, "ProviderName"),
-        "provider_url": lambda self: fnGetAtt(self.logical_id, "ProviderURL"),
+        "name": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),  # type: ignore[no-untyped-call]
+        "provider_name": lambda self: fnGetAtt(self.logical_id, "ProviderName"),  # type: ignore[no-untyped-call]
+        "provider_url": lambda self: fnGetAtt(self.logical_id, "ProviderURL"),  # type: ignore[no-untyped-call]
     }

--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -32,7 +32,7 @@ def _is_nonblank_str(s: Any) -> bool:
     return s and isinstance(s, str)
 
 
-def add_depends_on(logical_id: str, depends_on: str, resource_resolver: ResourceResolver):
+def add_depends_on(logical_id: str, depends_on: str, resource_resolver: ResourceResolver):  # type: ignore[no-untyped-def]
     """
     Add DependsOn attribute to resource.
     """
@@ -57,7 +57,7 @@ def replace_depends_on_logical_id(logical_id: str, replacement: List[str], resou
             resource["DependsOn"] = insert_unique(depends_on, replacement)
 
 
-def get_event_source_mappings(event_source_id: str, function_id: str, resource_resolver: ResourceResolver):
+def get_event_source_mappings(event_source_id: str, function_id: str, resource_resolver: ResourceResolver):  # type: ignore[no-untyped-def]
     """
     Get logical IDs of `AWS::Lambda::EventSourceMapping`s between resource logical IDs.
     """
@@ -67,8 +67,8 @@ def get_event_source_mappings(event_source_id: str, function_id: str, resource_r
             properties = resource.get("Properties", {})
             # Not taking intrinsics as input to function as FunctionName could be a number of
             # formats, which would require parsing it anyway
-            resource_function_id = get_logical_id_from_intrinsic(properties.get("FunctionName"))
-            resource_event_source_id = get_logical_id_from_intrinsic(properties.get("EventSourceArn"))
+            resource_function_id = get_logical_id_from_intrinsic(properties.get("FunctionName"))  # type: ignore[no-untyped-call]
+            resource_event_source_id = get_logical_id_from_intrinsic(properties.get("EventSourceArn"))  # type: ignore[no-untyped-call]
             if (
                 resource_function_id
                 and resource_event_source_id
@@ -160,7 +160,7 @@ def _get_resource_role_property(
     if resource_type == "AWS::Events::Rule":
         for target in properties.get("Targets", []):
             target_arn = target.get("Arn")
-            target_logical_id = get_logical_id_from_intrinsic(target_arn)
+            target_logical_id = get_logical_id_from_intrinsic(target_arn)  # type: ignore[no-untyped-call]
             if (target_logical_id and target_logical_id == connecting_obj_id) or (
                 connecting_obj_arn and target_arn == connecting_obj_arn
             ):
@@ -175,26 +175,26 @@ def _get_resource_role_name(
     if not role:
         return None
 
-    logical_id = get_logical_id_from_intrinsic(role)
+    logical_id = get_logical_id_from_intrinsic(role)  # type: ignore[no-untyped-call]
     if not logical_id:
         return None
 
-    return ref(logical_id)
+    return ref(logical_id)  # type: ignore[no-untyped-call]
 
 
 def _get_resource_queue_url(logical_id: str, resource_type: str) -> Any:
     if resource_type == "AWS::SQS::Queue":
-        return ref(logical_id)
+        return ref(logical_id)  # type: ignore[no-untyped-call]
 
 
 def _get_resource_id(logical_id: str, resource_type: str) -> Any:
     if resource_type in ["AWS::ApiGateway::RestApi", "AWS::ApiGatewayV2::Api"]:
-        return ref(logical_id)
+        return ref(logical_id)  # type: ignore[no-untyped-call]
 
 
 def _get_resource_name(logical_id: str, resource_type: str) -> Any:
     if resource_type == "AWS::StepFunctions::StateMachine":
-        return fnGetAtt(logical_id, "Name")
+        return fnGetAtt(logical_id, "Name")  # type: ignore[no-untyped-call]
 
 
 def _get_resource_qualifier(resource_type: str) -> Any:
@@ -208,6 +208,6 @@ def _get_resource_arn(logical_id: str, resource_type: str) -> Any:
         # according to documentation, Ref returns ARNs for these two resource types
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#aws-resource-stepfunctions-statemachine-return-values
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html#aws-resource-sns-topic-return-values
-        return ref(logical_id)
+        return ref(logical_id)  # type: ignore[no-untyped-call]
     # For all other supported resources, we can typically use Fn::GetAtt LogicalId.Arn to obtain ARNs
-    return fnGetAtt(logical_id, "Arn")
+    return fnGetAtt(logical_id, "Arn")  # type: ignore[no-untyped-call]

--- a/samtranslator/model/connector_profiles/profile.py
+++ b/samtranslator/model/connector_profiles/profile.py
@@ -10,7 +10,7 @@ with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "profiles.jso
     PROFILE: ConnectorProfile = json.load(f)
 
 
-def get_profile(source_type: str, dest_type: str):
+def get_profile(source_type: str, dest_type: str):  # type: ignore[no-untyped-def]
     profile = PROFILE["Permissions"].get(source_type, {}).get(dest_type)
     # Ensure not passing a mutable shared variable
     return copy.deepcopy(profile)
@@ -26,7 +26,7 @@ def verify_profile_variables_replaced(obj: Any) -> None:
         raise ValueError(f"The following variables have not been replaced: {matches}")
 
 
-def profile_replace(obj: Any, replacements: Dict[str, Any]):
+def profile_replace(obj: Any, replacements: Dict[str, Any]):  # type: ignore[no-untyped-def]
     """
     This function is used to recursively replace all keys in 'replacements' found
     in 'obj' with matching values in 'replacement' dictionary.
@@ -37,7 +37,7 @@ def profile_replace(obj: Any, replacements: Dict[str, Any]):
     return _map_nested(obj, lambda v: _profile_replace_str(v, replacements))
 
 
-def _map_nested(obj: Any, fn):
+def _map_nested(obj: Any, fn):  # type: ignore[no-untyped-def, no-untyped-def]
     if isinstance(obj, dict):
         return {k: _map_nested(v, fn) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -50,7 +50,7 @@ def _sanitize(s: str) -> str:
     return "".join(c for c in s if c.isalnum())
 
 
-def _profile_replace_str(s: Any, replacements: Dict[str, Any]):
+def _profile_replace_str(s: Any, replacements: Dict[str, Any]):  # type: ignore[no-untyped-def]
     if not isinstance(s, str):
         return s
     res = {}

--- a/samtranslator/model/dynamodb.py
+++ b/samtranslator/model/dynamodb.py
@@ -6,20 +6,20 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class DynamoDBTable(Resource):
     resource_type = "AWS::DynamoDB::Table"
     property_types = {
-        "AttributeDefinitions": PropertyType(True, list_of(is_type(dict))),
-        "GlobalSecondaryIndexes": PropertyType(False, list_of(is_type(dict))),
-        "KeySchema": PropertyType(False, list_of(is_type(dict))),
-        "LocalSecondaryIndexes": PropertyType(False, list_of(is_type(dict))),
-        "ProvisionedThroughput": PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),
-        "StreamSpecification": PropertyType(False, is_type(dict)),
-        "TableName": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "Tags": PropertyType(False, list_of(is_type(dict))),
-        "SSESpecification": PropertyType(False, is_type(dict)),
-        "BillingMode": PropertyType(False, is_str()),
+        "AttributeDefinitions": PropertyType(True, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "GlobalSecondaryIndexes": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "KeySchema": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "LocalSecondaryIndexes": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "ProvisionedThroughput": PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "StreamSpecification": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TableName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "SSESpecification": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BillingMode": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
     runtime_attrs = {
-        "name": lambda self: ref(self.logical_id),
-        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),
-        "stream_arn": lambda self: fnGetAtt(self.logical_id, "StreamArn"),
+        "name": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),  # type: ignore[no-untyped-call]
+        "stream_arn": lambda self: fnGetAtt(self.logical_id, "StreamArn"),  # type: ignore[no-untyped-call]
     }

--- a/samtranslator/model/eventbridge_utils.py
+++ b/samtranslator/model/eventbridge_utils.py
@@ -4,55 +4,55 @@ from samtranslator.model.exceptions import InvalidEventException
 
 class EventBridgeRuleUtils:
     @staticmethod
-    def create_dead_letter_queue_with_policy(rule_logical_id, rule_arn, queue_logical_id=None, attributes=None):
+    def create_dead_letter_queue_with_policy(rule_logical_id, rule_arn, queue_logical_id=None, attributes=None):  # type: ignore[no-untyped-def]
         resources = []
 
-        queue = SQSQueue(queue_logical_id or rule_logical_id + "Queue", attributes=attributes)
-        dlq_queue_arn = queue.get_runtime_attr("arn")
-        dlq_queue_url = queue.get_runtime_attr("queue_url")
+        queue = SQSQueue(queue_logical_id or rule_logical_id + "Queue", attributes=attributes)  # type: ignore[no-untyped-call]
+        dlq_queue_arn = queue.get_runtime_attr("arn")  # type: ignore[no-untyped-call]
+        dlq_queue_url = queue.get_runtime_attr("queue_url")  # type: ignore[no-untyped-call]
 
         # grant necessary permission to Eventbridge Rule resource for sending messages to dead-letter queue
-        policy = SQSQueuePolicy(rule_logical_id + "QueuePolicy", attributes=attributes)
-        policy.PolicyDocument = SQSQueuePolicies.eventbridge_dlq_send_message_resource_based_policy(
+        policy = SQSQueuePolicy(rule_logical_id + "QueuePolicy", attributes=attributes)  # type: ignore[no-untyped-call]
+        policy.PolicyDocument = SQSQueuePolicies.eventbridge_dlq_send_message_resource_based_policy(  # type: ignore[no-untyped-call]
             rule_arn, dlq_queue_arn
         )
         policy.Queues = [dlq_queue_url]
 
         resources.append(queue)
-        resources.append(policy)
+        resources.append(policy)  # type: ignore[arg-type]
 
         return resources
 
     @staticmethod
-    def validate_dlq_config(source_logical_id, dead_letter_config):
+    def validate_dlq_config(source_logical_id, dead_letter_config):  # type: ignore[no-untyped-def]
         supported_types = ["SQS"]
         is_arn_defined = "Arn" in dead_letter_config
         is_type_defined = "Type" in dead_letter_config
         if is_arn_defined and is_type_defined:
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 source_logical_id, "You can either define 'Arn' or 'Type' property of DeadLetterConfig"
             )
         if is_type_defined and dead_letter_config.get("Type") not in supported_types:
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 source_logical_id,
                 "The only valid value for 'Type' property of DeadLetterConfig is 'SQS'",
             )
         if not is_arn_defined and not is_type_defined:
-            raise InvalidEventException(source_logical_id, "No 'Arn' or 'Type' property provided for DeadLetterConfig")
+            raise InvalidEventException(source_logical_id, "No 'Arn' or 'Type' property provided for DeadLetterConfig")  # type: ignore[no-untyped-call]
 
     @staticmethod
-    def get_dlq_queue_arn_and_resources(cw_event_source, source_arn, attributes):
+    def get_dlq_queue_arn_and_resources(cw_event_source, source_arn, attributes):  # type: ignore[no-untyped-def]
         """returns dlq queue arn and dlq_resources, assuming cw_event_source.DeadLetterConfig has been validated"""
         dlq_queue_arn = cw_event_source.DeadLetterConfig.get("Arn")
         if dlq_queue_arn is not None:
             return dlq_queue_arn, []
         queue_logical_id = cw_event_source.DeadLetterConfig.get("QueueLogicalId")
         if queue_logical_id is not None and not isinstance(queue_logical_id, str):
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 cw_event_source.logical_id,
                 "QueueLogicalId must be a string",
             )
-        dlq_resources = EventBridgeRuleUtils.create_dead_letter_queue_with_policy(
+        dlq_resources = EventBridgeRuleUtils.create_dead_letter_queue_with_policy(  # type: ignore[no-untyped-call]
             cw_event_source.logical_id, source_arn, queue_logical_id, attributes
         )
         dlq_queue_arn = dlq_resources[0].get_runtime_attr("arn")

--- a/samtranslator/model/events.py
+++ b/samtranslator/model/events.py
@@ -6,14 +6,14 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class EventsRule(Resource):
     resource_type = "AWS::Events::Rule"
     property_types = {
-        "Description": PropertyType(False, is_str()),
-        "EventBusName": PropertyType(False, is_str()),
-        "EventPattern": PropertyType(False, is_type(dict)),
-        "Name": PropertyType(False, is_str()),
-        "RoleArn": PropertyType(False, is_str()),
-        "ScheduleExpression": PropertyType(False, is_str()),
-        "State": PropertyType(False, is_str()),
-        "Targets": PropertyType(False, list_of(is_type(dict))),
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EventBusName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EventPattern": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RoleArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ScheduleExpression": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Targets": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"rule_id": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+    runtime_attrs = {"rule_id": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]

--- a/samtranslator/model/eventsources/cloudwatchlogs.py
+++ b/samtranslator/model/eventsources/cloudwatchlogs.py
@@ -13,10 +13,10 @@ class CloudWatchLogs(PushEventSource):
 
     resource_type = "CloudWatchLogs"
     principal = "logs.amazonaws.com"
-    property_types = {"LogGroupName": PropertyType(True, is_str()), "FilterPattern": PropertyType(True, is_str())}
+    property_types = {"LogGroupName": PropertyType(True, is_str()), "FilterPattern": PropertyType(True, is_str())}  # type: ignore[no-untyped-call, no-untyped-call]
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the CloudWatch Logs Subscription Filter and Lambda Permission to which this CloudWatch Logs event source
         corresponds.
 
@@ -29,30 +29,30 @@ class CloudWatchLogs(PushEventSource):
         if not function:
             raise TypeError("Missing required keyword argument: function")
 
-        source_arn = self.get_source_arn()
-        permission = self._construct_permission(function, source_arn=source_arn)
-        subscription_filter = self.get_subscription_filter(function, permission)
+        source_arn = self.get_source_arn()  # type: ignore[no-untyped-call]
+        permission = self._construct_permission(function, source_arn=source_arn)  # type: ignore[no-untyped-call]
+        subscription_filter = self.get_subscription_filter(function, permission)  # type: ignore[no-untyped-call]
         resources = [permission, subscription_filter]
 
         return resources
 
-    def get_source_arn(self):
+    def get_source_arn(self):  # type: ignore[no-untyped-def]
         resource = "log-group:${__LogGroupName__}:*"
-        partition = ArnGenerator.get_partition_name()
+        partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
 
-        return fnSub(
-            ArnGenerator.generate_arn(partition=partition, service="logs", resource=resource),
-            {"__LogGroupName__": self.LogGroupName},
+        return fnSub(  # type: ignore[no-untyped-call]
+            ArnGenerator.generate_arn(partition=partition, service="logs", resource=resource),  # type: ignore[no-untyped-call]
+            {"__LogGroupName__": self.LogGroupName},  # type: ignore[attr-defined]
         )
 
-    def get_subscription_filter(self, function, permission):
-        subscription_filter = SubscriptionFilter(
+    def get_subscription_filter(self, function, permission):  # type: ignore[no-untyped-def]
+        subscription_filter = SubscriptionFilter(  # type: ignore[no-untyped-call]
             self.logical_id,
             depends_on=[permission.logical_id],
             attributes=function.get_passthrough_resource_attributes(),
         )
-        subscription_filter.LogGroupName = self.LogGroupName
-        subscription_filter.FilterPattern = self.FilterPattern
+        subscription_filter.LogGroupName = self.LogGroupName  # type: ignore[attr-defined]
+        subscription_filter.FilterPattern = self.FilterPattern  # type: ignore[attr-defined]
         subscription_filter.DestinationArn = function.get_runtime_attr("arn")
 
         return subscription_filter

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -29,37 +29,37 @@ class PullEventSource(ResourceMacro):
     resource_type: str = None  # type: ignore
     requires_stream_queue_broker = True
     property_types = {
-        "Stream": PropertyType(False, is_str()),
-        "Queue": PropertyType(False, is_str()),
-        "BatchSize": PropertyType(False, is_type(int)),
-        "StartingPosition": PropertyType(False, is_str()),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
-        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),
-        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),
-        "DestinationConfig": PropertyType(False, is_type(dict)),
-        "ParallelizationFactor": PropertyType(False, is_type(int)),
-        "Topics": PropertyType(False, is_type(list)),
-        "Broker": PropertyType(False, is_str()),
-        "Queues": PropertyType(False, is_type(list)),
-        "SourceAccessConfigurations": PropertyType(False, is_type(list)),
-        "SecretsManagerKmsKeyId": PropertyType(False, is_str()),
-        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),
-        "FunctionResponseTypes": PropertyType(False, is_type(list)),
-        "KafkaBootstrapServers": PropertyType(False, is_type(list)),
-        "FilterCriteria": PropertyType(False, is_type(dict)),
-        "ConsumerGroupId": PropertyType(False, is_str()),
+        "Stream": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Queue": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BatchSize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StartingPosition": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MaximumRetryAttempts": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DestinationConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ParallelizationFactor": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Topics": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Broker": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Queues": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SourceAccessConfigurations": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SecretsManagerKmsKeyId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionResponseTypes": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "KafkaBootstrapServers": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FilterCriteria": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ConsumerGroupId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    def get_policy_arn(self):
+    def get_policy_arn(self):  # type: ignore[no-untyped-def]
         raise NotImplementedError("Subclass must implement this method")
 
-    def get_policy_statements(self):
+    def get_policy_statements(self):  # type: ignore[no-untyped-def]
         raise NotImplementedError("Subclass must implement this method")
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the Lambda EventSourceMapping to which this pull event corresponds. Adds the appropriate managed
         policy to the function's execution role, if such a role is provided.
 
@@ -74,7 +74,7 @@ class PullEventSource(ResourceMacro):
 
         resources = []
 
-        lambda_eventsourcemapping = LambdaEventSourceMapping(
+        lambda_eventsourcemapping = LambdaEventSourceMapping(  # type: ignore[no-untyped-call]
             self.logical_id, attributes=function.get_passthrough_resource_attributes()
         )
         resources.append(lambda_eventsourcemapping)
@@ -85,90 +85,90 @@ class PullEventSource(ResourceMacro):
         except NotImplementedError:
             function_name_or_arn = function.get_runtime_attr("arn")
 
-        if self.requires_stream_queue_broker and not self.Stream and not self.Queue and not self.Broker:
-            raise InvalidEventException(
+        if self.requires_stream_queue_broker and not self.Stream and not self.Queue and not self.Broker:  # type: ignore[attr-defined, attr-defined, attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "No Queue (for SQS) or Stream (for Kinesis, DynamoDB or MSK) or Broker (for Amazon MQ) provided.",
             )
 
-        if self.Stream and not self.StartingPosition:
-            raise InvalidEventException(self.relative_id, "StartingPosition is required for Kinesis, DynamoDB and MSK.")
+        if self.Stream and not self.StartingPosition:  # type: ignore[attr-defined, attr-defined]
+            raise InvalidEventException(self.relative_id, "StartingPosition is required for Kinesis, DynamoDB and MSK.")  # type: ignore[no-untyped-call]
 
         lambda_eventsourcemapping.FunctionName = function_name_or_arn
-        lambda_eventsourcemapping.EventSourceArn = self.Stream or self.Queue or self.Broker
-        lambda_eventsourcemapping.StartingPosition = self.StartingPosition
-        lambda_eventsourcemapping.BatchSize = self.BatchSize
-        lambda_eventsourcemapping.Enabled = self.Enabled
-        lambda_eventsourcemapping.MaximumBatchingWindowInSeconds = self.MaximumBatchingWindowInSeconds
-        lambda_eventsourcemapping.MaximumRetryAttempts = self.MaximumRetryAttempts
-        lambda_eventsourcemapping.BisectBatchOnFunctionError = self.BisectBatchOnFunctionError
-        lambda_eventsourcemapping.MaximumRecordAgeInSeconds = self.MaximumRecordAgeInSeconds
-        lambda_eventsourcemapping.ParallelizationFactor = self.ParallelizationFactor
-        lambda_eventsourcemapping.Topics = self.Topics
-        lambda_eventsourcemapping.Queues = self.Queues
-        lambda_eventsourcemapping.SourceAccessConfigurations = self.SourceAccessConfigurations
-        lambda_eventsourcemapping.TumblingWindowInSeconds = self.TumblingWindowInSeconds
-        lambda_eventsourcemapping.FunctionResponseTypes = self.FunctionResponseTypes
-        lambda_eventsourcemapping.FilterCriteria = self.FilterCriteria
-        self._validate_filter_criteria()
+        lambda_eventsourcemapping.EventSourceArn = self.Stream or self.Queue or self.Broker  # type: ignore[attr-defined, attr-defined, attr-defined]
+        lambda_eventsourcemapping.StartingPosition = self.StartingPosition  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.BatchSize = self.BatchSize  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.Enabled = self.Enabled  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.MaximumBatchingWindowInSeconds = self.MaximumBatchingWindowInSeconds  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.MaximumRetryAttempts = self.MaximumRetryAttempts  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.BisectBatchOnFunctionError = self.BisectBatchOnFunctionError  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.MaximumRecordAgeInSeconds = self.MaximumRecordAgeInSeconds  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.ParallelizationFactor = self.ParallelizationFactor  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.Topics = self.Topics  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.Queues = self.Queues  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.SourceAccessConfigurations = self.SourceAccessConfigurations  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.TumblingWindowInSeconds = self.TumblingWindowInSeconds  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.FunctionResponseTypes = self.FunctionResponseTypes  # type: ignore[attr-defined]
+        lambda_eventsourcemapping.FilterCriteria = self.FilterCriteria  # type: ignore[attr-defined]
+        self._validate_filter_criteria()  # type: ignore[no-untyped-call]
 
-        if self.KafkaBootstrapServers:
+        if self.KafkaBootstrapServers:  # type: ignore[attr-defined]
             lambda_eventsourcemapping.SelfManagedEventSource = {
-                "Endpoints": {"KafkaBootstrapServers": self.KafkaBootstrapServers}
+                "Endpoints": {"KafkaBootstrapServers": self.KafkaBootstrapServers}  # type: ignore[attr-defined]
             }
-        if self.ConsumerGroupId:
-            consumer_group_id_structure = {"ConsumerGroupId": self.ConsumerGroupId}
+        if self.ConsumerGroupId:  # type: ignore[attr-defined]
+            consumer_group_id_structure = {"ConsumerGroupId": self.ConsumerGroupId}  # type: ignore[attr-defined]
             if self.resource_type == "MSK":
                 lambda_eventsourcemapping.AmazonManagedKafkaEventSourceConfig = consumer_group_id_structure
             elif self.resource_type == "SelfManagedKafka":
                 lambda_eventsourcemapping.SelfManagedKafkaEventSourceConfig = consumer_group_id_structure
             else:
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     "Property ConsumerGroupId not defined for resource of type {}.".format(self.resource_type),
                 )
 
         destination_config_policy = None
-        if self.DestinationConfig:
-            if self.DestinationConfig.get("OnFailure") is None:
-                raise InvalidEventException(self.logical_id, "'OnFailure' is a required field for 'DestinationConfig'")
+        if self.DestinationConfig:  # type: ignore[attr-defined]
+            if self.DestinationConfig.get("OnFailure") is None:  # type: ignore[attr-defined]
+                raise InvalidEventException(self.logical_id, "'OnFailure' is a required field for 'DestinationConfig'")  # type: ignore[no-untyped-call]
 
             # `Type` property is for sam to attach the right policies
-            destination_type = self.DestinationConfig.get("OnFailure").get("Type")
+            destination_type = self.DestinationConfig.get("OnFailure").get("Type")  # type: ignore[attr-defined]
 
             # SAM attaches the policies for SQS or SNS only if 'Type' is given
             if destination_type:
                 # delete this field as its used internally for SAM to determine the policy
-                del self.DestinationConfig["OnFailure"]["Type"]
+                del self.DestinationConfig["OnFailure"]["Type"]  # type: ignore[attr-defined]
                 # the values 'SQS' and 'SNS' are allowed. No intrinsics are allowed
                 if destination_type not in ["SQS", "SNS"]:
-                    raise InvalidEventException(self.logical_id, "The only valid values for 'Type' are 'SQS' and 'SNS'")
+                    raise InvalidEventException(self.logical_id, "The only valid values for 'Type' are 'SQS' and 'SNS'")  # type: ignore[no-untyped-call]
                 if destination_type == "SQS":
-                    queue_arn = self.DestinationConfig.get("OnFailure").get("Destination")
-                    destination_config_policy = IAMRolePolicies().sqs_send_message_role_policy(
+                    queue_arn = self.DestinationConfig.get("OnFailure").get("Destination")  # type: ignore[attr-defined]
+                    destination_config_policy = IAMRolePolicies().sqs_send_message_role_policy(  # type: ignore[no-untyped-call]
                         queue_arn, self.logical_id
                     )
                 elif destination_type == "SNS":
-                    sns_topic_arn = self.DestinationConfig.get("OnFailure").get("Destination")
-                    destination_config_policy = IAMRolePolicies().sns_publish_role_policy(
+                    sns_topic_arn = self.DestinationConfig.get("OnFailure").get("Destination")  # type: ignore[attr-defined]
+                    destination_config_policy = IAMRolePolicies().sns_publish_role_policy(  # type: ignore[no-untyped-call]
                         sns_topic_arn, self.logical_id
                     )
 
-            lambda_eventsourcemapping.DestinationConfig = self.DestinationConfig
+            lambda_eventsourcemapping.DestinationConfig = self.DestinationConfig  # type: ignore[attr-defined]
 
         if "role" in kwargs:
-            self._link_policy(kwargs["role"], destination_config_policy)
+            self._link_policy(kwargs["role"], destination_config_policy)  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _link_policy(self, role, destination_config_policy=None):
+    def _link_policy(self, role, destination_config_policy=None):  # type: ignore[no-untyped-def]
         """If this source triggers a Lambda function whose execution role is auto-generated by SAM, add the
         appropriate managed policy to this Role.
 
         :param model.iam.IAMRole role: the execution role generated for the function
         """
-        policy_arn = self.get_policy_arn()
-        policy_statements = self.get_policy_statements()
+        policy_arn = self.get_policy_arn()  # type: ignore[no-untyped-call]
+        policy_statements = self.get_policy_statements()  # type: ignore[no-untyped-call]
         if role is not None:
             if policy_arn is not None and policy_arn not in role.ManagedPolicyArns:
                 role.ManagedPolicyArns.append(policy_arn)
@@ -189,23 +189,23 @@ class PullEventSource(ResourceMacro):
                 if not destination_config_policy.get("PolicyDocument") in [d["PolicyDocument"] for d in role.Policies]:
                     role.Policies.append(destination_config_policy)
 
-    def _validate_filter_criteria(self):
-        if not self.FilterCriteria or is_intrinsic(self.FilterCriteria):
+    def _validate_filter_criteria(self):  # type: ignore[no-untyped-def]
+        if not self.FilterCriteria or is_intrinsic(self.FilterCriteria):  # type: ignore[attr-defined, no-untyped-call]
             return
         if self.resource_type not in self.RESOURCE_TYPES_WITH_EVENT_FILTERING:
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "FilterCriteria is only available for {} events.".format(
                     ", ".join(self.RESOURCE_TYPES_WITH_EVENT_FILTERING)
                 ),
             )
         # FilterCriteria is either empty or only has "Filters"
-        if list(self.FilterCriteria.keys()) not in [[], ["Filters"]]:
-            raise InvalidEventException(self.relative_id, "FilterCriteria field has a wrong format")
+        if list(self.FilterCriteria.keys()) not in [[], ["Filters"]]:  # type: ignore[attr-defined]
+            raise InvalidEventException(self.relative_id, "FilterCriteria field has a wrong format")  # type: ignore[no-untyped-call]
 
-    def validate_secrets_manager_kms_key_id(self):
-        if self.SecretsManagerKmsKeyId and not isinstance(self.SecretsManagerKmsKeyId, str):
-            raise InvalidEventException(
+    def validate_secrets_manager_kms_key_id(self):  # type: ignore[no-untyped-def]
+        if self.SecretsManagerKmsKeyId and not isinstance(self.SecretsManagerKmsKeyId, str):  # type: ignore[attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "Provided SecretsManagerKmsKeyId should be of type str.",
             )
@@ -216,10 +216,10 @@ class Kinesis(PullEventSource):
 
     resource_type = "Kinesis"
 
-    def get_policy_arn(self):
-        return ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaKinesisExecutionRole")
+    def get_policy_arn(self):  # type: ignore[no-untyped-def]
+        return ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaKinesisExecutionRole")  # type: ignore[no-untyped-call]
 
-    def get_policy_statements(self):
+    def get_policy_statements(self):  # type: ignore[no-untyped-def]
         return None
 
 
@@ -228,10 +228,10 @@ class DynamoDB(PullEventSource):
 
     resource_type = "DynamoDB"
 
-    def get_policy_arn(self):
-        return ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaDynamoDBExecutionRole")
+    def get_policy_arn(self):  # type: ignore[no-untyped-def]
+        return ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaDynamoDBExecutionRole")  # type: ignore[no-untyped-call]
 
-    def get_policy_statements(self):
+    def get_policy_statements(self):  # type: ignore[no-untyped-def]
         return None
 
 
@@ -240,10 +240,10 @@ class SQS(PullEventSource):
 
     resource_type = "SQS"
 
-    def get_policy_arn(self):
-        return ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaSQSQueueExecutionRole")
+    def get_policy_arn(self):  # type: ignore[no-untyped-def]
+        return ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaSQSQueueExecutionRole")  # type: ignore[no-untyped-call]
 
-    def get_policy_statements(self):
+    def get_policy_statements(self):  # type: ignore[no-untyped-def]
         return None
 
 
@@ -252,10 +252,10 @@ class MSK(PullEventSource):
 
     resource_type = "MSK"
 
-    def get_policy_arn(self):
-        return ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaMSKExecutionRole")
+    def get_policy_arn(self):  # type: ignore[no-untyped-def]
+        return ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaMSKExecutionRole")  # type: ignore[no-untyped-call]
 
-    def get_policy_statements(self):
+    def get_policy_statements(self):  # type: ignore[no-untyped-def]
         return None
 
 
@@ -264,25 +264,25 @@ class MQ(PullEventSource):
 
     resource_type = "MQ"
 
-    def get_policy_arn(self):
+    def get_policy_arn(self):  # type: ignore[no-untyped-def]
         return None
 
-    def get_policy_statements(self):
-        if not self.SourceAccessConfigurations:
-            raise InvalidEventException(
+    def get_policy_statements(self):  # type: ignore[no-untyped-def]
+        if not self.SourceAccessConfigurations:  # type: ignore[attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "No SourceAccessConfigurations for Amazon MQ event provided.",
             )
-        if not type(self.SourceAccessConfigurations) is list:
-            raise InvalidEventException(
+        if not type(self.SourceAccessConfigurations) is list:  # type: ignore[attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "Provided SourceAccessConfigurations cannot be parsed into a list.",
             )
         basic_auth_uri = None
-        for conf in self.SourceAccessConfigurations:
+        for conf in self.SourceAccessConfigurations:  # type: ignore[attr-defined]
             event_type = conf.get("Type")
             if event_type not in ("BASIC_AUTH", "VIRTUAL_HOST"):
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Invalid property specified in SourceAccessConfigurations for Amazon MQ event.",
                 )
@@ -294,13 +294,13 @@ class MQ(PullEventSource):
                     )
                 basic_auth_uri = conf.get("URI")
                 if not basic_auth_uri:
-                    raise InvalidEventException(
+                    raise InvalidEventException(  # type: ignore[no-untyped-call]
                         self.relative_id,
                         "No BASIC_AUTH URI property specified in SourceAccessConfigurations for Amazon MQ event.",
                     )
 
         if not basic_auth_uri:
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "No BASIC_AUTH property specified in SourceAccessConfigurations for Amazon MQ event.",
             )
@@ -320,22 +320,22 @@ class MQ(PullEventSource):
                             "mq:DescribeBroker",
                         ],
                         "Effect": "Allow",
-                        "Resource": self.Broker,
+                        "Resource": self.Broker,  # type: ignore[attr-defined]
                     },
                 ]
             },
         }
-        if self.SecretsManagerKmsKeyId:
-            self.validate_secrets_manager_kms_key_id()
+        if self.SecretsManagerKmsKeyId:  # type: ignore[attr-defined]
+            self.validate_secrets_manager_kms_key_id()  # type: ignore[no-untyped-call]
             kms_policy = {
                 "Action": "kms:Decrypt",
                 "Effect": "Allow",
                 "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/"
-                    + self.SecretsManagerKmsKeyId
+                    + self.SecretsManagerKmsKeyId  # type: ignore[attr-defined]
                 },
             }
-            document["PolicyDocument"]["Statement"].append(kms_policy)
+            document["PolicyDocument"]["Statement"].append(kms_policy)  # type: ignore[index]
         return [document]
 
 
@@ -348,50 +348,50 @@ class SelfManagedKafka(PullEventSource):
     requires_stream_queue_broker = False
     AUTH_MECHANISM = ["SASL_SCRAM_256_AUTH", "SASL_SCRAM_512_AUTH", "BASIC_AUTH"]
 
-    def get_policy_arn(self):
+    def get_policy_arn(self):  # type: ignore[no-untyped-def]
         return None
 
-    def get_policy_statements(self):
-        if not self.KafkaBootstrapServers:
-            raise InvalidEventException(
+    def get_policy_statements(self):  # type: ignore[no-untyped-def]
+        if not self.KafkaBootstrapServers:  # type: ignore[attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "No KafkaBootstrapServers provided for self managed kafka as an event source",
             )
 
-        if not self.Topics:
-            raise InvalidEventException(
+        if not self.Topics:  # type: ignore[attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "No Topics provided for self managed kafka as an event source",
             )
 
-        if len(self.Topics) != 1:
-            raise InvalidEventException(
+        if len(self.Topics) != 1:  # type: ignore[attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "Topics for self managed kafka only supports single configuration entry.",
             )
 
-        if not self.SourceAccessConfigurations:
-            raise InvalidEventException(
+        if not self.SourceAccessConfigurations:  # type: ignore[attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "No SourceAccessConfigurations for self managed kafka event provided.",
             )
-        document = self.generate_policy_document()
+        document = self.generate_policy_document()  # type: ignore[no-untyped-call]
         return [document]
 
-    def generate_policy_document(self):
+    def generate_policy_document(self):  # type: ignore[no-untyped-def]
         statements = []
-        authentication_uri, has_vpc_config = self.get_secret_key()
+        authentication_uri, has_vpc_config = self.get_secret_key()  # type: ignore[no-untyped-call]
         if authentication_uri:
-            secret_manager = self.get_secret_manager_secret(authentication_uri)
+            secret_manager = self.get_secret_manager_secret(authentication_uri)  # type: ignore[no-untyped-call]
             statements.append(secret_manager)
 
         if has_vpc_config:
-            vpc_permissions = self.get_vpc_permission()
+            vpc_permissions = self.get_vpc_permission()  # type: ignore[no-untyped-call]
             statements.append(vpc_permissions)
 
-        if self.SecretsManagerKmsKeyId:
-            self.validate_secrets_manager_kms_key_id()
-            kms_policy = self.get_kms_policy()
+        if self.SecretsManagerKmsKeyId:  # type: ignore[attr-defined]
+            self.validate_secrets_manager_kms_key_id()  # type: ignore[no-untyped-call]
+            kms_policy = self.get_kms_policy()  # type: ignore[no-untyped-call]
             statements.append(kms_policy)
 
         document = {
@@ -404,17 +404,17 @@ class SelfManagedKafka(PullEventSource):
 
         return document
 
-    def get_secret_key(self):
+    def get_secret_key(self):  # type: ignore[no-untyped-def]
         authentication_uri = None
         has_vpc_subnet = False
         has_vpc_security_group = False
-        for config in self.SourceAccessConfigurations:
+        for config in self.SourceAccessConfigurations:  # type: ignore[attr-defined]
             if config.get("Type") == "VPC_SUBNET":
-                self.validate_uri(config, "VPC_SUBNET")
+                self.validate_uri(config, "VPC_SUBNET")  # type: ignore[no-untyped-call]
                 has_vpc_subnet = True
 
             elif config.get("Type") == "VPC_SECURITY_GROUP":
-                self.validate_uri(config, "VPC_SECURITY_GROUP")
+                self.validate_uri(config, "VPC_SECURITY_GROUP")  # type: ignore[no-untyped-call]
                 has_vpc_security_group = True
 
             elif config.get("Type") in self.AUTH_MECHANISM:
@@ -423,45 +423,45 @@ class SelfManagedKafka(PullEventSource):
                         self.relative_id,
                         "Multiple auth mechanism properties specified in SourceAccessConfigurations for self managed kafka event.",
                     )
-                self.validate_uri(config, "auth mechanism")
+                self.validate_uri(config, "auth mechanism")  # type: ignore[no-untyped-call]
                 authentication_uri = config.get("URI")
 
             else:
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Invalid SourceAccessConfigurations Type provided for self managed kafka event.",
                 )
 
         if (not has_vpc_subnet and has_vpc_security_group) or (has_vpc_subnet and not has_vpc_security_group):
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "VPC_SUBNET and VPC_SECURITY_GROUP in SourceAccessConfigurations for SelfManagedKafka must be both provided.",
             )
         return authentication_uri, (has_vpc_subnet and has_vpc_security_group)
 
-    def validate_uri(self, config, msg):
+    def validate_uri(self, config, msg):  # type: ignore[no-untyped-def]
         if not config.get("URI"):
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "No {} URI property specified in SourceAccessConfigurations for self managed kafka event.".format(msg),
             )
 
-        if not isinstance(config.get("URI"), str) and not is_intrinsic(config.get("URI")):
-            raise InvalidEventException(
+        if not isinstance(config.get("URI"), str) and not is_intrinsic(config.get("URI")):  # type: ignore[no-untyped-call]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "Wrong Type for {} URI property specified in SourceAccessConfigurations for self managed kafka event.".format(
                     msg
                 ),
             )
 
-    def get_secret_manager_secret(self, authentication_uri):
+    def get_secret_manager_secret(self, authentication_uri):  # type: ignore[no-untyped-def]
         return {
             "Action": ["secretsmanager:GetSecretValue"],
             "Effect": "Allow",
             "Resource": authentication_uri,
         }
 
-    def get_vpc_permission(self):
+    def get_vpc_permission(self):  # type: ignore[no-untyped-def]
         return {
             "Action": [
                 "ec2:CreateNetworkInterface",
@@ -475,12 +475,12 @@ class SelfManagedKafka(PullEventSource):
             "Resource": "*",
         }
 
-    def get_kms_policy(self):
+    def get_kms_policy(self):  # type: ignore[no-untyped-def]
         return {
             "Action": ["kms:Decrypt"],
             "Effect": "Allow",
             "Resource": {
                 "Fn::Sub": "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/"
-                + self.SecretsManagerKmsKeyId
+                + self.SecretsManagerKmsKeyId  # type: ignore[attr-defined]
             },
         }

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -55,7 +55,7 @@ class PushEventSource(ResourceMacro):
     # TODO: Make `PushEventSource` an abstract class and not giving `principal` initial value.
     principal: str = None  # type: ignore
 
-    def _construct_permission(
+    def _construct_permission(  # type: ignore[no-untyped-def]
         self, function, source_arn=None, source_account=None, suffix="", event_source_token=None, prefix=None
     ):
         """Constructs the Lambda Permission resource allowing the source service to invoke the function this event
@@ -69,9 +69,9 @@ class PushEventSource(ResourceMacro):
         if suffix.isalnum():
             permission_logical_id = prefix + "Permission" + suffix
         else:
-            generator = logical_id_generator.LogicalIdGenerator(prefix + "Permission", suffix)
-            permission_logical_id = generator.gen()
-        lambda_permission = LambdaPermission(
+            generator = logical_id_generator.LogicalIdGenerator(prefix + "Permission", suffix)  # type: ignore[no-untyped-call]
+            permission_logical_id = generator.gen()  # type: ignore[no-untyped-call]
+        lambda_permission = LambdaPermission(  # type: ignore[no-untyped-call]
             permission_logical_id, attributes=function.get_passthrough_resource_attributes()
         )
         try:
@@ -96,18 +96,18 @@ class Schedule(PushEventSource):
     resource_type = "Schedule"
     principal = "events.amazonaws.com"
     property_types = {
-        "Schedule": PropertyType(True, is_str()),
-        "Input": PropertyType(False, is_str()),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "State": PropertyType(False, is_str()),
-        "Name": PropertyType(False, is_str()),
-        "Description": PropertyType(False, is_str()),
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),
-        "RetryPolicy": PropertyType(False, is_type(dict)),
+        "Schedule": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Input": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RetryPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the EventBridge Rule and Lambda Permission to which this Schedule event source corresponds.
 
         :param dict kwargs: no existing resources need to be modified
@@ -122,53 +122,53 @@ class Schedule(PushEventSource):
         resources = []
 
         passthrough_resource_attributes = function.get_passthrough_resource_attributes()
-        events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)
+        events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)  # type: ignore[no-untyped-call]
         resources.append(events_rule)
 
-        events_rule.ScheduleExpression = self.Schedule
+        events_rule.ScheduleExpression = self.Schedule  # type: ignore[attr-defined]
 
-        if self.State and self.Enabled is not None:
-            raise InvalidEventException(self.relative_id, "State and Enabled Properties cannot both be specified.")
+        if self.State and self.Enabled is not None:  # type: ignore[attr-defined, attr-defined]
+            raise InvalidEventException(self.relative_id, "State and Enabled Properties cannot both be specified.")  # type: ignore[no-untyped-call]
 
-        if self.State:
-            events_rule.State = self.State
+        if self.State:  # type: ignore[attr-defined]
+            events_rule.State = self.State  # type: ignore[attr-defined]
 
-        if self.Enabled is not None:
-            events_rule.State = "ENABLED" if self.Enabled else "DISABLED"
+        if self.Enabled is not None:  # type: ignore[attr-defined]
+            events_rule.State = "ENABLED" if self.Enabled else "DISABLED"  # type: ignore[attr-defined]
 
-        events_rule.Name = self.Name
-        events_rule.Description = self.Description
+        events_rule.Name = self.Name  # type: ignore[attr-defined]
+        events_rule.Description = self.Description  # type: ignore[attr-defined]
 
-        source_arn = events_rule.get_runtime_attr("arn")
+        source_arn = events_rule.get_runtime_attr("arn")  # type: ignore[no-untyped-call]
         dlq_queue_arn = None
-        if self.DeadLetterConfig is not None:
-            EventBridgeRuleUtils.validate_dlq_config(self.logical_id, self.DeadLetterConfig)
-            dlq_queue_arn, dlq_resources = EventBridgeRuleUtils.get_dlq_queue_arn_and_resources(
+        if self.DeadLetterConfig is not None:  # type: ignore[attr-defined]
+            EventBridgeRuleUtils.validate_dlq_config(self.logical_id, self.DeadLetterConfig)  # type: ignore[attr-defined, no-untyped-call]
+            dlq_queue_arn, dlq_resources = EventBridgeRuleUtils.get_dlq_queue_arn_and_resources(  # type: ignore[no-untyped-call]
                 self, source_arn, passthrough_resource_attributes
             )
             resources.extend(dlq_resources)
 
-        events_rule.Targets = [self._construct_target(function, dlq_queue_arn)]
+        events_rule.Targets = [self._construct_target(function, dlq_queue_arn)]  # type: ignore[no-untyped-call]
 
-        resources.append(self._construct_permission(function, source_arn=source_arn))
+        resources.append(self._construct_permission(function, source_arn=source_arn))  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _construct_target(self, function, dead_letter_queue_arn=None):
+    def _construct_target(self, function, dead_letter_queue_arn=None):  # type: ignore[no-untyped-def]
         """Constructs the Target property for the EventBridge Rule.
 
         :returns: the Target property
         :rtype: dict
         """
         target = {"Arn": function.get_runtime_attr("arn"), "Id": self.logical_id + "LambdaTarget"}
-        if self.Input is not None:
-            target["Input"] = self.Input
+        if self.Input is not None:  # type: ignore[attr-defined]
+            target["Input"] = self.Input  # type: ignore[attr-defined]
 
-        if self.DeadLetterConfig is not None:
+        if self.DeadLetterConfig is not None:  # type: ignore[attr-defined]
             target["DeadLetterConfig"] = {"Arn": dead_letter_queue_arn}
 
-        if self.RetryPolicy is not None:
-            target["RetryPolicy"] = self.RetryPolicy
+        if self.RetryPolicy is not None:  # type: ignore[attr-defined]
+            target["RetryPolicy"] = self.RetryPolicy  # type: ignore[attr-defined]
 
         return target
 
@@ -179,19 +179,19 @@ class CloudWatchEvent(PushEventSource):
     resource_type = "CloudWatchEvent"
     principal = "events.amazonaws.com"
     property_types = {
-        "EventBusName": PropertyType(False, is_str()),
-        "Pattern": PropertyType(False, is_type(dict)),
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),
-        "RetryPolicy": PropertyType(False, is_type(dict)),
-        "Input": PropertyType(False, is_str()),
-        "InputPath": PropertyType(False, is_str()),
-        "Target": PropertyType(False, is_type(dict)),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "State": PropertyType(False, is_str()),
+        "EventBusName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Pattern": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RetryPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Input": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "InputPath": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Target": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the CloudWatch Events/EventBridge Rule and Lambda Permission to which
         this CloudWatch Events/EventBridge event source corresponds.
 
@@ -207,54 +207,54 @@ class CloudWatchEvent(PushEventSource):
         resources = []
 
         passthrough_resource_attributes = function.get_passthrough_resource_attributes()
-        events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)
-        events_rule.EventBusName = self.EventBusName
-        events_rule.EventPattern = self.Pattern
-        source_arn = events_rule.get_runtime_attr("arn")
+        events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)  # type: ignore[no-untyped-call]
+        events_rule.EventBusName = self.EventBusName  # type: ignore[attr-defined]
+        events_rule.EventPattern = self.Pattern  # type: ignore[attr-defined]
+        source_arn = events_rule.get_runtime_attr("arn")  # type: ignore[no-untyped-call]
 
         dlq_queue_arn = None
-        if self.DeadLetterConfig is not None:
-            EventBridgeRuleUtils.validate_dlq_config(self.logical_id, self.DeadLetterConfig)
-            dlq_queue_arn, dlq_resources = EventBridgeRuleUtils.get_dlq_queue_arn_and_resources(
+        if self.DeadLetterConfig is not None:  # type: ignore[attr-defined]
+            EventBridgeRuleUtils.validate_dlq_config(self.logical_id, self.DeadLetterConfig)  # type: ignore[attr-defined, no-untyped-call]
+            dlq_queue_arn, dlq_resources = EventBridgeRuleUtils.get_dlq_queue_arn_and_resources(  # type: ignore[no-untyped-call]
                 self, source_arn, passthrough_resource_attributes
             )
             resources.extend(dlq_resources)
 
-        if self.State and self.Enabled is not None:
-            raise InvalidEventException(self.relative_id, "State and Enabled Properties cannot both be specified.")
+        if self.State and self.Enabled is not None:  # type: ignore[attr-defined, attr-defined]
+            raise InvalidEventException(self.relative_id, "State and Enabled Properties cannot both be specified.")  # type: ignore[no-untyped-call]
 
-        if self.State:
-            events_rule.State = self.State
+        if self.State:  # type: ignore[attr-defined]
+            events_rule.State = self.State  # type: ignore[attr-defined]
 
-        if self.Enabled is not None:
-            events_rule.State = "ENABLED" if self.Enabled else "DISABLED"
+        if self.Enabled is not None:  # type: ignore[attr-defined]
+            events_rule.State = "ENABLED" if self.Enabled else "DISABLED"  # type: ignore[attr-defined]
 
-        events_rule.Targets = [self._construct_target(function, dlq_queue_arn)]
+        events_rule.Targets = [self._construct_target(function, dlq_queue_arn)]  # type: ignore[no-untyped-call]
 
         resources.append(events_rule)
-        resources.append(self._construct_permission(function, source_arn=source_arn))
+        resources.append(self._construct_permission(function, source_arn=source_arn))  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _construct_target(self, function, dead_letter_queue_arn=None):
+    def _construct_target(self, function, dead_letter_queue_arn=None):  # type: ignore[no-untyped-def]
         """Constructs the Target property for the CloudWatch Events/EventBridge Rule.
 
         :returns: the Target property
         :rtype: dict
         """
-        target_id = self.Target["Id"] if self.Target and "Id" in self.Target else self.logical_id + "LambdaTarget"
+        target_id = self.Target["Id"] if self.Target and "Id" in self.Target else self.logical_id + "LambdaTarget"  # type: ignore[attr-defined]
         target = {"Arn": function.get_runtime_attr("arn"), "Id": target_id}
-        if self.Input is not None:
-            target["Input"] = self.Input
+        if self.Input is not None:  # type: ignore[attr-defined]
+            target["Input"] = self.Input  # type: ignore[attr-defined]
 
-        if self.InputPath is not None:
-            target["InputPath"] = self.InputPath
+        if self.InputPath is not None:  # type: ignore[attr-defined]
+            target["InputPath"] = self.InputPath  # type: ignore[attr-defined]
 
-        if self.DeadLetterConfig is not None:
+        if self.DeadLetterConfig is not None:  # type: ignore[attr-defined]
             target["DeadLetterConfig"] = {"Arn": dead_letter_queue_arn}
 
-        if self.RetryPolicy is not None:
-            target["RetryPolicy"] = self.RetryPolicy
+        if self.RetryPolicy is not None:  # type: ignore[attr-defined]
+            target["RetryPolicy"] = self.RetryPolicy  # type: ignore[attr-defined]
 
         return target
 
@@ -271,22 +271,22 @@ class S3(PushEventSource):
     resource_type = "S3"
     principal = "s3.amazonaws.com"
     property_types = {
-        "Bucket": PropertyType(True, is_str()),
-        "Events": PropertyType(True, one_of(is_str(), list_of(is_str())), False),
-        "Filter": PropertyType(False, dict_of(is_str(), is_str())),
+        "Bucket": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Events": PropertyType(True, one_of(is_str(), list_of(is_str())), False),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Filter": PropertyType(False, dict_of(is_str(), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
     }
 
-    def resources_to_link(self, resources):
-        if isinstance(self.Bucket, dict) and "Ref" in self.Bucket:
-            bucket_id = self.Bucket["Ref"]
+    def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
+        if isinstance(self.Bucket, dict) and "Ref" in self.Bucket:  # type: ignore[attr-defined]
+            bucket_id = self.Bucket["Ref"]  # type: ignore[attr-defined]
             if not isinstance(bucket_id, str):
-                raise InvalidEventException(self.relative_id, "'Ref' value in S3 events is not a valid string.")
+                raise InvalidEventException(self.relative_id, "'Ref' value in S3 events is not a valid string.")  # type: ignore[no-untyped-call]
             if bucket_id in resources:
                 return {"bucket": resources[bucket_id], "bucket_id": bucket_id}
-        raise InvalidEventException(self.relative_id, "S3 events must reference an S3 bucket in the same template.")
+        raise InvalidEventException(self.relative_id, "S3 events must reference an S3 bucket in the same template.")  # type: ignore[no-untyped-call]
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the Lambda Permission resource allowing S3 to invoke the function this event source triggers.
 
         :param dict kwargs: S3 bucket resource
@@ -309,12 +309,12 @@ class S3(PushEventSource):
 
         resources = []
 
-        source_account = ref("AWS::AccountId")
-        permission = self._construct_permission(function, source_account=source_account)
+        source_account = ref("AWS::AccountId")  # type: ignore[no-untyped-call]
+        permission = self._construct_permission(function, source_account=source_account)  # type: ignore[no-untyped-call]
         if CONDITION in permission.resource_attributes:
-            self._depend_on_lambda_permissions_using_tag(bucket, permission)
+            self._depend_on_lambda_permissions_using_tag(bucket, permission)  # type: ignore[no-untyped-call]
         else:
-            self._depend_on_lambda_permissions(bucket, permission)
+            self._depend_on_lambda_permissions(bucket, permission)  # type: ignore[no-untyped-call]
         resources.append(permission)
 
         # NOTE: `bucket` here is a dictionary representing the S3 Bucket resource in your SAM template. If there are
@@ -327,12 +327,12 @@ class S3(PushEventSource):
         #   merging is literally "last one wins", which works fine because we linearly loop through the template once.
         #   The de-dupe happens inside `samtranslator.translator.Translator.translate` method when merging results of
         #   to_cloudformation() to output template.
-        self._inject_notification_configuration(function, bucket, bucket_id)
-        resources.append(S3Bucket.from_dict(bucket_id, bucket))
+        self._inject_notification_configuration(function, bucket, bucket_id)  # type: ignore[no-untyped-call]
+        resources.append(S3Bucket.from_dict(bucket_id, bucket))  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _depend_on_lambda_permissions(self, bucket, permission):
+    def _depend_on_lambda_permissions(self, bucket, permission):  # type: ignore[no-untyped-def]
         """
         Make the S3 bucket depends on Lambda Permissions resource because when S3 adds a Notification Configuration,
         it will check whether it has permissions to access Lambda. This will fail if the Lambda::Permissions is not
@@ -354,7 +354,7 @@ class S3(PushEventSource):
         try:
             depends_on_set = set(depends_on)
         except TypeError:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Invalid type for field 'DependsOn'. Expected a string or list of strings.",
             )
@@ -364,7 +364,7 @@ class S3(PushEventSource):
 
         return bucket
 
-    def _depend_on_lambda_permissions_using_tag(self, bucket, permission):
+    def _depend_on_lambda_permissions_using_tag(self, bucket, permission):  # type: ignore[no-untyped-def]
         """
         Since conditional DependsOn is not supported this undocumented way of
         implicitely  making dependency through tags is used.
@@ -386,21 +386,21 @@ class S3(PushEventSource):
         dep_tag = {
             "sam:ConditionalDependsOn:"
             + permission.logical_id: {
-                "Fn::If": [permission.resource_attributes[CONDITION], ref(permission.logical_id), "no dependency"]
+                "Fn::If": [permission.resource_attributes[CONDITION], ref(permission.logical_id), "no dependency"]  # type: ignore[no-untyped-call]
             }
         }
-        properties["Tags"] = tags + get_tag_list(dep_tag)
+        properties["Tags"] = tags + get_tag_list(dep_tag)  # type: ignore[no-untyped-call]
         return bucket
 
-    def _inject_notification_configuration(self, function, bucket, bucket_id):
+    def _inject_notification_configuration(self, function, bucket, bucket_id):  # type: ignore[no-untyped-def]
         base_event_mapping = {"Function": function.get_runtime_attr("arn")}
 
-        if self.Filter is not None:
-            base_event_mapping["Filter"] = self.Filter
+        if self.Filter is not None:  # type: ignore[attr-defined]
+            base_event_mapping["Filter"] = self.Filter  # type: ignore[attr-defined]
 
-        event_types = self.Events
-        if isinstance(self.Events, str):
-            event_types = [self.Events]
+        event_types = self.Events  # type: ignore[attr-defined]
+        if isinstance(self.Events, str):  # type: ignore[attr-defined]
+            event_types = [self.Events]  # type: ignore[attr-defined]
 
         event_mappings = []
         for event_type in event_types:
@@ -408,7 +408,7 @@ class S3(PushEventSource):
             lambda_event = copy.deepcopy(base_event_mapping)
             lambda_event["Event"] = event_type
             if CONDITION in function.resource_attributes:
-                lambda_event = make_conditional(function.resource_attributes[CONDITION], lambda_event)
+                lambda_event = make_conditional(function.resource_attributes[CONDITION], lambda_event)  # type: ignore[no-untyped-call]
             event_mappings.append(lambda_event)
 
         properties = bucket.get("Properties", None)
@@ -422,7 +422,7 @@ class S3(PushEventSource):
             properties["NotificationConfiguration"] = notification_config
 
         if not isinstance(notification_config, dict):
-            raise InvalidResourceException(bucket_id, "Invalid type for NotificationConfiguration.")
+            raise InvalidResourceException(bucket_id, "Invalid type for NotificationConfiguration.")  # type: ignore[no-untyped-call]
 
         lambda_notifications = notification_config.get("LambdaConfigurations", None)
         if lambda_notifications is None:
@@ -430,7 +430,7 @@ class S3(PushEventSource):
             notification_config["LambdaConfigurations"] = lambda_notifications
 
         if not isinstance(lambda_notifications, list):
-            raise InvalidResourceException(bucket_id, "Invalid type for LambdaConfigurations. Must be a list.")
+            raise InvalidResourceException(bucket_id, "Invalid type for LambdaConfigurations. Must be a list.")  # type: ignore[no-untyped-call]
 
         for event_mapping in event_mappings:
             if event_mapping not in lambda_notifications:
@@ -444,14 +444,14 @@ class SNS(PushEventSource):
     resource_type = "SNS"
     principal = "sns.amazonaws.com"
     property_types = {
-        "Topic": PropertyType(True, is_str()),
-        "Region": PropertyType(False, is_str()),
-        "FilterPolicy": PropertyType(False, dict_of(is_str(), list_of(one_of(is_str(), is_type(dict))))),
-        "SqsSubscription": PropertyType(False, one_of(is_type(bool), is_type(dict))),
+        "Topic": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Region": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FilterPolicy": PropertyType(False, dict_of(is_str(), list_of(one_of(is_str(), is_type(dict))))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "SqsSubscription": PropertyType(False, one_of(is_type(bool), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
     }
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the Lambda Permission resource allowing SNS to invoke the function this event source triggers.
 
         :param dict kwargs: no existing resources need to be modified
@@ -465,29 +465,29 @@ class SNS(PushEventSource):
             raise TypeError("Missing required keyword argument: function")
 
         # SNS -> Lambda
-        if not self.SqsSubscription:
-            subscription = self._inject_subscription(
+        if not self.SqsSubscription:  # type: ignore[attr-defined]
+            subscription = self._inject_subscription(  # type: ignore[no-untyped-call]
                 "lambda",
                 function.get_runtime_attr("arn"),
-                self.Topic,
-                self.Region,
-                self.FilterPolicy,
+                self.Topic,  # type: ignore[attr-defined]
+                self.Region,  # type: ignore[attr-defined]
+                self.FilterPolicy,  # type: ignore[attr-defined]
                 function,
             )
-            return [self._construct_permission(function, source_arn=self.Topic), subscription]
+            return [self._construct_permission(function, source_arn=self.Topic), subscription]  # type: ignore[attr-defined, no-untyped-call]
 
         # SNS -> SQS(Create New) -> Lambda
-        if isinstance(self.SqsSubscription, bool):
-            resources = []
-            queue = self._inject_sqs_queue(function)
+        if isinstance(self.SqsSubscription, bool):  # type: ignore[attr-defined]
+            resources = []  # type: ignore[var-annotated]
+            queue = self._inject_sqs_queue(function)  # type: ignore[no-untyped-call]
             queue_arn = queue.get_runtime_attr("arn")
             queue_url = queue.get_runtime_attr("queue_url")
 
-            queue_policy = self._inject_sqs_queue_policy(self.Topic, queue_arn, queue_url, function)
-            subscription = self._inject_subscription(
-                "sqs", queue_arn, self.Topic, self.Region, self.FilterPolicy, function
+            queue_policy = self._inject_sqs_queue_policy(self.Topic, queue_arn, queue_url, function)  # type: ignore[attr-defined, no-untyped-call]
+            subscription = self._inject_subscription(  # type: ignore[no-untyped-call]
+                "sqs", queue_arn, self.Topic, self.Region, self.FilterPolicy, function  # type: ignore[attr-defined, attr-defined, attr-defined]
             )
-            event_source = self._inject_sqs_event_source_mapping(function, role, queue_arn)
+            event_source = self._inject_sqs_event_source_mapping(function, role, queue_arn)  # type: ignore[no-untyped-call]
 
             resources = resources + event_source
             resources.append(queue)
@@ -497,28 +497,28 @@ class SNS(PushEventSource):
 
         # SNS -> SQS(Existing) -> Lambda
         resources = []
-        queue_arn = self.SqsSubscription.get("QueueArn", None)
-        queue_url = self.SqsSubscription.get("QueueUrl", None)
+        queue_arn = self.SqsSubscription.get("QueueArn", None)  # type: ignore[attr-defined]
+        queue_url = self.SqsSubscription.get("QueueUrl", None)  # type: ignore[attr-defined]
         if not queue_arn or not queue_url:
-            raise InvalidEventException(self.relative_id, "No QueueARN or QueueURL provided.")
+            raise InvalidEventException(self.relative_id, "No QueueARN or QueueURL provided.")  # type: ignore[no-untyped-call]
 
-        queue_policy_logical_id = self.SqsSubscription.get("QueuePolicyLogicalId", None)
-        batch_size = self.SqsSubscription.get("BatchSize", None)
-        enabled = self.SqsSubscription.get("Enabled", None)
+        queue_policy_logical_id = self.SqsSubscription.get("QueuePolicyLogicalId", None)  # type: ignore[attr-defined]
+        batch_size = self.SqsSubscription.get("BatchSize", None)  # type: ignore[attr-defined]
+        enabled = self.SqsSubscription.get("Enabled", None)  # type: ignore[attr-defined]
 
-        queue_policy = self._inject_sqs_queue_policy(
-            self.Topic, queue_arn, queue_url, function, queue_policy_logical_id
+        queue_policy = self._inject_sqs_queue_policy(  # type: ignore[no-untyped-call]
+            self.Topic, queue_arn, queue_url, function, queue_policy_logical_id  # type: ignore[attr-defined]
         )
-        subscription = self._inject_subscription("sqs", queue_arn, self.Topic, self.Region, self.FilterPolicy, function)
-        event_source = self._inject_sqs_event_source_mapping(function, role, queue_arn, batch_size, enabled)
+        subscription = self._inject_subscription("sqs", queue_arn, self.Topic, self.Region, self.FilterPolicy, function)  # type: ignore[attr-defined, attr-defined, attr-defined, no-untyped-call]
+        event_source = self._inject_sqs_event_source_mapping(function, role, queue_arn, batch_size, enabled)  # type: ignore[no-untyped-call]
 
         resources = resources + event_source
         resources.append(queue_policy)
         resources.append(subscription)
         return resources
 
-    def _inject_subscription(self, protocol, endpoint, topic, region, filterPolicy, function):
-        subscription = SNSSubscription(self.logical_id, attributes=function.get_passthrough_resource_attributes())
+    def _inject_subscription(self, protocol, endpoint, topic, region, filterPolicy, function):  # type: ignore[no-untyped-def]
+        subscription = SNSSubscription(self.logical_id, attributes=function.get_passthrough_resource_attributes())  # type: ignore[no-untyped-call]
         subscription.Protocol = protocol
         subscription.Endpoint = endpoint
         subscription.TopicArn = topic
@@ -531,11 +531,11 @@ class SNS(PushEventSource):
 
         return subscription
 
-    def _inject_sqs_queue(self, function):
-        return SQSQueue(self.logical_id + "Queue", attributes=function.get_passthrough_resource_attributes())
+    def _inject_sqs_queue(self, function):  # type: ignore[no-untyped-def]
+        return SQSQueue(self.logical_id + "Queue", attributes=function.get_passthrough_resource_attributes())  # type: ignore[no-untyped-call]
 
-    def _inject_sqs_event_source_mapping(self, function, role, queue_arn, batch_size=None, enabled=None):
-        event_source = SQS(
+    def _inject_sqs_event_source_mapping(self, function, role, queue_arn, batch_size=None, enabled=None):  # type: ignore[no-untyped-def]
+        event_source = SQS(  # type: ignore[no-untyped-call]
             self.logical_id + "EventSourceMapping", attributes=function.get_passthrough_resource_attributes()
         )
         event_source.Queue = queue_arn
@@ -543,12 +543,12 @@ class SNS(PushEventSource):
         event_source.Enabled = enabled or True
         return event_source.to_cloudformation(function=function, role=role)
 
-    def _inject_sqs_queue_policy(self, topic_arn, queue_arn, queue_url, function, logical_id=None):
-        policy = SQSQueuePolicy(
+    def _inject_sqs_queue_policy(self, topic_arn, queue_arn, queue_url, function, logical_id=None):  # type: ignore[no-untyped-def]
+        policy = SQSQueuePolicy(  # type: ignore[no-untyped-call]
             logical_id or self.logical_id + "QueuePolicy", attributes=function.get_passthrough_resource_attributes()
         )
 
-        policy.PolicyDocument = SQSQueuePolicies.sns_topic_send_message_role_policy(topic_arn, queue_arn)
+        policy.PolicyDocument = SQSQueuePolicies.sns_topic_send_message_role_policy(topic_arn, queue_arn)  # type: ignore[no-untyped-call]
         policy.Queues = [queue_url]
         return policy
 
@@ -559,17 +559,17 @@ class Api(PushEventSource):
     resource_type = "Api"
     principal = "apigateway.amazonaws.com"
     property_types = {
-        "Path": PropertyType(True, is_str()),
-        "Method": PropertyType(True, is_str()),
+        "Path": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Method": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
         # Api Event sources must "always" be paired with a Serverless::Api
-        "RestApiId": PropertyType(True, is_str()),
-        "Stage": PropertyType(False, is_str()),
-        "Auth": PropertyType(False, is_type(dict)),
-        "RequestModel": PropertyType(False, is_type(dict)),
-        "RequestParameters": PropertyType(False, is_type(list)),
+        "RestApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Stage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RequestModel": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RequestParameters": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    def resources_to_link(self, resources):
+    def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
         """
         If this API Event Source refers to an explicit API resource, resolve the reference and grab
         necessary data from the explicit API
@@ -584,7 +584,7 @@ class Api(PushEventSource):
         permitted_stage = "*"
         stage_suffix = "AllStages"
         explicit_api = None
-        rest_api_id = self.get_rest_api_id_string(self.RestApiId)
+        rest_api_id = self.get_rest_api_id_string(self.RestApiId)  # type: ignore[attr-defined, no-untyped-call]
         if isinstance(rest_api_id, str):
 
             if (
@@ -599,22 +599,22 @@ class Api(PushEventSource):
                 # Stage could be a intrinsic, in which case leave the suffix to default value
                 if isinstance(permitted_stage, str):
                     if not permitted_stage:
-                        raise InvalidResourceException(rest_api_id, "StageName cannot be empty.")
+                        raise InvalidResourceException(rest_api_id, "StageName cannot be empty.")  # type: ignore[no-untyped-call]
                     stage_suffix = permitted_stage
                 else:
-                    stage_suffix = "Stage"
+                    stage_suffix = "Stage"  # type: ignore[unreachable]
 
             else:
                 # RestApiId is a string, not an intrinsic, but we did not find a valid API resource for this ID
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "RestApiId property of Api event must reference a valid resource in the same template.",
                 )
 
         return {"explicit_api": explicit_api, "explicit_api_stage": {"suffix": stage_suffix}}
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """If the Api event source has a RestApi property, then simply return the Lambda Permission resource allowing
         API Gateway to call the function. If no RestApi is provided, then additionally inject the path, method, and the
         x-amazon-apigateway-integration into the Swagger body for a provided implicit API.
@@ -632,19 +632,19 @@ class Api(PushEventSource):
         if not function:
             raise TypeError("Missing required keyword argument: function")
 
-        if self.Method is not None:
+        if self.Method is not None:  # type: ignore[has-type]
             # Convert to lower case so that user can specify either GET or get
-            self.Method = self.Method.lower()
+            self.Method = self.Method.lower()  # type: ignore[has-type]
 
-        resources.extend(self._get_permissions(kwargs))
+        resources.extend(self._get_permissions(kwargs))  # type: ignore[no-untyped-call]
 
         explicit_api = kwargs["explicit_api"]
         if explicit_api.get("__MANAGE_SWAGGER"):
-            self._add_swagger_integration(explicit_api, function, intrinsics_resolver)
+            self._add_swagger_integration(explicit_api, function, intrinsics_resolver)  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _get_permissions(self, resources_to_link):
+    def _get_permissions(self, resources_to_link):  # type: ignore[no-untyped-def]
         permissions = []
 
         # By default, implicit APIs get a stage called Prod. If the API event refers to an
@@ -656,34 +656,34 @@ class Api(PushEventSource):
             suffix = resources_to_link["explicit_api_stage"]["suffix"]
         self.Stage = suffix
 
-        permissions.append(self._get_permission(resources_to_link, permitted_stage, suffix))
+        permissions.append(self._get_permission(resources_to_link, permitted_stage, suffix))  # type: ignore[no-untyped-call]
         return permissions
 
-    def _get_permission(self, resources_to_link, stage, suffix):
+    def _get_permission(self, resources_to_link, stage, suffix):  # type: ignore[no-untyped-def]
         # It turns out that APIGW doesn't like trailing slashes in paths (#665)
         # and removes as a part of their behaviour, but this isn't documented.
         # The regex removes the tailing slash to ensure the permission works as intended
-        path = re.sub(r"^(.+)/$", r"\1", self.Path)
+        path = re.sub(r"^(.+)/$", r"\1", self.Path)  # type: ignore[attr-defined]
 
         if not stage or not suffix:
             raise RuntimeError("Could not add permission to lambda function.")
 
-        path = SwaggerEditor.get_path_without_trailing_slash(path)
+        path = SwaggerEditor.get_path_without_trailing_slash(path)  # type: ignore[no-untyped-call]
         method = "*" if self.Method.lower() == "any" else self.Method.upper()
 
-        api_id = self.RestApiId
+        api_id = self.RestApiId  # type: ignore[attr-defined]
 
         # RestApiId can be a simple string or intrinsic function like !Ref. Using Fn::Sub will handle both cases
         resource = "${__ApiId__}/" + "${__Stage__}/" + method + path
-        partition = ArnGenerator.get_partition_name()
-        source_arn = fnSub(
-            ArnGenerator.generate_arn(partition=partition, service="execute-api", resource=resource),
+        partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
+        source_arn = fnSub(  # type: ignore[no-untyped-call]
+            ArnGenerator.generate_arn(partition=partition, service="execute-api", resource=resource),  # type: ignore[no-untyped-call]
             {"__ApiId__": api_id, "__Stage__": stage},
         )
 
-        return self._construct_permission(resources_to_link["function"], source_arn=source_arn, suffix=suffix)
+        return self._construct_permission(resources_to_link["function"], source_arn=source_arn, suffix=suffix)  # type: ignore[no-untyped-call]
 
-    def _add_swagger_integration(self, api, function, intrinsics_resolver):
+    def _add_swagger_integration(self, api, function, intrinsics_resolver):  # type: ignore[no-untyped-def]
         # pylint: disable=duplicate-code
         """Adds the path and method for this Api event source to the Swagger body for the provided RestApi.
 
@@ -693,17 +693,17 @@ class Api(PushEventSource):
         if swagger_body is None:
             return
 
-        partition = ArnGenerator.get_partition_name()
-        uri = _build_apigw_integration_uri(function, partition)
+        partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
+        uri = _build_apigw_integration_uri(function, partition)  # type: ignore[no-untyped-call]
 
-        editor = SwaggerEditor(swagger_body)
+        editor = SwaggerEditor(swagger_body)  # type: ignore[no-untyped-call]
 
-        if editor.has_integration(self.Path, self.Method):
+        if editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined, no-untyped-call]
             # Cannot add the Lambda Integration, if it is already present
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 'API method "{method}" defined multiple times for path "{path}".'.format(
-                    method=self.Method, path=self.Path
+                    method=self.Method, path=self.Path  # type: ignore[attr-defined]
                 ),
             )
 
@@ -711,10 +711,10 @@ class Api(PushEventSource):
         if CONDITION in function.resource_attributes:
             condition = function.resource_attributes[CONDITION]
 
-        editor.add_lambda_integration(self.Path, self.Method, uri, self.Auth, api.get("Auth"), condition=condition)
+        editor.add_lambda_integration(self.Path, self.Method, uri, self.Auth, api.get("Auth"), condition=condition)  # type: ignore[attr-defined, attr-defined, no-untyped-call]
 
-        if self.Auth:
-            method_authorizer = self.Auth.get("Authorizer")
+        if self.Auth:  # type: ignore[attr-defined]
+            method_authorizer = self.Auth.get("Authorizer")  # type: ignore[attr-defined]
             api_auth = api.get("Auth")
             api_auth = intrinsics_resolver.resolve_parameter_refs(api_auth)
 
@@ -723,109 +723,109 @@ class Api(PushEventSource):
 
                 if method_authorizer != "AWS_IAM":
                     if method_authorizer != "NONE" and not api_authorizers:
-                        raise InvalidEventException(
+                        raise InvalidEventException(  # type: ignore[no-untyped-call]
                             self.relative_id,
                             "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "
                             "because the related API does not define any Authorizers.".format(
-                                authorizer=method_authorizer, method=self.Method, path=self.Path
+                                authorizer=method_authorizer, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                             ),
                         )
 
-                    _check_valid_authorizer_types(
-                        self.relative_id, self.Method, self.Path, method_authorizer, api_authorizers, False
+                    _check_valid_authorizer_types(  # type: ignore[no-untyped-call]
+                        self.relative_id, self.Method, self.Path, method_authorizer, api_authorizers, False  # type: ignore[attr-defined]
                     )
 
                     if method_authorizer != "NONE" and not api_authorizers.get(method_authorizer):
-                        raise InvalidEventException(
+                        raise InvalidEventException(  # type: ignore[no-untyped-call]
                             self.relative_id,
                             "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "
                             "because it wasn't defined in the API's Authorizers.".format(
-                                authorizer=method_authorizer, method=self.Method, path=self.Path
+                                authorizer=method_authorizer, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                             ),
                         )
 
                     if method_authorizer == "NONE":
                         if not api_auth or not api_auth.get("DefaultAuthorizer"):
-                            raise InvalidEventException(
+                            raise InvalidEventException(  # type: ignore[no-untyped-call]
                                 self.relative_id,
                                 "Unable to set Authorizer on API method [{method}] for path [{path}] because 'NONE' "
                                 "is only a valid value when a DefaultAuthorizer on the API is specified.".format(
-                                    method=self.Method, path=self.Path
+                                    method=self.Method, path=self.Path  # type: ignore[attr-defined]
                                 ),
                             )
 
-            if self.Auth.get("AuthorizationScopes") and not isinstance(self.Auth.get("AuthorizationScopes"), list):
-                raise InvalidEventException(
+            if self.Auth.get("AuthorizationScopes") and not isinstance(self.Auth.get("AuthorizationScopes"), list):  # type: ignore[attr-defined]
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Unable to set Authorizer on API method [{method}] for path [{path}] because "
-                    "'AuthorizationScopes' must be a list of strings.".format(method=self.Method, path=self.Path),
+                    "'AuthorizationScopes' must be a list of strings.".format(method=self.Method, path=self.Path),  # type: ignore[attr-defined]
                 )
 
-            apikey_required_setting = self.Auth.get("ApiKeyRequired")
+            apikey_required_setting = self.Auth.get("ApiKeyRequired")  # type: ignore[attr-defined]
             apikey_required_setting_is_false = apikey_required_setting is not None and not apikey_required_setting
             if apikey_required_setting_is_false and (not api_auth or not api_auth.get("ApiKeyRequired")):
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Unable to set ApiKeyRequired [False] on API method [{method}] for path [{path}] "
                     "because the related API does not specify any ApiKeyRequired.".format(
-                        method=self.Method, path=self.Path
+                        method=self.Method, path=self.Path  # type: ignore[attr-defined]
                     ),
                 )
 
             if method_authorizer or apikey_required_setting is not None:
-                editor.add_auth_to_method(api=api, path=self.Path, method_name=self.Method, auth=self.Auth)
+                editor.add_auth_to_method(api=api, path=self.Path, method_name=self.Method, auth=self.Auth)  # type: ignore[attr-defined, attr-defined, no-untyped-call]
 
-            if self.Auth.get("ResourcePolicy"):
-                resource_policy = self.Auth.get("ResourcePolicy")
-                editor.add_resource_policy(resource_policy=resource_policy, path=self.Path, stage=self.Stage)
+            if self.Auth.get("ResourcePolicy"):  # type: ignore[attr-defined]
+                resource_policy = self.Auth.get("ResourcePolicy")  # type: ignore[attr-defined]
+                editor.add_resource_policy(resource_policy=resource_policy, path=self.Path, stage=self.Stage)  # type: ignore[attr-defined, no-untyped-call]
                 if resource_policy.get("CustomStatements"):
-                    editor.add_custom_statements(resource_policy.get("CustomStatements"))
+                    editor.add_custom_statements(resource_policy.get("CustomStatements"))  # type: ignore[no-untyped-call]
 
-        if self.RequestModel:
-            method_model = self.RequestModel.get("Model")
+        if self.RequestModel:  # type: ignore[attr-defined]
+            method_model = self.RequestModel.get("Model")  # type: ignore[attr-defined]
 
             if method_model:
                 api_models = api.get("Models")
                 if not api_models:
-                    raise InvalidEventException(
+                    raise InvalidEventException(  # type: ignore[no-untyped-call]
                         self.relative_id,
                         "Unable to set RequestModel [{model}] on API method [{method}] for path [{path}] "
                         "because the related API does not define any Models.".format(
-                            model=method_model, method=self.Method, path=self.Path
+                            model=method_model, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                         ),
                     )
-                if not is_intrinsic(api_models) and not isinstance(api_models, dict):
-                    raise InvalidEventException(
+                if not is_intrinsic(api_models) and not isinstance(api_models, dict):  # type: ignore[no-untyped-call]
+                    raise InvalidEventException(  # type: ignore[no-untyped-call]
                         self.relative_id,
                         "Unable to set RequestModel [{model}] on API method [{method}] for path [{path}] "
                         "because the related API Models defined is of invalid type.".format(
-                            model=method_model, method=self.Method, path=self.Path
+                            model=method_model, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                         ),
                     )
                 if not isinstance(method_model, str):
-                    raise InvalidEventException(
+                    raise InvalidEventException(  # type: ignore[no-untyped-call]
                         self.relative_id,
                         "Unable to set RequestModel [{model}] on API method [{method}] for path [{path}] "
                         "because the related API does not contain valid Models.".format(
-                            model=method_model, method=self.Method, path=self.Path
+                            model=method_model, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                         ),
                     )
 
                 if not api_models.get(method_model):
-                    raise InvalidEventException(
+                    raise InvalidEventException(  # type: ignore[no-untyped-call]
                         self.relative_id,
                         "Unable to set RequestModel [{model}] on API method [{method}] for path [{path}] "
                         "because it wasn't defined in the API's Models.".format(
-                            model=method_model, method=self.Method, path=self.Path
+                            model=method_model, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                         ),
                     )
 
-                editor.add_request_model_to_method(
-                    path=self.Path, method_name=self.Method, request_model=self.RequestModel
+                editor.add_request_model_to_method(  # type: ignore[no-untyped-call]
+                    path=self.Path, method_name=self.Method, request_model=self.RequestModel  # type: ignore[attr-defined, attr-defined]
                 )
 
-                validate_body = self.RequestModel.get("ValidateBody")
-                validate_parameters = self.RequestModel.get("ValidateParameters")
+                validate_body = self.RequestModel.get("ValidateBody")  # type: ignore[attr-defined]
+                validate_parameters = self.RequestModel.get("ValidateParameters")  # type: ignore[attr-defined]
 
                 # Checking if any of the fields are defined as it can be false we are checking if the field are not None
                 if validate_body is not None or validate_parameters is not None:
@@ -838,34 +838,34 @@ class Api(PushEventSource):
                     # If not type None but any other type it should explicitly invalidate the Spec
                     # Those fields should be only a boolean
                     if not isinstance(validate_body, bool) or not isinstance(validate_parameters, bool):
-                        raise InvalidEventException(
+                        raise InvalidEventException(  # type: ignore[no-untyped-call]
                             self.relative_id,
                             "Unable to set Validator to RequestModel [{model}] on API method [{method}] for path [{path}] "
                             "ValidateBody and ValidateParameters must be a boolean type, strings or intrinsics are not supported.".format(
-                                model=method_model, method=self.Method, path=self.Path
+                                model=method_model, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                             ),
                         )
 
-                    editor.add_request_validator_to_method(
-                        path=self.Path,
+                    editor.add_request_validator_to_method(  # type: ignore[no-untyped-call]
+                        path=self.Path,  # type: ignore[attr-defined]
                         method_name=self.Method,
                         validate_body=validate_body,
                         validate_parameters=validate_parameters,
                     )
 
-        if self.RequestParameters:
+        if self.RequestParameters:  # type: ignore[attr-defined]
 
             default_value = {"Required": False, "Caching": False}
 
             parameters = []
-            for parameter in self.RequestParameters:
+            for parameter in self.RequestParameters:  # type: ignore[attr-defined]
 
                 if isinstance(parameter, dict):
 
                     parameter_name, parameter_value = next(iter(parameter.items()))
 
                     if not re.match(r"method\.request\.(querystring|path|header)\.", parameter_name):
-                        raise InvalidEventException(
+                        raise InvalidEventException(  # type: ignore[no-untyped-call]
                             self.relative_id,
                             "Invalid value for 'RequestParameters' property. Keys must be in the format "
                             "'method.request.[querystring|path|header].{value}', "
@@ -875,7 +875,7 @@ class Api(PushEventSource):
                     if not isinstance(parameter_value, dict) or not all(
                         key in REQUEST_PARAMETER_PROPERTIES for key in parameter_value.keys()
                     ):
-                        raise InvalidEventException(
+                        raise InvalidEventException(  # type: ignore[no-untyped-call]
                             self.relative_id,
                             "Invalid value for 'RequestParameters' property. Values must be an object, "
                             "e.g { Required: true, Caching: false }",
@@ -889,7 +889,7 @@ class Api(PushEventSource):
 
                 elif isinstance(parameter, str):
                     if not re.match(r"method\.request\.(querystring|path|header)\.", parameter):
-                        raise InvalidEventException(
+                        raise InvalidEventException(  # type: ignore[no-untyped-call]
                             self.relative_id,
                             "Invalid value for 'RequestParameters' property. Keys must be in the format "
                             "'method.request.[querystring|path|header].{value}', "
@@ -897,24 +897,24 @@ class Api(PushEventSource):
                         )
 
                     settings = default_value.copy()
-                    settings.update({"Name": parameter})
+                    settings.update({"Name": parameter})  # type: ignore[dict-item]
 
                     parameters.append(settings)
 
                 else:
-                    raise InvalidEventException(
+                    raise InvalidEventException(  # type: ignore[no-untyped-call]
                         self.relative_id,
                         "Invalid value for 'RequestParameters' property. Property must be either a string or an object",
                     )
 
-            editor.add_request_parameters_to_method(
-                path=self.Path, method_name=self.Method, request_parameters=parameters
+            editor.add_request_parameters_to_method(  # type: ignore[no-untyped-call]
+                path=self.Path, method_name=self.Method, request_parameters=parameters  # type: ignore[attr-defined]
             )
 
         api["DefinitionBody"] = editor.swagger
 
     @staticmethod
-    def get_rest_api_id_string(rest_api_id):
+    def get_rest_api_id_string(rest_api_id):  # type: ignore[no-untyped-def]
         """
         rest_api_id can be either a string or a dictionary where the actual api id is the value at key "Ref".
         If rest_api_id is a dictionary with key "Ref", returns value at key "Ref". Otherwise, return rest_api_id.
@@ -929,17 +929,17 @@ class AlexaSkill(PushEventSource):
     resource_type = "AlexaSkill"
     principal = "alexa-appkit.amazon.com"
 
-    property_types = {"SkillId": PropertyType(False, is_str())}
+    property_types = {"SkillId": PropertyType(False, is_str())}  # type: ignore[no-untyped-call, no-untyped-call]
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         function = kwargs.get("function")
 
         if not function:
             raise TypeError("Missing required keyword argument: function")
 
         resources = []
-        resources.append(self._construct_permission(function, event_source_token=self.SkillId))
+        resources.append(self._construct_permission(function, event_source_token=self.SkillId))  # type: ignore[attr-defined, no-untyped-call]
 
         return resources
 
@@ -948,10 +948,10 @@ class IoTRule(PushEventSource):
     resource_type = "IoTRule"
     principal = "iot.amazonaws.com"
 
-    property_types = {"Sql": PropertyType(True, is_str()), "AwsIotSqlVersion": PropertyType(False, is_str())}
+    property_types = {"Sql": PropertyType(True, is_str()), "AwsIotSqlVersion": PropertyType(False, is_str())}  # type: ignore[no-untyped-call, no-untyped-call]
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         function = kwargs.get("function")
 
         if not function:
@@ -961,29 +961,29 @@ class IoTRule(PushEventSource):
 
         resource = "rule/${RuleName}"
 
-        partition = ArnGenerator.get_partition_name()
-        source_arn = fnSub(
-            ArnGenerator.generate_arn(partition=partition, service="iot", resource=resource),
-            {"RuleName": ref(self.logical_id)},
+        partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
+        source_arn = fnSub(  # type: ignore[no-untyped-call]
+            ArnGenerator.generate_arn(partition=partition, service="iot", resource=resource),  # type: ignore[no-untyped-call]
+            {"RuleName": ref(self.logical_id)},  # type: ignore[no-untyped-call]
         )
-        source_account = fnSub("${AWS::AccountId}")
+        source_account = fnSub("${AWS::AccountId}")  # type: ignore[no-untyped-call]
 
-        resources.append(self._construct_permission(function, source_arn=source_arn, source_account=source_account))
-        resources.append(self._construct_iot_rule(function))
+        resources.append(self._construct_permission(function, source_arn=source_arn, source_account=source_account))  # type: ignore[no-untyped-call]
+        resources.append(self._construct_iot_rule(function))  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _construct_iot_rule(self, function):
-        rule = IotTopicRule(self.logical_id, attributes=function.get_passthrough_resource_attributes())
+    def _construct_iot_rule(self, function):  # type: ignore[no-untyped-def]
+        rule = IotTopicRule(self.logical_id, attributes=function.get_passthrough_resource_attributes())  # type: ignore[no-untyped-call]
 
         payload = {
-            "Sql": self.Sql,
+            "Sql": self.Sql,  # type: ignore[attr-defined]
             "RuleDisabled": False,
             "Actions": [{"Lambda": {"FunctionArn": function.get_runtime_attr("arn")}}],
         }
 
-        if self.AwsIotSqlVersion:
-            payload["AwsIotSqlVersion"] = self.AwsIotSqlVersion
+        if self.AwsIotSqlVersion:  # type: ignore[attr-defined]
+            payload["AwsIotSqlVersion"] = self.AwsIotSqlVersion  # type: ignore[attr-defined]
 
         rule.TopicRulePayload = payload
 
@@ -995,26 +995,26 @@ class Cognito(PushEventSource):
     principal = "cognito-idp.amazonaws.com"
 
     property_types = {
-        "UserPool": PropertyType(True, is_str()),
-        "Trigger": PropertyType(True, one_of(is_str(), list_of(is_str())), False),
+        "UserPool": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Trigger": PropertyType(True, one_of(is_str(), list_of(is_str())), False),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
     }
 
-    def resources_to_link(self, resources):
-        if isinstance(self.UserPool, dict) and "Ref" in self.UserPool:
-            userpool_id = self.UserPool["Ref"]
+    def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
+        if isinstance(self.UserPool, dict) and "Ref" in self.UserPool:  # type: ignore[attr-defined]
+            userpool_id = self.UserPool["Ref"]  # type: ignore[attr-defined]
             if not isinstance(userpool_id, str):
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     "Ref in Userpool is not a string.",
                 )
             if userpool_id in resources:
                 return {"userpool": resources[userpool_id], "userpool_id": userpool_id}
-        raise InvalidEventException(
+        raise InvalidEventException(  # type: ignore[no-untyped-call]
             self.relative_id, "Cognito events must reference a Cognito UserPool in the same template."
         )
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         function = kwargs.get("function")
 
         if not function:
@@ -1030,22 +1030,22 @@ class Cognito(PushEventSource):
         userpool_id = kwargs["userpool_id"]
 
         resources = []
-        source_arn = fnGetAtt(userpool_id, "Arn")
-        lambda_permission = self._construct_permission(
+        source_arn = fnGetAtt(userpool_id, "Arn")  # type: ignore[no-untyped-call]
+        lambda_permission = self._construct_permission(  # type: ignore[no-untyped-call]
             function, source_arn=source_arn, prefix=function.logical_id + "Cognito"
         )
         for attribute, value in function.get_passthrough_resource_attributes().items():
             lambda_permission.set_resource_attribute(attribute, value)
         resources.append(lambda_permission)
 
-        self._inject_lambda_config(function, userpool)
-        resources.append(CognitoUserPool.from_dict(userpool_id, userpool))
+        self._inject_lambda_config(function, userpool)  # type: ignore[no-untyped-call]
+        resources.append(CognitoUserPool.from_dict(userpool_id, userpool))  # type: ignore[no-untyped-call]
         return resources
 
-    def _inject_lambda_config(self, function, userpool):
-        event_triggers = self.Trigger
-        if isinstance(self.Trigger, str):
-            event_triggers = [self.Trigger]
+    def _inject_lambda_config(self, function, userpool):  # type: ignore[no-untyped-def]
+        event_triggers = self.Trigger  # type: ignore[attr-defined]
+        if isinstance(self.Trigger, str):  # type: ignore[attr-defined]
+            event_triggers = [self.Trigger]  # type: ignore[attr-defined]
 
         # TODO can these be conditional?
 
@@ -1063,8 +1063,8 @@ class Cognito(PushEventSource):
             if event_trigger not in lambda_config:
                 lambda_config[event_trigger] = function.get_runtime_attr("arn")
             else:
-                raise InvalidEventException(
-                    self.relative_id, 'Cognito trigger "{trigger}" defined multiple times.'.format(trigger=self.Trigger)
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
+                    self.relative_id, 'Cognito trigger "{trigger}" defined multiple times.'.format(trigger=self.Trigger)  # type: ignore[attr-defined]
                 )
         return userpool
 
@@ -1075,23 +1075,23 @@ class HttpApi(PushEventSource):
     resource_type = "HttpApi"
     principal = "apigateway.amazonaws.com"
     property_types = {
-        "Path": PropertyType(False, is_str()),
-        "Method": PropertyType(False, is_str()),
-        "ApiId": PropertyType(False, is_str()),
-        "Stage": PropertyType(False, is_str()),
-        "Auth": PropertyType(False, is_type(dict)),
-        "TimeoutInMillis": PropertyType(False, is_type(int)),
-        "RouteSettings": PropertyType(False, is_type(dict)),
-        "PayloadFormatVersion": PropertyType(False, is_str()),
+        "Path": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Method": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ApiId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Stage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TimeoutInMillis": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "PayloadFormatVersion": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    def resources_to_link(self, resources):
+    def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
         """
         If this API Event Source refers to an explicit API resource, resolve the reference and grab
         necessary data from the explicit API
         """
 
-        api_id = self.ApiId
+        api_id = self.ApiId  # type: ignore[attr-defined]
         if isinstance(api_id, dict) and "Ref" in api_id:
             api_id = api_id["Ref"]
 
@@ -1099,8 +1099,8 @@ class HttpApi(PushEventSource):
 
         return {"explicit_api": explicit_api}
 
-    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, **kwargs):
+    @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """If the Api event source has a RestApi property, then simply return the Lambda Permission resource allowing
         API Gateway to call the function. If no RestApi is provided, then additionally inject the path, method, and the
         x-amazon-apigateway-integration into the OpenApi body for a provided implicit API.
@@ -1114,53 +1114,53 @@ class HttpApi(PushEventSource):
 
         function = kwargs.get("function")
 
-        if self.Method is not None:
+        if self.Method is not None:  # type: ignore[has-type]
             # Convert to lower case so that user can specify either GET or get
-            self.Method = self.Method.lower()
+            self.Method = self.Method.lower()  # type: ignore[has-type]
 
-        resources.extend(self._get_permissions(kwargs))
+        resources.extend(self._get_permissions(kwargs))  # type: ignore[no-untyped-call]
 
         explicit_api = kwargs["explicit_api"]
-        self._add_openapi_integration(explicit_api, function, explicit_api.get("__MANAGE_SWAGGER"))
+        self._add_openapi_integration(explicit_api, function, explicit_api.get("__MANAGE_SWAGGER"))  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _get_permissions(self, resources_to_link):
+    def _get_permissions(self, resources_to_link):  # type: ignore[no-untyped-def]
         permissions = []
 
         # Give permission to all stages by default
         permitted_stage = "*"
 
-        permission = self._get_permission(resources_to_link, permitted_stage)
+        permission = self._get_permission(resources_to_link, permitted_stage)  # type: ignore[no-untyped-call]
         if permission:
             permissions.append(permission)
         return permissions
 
-    def _get_permission(self, resources_to_link, stage):
+    def _get_permission(self, resources_to_link, stage):  # type: ignore[no-untyped-def]
         # It turns out that APIGW doesn't like trailing slashes in paths (#665)
         # and removes as a part of their behaviour, but this isn't documented.
         # The regex removes the tailing slash to ensure the permission works as intended
-        path = re.sub(r"^(.+)/$", r"\1", self.Path)
+        path = re.sub(r"^(.+)/$", r"\1", self.Path)  # type: ignore[attr-defined]
 
         editor = None
         if resources_to_link["explicit_api"].get("DefinitionBody"):
             try:
-                editor = OpenApiEditor(resources_to_link["explicit_api"].get("DefinitionBody"))
+                editor = OpenApiEditor(resources_to_link["explicit_api"].get("DefinitionBody"))  # type: ignore[no-untyped-call]
             except InvalidDocumentException as e:
-                api_logical_id = self.ApiId.get("Ref") if isinstance(self.ApiId, dict) else self.ApiId
-                raise InvalidResourceException(api_logical_id, " ".join(ex.message for ex in e.causes))
+                api_logical_id = self.ApiId.get("Ref") if isinstance(self.ApiId, dict) else self.ApiId  # type: ignore[attr-defined]
+                raise InvalidResourceException(api_logical_id, " ".join(ex.message for ex in e.causes))  # type: ignore[no-untyped-call]
 
         # If this is using the new $default path, keep path blank and add a * permission
         if path == OpenApiEditor._DEFAULT_PATH:
             path = ""
-        elif editor and editor.is_integration_function_logical_id_match(
+        elif editor and editor.is_integration_function_logical_id_match(  # type: ignore[no-untyped-call]
             OpenApiEditor._DEFAULT_PATH, OpenApiEditor._X_ANY_METHOD, resources_to_link.get("function").logical_id
         ):
             # Case where default exists for this function, and so the permissions for that will apply here as well
             # This can save us several CFN resources (not duplicating permissions)
             return
         else:
-            path = OpenApiEditor.get_path_without_trailing_slash(path)
+            path = OpenApiEditor.get_path_without_trailing_slash(path)  # type: ignore[no-untyped-call]
 
         # Handle case where Method is already the ANY ApiGateway extension
         if self.Method.lower() == "any" or self.Method.lower() == OpenApiEditor._X_ANY_METHOD:
@@ -1168,18 +1168,18 @@ class HttpApi(PushEventSource):
         else:
             method = self.Method.upper()
 
-        api_id = self.ApiId
+        api_id = self.ApiId  # type: ignore[attr-defined]
 
         # ApiId can be a simple string or intrinsic function like !Ref. Using Fn::Sub will handle both cases
         resource = "${__ApiId__}/" + "${__Stage__}/" + method + path
-        source_arn = fnSub(
-            ArnGenerator.generate_arn(partition="${AWS::Partition}", service="execute-api", resource=resource),
+        source_arn = fnSub(  # type: ignore[no-untyped-call]
+            ArnGenerator.generate_arn(partition="${AWS::Partition}", service="execute-api", resource=resource),  # type: ignore[no-untyped-call]
             {"__ApiId__": api_id, "__Stage__": stage},
         )
 
-        return self._construct_permission(resources_to_link["function"], source_arn=source_arn)
+        return self._construct_permission(resources_to_link["function"], source_arn=source_arn)  # type: ignore[no-untyped-call]
 
-    def _add_openapi_integration(self, api, function, manage_swagger=False):
+    def _add_openapi_integration(self, api, function, manage_swagger=False):  # type: ignore[no-untyped-def]
         """Adds the path and method for this Api event source to the OpenApi body for the provided RestApi.
 
         :param model.apigateway.ApiGatewayRestApi rest_api: the RestApi to which the path and method should be added.
@@ -1188,16 +1188,16 @@ class HttpApi(PushEventSource):
         if open_api_body is None:
             return
 
-        uri = _build_apigw_integration_uri(function, "${AWS::Partition}")
+        uri = _build_apigw_integration_uri(function, "${AWS::Partition}")  # type: ignore[no-untyped-call]
 
-        editor = OpenApiEditor(open_api_body)
+        editor = OpenApiEditor(open_api_body)  # type: ignore[no-untyped-call]
 
-        if manage_swagger and editor.has_integration(self.Path, self.Method):
+        if manage_swagger and editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined, no-untyped-call]
             # Cannot add the Lambda Integration, if it is already present
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "API method '{method}' defined multiple times for path '{path}'.".format(
-                    method=self.Method, path=self.Path
+                    method=self.Method, path=self.Path  # type: ignore[attr-defined]
                 ),
             )
 
@@ -1205,36 +1205,36 @@ class HttpApi(PushEventSource):
         if CONDITION in function.resource_attributes:
             condition = function.resource_attributes[CONDITION]
 
-        editor.add_lambda_integration(self.Path, self.Method, uri, self.Auth, api.get("Auth"), condition=condition)
-        if self.Auth:
-            self._add_auth_to_openapi_integration(api, editor)
-        if self.TimeoutInMillis:
-            editor.add_timeout_to_method(api=api, path=self.Path, method_name=self.Method, timeout=self.TimeoutInMillis)
-        path_parameters = re.findall("{(.*?)}", self.Path)
+        editor.add_lambda_integration(self.Path, self.Method, uri, self.Auth, api.get("Auth"), condition=condition)  # type: ignore[attr-defined, attr-defined, no-untyped-call]
+        if self.Auth:  # type: ignore[attr-defined]
+            self._add_auth_to_openapi_integration(api, editor)  # type: ignore[no-untyped-call]
+        if self.TimeoutInMillis:  # type: ignore[attr-defined]
+            editor.add_timeout_to_method(api=api, path=self.Path, method_name=self.Method, timeout=self.TimeoutInMillis)  # type: ignore[attr-defined, attr-defined, no-untyped-call]
+        path_parameters = re.findall("{(.*?)}", self.Path)  # type: ignore[attr-defined]
         if path_parameters:
-            editor.add_path_parameters_to_method(
-                api=api, path=self.Path, method_name=self.Method, path_parameters=path_parameters
+            editor.add_path_parameters_to_method(  # type: ignore[no-untyped-call]
+                api=api, path=self.Path, method_name=self.Method, path_parameters=path_parameters  # type: ignore[attr-defined]
             )
 
-        if self.PayloadFormatVersion:
-            editor.add_payload_format_version_to_method(
-                api=api, path=self.Path, method_name=self.Method, payload_format_version=self.PayloadFormatVersion
+        if self.PayloadFormatVersion:  # type: ignore[attr-defined]
+            editor.add_payload_format_version_to_method(  # type: ignore[no-untyped-call]
+                api=api, path=self.Path, method_name=self.Method, payload_format_version=self.PayloadFormatVersion  # type: ignore[attr-defined, attr-defined]
             )
         api["DefinitionBody"] = editor.openapi
 
-    def _add_auth_to_openapi_integration(self, api, editor):
+    def _add_auth_to_openapi_integration(self, api, editor):  # type: ignore[no-untyped-def]
         """Adds authorization to the lambda integration
         :param api: api object
         :param editor: OpenApiEditor object that contains the OpenApi definition
         """
-        method_authorizer = self.Auth.get("Authorizer")
+        method_authorizer = self.Auth.get("Authorizer")  # type: ignore[attr-defined]
         api_auth = api.get("Auth", {})
         if not method_authorizer:
             if api_auth.get("DefaultAuthorizer"):
-                self.Auth["Authorizer"] = method_authorizer = api_auth.get("DefaultAuthorizer")
+                self.Auth["Authorizer"] = method_authorizer = api_auth.get("DefaultAuthorizer")  # type: ignore[attr-defined]
             else:
                 # currently, we require either a default auth or auth in the method
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "'Auth' section requires either "
                     "an explicit 'Authorizer' set or a 'DefaultAuthorizer' "
@@ -1247,17 +1247,17 @@ class HttpApi(PushEventSource):
         # The IAM authorizer is built-in and not defined as a regular Authorizer.
         iam_authorizer_enabled = api_auth and api_auth.get("EnableIamAuthorizer", False) is True
 
-        _check_valid_authorizer_types(
-            self.relative_id, self.Method, self.Path, method_authorizer, api_authorizers, iam_authorizer_enabled
+        _check_valid_authorizer_types(  # type: ignore[no-untyped-call]
+            self.relative_id, self.Method, self.Path, method_authorizer, api_authorizers, iam_authorizer_enabled  # type: ignore[attr-defined]
         )
 
         if method_authorizer == "NONE":
             if not api_auth.get("DefaultAuthorizer"):
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Unable to set Authorizer on API method [{method}] for path [{path}] because 'NONE' "
                     "is only a valid value when a DefaultAuthorizer on the API is specified.".format(
-                        method=self.Method, path=self.Path
+                        method=self.Method, path=self.Path  # type: ignore[attr-defined]
                     ),
                 )
         # If the method authorizer is "AWS_IAM" but it's not enabled it's possible that's a custom authorizer, not the "official" one.
@@ -1265,50 +1265,50 @@ class HttpApi(PushEventSource):
         # The "official" AWS IAM authorizer is not defined as a normal authorizer so it won't exist in api_authorizer.
         elif (method_authorizer == "AWS_IAM" and not iam_authorizer_enabled) or method_authorizer != "AWS_IAM":
             if not api_authorizers:
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "
                     "because the related API does not define any Authorizers.".format(
-                        authorizer=method_authorizer, method=self.Method, path=self.Path
+                        authorizer=method_authorizer, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                     ),
                 )
 
             if not api_authorizers.get(method_authorizer):
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "
                     "because it wasn't defined in the API's Authorizers.".format(
-                        authorizer=method_authorizer, method=self.Method, path=self.Path
+                        authorizer=method_authorizer, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                     ),
                 )
 
-        if self.Auth.get("AuthorizationScopes") and not isinstance(self.Auth.get("AuthorizationScopes"), list):
-            raise InvalidEventException(
+        if self.Auth.get("AuthorizationScopes") and not isinstance(self.Auth.get("AuthorizationScopes"), list):  # type: ignore[attr-defined]
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "Unable to set Authorizer on API method [{method}] for path [{path}] because "
-                "'AuthorizationScopes' must be a list of strings.".format(method=self.Method, path=self.Path),
+                "'AuthorizationScopes' must be a list of strings.".format(method=self.Method, path=self.Path),  # type: ignore[attr-defined]
             )
 
-        editor.add_auth_to_method(api=api, path=self.Path, method_name=self.Method, auth=self.Auth)
+        editor.add_auth_to_method(api=api, path=self.Path, method_name=self.Method, auth=self.Auth)  # type: ignore[attr-defined, attr-defined]
 
 
-def _build_apigw_integration_uri(function, partition):
+def _build_apigw_integration_uri(function, partition):  # type: ignore[no-untyped-def]
     function_arn = function.get_runtime_attr("arn")
     arn = (
         "arn:"
         + partition
         + ":apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/"
-        + make_shorthand(function_arn)
+        + make_shorthand(function_arn)  # type: ignore[no-untyped-call]
         + "/invocations"
     )
     # function_arn is always of the form {"Fn::GetAtt": ["<function_logical_id>", "Arn"]}.
     # We only want to check if the function logical id is a Py27UniStr instance.
     if function_arn.get("Fn::GetAtt") and isinstance(function_arn["Fn::GetAtt"][0], Py27UniStr):
         arn = Py27UniStr(arn)
-    return Py27Dict(fnSub(arn))
+    return Py27Dict(fnSub(arn))  # type: ignore[no-untyped-call, no-untyped-call]
 
 
-def _check_valid_authorizer_types(
+def _check_valid_authorizer_types(  # type: ignore[no-untyped-def]
     relative_id, method, path, method_authorizer, api_authorizers, iam_authorizer_enabled
 ):
     if method_authorizer == "NONE":
@@ -1322,7 +1322,7 @@ def _check_valid_authorizer_types(
         return
 
     if not isinstance(method_authorizer, str) or not isinstance(api_authorizers, dict):
-        raise InvalidEventException(
+        raise InvalidEventException(  # type: ignore[no-untyped-call]
             relative_id,
             "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}]. "
             "The method authorizer must be a string with a corresponding dict entry in the api authorizer.".format(

--- a/samtranslator/model/exceptions.py
+++ b/samtranslator/model/exceptions.py
@@ -6,17 +6,17 @@ class InvalidDocumentException(Exception):
         causes -- list of errors which caused this document to be invalid
     """
 
-    def __init__(self, causes):
+    def __init__(self, causes):  # type: ignore[no-untyped-def]
         self._causes = causes
 
     @property
-    def message(self):
+    def message(self):  # type: ignore[no-untyped-def]
         return "Invalid Serverless Application Specification document. Number of errors found: {}.".format(
             len(self.causes)
         )
 
     @property
-    def causes(self):
+    def causes(self):  # type: ignore[no-untyped-def]
         return self._causes
 
 
@@ -26,13 +26,13 @@ class DuplicateLogicalIdException(Exception):
         message -- explanation of the error
     """
 
-    def __init__(self, logical_id, duplicate_id, type):
+    def __init__(self, logical_id, duplicate_id, type):  # type: ignore[no-untyped-def]
         self._logical_id = logical_id
         self._duplicate_id = duplicate_id
         self._type = type
 
     @property
-    def message(self):
+    def message(self):  # type: ignore[no-untyped-def]
         return (
             "Transforming resource with id [{logical_id}] attempts to create a new"
             ' resource with id [{duplicate_id}] and type "{type}". A resource with that id already'
@@ -49,11 +49,11 @@ class InvalidTemplateException(Exception):
         message -- explanation of the error
     """
 
-    def __init__(self, message):
+    def __init__(self, message):  # type: ignore[no-untyped-def]
         self._message = message
 
     @property
-    def message(self):
+    def message(self):  # type: ignore[no-untyped-def]
         return "Structure of the SAM template is invalid. {}".format(self._message)
 
 
@@ -64,15 +64,15 @@ class InvalidResourceException(Exception):
         message -- explanation of the error
     """
 
-    def __init__(self, logical_id, message):
+    def __init__(self, logical_id, message):  # type: ignore[no-untyped-def]
         self._logical_id = logical_id
         self._message = message
 
-    def __lt__(self, other):
+    def __lt__(self, other):  # type: ignore[no-untyped-def]
         return self._logical_id < other._logical_id
 
     @property
-    def message(self):
+    def message(self):  # type: ignore[no-untyped-def]
         return "Resource with id [{}] is invalid. {}".format(self._logical_id, self._message)
 
 
@@ -83,16 +83,16 @@ class InvalidEventException(Exception):
         message -- explanation of the error
     """
 
-    def __init__(self, event_id, message):
+    def __init__(self, event_id, message):  # type: ignore[no-untyped-def]
         self._event_id = event_id
         self._message = message
 
     @property
-    def message(self):
+    def message(self):  # type: ignore[no-untyped-def]
         return "Event with id [{}] is invalid. {}".format(self._event_id, self._message)
 
 
-def prepend(exception, message, end=": "):
+def prepend(exception, message, end=": "):  # type: ignore[no-untyped-def]
     """Prepends the first argument (i.e., the exception message) of the a BaseException with the provided message.
     Useful for reraising exceptions with additional information.
 

--- a/samtranslator/model/iam.py
+++ b/samtranslator/model/iam.py
@@ -6,33 +6,33 @@ from samtranslator.model.intrinsics import ref, fnGetAtt
 class IAMRole(Resource):
     resource_type = "AWS::IAM::Role"
     property_types = {
-        "AssumeRolePolicyDocument": PropertyType(True, is_type(dict)),
-        "ManagedPolicyArns": PropertyType(False, is_type(list)),
-        "Path": PropertyType(False, is_str()),
-        "Policies": PropertyType(False, is_type(list)),
-        "PermissionsBoundary": PropertyType(False, is_str()),
-        "Tags": PropertyType(False, list_of(is_type(dict))),
+        "AssumeRolePolicyDocument": PropertyType(True, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ManagedPolicyArns": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Path": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Policies": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "PermissionsBoundary": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
 
 
 class IAMManagedPolicy(Resource):
     resource_type = "AWS::IAM::ManagedPolicy"
     property_types = {
-        "Description": PropertyType(False, is_str()),
-        "Groups": PropertyType(False, is_str()),
-        "PolicyDocument": PropertyType(True, is_type(dict)),
-        "ManagedPolicyName": PropertyType(False, is_str()),
-        "Path": PropertyType(False, is_str()),
-        "Roles": PropertyType(False, is_type(list)),
-        "Users": PropertyType(False, list_of(is_str())),
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Groups": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "PolicyDocument": PropertyType(True, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ManagedPolicyName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Path": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Roles": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Users": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
     }
 
 
 class IAMRolePolicies:
     @classmethod
-    def construct_assume_role_policy_for_service_principal(cls, service_principal):
+    def construct_assume_role_policy_for_service_principal(cls, service_principal):  # type: ignore[no-untyped-def]
         document = {
             "Version": "2012-10-17",
             "Statement": [
@@ -46,7 +46,7 @@ class IAMRolePolicies:
         return document
 
     @classmethod
-    def step_functions_start_execution_role_policy(cls, state_machine_arn, logical_id):
+    def step_functions_start_execution_role_policy(cls, state_machine_arn, logical_id):  # type: ignore[no-untyped-def]
         document = {
             "PolicyName": logical_id + "StartExecutionPolicy",
             "PolicyDocument": {
@@ -56,7 +56,7 @@ class IAMRolePolicies:
         return document
 
     @classmethod
-    def stepfunctions_assume_role_policy(cls):
+    def stepfunctions_assume_role_policy(cls):  # type: ignore[no-untyped-def]
         document = {
             "Version": "2012-10-17",
             "Statement": [
@@ -70,7 +70,7 @@ class IAMRolePolicies:
         return document
 
     @classmethod
-    def cloud_watch_log_assume_role_policy(cls):
+    def cloud_watch_log_assume_role_policy(cls):  # type: ignore[no-untyped-def]
         document = {
             "Version": "2012-10-17",
             "Statement": [
@@ -84,7 +84,7 @@ class IAMRolePolicies:
         return document
 
     @classmethod
-    def lambda_assume_role_policy(cls):
+    def lambda_assume_role_policy(cls):  # type: ignore[no-untyped-def]
         document = {
             "Version": "2012-10-17",
             "Statement": [
@@ -94,7 +94,7 @@ class IAMRolePolicies:
         return document
 
     @classmethod
-    def dead_letter_queue_policy(cls, action, resource):
+    def dead_letter_queue_policy(cls, action, resource):  # type: ignore[no-untyped-def]
         """Return the DeadLetterQueue Policy to be added to the LambdaRole
         :returns: Policy for the DeadLetterQueue
         :rtype: Dict
@@ -108,7 +108,7 @@ class IAMRolePolicies:
         }
 
     @classmethod
-    def sqs_send_message_role_policy(cls, queue_arn, logical_id):
+    def sqs_send_message_role_policy(cls, queue_arn, logical_id):  # type: ignore[no-untyped-def]
         document = {
             "PolicyName": logical_id + "SQSPolicy",
             "PolicyDocument": {"Statement": [{"Action": "sqs:SendMessage", "Effect": "Allow", "Resource": queue_arn}]},
@@ -116,7 +116,7 @@ class IAMRolePolicies:
         return document
 
     @classmethod
-    def sns_publish_role_policy(cls, topic_arn, logical_id):
+    def sns_publish_role_policy(cls, topic_arn, logical_id):  # type: ignore[no-untyped-def]
         document = {
             "PolicyName": logical_id + "SNSPolicy",
             "PolicyDocument": {"Statement": [{"Action": "sns:publish", "Effect": "Allow", "Resource": topic_arn}]},
@@ -124,7 +124,7 @@ class IAMRolePolicies:
         return document
 
     @classmethod
-    def event_bus_put_events_role_policy(cls, event_bus_arn, logical_id):
+    def event_bus_put_events_role_policy(cls, event_bus_arn, logical_id):  # type: ignore[no-untyped-def]
         document = {
             "PolicyName": logical_id + "EventBridgePolicy",
             "PolicyDocument": {
@@ -134,7 +134,7 @@ class IAMRolePolicies:
         return document
 
     @classmethod
-    def lambda_invoke_function_role_policy(cls, function_arn, logical_id):
+    def lambda_invoke_function_role_policy(cls, function_arn, logical_id):  # type: ignore[no-untyped-def]
         document = {
             "PolicyName": logical_id + "LambdaPolicy",
             "PolicyDocument": {

--- a/samtranslator/model/intrinsics.py
+++ b/samtranslator/model/intrinsics.py
@@ -1,40 +1,40 @@
-def fnGetAtt(logical_name, attribute_name):
+def fnGetAtt(logical_name, attribute_name):  # type: ignore[no-untyped-def]
     return {"Fn::GetAtt": [logical_name, attribute_name]}
 
 
-def ref(logical_name):
+def ref(logical_name):  # type: ignore[no-untyped-def]
     return {"Ref": logical_name}
 
 
-def fnJoin(delimiter, values):
+def fnJoin(delimiter, values):  # type: ignore[no-untyped-def]
     return {"Fn::Join": [delimiter, values]}
 
 
-def fnSub(string, variables=None):
+def fnSub(string, variables=None):  # type: ignore[no-untyped-def]
     if variables:
         return {"Fn::Sub": [string, variables]}
     return {"Fn::Sub": string}
 
 
-def fnOr(argument_list):
+def fnOr(argument_list):  # type: ignore[no-untyped-def]
     return {"Fn::Or": argument_list}
 
 
-def fnAnd(argument_list):
+def fnAnd(argument_list):  # type: ignore[no-untyped-def]
     return {"Fn::And": argument_list}
 
 
-def make_conditional(condition, true_data, false_data=None):
+def make_conditional(condition, true_data, false_data=None):  # type: ignore[no-untyped-def]
     if false_data is None:
         false_data = {"Ref": "AWS::NoValue"}
     return {"Fn::If": [condition, true_data, false_data]}
 
 
-def make_not_conditional(condition):
+def make_not_conditional(condition):  # type: ignore[no-untyped-def]
     return {"Fn::Not": [{"Condition": condition}]}
 
 
-def make_condition_or_list(conditions_list):
+def make_condition_or_list(conditions_list):  # type: ignore[no-untyped-def]
     condition_or_list = []
     for condition in conditions_list:
         c = {"Condition": condition}
@@ -42,19 +42,19 @@ def make_condition_or_list(conditions_list):
     return condition_or_list
 
 
-def make_or_condition(conditions_list):
-    or_list = make_condition_or_list(conditions_list)
-    condition = fnOr(or_list)
+def make_or_condition(conditions_list):  # type: ignore[no-untyped-def]
+    or_list = make_condition_or_list(conditions_list)  # type: ignore[no-untyped-call]
+    condition = fnOr(or_list)  # type: ignore[no-untyped-call]
     return condition
 
 
-def make_and_condition(conditions_list):
-    and_list = make_condition_or_list(conditions_list)
-    condition = fnAnd(and_list)
+def make_and_condition(conditions_list):  # type: ignore[no-untyped-def]
+    and_list = make_condition_or_list(conditions_list)  # type: ignore[no-untyped-call]
+    condition = fnAnd(and_list)  # type: ignore[no-untyped-call]
     return condition
 
 
-def calculate_number_of_conditions(conditions_length, max_conditions):
+def calculate_number_of_conditions(conditions_length, max_conditions):  # type: ignore[no-untyped-def]
     """
     Every condition can hold up to max_conditions, which (as of writing this) is 10.
     Every time a condition is created, (max_conditions) are used and 1 new one is added to the conditions list.
@@ -73,7 +73,7 @@ def calculate_number_of_conditions(conditions_length, max_conditions):
     return num_conditions
 
 
-def make_combined_condition(conditions_list, condition_name):
+def make_combined_condition(conditions_list, condition_name):  # type: ignore[no-untyped-def]
     """
     Makes a combined condition using Fn::Or. Since Fn::Or only accepts up to 10 conditions,
     this method optionally creates multiple conditions. These conditions are named based on
@@ -94,7 +94,7 @@ def make_combined_condition(conditions_list, condition_name):
     conditions = {}
     conditions_length = len(conditions_list)
     # Get number of conditions needed, then minus one to use them as 0-based indices
-    zero_based_num_conditions = calculate_number_of_conditions(conditions_length, max_conditions) - 1
+    zero_based_num_conditions = calculate_number_of_conditions(conditions_length, max_conditions) - 1  # type: ignore[no-untyped-call]
 
     while len(conditions_list) > 1:
         new_condition_name = condition_name
@@ -102,14 +102,14 @@ def make_combined_condition(conditions_list, condition_name):
         if zero_based_num_conditions > 0:
             new_condition_name = "{}{}".format(condition_name, zero_based_num_conditions)
             zero_based_num_conditions -= 1
-        new_condition_content = make_or_condition(conditions_list[:max_conditions])
+        new_condition_content = make_or_condition(conditions_list[:max_conditions])  # type: ignore[no-untyped-call]
         conditions_list = conditions_list[max_conditions:]
         conditions_list.append(new_condition_name)
         conditions[new_condition_name] = new_condition_content
     return conditions
 
 
-def make_shorthand(intrinsic_dict):
+def make_shorthand(intrinsic_dict):  # type: ignore[no-untyped-def]
     """
     Converts a given intrinsics dictionary into a short-hand notation that Fn::Sub can use. Only Ref and Fn::GetAtt
     support shorthands.
@@ -130,7 +130,7 @@ def make_shorthand(intrinsic_dict):
     raise NotImplementedError("Shorthanding is only supported for Ref and Fn::GetAtt")
 
 
-def is_intrinsic(input):
+def is_intrinsic(input):  # type: ignore[no-untyped-def]
     """
     Checks if the given input is an intrinsic function dictionary. Intrinsic function is a dictionary with single
     key that is the name of the intrinsics.
@@ -147,7 +147,7 @@ def is_intrinsic(input):
     return False
 
 
-def is_intrinsic_if(input):
+def is_intrinsic_if(input):  # type: ignore[no-untyped-def]
     """
     Is the given input an intrinsic if? Intrinsic function 'if' is a dictionary with single
     key - if
@@ -156,14 +156,14 @@ def is_intrinsic_if(input):
     :return: True, if yes
     """
 
-    if not is_intrinsic(input):
+    if not is_intrinsic(input):  # type: ignore[no-untyped-call]
         return False
 
     key = list(input.keys())[0]
     return key == "Fn::If"
 
 
-def validate_intrinsic_if_items(items):
+def validate_intrinsic_if_items(items):  # type: ignore[no-untyped-def]
     """
     Validates Fn::If items
 
@@ -181,7 +181,7 @@ def validate_intrinsic_if_items(items):
         raise ValueError("Fn::If requires 3 arguments")
 
 
-def is_intrinsic_no_value(input):
+def is_intrinsic_no_value(input):  # type: ignore[no-untyped-def]
     """
     Is the given input an intrinsic Ref: AWS::NoValue? Intrinsic function is a dictionary with single
     key - Ref and value - AWS::NoValue
@@ -190,21 +190,21 @@ def is_intrinsic_no_value(input):
     :return: True, if yes
     """
 
-    if not is_intrinsic(input):
+    if not is_intrinsic(input):  # type: ignore[no-untyped-call]
         return False
 
     key = list(input.keys())[0]
     return key == "Ref" and input["Ref"] == "AWS::NoValue"
 
 
-def get_logical_id_from_intrinsic(input):
+def get_logical_id_from_intrinsic(input):  # type: ignore[no-untyped-def]
     """
     Verify if input is an Fn:GetAtt or Ref intrinsic
 
     :param input: Input value to check if it is an intrinsic
     :return: logical id if yes, return input for any other intrinsic function
     """
-    if not is_intrinsic(input):
+    if not is_intrinsic(input):  # type: ignore[no-untyped-call]
         return None
 
     # !Ref <logical-id>

--- a/samtranslator/model/iot.py
+++ b/samtranslator/model/iot.py
@@ -5,6 +5,6 @@ from samtranslator.model.intrinsics import ref, fnGetAtt
 
 class IotTopicRule(Resource):
     resource_type = "AWS::IoT::TopicRule"
-    property_types = {"TopicRulePayload": PropertyType(False, is_type(dict))}
+    property_types = {"TopicRulePayload": PropertyType(False, is_type(dict))}  # type: ignore[no-untyped-call, no-untyped-call]
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -6,109 +6,109 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class LambdaFunction(Resource):
     resource_type = "AWS::Lambda::Function"
     property_types = {
-        "Code": PropertyType(True, is_type(dict)),
-        "PackageType": PropertyType(False, is_str()),
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),
-        "Description": PropertyType(False, is_str()),
-        "FunctionName": PropertyType(False, is_str()),
-        "Handler": PropertyType(False, is_str()),
-        "MemorySize": PropertyType(False, is_type(int)),
-        "Role": PropertyType(False, is_str()),
-        "Runtime": PropertyType(False, is_str()),
-        "Timeout": PropertyType(False, is_type(int)),
-        "VpcConfig": PropertyType(False, is_type(dict)),
-        "Environment": PropertyType(False, is_type(dict)),
-        "Tags": PropertyType(False, list_of(is_type(dict))),
-        "TracingConfig": PropertyType(False, is_type(dict)),
-        "KmsKeyArn": PropertyType(False, one_of(is_type(dict), is_str())),
-        "Layers": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "ReservedConcurrentExecutions": PropertyType(False, any_type()),
-        "FileSystemConfigs": PropertyType(False, list_of(is_type(dict))),
-        "CodeSigningConfigArn": PropertyType(False, is_str()),
-        "ImageConfig": PropertyType(False, is_type(dict)),
-        "Architectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "EphemeralStorage": PropertyType(False, is_type(dict)),
+        "Code": PropertyType(True, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "PackageType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Handler": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MemorySize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Role": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Runtime": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Timeout": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "VpcConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Environment": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "TracingConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "KmsKeyArn": PropertyType(False, one_of(is_type(dict), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Layers": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "ReservedConcurrentExecutions": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FileSystemConfigs": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "CodeSigningConfigArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ImageConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Architectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "EphemeralStorage": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
 
 
 class LambdaVersion(Resource):
     resource_type = "AWS::Lambda::Version"
     property_types = {
-        "CodeSha256": PropertyType(False, is_str()),
-        "Description": PropertyType(False, is_str()),
-        "FunctionName": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "CodeSha256": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
     }
 
     runtime_attrs = {
-        "arn": lambda self: ref(self.logical_id),
-        "version": lambda self: fnGetAtt(self.logical_id, "Version"),
+        "arn": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
+        "version": lambda self: fnGetAtt(self.logical_id, "Version"),  # type: ignore[no-untyped-call]
     }
 
 
 class LambdaAlias(Resource):
     resource_type = "AWS::Lambda::Alias"
     property_types = {
-        "Description": PropertyType(False, is_str()),
-        "Name": PropertyType(False, is_str()),
-        "FunctionName": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "FunctionVersion": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "FunctionVersion": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"arn": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"arn": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
 
 class LambdaEventSourceMapping(Resource):
     resource_type = "AWS::Lambda::EventSourceMapping"
     property_types = {
-        "BatchSize": PropertyType(False, is_type(int)),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "EventSourceArn": PropertyType(False, is_str()),
-        "FunctionName": PropertyType(True, is_str()),
-        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
-        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),
-        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),
-        "DestinationConfig": PropertyType(False, is_type(dict)),
-        "ParallelizationFactor": PropertyType(False, is_type(int)),
-        "StartingPosition": PropertyType(False, is_str()),
-        "Topics": PropertyType(False, is_type(list)),
-        "Queues": PropertyType(False, is_type(list)),
-        "SourceAccessConfigurations": PropertyType(False, is_type(list)),
-        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),
-        "FunctionResponseTypes": PropertyType(False, is_type(list)),
-        "SelfManagedEventSource": PropertyType(False, is_type(dict)),
-        "FilterCriteria": PropertyType(False, is_type(dict)),
-        "AmazonManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),
-        "SelfManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),
+        "BatchSize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EventSourceArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MaximumRetryAttempts": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DestinationConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ParallelizationFactor": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StartingPosition": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Topics": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Queues": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SourceAccessConfigurations": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionResponseTypes": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SelfManagedEventSource": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FilterCriteria": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AmazonManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SelfManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id)}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
 
 class LambdaPermission(Resource):
     resource_type = "AWS::Lambda::Permission"
     property_types = {
-        "Action": PropertyType(True, is_str()),
-        "FunctionName": PropertyType(True, is_str()),
-        "Principal": PropertyType(True, is_str()),
-        "SourceAccount": PropertyType(False, is_str()),
-        "SourceArn": PropertyType(False, is_str()),
-        "EventSourceToken": PropertyType(False, is_str()),
-        "FunctionUrlAuthType": PropertyType(False, is_str()),
+        "Action": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Principal": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SourceAccount": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SourceArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EventSourceToken": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionUrlAuthType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
 
 class LambdaEventInvokeConfig(Resource):
     resource_type = "AWS::Lambda::EventInvokeConfig"
     property_types = {
-        "DestinationConfig": PropertyType(False, is_type(dict)),
-        "FunctionName": PropertyType(True, is_str()),
-        "MaximumEventAgeInSeconds": PropertyType(False, is_type(int)),
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
-        "Qualifier": PropertyType(True, is_str()),
+        "DestinationConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MaximumEventAgeInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MaximumRetryAttempts": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Qualifier": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
 
@@ -117,21 +117,21 @@ class LambdaLayerVersion(Resource):
 
     resource_type = "AWS::Lambda::LayerVersion"
     property_types = {
-        "Content": PropertyType(True, is_type(dict)),
-        "Description": PropertyType(False, is_str()),
-        "LayerName": PropertyType(False, is_str()),
-        "CompatibleArchitectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "LicenseInfo": PropertyType(False, is_str()),
+        "Content": PropertyType(True, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "LayerName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CompatibleArchitectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "LicenseInfo": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
 
 
 class LambdaUrl(Resource):
     resource_type = "AWS::Lambda::Url"
     property_types = {
-        "TargetFunctionArn": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "AuthType": PropertyType(True, is_str()),
-        "Cors": PropertyType(False, is_type(dict)),
+        "TargetFunctionArn": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "AuthType": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Cors": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }

--- a/samtranslator/model/log.py
+++ b/samtranslator/model/log.py
@@ -6,9 +6,9 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class SubscriptionFilter(Resource):
     resource_type = "AWS::Logs::SubscriptionFilter"
     property_types = {
-        "LogGroupName": PropertyType(True, is_str()),
-        "FilterPattern": PropertyType(True, is_str()),
-        "DestinationArn": PropertyType(True, is_str()),
+        "LogGroupName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FilterPattern": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DestinationArn": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]

--- a/samtranslator/model/naming.py
+++ b/samtranslator/model/naming.py
@@ -6,9 +6,9 @@ class GeneratedLogicalId(object):
     """
 
     @staticmethod
-    def implicit_api():
+    def implicit_api():  # type: ignore[no-untyped-def]
         return "ServerlessRestApi"
 
     @staticmethod
-    def implicit_http_api():
+    def implicit_http_api():  # type: ignore[no-untyped-def]
         return "ServerlessHttpApi"

--- a/samtranslator/model/preferences/deployment_preference.py
+++ b/samtranslator/model/preferences/deployment_preference.py
@@ -46,7 +46,7 @@ class DeploymentPreference(DeploymentPreferenceTuple):
     """
 
     @classmethod
-    def from_dict(cls, logical_id, deployment_preference_dict, condition=None):
+    def from_dict(cls, logical_id, deployment_preference_dict, condition=None):  # type: ignore[no-untyped-def]
         """
         :param logical_id: the logical_id of the resource that owns this deployment preference
         :param deployment_preference_dict: the dict object taken from the SAM template
@@ -60,12 +60,12 @@ class DeploymentPreference(DeploymentPreferenceTuple):
             return DeploymentPreference(None, None, None, None, False, None, None, None)
 
         if "Type" not in deployment_preference_dict:
-            raise InvalidResourceException(logical_id, "'DeploymentPreference' is missing required Property 'Type'")
+            raise InvalidResourceException(logical_id, "'DeploymentPreference' is missing required Property 'Type'")  # type: ignore[no-untyped-call]
 
         deployment_type = deployment_preference_dict["Type"]
         hooks = deployment_preference_dict.get("Hooks", {})
         if not isinstance(hooks, dict):
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 logical_id, "'Hooks' property of 'DeploymentPreference' must be a dictionary"
             )
 

--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -43,14 +43,14 @@ class DeploymentPreferenceCollection(object):
     resources.
     """
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         """
         This collection stores an internal dict of the deployment preferences for each function's
         deployment preference in the SAM Template.
         """
         self._resource_preferences = {}
 
-    def add(self, logical_id, deployment_preference_dict, condition=None):
+    def add(self, logical_id, deployment_preference_dict, condition=None):  # type: ignore[no-untyped-def]
         """
         Add this deployment preference to the collection
 
@@ -66,23 +66,23 @@ class DeploymentPreferenceCollection(object):
                 )
             )
 
-        self._resource_preferences[logical_id] = DeploymentPreference.from_dict(
+        self._resource_preferences[logical_id] = DeploymentPreference.from_dict(  # type: ignore[no-untyped-call]
             logical_id, deployment_preference_dict, condition
         )
 
-    def get(self, logical_id):
+    def get(self, logical_id):  # type: ignore[no-untyped-def]
         """
         :rtype: DeploymentPreference object previously added for this given logical_id
         """
         return self._resource_preferences.get(logical_id)
 
-    def any_enabled(self):
+    def any_enabled(self):  # type: ignore[no-untyped-def]
         """
         :return: boolean whether any deployment preferences in the collection are enabled
         """
         return any(preference.enabled for preference in self._resource_preferences.values())
 
-    def can_skip_service_role(self):
+    def can_skip_service_role(self):  # type: ignore[no-untyped-def]
         """
         If every one of the deployment preferences have a custom IAM role provided, we can skip creating the
         service role altogether.
@@ -90,7 +90,7 @@ class DeploymentPreferenceCollection(object):
         """
         return all(preference.role or not preference.enabled for preference in self._resource_preferences.values())
 
-    def needs_resource_condition(self):
+    def needs_resource_condition(self):  # type: ignore[no-untyped-def]
         """
         If all preferences have a condition, all code deploy resources need to be conditionally created
         :return: True, if a condition needs to be created
@@ -100,7 +100,7 @@ class DeploymentPreferenceCollection(object):
             not preference.condition and preference.enabled for preference in self._resource_preferences.values()
         )
 
-    def get_all_deployment_conditions(self):
+    def get_all_deployment_conditions(self):  # type: ignore[no-untyped-def]
         """
         Returns a list of all conditions associated with the deployment preference resources
         :return: List of condition names
@@ -111,32 +111,32 @@ class DeploymentPreferenceCollection(object):
             conditions_set.remove(None)
         return list(conditions_set)
 
-    def create_aggregate_deployment_condition(self):
+    def create_aggregate_deployment_condition(self):  # type: ignore[no-untyped-def]
         """
         Creates an aggregate deployment condition if necessary
         :return: None if <2 conditions are found, otherwise a dictionary of new conditions to add to template
         """
-        return make_combined_condition(self.get_all_deployment_conditions(), CODE_DEPLOY_CONDITION_NAME)
+        return make_combined_condition(self.get_all_deployment_conditions(), CODE_DEPLOY_CONDITION_NAME)  # type: ignore[no-untyped-call, no-untyped-call]
 
-    def enabled_logical_ids(self):
+    def enabled_logical_ids(self):  # type: ignore[no-untyped-def]
         """
         :return: only the logical id's for the deployment preferences in this collection which are enabled
         """
         return [logical_id for logical_id, preference in self._resource_preferences.items() if preference.enabled]
 
-    def get_codedeploy_application(self):
-        codedeploy_application_resource = CodeDeployApplication(CODEDEPLOY_APPLICATION_LOGICAL_ID)
+    def get_codedeploy_application(self):  # type: ignore[no-untyped-def]
+        codedeploy_application_resource = CodeDeployApplication(CODEDEPLOY_APPLICATION_LOGICAL_ID)  # type: ignore[no-untyped-call]
         codedeploy_application_resource.ComputePlatform = "Lambda"
-        if self.needs_resource_condition():
-            conditions = self.get_all_deployment_conditions()
+        if self.needs_resource_condition():  # type: ignore[no-untyped-call]
+            conditions = self.get_all_deployment_conditions()  # type: ignore[no-untyped-call]
             condition_name = CODE_DEPLOY_CONDITION_NAME
             if len(conditions) <= 1:
                 condition_name = conditions.pop()
-            codedeploy_application_resource.set_resource_attribute("Condition", condition_name)
+            codedeploy_application_resource.set_resource_attribute("Condition", condition_name)  # type: ignore[no-untyped-call]
         return codedeploy_application_resource
 
-    def get_codedeploy_iam_role(self):
-        iam_role = IAMRole(CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID)
+    def get_codedeploy_iam_role(self):  # type: ignore[no-untyped-def]
+        iam_role = IAMRole(CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID)  # type: ignore[no-untyped-call]
         iam_role.AssumeRolePolicyDocument = {
             "Version": "2012-10-17",
             "Statement": [
@@ -150,51 +150,51 @@ class DeploymentPreferenceCollection(object):
 
         # CodeDeploy has a new managed policy. We cannot update any existing partitions, without customer reach out
         # that support AWSCodeDeployRoleForLambda since this could regress stacks that are currently deployed.
-        if ArnGenerator.get_partition_name() in ["aws-iso", "aws-iso-b"]:
+        if ArnGenerator.get_partition_name() in ["aws-iso", "aws-iso-b"]:  # type: ignore[no-untyped-call]
             iam_role.ManagedPolicyArns = [
-                ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSCodeDeployRoleForLambdaLimited")
+                ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSCodeDeployRoleForLambdaLimited")  # type: ignore[no-untyped-call]
             ]
         else:
             iam_role.ManagedPolicyArns = [
-                ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSCodeDeployRoleForLambda")
+                ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSCodeDeployRoleForLambda")  # type: ignore[no-untyped-call]
             ]
 
-        if self.needs_resource_condition():
-            conditions = self.get_all_deployment_conditions()
+        if self.needs_resource_condition():  # type: ignore[no-untyped-call]
+            conditions = self.get_all_deployment_conditions()  # type: ignore[no-untyped-call]
             condition_name = CODE_DEPLOY_CONDITION_NAME
             if len(conditions) <= 1:
                 condition_name = conditions.pop()
-            iam_role.set_resource_attribute("Condition", condition_name)
+            iam_role.set_resource_attribute("Condition", condition_name)  # type: ignore[no-untyped-call]
         return iam_role
 
-    def deployment_group(self, function_logical_id):
+    def deployment_group(self, function_logical_id):  # type: ignore[no-untyped-def]
         """
         :param function_logical_id: logical_id of the function this deployment group belongs to
         :return: CodeDeployDeploymentGroup resource
         """
 
-        deployment_preference = self.get(function_logical_id)
+        deployment_preference = self.get(function_logical_id)  # type: ignore[no-untyped-call]
 
-        deployment_group = CodeDeployDeploymentGroup(self.deployment_group_logical_id(function_logical_id))
+        deployment_group = CodeDeployDeploymentGroup(self.deployment_group_logical_id(function_logical_id))  # type: ignore[no-untyped-call, no-untyped-call]
 
         try:
-            deployment_group.AlarmConfiguration = self._convert_alarms(deployment_preference.alarms)
+            deployment_group.AlarmConfiguration = self._convert_alarms(deployment_preference.alarms)  # type: ignore[no-untyped-call]
         except ValueError as e:
-            raise InvalidResourceException(function_logical_id, str(e))
+            raise InvalidResourceException(function_logical_id, str(e))  # type: ignore[no-untyped-call]
 
-        deployment_group.ApplicationName = ref(CODEDEPLOY_APPLICATION_LOGICAL_ID)
+        deployment_group.ApplicationName = ref(CODEDEPLOY_APPLICATION_LOGICAL_ID)  # type: ignore[no-untyped-call]
         deployment_group.AutoRollbackConfiguration = {
             "Enabled": True,
             "Events": ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM", "DEPLOYMENT_STOP_ON_REQUEST"],
         }
 
-        deployment_group.DeploymentConfigName = self._replace_deployment_types(
+        deployment_group.DeploymentConfigName = self._replace_deployment_types(  # type: ignore[no-untyped-call]
             copy.deepcopy(deployment_preference.deployment_type)
         )
 
         deployment_group.DeploymentStyle = {"DeploymentType": "BLUE_GREEN", "DeploymentOption": "WITH_TRAFFIC_CONTROL"}
 
-        deployment_group.ServiceRoleArn = fnGetAtt(CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID, "Arn")
+        deployment_group.ServiceRoleArn = fnGetAtt(CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID, "Arn")  # type: ignore[no-untyped-call]
         if deployment_preference.role:
             deployment_group.ServiceRoleArn = deployment_preference.role
 
@@ -202,11 +202,11 @@ class DeploymentPreferenceCollection(object):
             deployment_group.TriggerConfigurations = deployment_preference.trigger_configurations
 
         if deployment_preference.condition:
-            deployment_group.set_resource_attribute("Condition", deployment_preference.condition)
+            deployment_group.set_resource_attribute("Condition", deployment_preference.condition)  # type: ignore[no-untyped-call]
 
         return deployment_group
 
-    def _convert_alarms(self, preference_alarms):
+    def _convert_alarms(self, preference_alarms):  # type: ignore[no-untyped-def]
         """
         Converts deployment preference alarms to an AlarmsConfiguration
 
@@ -225,20 +225,20 @@ class DeploymentPreferenceCollection(object):
         ValueError
             If Alarms is in the wrong format
         """
-        if not preference_alarms or is_intrinsic_no_value(preference_alarms):
+        if not preference_alarms or is_intrinsic_no_value(preference_alarms):  # type: ignore[no-untyped-call]
             return None
 
-        if is_intrinsic_if(preference_alarms):
+        if is_intrinsic_if(preference_alarms):  # type: ignore[no-untyped-call]
             processed_alarms = copy.deepcopy(preference_alarms)
             alarms_list = processed_alarms.get("Fn::If")
-            validate_intrinsic_if_items(alarms_list)
-            alarms_list[1] = self._build_alarm_configuration(alarms_list[1])
-            alarms_list[2] = self._build_alarm_configuration(alarms_list[2])
+            validate_intrinsic_if_items(alarms_list)  # type: ignore[no-untyped-call]
+            alarms_list[1] = self._build_alarm_configuration(alarms_list[1])  # type: ignore[no-untyped-call]
+            alarms_list[2] = self._build_alarm_configuration(alarms_list[2])  # type: ignore[no-untyped-call]
             return processed_alarms
 
-        return self._build_alarm_configuration(preference_alarms)
+        return self._build_alarm_configuration(preference_alarms)  # type: ignore[no-untyped-call]
 
-    def _build_alarm_configuration(self, alarms):
+    def _build_alarm_configuration(self, alarms):  # type: ignore[no-untyped-def]
         """
         Builds an AlarmConfiguration from a list of alarms
 
@@ -260,7 +260,7 @@ class DeploymentPreferenceCollection(object):
         if not isinstance(alarms, list):
             raise ValueError("Alarms must be a list")
 
-        if len(alarms) == 0 or is_intrinsic_no_value(alarms[0]):
+        if len(alarms) == 0 or is_intrinsic_no_value(alarms[0]):  # type: ignore[no-untyped-call]
             return {}
 
         return {
@@ -268,43 +268,43 @@ class DeploymentPreferenceCollection(object):
             "Alarms": [{"Name": alarm} for alarm in alarms],
         }
 
-    def _replace_deployment_types(self, value, key=None):
+    def _replace_deployment_types(self, value, key=None):  # type: ignore[no-untyped-def]
         if isinstance(value, list):
             for i, v in enumerate(value):
-                value[i] = self._replace_deployment_types(v)
+                value[i] = self._replace_deployment_types(v)  # type: ignore[no-untyped-call]
             return value
-        if is_intrinsic(value):
+        if is_intrinsic(value):  # type: ignore[no-untyped-call]
             for (k, v) in value.items():
-                value[k] = self._replace_deployment_types(v, k)
+                value[k] = self._replace_deployment_types(v, k)  # type: ignore[no-untyped-call]
             return value
         if value in CODEDEPLOY_PREDEFINED_CONFIGURATIONS_LIST:
             if key == "Fn::Sub":  # Don't nest a "Sub" in a "Sub"
                 return ["CodeDeployDefault.Lambda${ConfigName}", {"ConfigName": value}]
-            return fnSub("CodeDeployDefault.Lambda${ConfigName}", {"ConfigName": value})
+            return fnSub("CodeDeployDefault.Lambda${ConfigName}", {"ConfigName": value})  # type: ignore[no-untyped-call]
         return value
 
-    def update_policy(self, function_logical_id):
-        deployment_preference = self.get(function_logical_id)
+    def update_policy(self, function_logical_id):  # type: ignore[no-untyped-def]
+        deployment_preference = self.get(function_logical_id)  # type: ignore[no-untyped-call]
 
         return UpdatePolicy(
-            ref(CODEDEPLOY_APPLICATION_LOGICAL_ID),
-            self.deployment_group(function_logical_id).get_runtime_attr("name"),
+            ref(CODEDEPLOY_APPLICATION_LOGICAL_ID),  # type: ignore[no-untyped-call]
+            self.deployment_group(function_logical_id).get_runtime_attr("name"),  # type: ignore[no-untyped-call]
             deployment_preference.pre_traffic_hook,
             deployment_preference.post_traffic_hook,
         )
 
-    def deployment_group_logical_id(self, function_logical_id):
+    def deployment_group_logical_id(self, function_logical_id):  # type: ignore[no-untyped-def]
         return function_logical_id + "DeploymentGroup"
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # type: ignore[no-untyped-def]
         if isinstance(other, self.__class__):
             return self.__dict__ == other.__dict__
         return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other):  # type: ignore[no-untyped-def]
         if isinstance(other, self.__class__):
-            return not self.__eq__(other)
+            return not self.__eq__(other)  # type: ignore[no-untyped-call]
         return NotImplemented
 
-    def __hash__(self):
+    def __hash__(self):  # type: ignore[no-untyped-def]
         return hash(tuple(sorted(self.__dict__.items())))

--- a/samtranslator/model/resource_policies.py
+++ b/samtranslator/model/resource_policies.py
@@ -28,7 +28,7 @@ class ResourcePolicies(object):
 
     POLICIES_PROPERTY_NAME = "Policies"
 
-    def __init__(self, resource_properties, policy_template_processor=None):
+    def __init__(self, resource_properties, policy_template_processor=None):  # type: ignore[no-untyped-def]
         """
         Initialize with policies data from resource's properties
 
@@ -41,9 +41,9 @@ class ResourcePolicies(object):
         self._policy_template_processor = policy_template_processor
 
         # Build the list of policies upon construction.
-        self.policies = self._get_policies(resource_properties)
+        self.policies = self._get_policies(resource_properties)  # type: ignore[no-untyped-call]
 
-    def get(self):
+    def get(self):  # type: ignore[no-untyped-def]
         """
         Iterator method that "yields" the next policy entry on subsequent calls to this method.
 
@@ -53,10 +53,10 @@ class ResourcePolicies(object):
         for policy_tuple in self.policies:
             yield policy_tuple
 
-    def __len__(self):
+    def __len__(self):  # type: ignore[no-untyped-def]
         return len(self.policies)
 
-    def _get_policies(self, resource_properties):
+    def _get_policies(self, resource_properties):  # type: ignore[no-untyped-def]
         """
         Returns a list of policies from the resource properties. This method knows how to interpret and handle
         polymorphic nature of the policies property.
@@ -78,7 +78,7 @@ class ResourcePolicies(object):
 
         policies = None
 
-        if self._contains_policies(resource_properties):
+        if self._contains_policies(resource_properties):  # type: ignore[no-untyped-call]
             policies = resource_properties[self.POLICIES_PROPERTY_NAME]
 
         if not policies:
@@ -91,13 +91,13 @@ class ResourcePolicies(object):
 
         result = []
         for policy in policies:
-            policy_type = self._get_type(policy)
+            policy_type = self._get_type(policy)  # type: ignore[no-untyped-call]
             entry = PolicyEntry(data=policy, type=policy_type)
             result.append(entry)
 
         return result
 
-    def _contains_policies(self, resource_properties):
+    def _contains_policies(self, resource_properties):  # type: ignore[no-untyped-def]
         """
         Is there policies data in this resource?
 
@@ -110,7 +110,7 @@ class ResourcePolicies(object):
             and self.POLICIES_PROPERTY_NAME in resource_properties
         )
 
-    def _get_type(self, policy):
+    def _get_type(self, policy):  # type: ignore[no-untyped-def]
         """
         Returns the type of the given policy
 
@@ -125,11 +125,11 @@ class ResourcePolicies(object):
             return PolicyTypes.MANAGED_POLICY
 
         # Handle the special case for 'if' intrinsic function
-        if is_intrinsic_if(policy):
-            return self._get_type_from_intrinsic_if(policy)
+        if is_intrinsic_if(policy):  # type: ignore[no-untyped-call]
+            return self._get_type_from_intrinsic_if(policy)  # type: ignore[no-untyped-call]
 
         # Intrinsic functions are treated as managed policies by default
-        if is_intrinsic(policy):
+        if is_intrinsic(policy):  # type: ignore[no-untyped-call]
             return PolicyTypes.MANAGED_POLICY
 
         # Policy statement is a dictionary with the key "Statement" in it
@@ -137,13 +137,13 @@ class ResourcePolicies(object):
             return PolicyTypes.POLICY_STATEMENT
 
         # This could be a policy template then.
-        if self._is_policy_template(policy):
+        if self._is_policy_template(policy):  # type: ignore[no-untyped-call]
             return PolicyTypes.POLICY_TEMPLATE
 
         # Nothing matches. Don't take opinions on how to handle it. Instead just set the appropriate type.
         return PolicyTypes.UNKNOWN
 
-    def _is_policy_template(self, policy):
+    def _is_policy_template(self, policy):  # type: ignore[no-untyped-def]
         """
         Is the given policy data a policy template? Policy templates is a dictionary with one key which is the name
         of the template.
@@ -159,7 +159,7 @@ class ResourcePolicies(object):
             and self._policy_template_processor.has(list(policy.keys())[0]) is True
         )
 
-    def _get_type_from_intrinsic_if(self, policy):
+    def _get_type_from_intrinsic_if(self, policy):  # type: ignore[no-untyped-def]
         """
         Returns the type of the given policy assuming that it is an intrinsic if function
 
@@ -169,26 +169,26 @@ class ResourcePolicies(object):
         intrinsic_if_value = policy["Fn::If"]
 
         try:
-            validate_intrinsic_if_items(intrinsic_if_value)
+            validate_intrinsic_if_items(intrinsic_if_value)  # type: ignore[no-untyped-call]
         except ValueError as e:
-            raise InvalidTemplateException(e)
+            raise InvalidTemplateException(e)  # type: ignore[no-untyped-call]
 
         if_data = intrinsic_if_value[1]
         else_data = intrinsic_if_value[2]
 
-        if_data_type = self._get_type(if_data)
-        else_data_type = self._get_type(else_data)
+        if_data_type = self._get_type(if_data)  # type: ignore[no-untyped-call]
+        else_data_type = self._get_type(else_data)  # type: ignore[no-untyped-call]
 
         if if_data_type == else_data_type:
             return if_data_type
 
-        if is_intrinsic_no_value(if_data):
+        if is_intrinsic_no_value(if_data):  # type: ignore[no-untyped-call]
             return else_data_type
 
-        if is_intrinsic_no_value(else_data):
+        if is_intrinsic_no_value(else_data):  # type: ignore[no-untyped-call]
             return if_data_type
 
-        raise InvalidTemplateException(
+        raise InvalidTemplateException(  # type: ignore[no-untyped-call]
             "Different policy types within the same Fn::If statement is unsupported. "
             "Separate different policy types into different Fn::If statements"
         )

--- a/samtranslator/model/role_utils/role_constructor.py
+++ b/samtranslator/model/role_utils/role_constructor.py
@@ -4,7 +4,7 @@ from samtranslator.model.intrinsics import is_intrinsic_if, is_intrinsic_no_valu
 from samtranslator.model.exceptions import InvalidResourceException
 
 
-def construct_role_for_resource(
+def construct_role_for_resource(  # type: ignore[no-untyped-def]
     resource_logical_id,
     attributes,
     managed_policy_map,
@@ -31,7 +31,7 @@ def construct_role_for_resource(
     :rtype: model.iam.IAMRole
     """
     role_logical_id = resource_logical_id + "Role"
-    execution_role = IAMRole(logical_id=role_logical_id, attributes=attributes)
+    execution_role = IAMRole(logical_id=role_logical_id, attributes=attributes)  # type: ignore[no-untyped-call]
     execution_role.AssumeRolePolicyDocument = assume_role_policy_document
 
     if not managed_policy_arns:
@@ -43,20 +43,20 @@ def construct_role_for_resource(
     for index, policy_entry in enumerate(resource_policies.get()):
         if policy_entry.type is PolicyTypes.POLICY_STATEMENT:
 
-            if is_intrinsic_if(policy_entry.data):
+            if is_intrinsic_if(policy_entry.data):  # type: ignore[no-untyped-call]
 
                 intrinsic_if = policy_entry.data
                 then_statement = intrinsic_if["Fn::If"][1]
                 else_statement = intrinsic_if["Fn::If"][2]
 
-                if not is_intrinsic_no_value(then_statement):
+                if not is_intrinsic_no_value(then_statement):  # type: ignore[no-untyped-call]
                     then_statement = {
                         "PolicyName": execution_role.logical_id + "Policy" + str(index),
                         "PolicyDocument": then_statement,
                     }
                     intrinsic_if["Fn::If"][1] = then_statement
 
-                if not is_intrinsic_no_value(else_statement):
+                if not is_intrinsic_no_value(else_statement):  # type: ignore[no-untyped-call]
                     else_statement = {
                         "PolicyName": execution_role.logical_id + "Policy" + str(index),
                         "PolicyDocument": else_statement,
@@ -94,7 +94,7 @@ def construct_role_for_resource(
                 managed_policy_arns.append(policy_arn)
         else:
             # Policy Templates are not supported here in the "core"
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 resource_logical_id,
                 "Policy at index {} in the '{}' property is not valid".format(
                     index, resource_policies.POLICIES_PROPERTY_NAME

--- a/samtranslator/model/route53.py
+++ b/samtranslator/model/route53.py
@@ -5,7 +5,7 @@ from samtranslator.model.types import is_type, is_str
 class Route53RecordSetGroup(Resource):
     resource_type = "AWS::Route53::RecordSetGroup"
     property_types = {
-        "HostedZoneId": PropertyType(False, is_str()),
-        "HostedZoneName": PropertyType(False, is_str()),
-        "RecordSets": PropertyType(False, is_type(list)),
+        "HostedZoneId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "HostedZoneName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RecordSets": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
     }

--- a/samtranslator/model/s3.py
+++ b/samtranslator/model/s3.py
@@ -6,26 +6,26 @@ from samtranslator.model.intrinsics import ref, fnGetAtt
 class S3Bucket(Resource):
     resource_type = "AWS::S3::Bucket"
     property_types = {
-        "AccessControl": PropertyType(False, any_type()),
-        "AccelerateConfiguration": PropertyType(False, any_type()),
-        "AnalyticsConfigurations": PropertyType(False, any_type()),
-        "BucketEncryption": PropertyType(False, any_type()),
-        "BucketName": PropertyType(False, is_str()),
-        "CorsConfiguration": PropertyType(False, any_type()),
-        "IntelligentTieringConfigurations": PropertyType(False, any_type()),
-        "InventoryConfigurations": PropertyType(False, any_type()),
-        "LifecycleConfiguration": PropertyType(False, any_type()),
-        "LoggingConfiguration": PropertyType(False, any_type()),
-        "MetricsConfigurations": PropertyType(False, any_type()),
-        "NotificationConfiguration": PropertyType(False, is_type(dict)),
-        "ObjectLockConfiguration": PropertyType(False, any_type()),
-        "ObjectLockEnabled": PropertyType(False, any_type()),
-        "OwnershipControls": PropertyType(False, any_type()),
-        "PublicAccessBlockConfiguration": PropertyType(False, is_type(dict)),
-        "ReplicationConfiguration": PropertyType(False, any_type()),
-        "Tags": PropertyType(False, is_type(list)),
-        "VersioningConfiguration": PropertyType(False, any_type()),
-        "WebsiteConfiguration": PropertyType(False, any_type()),
+        "AccessControl": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AccelerateConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AnalyticsConfigurations": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BucketEncryption": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BucketName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CorsConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "IntelligentTieringConfigurations": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "InventoryConfigurations": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "LifecycleConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "LoggingConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MetricsConfigurations": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "NotificationConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ObjectLockConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ObjectLockEnabled": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "OwnershipControls": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "PublicAccessBlockConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ReplicationConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "VersioningConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "WebsiteConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]

--- a/samtranslator/model/s3_utils/uri_parser.py
+++ b/samtranslator/model/s3_utils/uri_parser.py
@@ -2,7 +2,7 @@ from urllib.parse import urlparse, parse_qs
 from samtranslator.model.exceptions import InvalidResourceException
 
 
-def parse_s3_uri(uri):
+def parse_s3_uri(uri):  # type: ignore[no-untyped-def]
     """Parses a S3 Uri into a dictionary of the Bucket, Key, and VersionId
 
     :return: a BodyS3Location dict or None if not an S3 Uri
@@ -22,7 +22,7 @@ def parse_s3_uri(uri):
     return None
 
 
-def to_s3_uri(code_dict):
+def to_s3_uri(code_dict):  # type: ignore[no-untyped-def]
     """Constructs a S3 URI string from given code dictionary
 
     :param dict code_dict: Dictionary containing Lambda function Code S3 location of the form
@@ -43,7 +43,7 @@ def to_s3_uri(code_dict):
     return uri
 
 
-def construct_image_code_object(image_uri, logical_id, property_name):
+def construct_image_code_object(image_uri, logical_id, property_name):  # type: ignore[no-untyped-def]
     """Constructs a Lambda `Code` or `Content` property, from the SAM `ImageUri` property.
     This follows the current scheme for Lambda Functions.
 
@@ -54,14 +54,14 @@ def construct_image_code_object(image_uri, logical_id, property_name):
     :rtype: dict
     """
     if not image_uri:
-        raise InvalidResourceException(
+        raise InvalidResourceException(  # type: ignore[no-untyped-call]
             logical_id, "'{}' requires that a image hosted at a registry be specified.".format(property_name)
         )
 
     return {"ImageUri": image_uri}
 
 
-def construct_s3_location_object(location_uri, logical_id, property_name):
+def construct_s3_location_object(location_uri, logical_id, property_name):  # type: ignore[no-untyped-def]
     """Constructs a Lambda `Code` or `Content` property, from the SAM `CodeUri` or `ContentUri` property.
     This follows the current scheme for Lambda Functions and LayerVersions.
 
@@ -74,7 +74,7 @@ def construct_s3_location_object(location_uri, logical_id, property_name):
     if isinstance(location_uri, dict):
         if not location_uri.get("Bucket") or not location_uri.get("Key"):
             # location_uri is a dictionary but does not contain Bucket or Key property
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 logical_id, "'{}' requires Bucket and Key properties to be specified.".format(property_name)
             )
 
@@ -82,7 +82,7 @@ def construct_s3_location_object(location_uri, logical_id, property_name):
 
     else:
         # location_uri is NOT a dictionary. Parse it as a string
-        s3_pointer = parse_s3_uri(location_uri)
+        s3_pointer = parse_s3_uri(location_uri)  # type: ignore[no-untyped-call]
 
         if s3_pointer is None:
             raise InvalidResourceException(

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -66,8 +66,8 @@ from samtranslator.model.intrinsics import (
 )
 from samtranslator.model.sqs import SQSQueue, SQSQueuePolicy
 from samtranslator.model.sns import SNSTopic, SNSTopicPolicy
-from samtranslator.model.stepfunctions import StateMachineGenerator
-from samtranslator.model.role_utils import construct_role_for_resource
+from samtranslator.model.stepfunctions import StateMachineGenerator  # type: ignore[attr-defined]
+from samtranslator.model.role_utils import construct_role_for_resource  # type: ignore[attr-defined]
 from samtranslator.model.xray_utils import get_xray_managed_policy_name
 
 
@@ -76,44 +76,44 @@ class SamFunction(SamResourceMacro):
 
     resource_type = "AWS::Serverless::Function"
     property_types = {
-        "FunctionName": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "Handler": PropertyType(False, is_str()),
-        "Runtime": PropertyType(False, is_str()),
-        "CodeUri": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "ImageUri": PropertyType(False, is_str()),
-        "PackageType": PropertyType(False, is_str()),
-        "InlineCode": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "DeadLetterQueue": PropertyType(False, is_type(dict)),
-        "Description": PropertyType(False, is_str()),
-        "MemorySize": PropertyType(False, is_type(int)),
-        "Timeout": PropertyType(False, is_type(int)),
-        "VpcConfig": PropertyType(False, is_type(dict)),
-        "Role": PropertyType(False, is_str()),
-        "AssumeRolePolicyDocument": PropertyType(False, is_type(dict)),
-        "Policies": PropertyType(False, one_of(is_str(), is_type(dict), list_of(one_of(is_str(), is_type(dict))))),
-        "PermissionsBoundary": PropertyType(False, is_str()),
-        "Environment": PropertyType(False, dict_of(is_str(), is_type(dict))),
-        "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),
-        "Tags": PropertyType(False, is_type(dict)),
-        "Tracing": PropertyType(False, one_of(is_type(dict), is_str())),
-        "KmsKeyArn": PropertyType(False, one_of(is_type(dict), is_str())),
-        "DeploymentPreference": PropertyType(False, is_type(dict)),
-        "ReservedConcurrentExecutions": PropertyType(False, any_type()),
-        "Layers": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "EventInvokeConfig": PropertyType(False, is_type(dict)),
-        "EphemeralStorage": PropertyType(False, is_type(dict)),
+        "FunctionName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Handler": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Runtime": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CodeUri": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "ImageUri": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "PackageType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "InlineCode": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "DeadLetterQueue": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MemorySize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Timeout": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "VpcConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Role": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AssumeRolePolicyDocument": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Policies": PropertyType(False, one_of(is_str(), is_type(dict), list_of(one_of(is_str(), is_type(dict))))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "PermissionsBoundary": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Environment": PropertyType(False, dict_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Tracing": PropertyType(False, one_of(is_type(dict), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "KmsKeyArn": PropertyType(False, one_of(is_type(dict), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "DeploymentPreference": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ReservedConcurrentExecutions": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Layers": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "EventInvokeConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EphemeralStorage": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
         # Intrinsic functions in value of Alias property are not supported, yet
-        "AutoPublishAlias": PropertyType(False, one_of(is_str())),
-        "AutoPublishCodeSha256": PropertyType(False, one_of(is_str())),
-        "VersionDescription": PropertyType(False, is_str()),
-        "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),
-        "FileSystemConfigs": PropertyType(False, list_of(is_type(dict))),
-        "ImageConfig": PropertyType(False, is_type(dict)),
-        "CodeSigningConfigArn": PropertyType(False, is_str()),
-        "Architectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "FunctionUrlConfig": PropertyType(False, is_type(dict)),
+        "AutoPublishAlias": PropertyType(False, one_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "AutoPublishCodeSha256": PropertyType(False, one_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "VersionDescription": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FileSystemConfigs": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "ImageConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CodeSigningConfigArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Architectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "FunctionUrlConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
-    event_resolver = ResourceTypeResolver(
+    event_resolver = ResourceTypeResolver(  # type: ignore[no-untyped-call]
         samtranslator.model.eventsources,
         samtranslator.model.eventsources.pull,
         samtranslator.model.eventsources.push,
@@ -136,14 +136,14 @@ class SamFunction(SamResourceMacro):
         "DestinationQueue": SQSQueue.resource_type,
     }
 
-    def resources_to_link(self, resources):
+    def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
         try:
-            return {"event_resources": self._event_resources_to_link(resources)}
+            return {"event_resources": self._event_resources_to_link(resources)}  # type: ignore[no-untyped-call]
         except InvalidEventException as e:
-            raise InvalidResourceException(self.logical_id, e.message)
+            raise InvalidResourceException(self.logical_id, e.message)  # type: ignore[no-untyped-call]
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the Lambda function, role, and event resources to which this SAM Function corresponds.
 
         :param dict kwargs: already-converted resources that may need to be modified when converting this \
@@ -157,58 +157,58 @@ class SamFunction(SamResourceMacro):
         conditions = kwargs.get("conditions", {})
         feature_toggle = kwargs.get("feature_toggle")
 
-        if self.DeadLetterQueue:
-            self._validate_dlq()
+        if self.DeadLetterQueue:  # type: ignore[attr-defined]
+            self._validate_dlq()  # type: ignore[no-untyped-call]
 
-        lambda_function = self._construct_lambda_function()
+        lambda_function = self._construct_lambda_function()  # type: ignore[no-untyped-call]
         resources.append(lambda_function)
 
-        if self.ProvisionedConcurrencyConfig:
-            if not self.AutoPublishAlias:
-                raise InvalidResourceException(
+        if self.ProvisionedConcurrencyConfig:  # type: ignore[attr-defined]
+            if not self.AutoPublishAlias:  # type: ignore[attr-defined]
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     "To set ProvisionedConcurrencyConfig AutoPublishALias must be defined on the function",
                 )
 
         lambda_alias = None
         alias_name = ""
-        if self.AutoPublishAlias:
-            alias_name = self._get_resolved_alias_name("AutoPublishAlias", self.AutoPublishAlias, intrinsics_resolver)
+        if self.AutoPublishAlias:  # type: ignore[attr-defined]
+            alias_name = self._get_resolved_alias_name("AutoPublishAlias", self.AutoPublishAlias, intrinsics_resolver)  # type: ignore[attr-defined, no-untyped-call]
             code_sha256 = None
-            if self.AutoPublishCodeSha256:
-                code_sha256 = intrinsics_resolver.resolve_parameter_refs(self.AutoPublishCodeSha256)
+            if self.AutoPublishCodeSha256:  # type: ignore[attr-defined]
+                code_sha256 = intrinsics_resolver.resolve_parameter_refs(self.AutoPublishCodeSha256)  # type: ignore[attr-defined]
                 if not isinstance(code_sha256, str):
-                    raise InvalidResourceException(
+                    raise InvalidResourceException(  # type: ignore[no-untyped-call]
                         self.logical_id,
                         "AutoPublishCodeSha256 must be a string",
                     )
-            lambda_version = self._construct_version(
+            lambda_version = self._construct_version(  # type: ignore[no-untyped-call]
                 lambda_function, intrinsics_resolver=intrinsics_resolver, code_sha256=code_sha256
             )
-            lambda_alias = self._construct_alias(alias_name, lambda_function, lambda_version)
+            lambda_alias = self._construct_alias(alias_name, lambda_function, lambda_version)  # type: ignore[no-untyped-call]
             resources.append(lambda_version)
             resources.append(lambda_alias)
 
-        if self.FunctionUrlConfig:
-            lambda_url = self._construct_function_url(lambda_function, lambda_alias)
+        if self.FunctionUrlConfig:  # type: ignore[attr-defined]
+            lambda_url = self._construct_function_url(lambda_function, lambda_alias)  # type: ignore[no-untyped-call]
             resources.append(lambda_url)
-            url_permission = self._construct_url_permission(lambda_function, lambda_alias)
+            url_permission = self._construct_url_permission(lambda_function, lambda_alias)  # type: ignore[no-untyped-call]
             if url_permission:
                 resources.append(url_permission)
 
-        if self.DeploymentPreference:
-            self._validate_deployment_preference_and_add_update_policy(
+        if self.DeploymentPreference:  # type: ignore[attr-defined]
+            self._validate_deployment_preference_and_add_update_policy(  # type: ignore[no-untyped-call]
                 kwargs.get("deployment_preference_collection", None),
                 lambda_alias,
                 intrinsics_resolver,
                 mappings_resolver,
-                self.get_passthrough_resource_attributes(),
+                self.get_passthrough_resource_attributes(),  # type: ignore[no-untyped-call]
                 feature_toggle,
             )
         event_invoke_policies = []
-        if self.EventInvokeConfig:
+        if self.EventInvokeConfig:  # type: ignore[attr-defined]
             function_name = lambda_function.logical_id
-            event_invoke_resources, event_invoke_policies = self._construct_event_invoke_config(
+            event_invoke_resources, event_invoke_policies = self._construct_event_invoke_config(  # type: ignore[no-untyped-call]
                 function_name, alias_name, lambda_alias, intrinsics_resolver, conditions
             )
             resources.extend(event_invoke_resources)
@@ -219,12 +219,12 @@ class SamFunction(SamResourceMacro):
 
         execution_role = None
         if lambda_function.Role is None:
-            execution_role = self._construct_role(managed_policy_map, event_invoke_policies)
+            execution_role = self._construct_role(managed_policy_map, event_invoke_policies)  # type: ignore[no-untyped-call]
             lambda_function.Role = execution_role.get_runtime_attr("arn")
             resources.append(execution_role)
 
         try:
-            resources += self._generate_event_resources(
+            resources += self._generate_event_resources(  # type: ignore[no-untyped-call]
                 lambda_function,
                 execution_role,
                 kwargs["event_resources"],
@@ -232,11 +232,11 @@ class SamFunction(SamResourceMacro):
                 lambda_alias=lambda_alias,
             )
         except InvalidEventException as e:
-            raise InvalidResourceException(self.logical_id, e.message)
+            raise InvalidResourceException(self.logical_id, e.message)  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _construct_event_invoke_config(self, function_name, alias_name, lambda_alias, intrinsics_resolver, conditions):
+    def _construct_event_invoke_config(self, function_name, alias_name, lambda_alias, intrinsics_resolver, conditions):  # type: ignore[no-untyped-def]
         """
         Create a `AWS::Lambda::EventInvokeConfig` based on the input dict `EventInvokeConfig`
         """
@@ -244,43 +244,43 @@ class SamFunction(SamResourceMacro):
         policy_document = []
 
         # Try to resolve.
-        resolved_event_invoke_config = intrinsics_resolver.resolve_parameter_refs(self.EventInvokeConfig)
+        resolved_event_invoke_config = intrinsics_resolver.resolve_parameter_refs(self.EventInvokeConfig)  # type: ignore[attr-defined]
 
         logical_id = "{id}EventInvokeConfig".format(id=function_name)
         if lambda_alias:
-            lambda_event_invoke_config = LambdaEventInvokeConfig(
+            lambda_event_invoke_config = LambdaEventInvokeConfig(  # type: ignore[no-untyped-call]
                 logical_id=logical_id, depends_on=[lambda_alias.logical_id], attributes=self.resource_attributes
             )
         else:
-            lambda_event_invoke_config = LambdaEventInvokeConfig(
+            lambda_event_invoke_config = LambdaEventInvokeConfig(  # type: ignore[no-untyped-call]
                 logical_id=logical_id, attributes=self.resource_attributes
             )
 
         dest_config = {}
         input_dest_config = resolved_event_invoke_config.get("DestinationConfig")
         if input_dest_config and input_dest_config.get("OnSuccess") is not None:
-            resource, on_success, policy = self._validate_and_inject_resource(
+            resource, on_success, policy = self._validate_and_inject_resource(  # type: ignore[no-untyped-call]
                 input_dest_config.get("OnSuccess"), "OnSuccess", logical_id, conditions
             )
             dest_config["OnSuccess"] = on_success
-            self.EventInvokeConfig["DestinationConfig"]["OnSuccess"]["Destination"] = on_success.get("Destination")
+            self.EventInvokeConfig["DestinationConfig"]["OnSuccess"]["Destination"] = on_success.get("Destination")  # type: ignore[attr-defined]
             if resource is not None:
                 resources.extend([resource])
             if policy is not None:
                 policy_document.append(policy)
 
         if input_dest_config and input_dest_config.get("OnFailure") is not None:
-            resource, on_failure, policy = self._validate_and_inject_resource(
+            resource, on_failure, policy = self._validate_and_inject_resource(  # type: ignore[no-untyped-call]
                 input_dest_config.get("OnFailure"), "OnFailure", logical_id, conditions
             )
             dest_config["OnFailure"] = on_failure
-            self.EventInvokeConfig["DestinationConfig"]["OnFailure"]["Destination"] = on_failure.get("Destination")
+            self.EventInvokeConfig["DestinationConfig"]["OnFailure"]["Destination"] = on_failure.get("Destination")  # type: ignore[attr-defined]
             if resource is not None:
                 resources.extend([resource])
             if policy is not None:
                 policy_document.append(policy)
 
-        lambda_event_invoke_config.FunctionName = ref(function_name)
+        lambda_event_invoke_config.FunctionName = ref(function_name)  # type: ignore[no-untyped-call]
         if alias_name:
             lambda_event_invoke_config.Qualifier = alias_name
         else:
@@ -294,7 +294,7 @@ class SamFunction(SamResourceMacro):
 
         return resources, policy_document
 
-    def _validate_and_inject_resource(self, dest_config, event, logical_id, conditions):
+    def _validate_and_inject_resource(self, dest_config, event, logical_id, conditions):  # type: ignore[no-untyped-def]
         """
         For Event Invoke Config, if the user has not specified a destination ARN for SQS/SNS, SAM
         auto creates a SQS and SNS resource with defaults. Intrinsics are supported in the Destination
@@ -310,62 +310,62 @@ class SamFunction(SamResourceMacro):
 
         resource_logical_id = logical_id + event
         if dest_config.get("Type") is None or dest_config.get("Type") not in accepted_types_list:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "'Type: {}' must be one of {}".format(dest_config.get("Type"), accepted_types_list)
             )
 
-        property_condition, dest_arn = self._get_or_make_condition(
+        property_condition, dest_arn = self._get_or_make_condition(  # type: ignore[no-untyped-call]
             dest_config.get("Destination"), logical_id, conditions
         )
         if dest_config.get("Destination") is None or property_condition is not None:
-            combined_condition = self._make_and_conditions(
-                self.get_passthrough_resource_attributes().get("Condition"), property_condition, conditions
+            combined_condition = self._make_and_conditions(  # type: ignore[no-untyped-call]
+                self.get_passthrough_resource_attributes().get("Condition"), property_condition, conditions  # type: ignore[no-untyped-call]
             )
             if dest_config.get("Type") in auto_inject_list:
                 if dest_config.get("Type") == "SQS":
-                    resource = SQSQueue(
-                        resource_logical_id + "Queue", attributes=self.get_passthrough_resource_attributes()
+                    resource = SQSQueue(  # type: ignore[no-untyped-call]
+                        resource_logical_id + "Queue", attributes=self.get_passthrough_resource_attributes()  # type: ignore[no-untyped-call]
                     )
                 if dest_config.get("Type") == "SNS":
-                    resource = SNSTopic(
-                        resource_logical_id + "Topic", attributes=self.get_passthrough_resource_attributes()
+                    resource = SNSTopic(  # type: ignore[no-untyped-call, assignment]
+                        resource_logical_id + "Topic", attributes=self.get_passthrough_resource_attributes()  # type: ignore[no-untyped-call]
                     )
                 if combined_condition:
-                    resource.set_resource_attribute("Condition", combined_condition)
+                    resource.set_resource_attribute("Condition", combined_condition)  # type: ignore[union-attr]
                 if property_condition:
-                    destination["Destination"] = make_conditional(
-                        property_condition, resource.get_runtime_attr("arn"), dest_arn
+                    destination["Destination"] = make_conditional(  # type: ignore[no-untyped-call]
+                        property_condition, resource.get_runtime_attr("arn"), dest_arn  # type: ignore[union-attr]
                     )
                 else:
-                    destination["Destination"] = resource.get_runtime_attr("arn")
-                policy = self._add_event_invoke_managed_policy(
+                    destination["Destination"] = resource.get_runtime_attr("arn")  # type: ignore[union-attr]
+                policy = self._add_event_invoke_managed_policy(  # type: ignore[no-untyped-call]
                     dest_config, resource_logical_id, property_condition, destination["Destination"]
                 )
             else:
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "Destination is required if Type is not {}".format(auto_inject_list)
                 )
         if dest_config.get("Destination") is not None and property_condition is None:
-            policy = self._add_event_invoke_managed_policy(
+            policy = self._add_event_invoke_managed_policy(  # type: ignore[no-untyped-call]
                 dest_config, resource_logical_id, None, dest_config.get("Destination")
             )
 
         return resource, destination, policy
 
-    def _make_and_conditions(self, resource_condition, property_condition, conditions):
+    def _make_and_conditions(self, resource_condition, property_condition, conditions):  # type: ignore[no-untyped-def]
         if resource_condition is None:
             return property_condition
 
         if property_condition is None:
             return resource_condition
 
-        and_condition = make_and_condition([{"Condition": resource_condition}, {"Condition": property_condition}])
-        condition_name = self._make_gen_condition_name(resource_condition + "AND" + property_condition, self.logical_id)
+        and_condition = make_and_condition([{"Condition": resource_condition}, {"Condition": property_condition}])  # type: ignore[no-untyped-call]
+        condition_name = self._make_gen_condition_name(resource_condition + "AND" + property_condition, self.logical_id)  # type: ignore[no-untyped-call]
         conditions[condition_name] = and_condition
 
         return condition_name
 
-    def _get_or_make_condition(self, destination, logical_id, conditions):
+    def _get_or_make_condition(self, destination, logical_id, conditions):  # type: ignore[no-untyped-def]
         """
         This method checks if there is an If condition on Destination property. Since we auto create
         SQS and SNS if the destination ARN is not provided, we need to make sure that If condition
@@ -381,28 +381,28 @@ class SamFunction(SamResourceMacro):
         """
         if destination is None:
             return None, None
-        if is_intrinsic_if(destination):
+        if is_intrinsic_if(destination):  # type: ignore[no-untyped-call]
             dest_list = destination.get("Fn::If")
-            if is_intrinsic_no_value(dest_list[1]) and is_intrinsic_no_value(dest_list[2]):
+            if is_intrinsic_no_value(dest_list[1]) and is_intrinsic_no_value(dest_list[2]):  # type: ignore[no-untyped-call]
                 return None, None
-            if is_intrinsic_no_value(dest_list[1]):
+            if is_intrinsic_no_value(dest_list[1]):  # type: ignore[no-untyped-call]
                 return dest_list[0], dest_list[2]
-            if is_intrinsic_no_value(dest_list[2]):
+            if is_intrinsic_no_value(dest_list[2]):  # type: ignore[no-untyped-call]
                 condition = dest_list[0]
-                not_condition = self._make_gen_condition_name("NOT" + condition, logical_id)
-                conditions[not_condition] = make_not_conditional(condition)
+                not_condition = self._make_gen_condition_name("NOT" + condition, logical_id)  # type: ignore[no-untyped-call]
+                conditions[not_condition] = make_not_conditional(condition)  # type: ignore[no-untyped-call]
                 return not_condition, dest_list[1]
         return None, None
 
-    def _make_gen_condition_name(self, name, hash_input):
+    def _make_gen_condition_name(self, name, hash_input):  # type: ignore[no-untyped-def]
         # Make sure the property name is not over 255 characters (CFN limit)
-        hash_digest = logical_id_generator.LogicalIdGenerator("", hash_input).gen()
+        hash_digest = logical_id_generator.LogicalIdGenerator("", hash_input).gen()  # type: ignore[no-untyped-call, no-untyped-call]
         condition_name = name + hash_digest
         if len(condition_name) > 255:
             return input(condition_name)[:255]
         return condition_name
 
-    def _get_resolved_alias_name(self, property_name, original_alias_value, intrinsics_resolver):
+    def _get_resolved_alias_name(self, property_name, original_alias_value, intrinsics_resolver):  # type: ignore[no-untyped-def]
         """
         Alias names can be supplied as an intrinsic function. This method tries to extract alias name from a reference
         to a parameter. If it cannot completely resolve (ie. if a complex intrinsic function was used), then this
@@ -420,108 +420,108 @@ class SamFunction(SamResourceMacro):
 
         if not isinstance(resolved_alias_name, str):
             # This is still a dictionary which means we are not able to completely resolve intrinsics
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "'{}' must be a string or a Ref to a template parameter".format(property_name)
             )
 
         return resolved_alias_name
 
-    def _construct_lambda_function(self):
+    def _construct_lambda_function(self):  # type: ignore[no-untyped-def]
         """Constructs and returns the Lambda function.
 
         :returns: a list containing the Lambda function and execution role resources
         :rtype: list
         """
-        lambda_function = LambdaFunction(
+        lambda_function = LambdaFunction(  # type: ignore[no-untyped-call]
             self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes
         )
 
-        if self.FunctionName:
-            lambda_function.FunctionName = self.FunctionName
+        if self.FunctionName:  # type: ignore[attr-defined]
+            lambda_function.FunctionName = self.FunctionName  # type: ignore[attr-defined]
 
-        lambda_function.Handler = self.Handler
-        lambda_function.Runtime = self.Runtime
-        lambda_function.Description = self.Description
-        lambda_function.MemorySize = self.MemorySize
-        lambda_function.Timeout = self.Timeout
-        lambda_function.VpcConfig = self.VpcConfig
-        lambda_function.Role = self.Role
-        lambda_function.Environment = self.Environment
-        lambda_function.Code = self._construct_code_dict()
-        lambda_function.KmsKeyArn = self.KmsKeyArn
-        lambda_function.ReservedConcurrentExecutions = self.ReservedConcurrentExecutions
-        lambda_function.Tags = self._construct_tag_list(self.Tags)
-        lambda_function.Layers = self.Layers
-        lambda_function.FileSystemConfigs = self.FileSystemConfigs
-        lambda_function.ImageConfig = self.ImageConfig
-        lambda_function.PackageType = self.PackageType
-        lambda_function.Architectures = self.Architectures
-        lambda_function.EphemeralStorage = self.EphemeralStorage
+        lambda_function.Handler = self.Handler  # type: ignore[attr-defined]
+        lambda_function.Runtime = self.Runtime  # type: ignore[attr-defined]
+        lambda_function.Description = self.Description  # type: ignore[attr-defined]
+        lambda_function.MemorySize = self.MemorySize  # type: ignore[attr-defined]
+        lambda_function.Timeout = self.Timeout  # type: ignore[attr-defined]
+        lambda_function.VpcConfig = self.VpcConfig  # type: ignore[attr-defined]
+        lambda_function.Role = self.Role  # type: ignore[attr-defined]
+        lambda_function.Environment = self.Environment  # type: ignore[attr-defined]
+        lambda_function.Code = self._construct_code_dict()  # type: ignore[no-untyped-call]
+        lambda_function.KmsKeyArn = self.KmsKeyArn  # type: ignore[attr-defined]
+        lambda_function.ReservedConcurrentExecutions = self.ReservedConcurrentExecutions  # type: ignore[attr-defined]
+        lambda_function.Tags = self._construct_tag_list(self.Tags)  # type: ignore[attr-defined, no-untyped-call]
+        lambda_function.Layers = self.Layers  # type: ignore[attr-defined]
+        lambda_function.FileSystemConfigs = self.FileSystemConfigs  # type: ignore[attr-defined]
+        lambda_function.ImageConfig = self.ImageConfig  # type: ignore[attr-defined]
+        lambda_function.PackageType = self.PackageType  # type: ignore[attr-defined]
+        lambda_function.Architectures = self.Architectures  # type: ignore[attr-defined]
+        lambda_function.EphemeralStorage = self.EphemeralStorage  # type: ignore[attr-defined]
 
-        if self.Tracing:
-            lambda_function.TracingConfig = {"Mode": self.Tracing}
+        if self.Tracing:  # type: ignore[attr-defined]
+            lambda_function.TracingConfig = {"Mode": self.Tracing}  # type: ignore[attr-defined]
 
-        if self.DeadLetterQueue:
-            lambda_function.DeadLetterConfig = {"TargetArn": self.DeadLetterQueue["TargetArn"]}
+        if self.DeadLetterQueue:  # type: ignore[attr-defined]
+            lambda_function.DeadLetterConfig = {"TargetArn": self.DeadLetterQueue["TargetArn"]}  # type: ignore[attr-defined]
 
-        lambda_function.CodeSigningConfigArn = self.CodeSigningConfigArn
+        lambda_function.CodeSigningConfigArn = self.CodeSigningConfigArn  # type: ignore[attr-defined]
 
-        self._validate_package_type(lambda_function)
-        self._validate_architectures(lambda_function)
+        self._validate_package_type(lambda_function)  # type: ignore[no-untyped-call]
+        self._validate_architectures(lambda_function)  # type: ignore[no-untyped-call]
         return lambda_function
 
-    def _add_event_invoke_managed_policy(self, dest_config, logical_id, condition, dest_arn):
+    def _add_event_invoke_managed_policy(self, dest_config, logical_id, condition, dest_arn):  # type: ignore[no-untyped-def]
         policy = {}
         if dest_config and dest_config.get("Type"):
             if dest_config.get("Type") == "SQS":
-                policy = IAMRolePolicies.sqs_send_message_role_policy(dest_arn, logical_id)
+                policy = IAMRolePolicies.sqs_send_message_role_policy(dest_arn, logical_id)  # type: ignore[no-untyped-call]
             if dest_config.get("Type") == "SNS":
-                policy = IAMRolePolicies.sns_publish_role_policy(dest_arn, logical_id)
+                policy = IAMRolePolicies.sns_publish_role_policy(dest_arn, logical_id)  # type: ignore[no-untyped-call]
             # Event Bridge and Lambda Arns are passthrough.
             if dest_config.get("Type") == "EventBridge":
-                policy = IAMRolePolicies.event_bus_put_events_role_policy(dest_arn, logical_id)
+                policy = IAMRolePolicies.event_bus_put_events_role_policy(dest_arn, logical_id)  # type: ignore[no-untyped-call]
             if dest_config.get("Type") == "Lambda":
-                policy = IAMRolePolicies.lambda_invoke_function_role_policy(dest_arn, logical_id)
+                policy = IAMRolePolicies.lambda_invoke_function_role_policy(dest_arn, logical_id)  # type: ignore[no-untyped-call]
         return policy
 
-    def _construct_role(self, managed_policy_map, event_invoke_policies):
+    def _construct_role(self, managed_policy_map, event_invoke_policies):  # type: ignore[no-untyped-def]
         """Constructs a Lambda execution role based on this SAM function's Policies property.
 
         :returns: the generated IAM Role
         :rtype: model.iam.IAMRole
         """
-        role_attributes = self.get_passthrough_resource_attributes()
+        role_attributes = self.get_passthrough_resource_attributes()  # type: ignore[no-untyped-call]
 
-        if self.AssumeRolePolicyDocument is not None:
-            assume_role_policy_document = self.AssumeRolePolicyDocument
+        if self.AssumeRolePolicyDocument is not None:  # type: ignore[attr-defined]
+            assume_role_policy_document = self.AssumeRolePolicyDocument  # type: ignore[attr-defined]
         else:
-            assume_role_policy_document = IAMRolePolicies.lambda_assume_role_policy()
+            assume_role_policy_document = IAMRolePolicies.lambda_assume_role_policy()  # type: ignore[no-untyped-call]
 
-        managed_policy_arns = [ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaBasicExecutionRole")]
-        if self.Tracing:
-            managed_policy_name = get_xray_managed_policy_name()
-            managed_policy_arns.append(ArnGenerator.generate_aws_managed_policy_arn(managed_policy_name))
-        if self.VpcConfig:
+        managed_policy_arns = [ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaBasicExecutionRole")]  # type: ignore[no-untyped-call]
+        if self.Tracing:  # type: ignore[attr-defined]
+            managed_policy_name = get_xray_managed_policy_name()  # type: ignore[no-untyped-call]
+            managed_policy_arns.append(ArnGenerator.generate_aws_managed_policy_arn(managed_policy_name))  # type: ignore[no-untyped-call]
+        if self.VpcConfig:  # type: ignore[attr-defined]
             managed_policy_arns.append(
-                ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaVPCAccessExecutionRole")
+                ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaVPCAccessExecutionRole")  # type: ignore[no-untyped-call]
             )
 
-        function_policies = ResourcePolicies(
-            {"Policies": self.Policies},
+        function_policies = ResourcePolicies(  # type: ignore[no-untyped-call]
+            {"Policies": self.Policies},  # type: ignore[attr-defined]
             # No support for policy templates in the "core"
             policy_template_processor=None,
         )
         policy_documents = []
 
-        if self.DeadLetterQueue:
+        if self.DeadLetterQueue:  # type: ignore[attr-defined]
             policy_documents.append(
-                IAMRolePolicies.dead_letter_queue_policy(
-                    self.dead_letter_queue_policy_actions[self.DeadLetterQueue["Type"]],
-                    self.DeadLetterQueue["TargetArn"],
+                IAMRolePolicies.dead_letter_queue_policy(  # type: ignore[no-untyped-call]
+                    self.dead_letter_queue_policy_actions[self.DeadLetterQueue["Type"]],  # type: ignore[attr-defined]
+                    self.DeadLetterQueue["TargetArn"],  # type: ignore[attr-defined]
                 )
             )
 
-        if self.EventInvokeConfig:
+        if self.EventInvokeConfig:  # type: ignore[attr-defined]
             if event_invoke_policies is not None:
                 policy_documents.extend(event_invoke_policies)
 
@@ -533,46 +533,46 @@ class SamFunction(SamResourceMacro):
             resource_policies=function_policies,
             managed_policy_arns=managed_policy_arns,
             policy_documents=policy_documents,
-            permissions_boundary=self.PermissionsBoundary,
-            tags=self._construct_tag_list(self.Tags),
+            permissions_boundary=self.PermissionsBoundary,  # type: ignore[attr-defined]
+            tags=self._construct_tag_list(self.Tags),  # type: ignore[attr-defined, no-untyped-call]
         )
         return execution_role
 
-    def _validate_package_type(self, lambda_function):
+    def _validate_package_type(self, lambda_function):  # type: ignore[no-untyped-def]
         """
         Validates Function based on the existence of Package type
         """
         packagetype = lambda_function.PackageType or ZIP
 
         if packagetype not in [ZIP, IMAGE]:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 lambda_function.logical_id,
                 "PackageType needs to be `{zip}` or `{image}`".format(zip=ZIP, image=IMAGE),
             )
 
-        def _validate_package_type_zip():
+        def _validate_package_type_zip():  # type: ignore[no-untyped-def]
             if not all([lambda_function.Runtime, lambda_function.Handler]):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_function.logical_id,
                     "Runtime and Handler needs to be present when PackageType is of type `{zip}`".format(zip=ZIP),
                 )
 
             if any([lambda_function.Code.get("ImageUri", False), lambda_function.ImageConfig]):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_function.logical_id,
                     "ImageUri or ImageConfig cannot be present when PackageType is of type `{zip}`".format(zip=ZIP),
                 )
 
-        def _validate_package_type_image():
+        def _validate_package_type_image():  # type: ignore[no-untyped-def]
             if any([lambda_function.Handler, lambda_function.Runtime, lambda_function.Layers]):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_function.logical_id,
                     "Runtime, Handler, Layers cannot be present when PackageType is of type `{image}`".format(
                         image=IMAGE
                     ),
                 )
             if not lambda_function.Code.get("ImageUri"):
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_function.logical_id,
                     "ImageUri needs to be present when PackageType is of type `{image}`".format(image=IMAGE),
                 )
@@ -580,9 +580,9 @@ class SamFunction(SamResourceMacro):
         _validate_per_package_type = {ZIP: _validate_package_type_zip, IMAGE: _validate_package_type_image}
 
         # Call appropriate validation function based on the package type.
-        return _validate_per_package_type[packagetype]()
+        return _validate_per_package_type[packagetype]()  # type: ignore[no-untyped-call]
 
-    def _validate_architectures(self, lambda_function):
+    def _validate_architectures(self, lambda_function):  # type: ignore[no-untyped-def]
         """
         Validates Function based on the existence of architecture type
 
@@ -599,58 +599,58 @@ class SamFunction(SamResourceMacro):
 
         architectures = [X86_64] if lambda_function.Architectures is None else lambda_function.Architectures
 
-        if is_intrinsic(architectures):
+        if is_intrinsic(architectures):  # type: ignore[no-untyped-call]
             return
 
         if (
             not isinstance(architectures, list)
             or len(architectures) != 1
-            or (not is_intrinsic(architectures[0]) and (architectures[0] not in [X86_64, ARM64]))
+            or (not is_intrinsic(architectures[0]) and (architectures[0] not in [X86_64, ARM64]))  # type: ignore[no-untyped-call]
         ):
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 lambda_function.logical_id,
                 "Architectures needs to be a list with one string, either `{}` or `{}`.".format(X86_64, ARM64),
             )
 
-    def _validate_dlq(self):
+    def _validate_dlq(self):  # type: ignore[no-untyped-def]
         """Validates whether the DeadLetterQueue LogicalId is validation
         :raise: InvalidResourceException
         """
         # Validate required logical ids
         valid_dlq_types = str(list(self.dead_letter_queue_policy_actions.keys()))
-        if not self.DeadLetterQueue.get("Type") or not self.DeadLetterQueue.get("TargetArn"):
-            raise InvalidResourceException(
+        if not self.DeadLetterQueue.get("Type") or not self.DeadLetterQueue.get("TargetArn"):  # type: ignore[attr-defined]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "'DeadLetterQueue' requires Type and TargetArn properties to be specified.",
             )
 
-        if not isinstance(self.DeadLetterQueue.get("Type"), str):
-            raise InvalidResourceException(
+        if not isinstance(self.DeadLetterQueue.get("Type"), str):  # type: ignore[attr-defined]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "'DeadLetterQueue' property 'Type' should be of type str.",
             )
 
         # Validate required Types
-        if not self.DeadLetterQueue["Type"] in self.dead_letter_queue_policy_actions:
-            raise InvalidResourceException(
+        if not self.DeadLetterQueue["Type"] in self.dead_letter_queue_policy_actions:  # type: ignore[attr-defined]
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "'DeadLetterQueue' requires Type of {}".format(valid_dlq_types)
             )
 
-    def _event_resources_to_link(self, resources):
+    def _event_resources_to_link(self, resources):  # type: ignore[no-untyped-def]
         event_resources = {}
-        if self.Events:
-            for logical_id, event_dict in self.Events.items():
+        if self.Events:  # type: ignore[attr-defined]
+            for logical_id, event_dict in self.Events.items():  # type: ignore[attr-defined]
                 try:
-                    event_source = self.event_resolver.resolve_resource_type(event_dict).from_dict(
+                    event_source = self.event_resolver.resolve_resource_type(event_dict).from_dict(  # type: ignore[no-untyped-call]
                         self.logical_id + logical_id, event_dict, logical_id
                     )
                 except (TypeError, AttributeError) as e:
-                    raise InvalidEventException(logical_id, "{}".format(e))
+                    raise InvalidEventException(logical_id, "{}".format(e))  # type: ignore[no-untyped-call]
                 event_resources[logical_id] = event_source.resources_to_link(resources)
         return event_resources
 
     @staticmethod
-    def order_events(event):
+    def order_events(event):  # type: ignore[no-untyped-def]
         """
         Helper method for sorting Function Events. Returns a key to use in sorting this event
 
@@ -664,7 +664,7 @@ class SamFunction(SamResourceMacro):
             return logical_id
         return event_dict.get("Properties", {}).get("Path", logical_id)
 
-    def _generate_event_resources(
+    def _generate_event_resources(  # type: ignore[no-untyped-def]
         self, lambda_function, execution_role, event_resources, intrinsics_resolver, lambda_alias=None
     ):
         """Generates and returns the resources associated with this function's events.
@@ -681,14 +681,14 @@ class SamFunction(SamResourceMacro):
         :rtype: list
         """
         resources = []
-        if self.Events:
-            for logical_id, event_dict in sorted(self.Events.items(), key=SamFunction.order_events):
+        if self.Events:  # type: ignore[attr-defined]
+            for logical_id, event_dict in sorted(self.Events.items(), key=SamFunction.order_events):  # type: ignore[attr-defined]
                 try:
-                    eventsource = self.event_resolver.resolve_resource_type(event_dict).from_dict(
+                    eventsource = self.event_resolver.resolve_resource_type(event_dict).from_dict(  # type: ignore[no-untyped-call]
                         lambda_function.logical_id + logical_id, event_dict, logical_id
                     )
                 except TypeError as e:
-                    raise InvalidEventException(logical_id, "{}".format(e))
+                    raise InvalidEventException(logical_id, "{}".format(e))  # type: ignore[no-untyped-call]
 
                 kwargs = {
                     # When Alias is provided, connect all event sources to the alias and *not* the function
@@ -703,7 +703,7 @@ class SamFunction(SamResourceMacro):
 
         return resources
 
-    def _construct_code_dict(self):
+    def _construct_code_dict(self):  # type: ignore[no-untyped-def]
         """Constructs Lambda Code Dictionary based on the accepted SAM artifact properties such
         as `InlineCode`, `CodeUri` and `ImageUri` and also raises errors if more than one of them is
         defined. `PackageType` determines which artifacts are considered.
@@ -711,21 +711,21 @@ class SamFunction(SamResourceMacro):
         :raises InvalidResourceException when conditions on the SAM artifact properties are not met.
         """
         # list of accepted artifacts
-        packagetype = self.PackageType or ZIP
+        packagetype = self.PackageType or ZIP  # type: ignore[attr-defined]
         artifacts = {}
 
         if packagetype == ZIP:
-            artifacts = {"InlineCode": self.InlineCode, "CodeUri": self.CodeUri}
+            artifacts = {"InlineCode": self.InlineCode, "CodeUri": self.CodeUri}  # type: ignore[attr-defined, attr-defined]
         elif packagetype == IMAGE:
-            artifacts = {"ImageUri": self.ImageUri}
+            artifacts = {"ImageUri": self.ImageUri}  # type: ignore[attr-defined]
 
         if packagetype not in [ZIP, IMAGE]:
-            raise InvalidResourceException(self.logical_id, "invalid 'PackageType' : {}".format(packagetype))
+            raise InvalidResourceException(self.logical_id, "invalid 'PackageType' : {}".format(packagetype))  # type: ignore[no-untyped-call]
 
         # Inline function for transformation of inline code.
         # It accepts arbitrary argumemnts, because the arguments do not matter for the result.
-        def _construct_inline_code(*args, **kwargs):
-            return {"ZipFile": self.InlineCode}
+        def _construct_inline_code(*args, **kwargs):  # type: ignore[no-untyped-def]
+            return {"ZipFile": self.InlineCode}  # type: ignore[attr-defined]
 
         # dispatch mechanism per artifact on how it needs to be transformed.
         artifact_dispatch = {
@@ -739,9 +739,9 @@ class SamFunction(SamResourceMacro):
         # There are no valid artifact types present, also raise an Error.
         if len(filtered_artifacts) > 1 or len(filtered_artifacts) == 0:
             if packagetype == ZIP and len(filtered_artifacts) == 0:
-                raise InvalidResourceException(self.logical_id, "Only one of 'InlineCode' or 'CodeUri' can be set.")
+                raise InvalidResourceException(self.logical_id, "Only one of 'InlineCode' or 'CodeUri' can be set.")  # type: ignore[no-untyped-call]
             if packagetype == IMAGE:
-                raise InvalidResourceException(self.logical_id, "'ImageUri' must be set.")
+                raise InvalidResourceException(self.logical_id, "'ImageUri' must be set.")  # type: ignore[no-untyped-call]
 
         filtered_keys = list(filtered_artifacts.keys())
         # NOTE(sriram-mv): This precedence order is important. It is protect against python2 vs python3
@@ -754,11 +754,11 @@ class SamFunction(SamResourceMacro):
         elif "ImageUri" in filtered_keys:
             filtered_key = "ImageUri"
         else:
-            raise InvalidResourceException(self.logical_id, "Either 'InlineCode' or 'CodeUri' must be set.")
+            raise InvalidResourceException(self.logical_id, "Either 'InlineCode' or 'CodeUri' must be set.")  # type: ignore[no-untyped-call]
         dispatch_function = artifact_dispatch[filtered_key]
-        return dispatch_function(artifacts[filtered_key], self.logical_id, filtered_key)
+        return dispatch_function(artifacts[filtered_key], self.logical_id, filtered_key)  # type: ignore[operator]
 
-    def _construct_version(self, function, intrinsics_resolver, code_sha256=None):
+    def _construct_version(self, function, intrinsics_resolver, code_sha256=None):  # type: ignore[no-untyped-def]
         """Constructs a Lambda Version resource that will be auto-published when CodeUri of the function changes.
         Old versions will not be deleted without a direct reference from the CloudFormation template.
 
@@ -808,21 +808,21 @@ class SamFunction(SamResourceMacro):
                 logical_dict.update(function.Environment)
             if function.MemorySize:
                 logical_dict.update({"MemorySize": function.MemorySize})
-        logical_id = logical_id_generator.LogicalIdGenerator(prefix, logical_dict, code_sha256).gen()
+        logical_id = logical_id_generator.LogicalIdGenerator(prefix, logical_dict, code_sha256).gen()  # type: ignore[no-untyped-call, no-untyped-call]
 
-        attributes = self.get_passthrough_resource_attributes()
+        attributes = self.get_passthrough_resource_attributes()  # type: ignore[no-untyped-call]
         if attributes is None:
             attributes = {}
         if "DeletionPolicy" not in attributes:
             attributes["DeletionPolicy"] = "Retain"
 
-        lambda_version = LambdaVersion(logical_id=logical_id, attributes=attributes)
+        lambda_version = LambdaVersion(logical_id=logical_id, attributes=attributes)  # type: ignore[no-untyped-call]
         lambda_version.FunctionName = function.get_runtime_attr("name")
-        lambda_version.Description = self.VersionDescription
+        lambda_version.Description = self.VersionDescription  # type: ignore[attr-defined]
 
         return lambda_version
 
-    def _construct_alias(self, name, function, version):
+    def _construct_alias(self, name, function, version):  # type: ignore[no-untyped-def]
         """Constructs a Lambda Alias for the given function and pointing to the given version
 
         :param string name: Name of the alias
@@ -833,19 +833,19 @@ class SamFunction(SamResourceMacro):
         """
 
         if not name:
-            raise InvalidResourceException(self.logical_id, "Alias name is required to create an alias")
+            raise InvalidResourceException(self.logical_id, "Alias name is required to create an alias")  # type: ignore[no-untyped-call]
 
         logical_id = "{id}Alias{suffix}".format(id=function.logical_id, suffix=name)
-        alias = LambdaAlias(logical_id=logical_id, attributes=self.get_passthrough_resource_attributes())
+        alias = LambdaAlias(logical_id=logical_id, attributes=self.get_passthrough_resource_attributes())  # type: ignore[no-untyped-call, no-untyped-call]
         alias.Name = name
         alias.FunctionName = function.get_runtime_attr("name")
         alias.FunctionVersion = version.get_runtime_attr("version")
-        if self.ProvisionedConcurrencyConfig:
-            alias.ProvisionedConcurrencyConfig = self.ProvisionedConcurrencyConfig
+        if self.ProvisionedConcurrencyConfig:  # type: ignore[attr-defined]
+            alias.ProvisionedConcurrencyConfig = self.ProvisionedConcurrencyConfig  # type: ignore[attr-defined]
 
         return alias
 
-    def _validate_deployment_preference_and_add_update_policy(
+    def _validate_deployment_preference_and_add_update_policy(  # type: ignore[no-untyped-def]
         self,
         deployment_preference_collection,
         lambda_alias,
@@ -854,46 +854,46 @@ class SamFunction(SamResourceMacro):
         passthrough_resource_attributes,
         feature_toggle=None,
     ):
-        if "Enabled" in self.DeploymentPreference:
+        if "Enabled" in self.DeploymentPreference:  # type: ignore[attr-defined]
             # resolve intrinsics and mappings for Enabled
-            enabled = self.DeploymentPreference["Enabled"]
+            enabled = self.DeploymentPreference["Enabled"]  # type: ignore[attr-defined]
             enabled = intrinsics_resolver.resolve_parameter_refs(enabled)
             enabled = mappings_resolver.resolve_parameter_refs(enabled)
-            self.DeploymentPreference["Enabled"] = enabled
+            self.DeploymentPreference["Enabled"] = enabled  # type: ignore[attr-defined]
 
-        if "Type" in self.DeploymentPreference:
+        if "Type" in self.DeploymentPreference:  # type: ignore[attr-defined]
             # resolve intrinsics and mappings for Type
-            preference_type = self.DeploymentPreference["Type"]
+            preference_type = self.DeploymentPreference["Type"]  # type: ignore[attr-defined]
             preference_type = intrinsics_resolver.resolve_parameter_refs(preference_type)
             preference_type = mappings_resolver.resolve_parameter_refs(preference_type)
-            self.DeploymentPreference["Type"] = preference_type
+            self.DeploymentPreference["Type"] = preference_type  # type: ignore[attr-defined]
 
-        if "PassthroughCondition" in self.DeploymentPreference:
-            self.DeploymentPreference["PassthroughCondition"] = self._resolve_property_to_boolean(
-                self.DeploymentPreference["PassthroughCondition"],
+        if "PassthroughCondition" in self.DeploymentPreference:  # type: ignore[attr-defined]
+            self.DeploymentPreference["PassthroughCondition"] = self._resolve_property_to_boolean(  # type: ignore[attr-defined]
+                self.DeploymentPreference["PassthroughCondition"],  # type: ignore[attr-defined]
                 "PassthroughCondition",
                 intrinsics_resolver,
                 mappings_resolver,
             )
         elif feature_toggle:
-            self.DeploymentPreference["PassthroughCondition"] = feature_toggle.is_enabled(
+            self.DeploymentPreference["PassthroughCondition"] = feature_toggle.is_enabled(  # type: ignore[attr-defined]
                 "deployment_preference_condition_fix"
             )
         else:
-            self.DeploymentPreference["PassthroughCondition"] = False
+            self.DeploymentPreference["PassthroughCondition"] = False  # type: ignore[attr-defined]
 
         if deployment_preference_collection is None:
             raise ValueError("deployment_preference_collection required for parsing the deployment preference")
 
         deployment_preference_collection.add(
             self.logical_id,
-            self.DeploymentPreference,
+            self.DeploymentPreference,  # type: ignore[attr-defined]
             passthrough_resource_attributes.get("Condition"),
         )
 
         if deployment_preference_collection.get(self.logical_id).enabled:
-            if not self.AutoPublishAlias:
-                raise InvalidResourceException(
+            if not self.AutoPublishAlias:  # type: ignore[attr-defined]
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "'DeploymentPreference' requires AutoPublishAlias property to be specified."
                 )
             if lambda_alias is None:
@@ -905,7 +905,7 @@ class SamFunction(SamResourceMacro):
 
     def _resolve_property_to_boolean(
         self,
-        property_value: Union[bool, str, dict],
+        property_value: Union[bool, str, dict],  # type: ignore[type-arg]
         property_name: str,
         intrinsics_resolver: IntrinsicsResolver,
         mappings_resolver: IntrinsicsResolver,
@@ -920,23 +920,23 @@ class SamFunction(SamResourceMacro):
         :param mappings_resolver: resolves FindInMap
         :return bool: resolved boolean value
         """
-        processed_property_value = intrinsics_resolver.resolve_parameter_refs(property_value)
-        processed_property_value = mappings_resolver.resolve_parameter_refs(processed_property_value)
+        processed_property_value = intrinsics_resolver.resolve_parameter_refs(property_value)  # type: ignore[no-untyped-call]
+        processed_property_value = mappings_resolver.resolve_parameter_refs(processed_property_value)  # type: ignore[no-untyped-call]
 
         # FIXME: We should support not only true/false, but also yes/no, on/off? See https://yaml.org/type/bool.html
         if processed_property_value in [True, "true", "True"]:
             return True
         if processed_property_value in [False, "false", "False"]:
             return False
-        if is_intrinsic(processed_property_value):  # couldn't resolve intrinsic
-            raise InvalidResourceException(
+        if is_intrinsic(processed_property_value):  # type: ignore[no-untyped-call] # couldn't resolve intrinsic
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 f"Unsupported intrinsic: the only intrinsic functions supported for "
                 f"property {property_name} are FindInMap and parameter Refs.",
             )
-        raise InvalidResourceException(self.logical_id, f"Invalid value for property {property_name}.")
+        raise InvalidResourceException(self.logical_id, f"Invalid value for property {property_name}.")  # type: ignore[no-untyped-call]
 
-    def _construct_function_url(self, lambda_function, lambda_alias):
+    def _construct_function_url(self, lambda_function, lambda_alias):  # type: ignore[no-untyped-def]
         """
         This method is used to construct a lambda url resource
 
@@ -952,44 +952,44 @@ class SamFunction(SamResourceMacro):
         LambdaUrl
             Lambda Url resource
         """
-        self._validate_function_url_params(lambda_function)
+        self._validate_function_url_params(lambda_function)  # type: ignore[no-untyped-call]
 
         logical_id = f"{lambda_function.logical_id}Url"
-        lambda_url_attributes = self.get_passthrough_resource_attributes()
-        lambda_url = LambdaUrl(logical_id=logical_id, attributes=lambda_url_attributes)
+        lambda_url_attributes = self.get_passthrough_resource_attributes()  # type: ignore[no-untyped-call]
+        lambda_url = LambdaUrl(logical_id=logical_id, attributes=lambda_url_attributes)  # type: ignore[no-untyped-call]
 
-        cors = self.FunctionUrlConfig.get("Cors")
+        cors = self.FunctionUrlConfig.get("Cors")  # type: ignore[attr-defined]
         if cors:
             lambda_url.Cors = cors
-        lambda_url.AuthType = self.FunctionUrlConfig.get("AuthType")
+        lambda_url.AuthType = self.FunctionUrlConfig.get("AuthType")  # type: ignore[attr-defined]
         lambda_url.TargetFunctionArn = (
             lambda_alias.get_runtime_attr("arn") if lambda_alias else lambda_function.get_runtime_attr("name")
         )
         return lambda_url
 
-    def _validate_function_url_params(self, lambda_function):
+    def _validate_function_url_params(self, lambda_function):  # type: ignore[no-untyped-def]
         """
         Validate parameters provided to configure Lambda Urls
         """
-        self._validate_url_auth_type(lambda_function)
-        self._validate_cors_config_parameter(lambda_function)
+        self._validate_url_auth_type(lambda_function)  # type: ignore[no-untyped-call]
+        self._validate_cors_config_parameter(lambda_function)  # type: ignore[no-untyped-call]
 
-    def _validate_url_auth_type(self, lambda_function):
-        if is_intrinsic(self.FunctionUrlConfig):
+    def _validate_url_auth_type(self, lambda_function):  # type: ignore[no-untyped-def]
+        if is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined, no-untyped-call]
             return
 
-        auth_type = self.FunctionUrlConfig.get("AuthType")
-        if auth_type and is_intrinsic(auth_type):
+        auth_type = self.FunctionUrlConfig.get("AuthType")  # type: ignore[attr-defined]
+        if auth_type and is_intrinsic(auth_type):  # type: ignore[no-untyped-call]
             return
 
         if not auth_type or auth_type not in ["AWS_IAM", "NONE"]:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 lambda_function.logical_id,
                 "AuthType is required to configure function property `FunctionUrlConfig`. Please provide either AWS_IAM or NONE.",
             )
 
-    def _validate_cors_config_parameter(self, lambda_function):
-        if is_intrinsic(self.FunctionUrlConfig):
+    def _validate_cors_config_parameter(self, lambda_function):  # type: ignore[no-untyped-def]
+        if is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined, no-untyped-call]
             return
 
         cors_property_data_type = {
@@ -1001,25 +1001,25 @@ class SamFunction(SamResourceMacro):
             "MaxAge": int,
         }
 
-        cors = self.FunctionUrlConfig.get("Cors")
+        cors = self.FunctionUrlConfig.get("Cors")  # type: ignore[attr-defined]
 
-        if not cors or is_intrinsic(cors):
+        if not cors or is_intrinsic(cors):  # type: ignore[no-untyped-call]
             return
 
         for prop_name, prop_value in cors.items():
             if prop_name not in cors_property_data_type:
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_function.logical_id,
                     "{} is not a valid property for configuring Cors.".format(prop_name),
                 )
             prop_type = cors_property_data_type.get(prop_name)
-            if not is_intrinsic(prop_value) and not isinstance(prop_value, prop_type):
-                raise InvalidResourceException(
+            if not is_intrinsic(prop_value) and not isinstance(prop_value, prop_type):  # type: ignore[arg-type, no-untyped-call]
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_function.logical_id,
                     "{} must be of type {}.".format(prop_name, str(prop_type).split("'")[1]),
                 )
 
-    def _construct_url_permission(self, lambda_function, lambda_alias):
+    def _construct_url_permission(self, lambda_function, lambda_alias):  # type: ignore[no-untyped-def]
         """
         Construct the lambda permission associated with the function url resource in a case
         for public access when AuthType is NONE
@@ -1037,14 +1037,14 @@ class SamFunction(SamResourceMacro):
         LambdaPermission
             The lambda permission appended to a function url resource with public access
         """
-        auth_type = self.FunctionUrlConfig.get("AuthType")
+        auth_type = self.FunctionUrlConfig.get("AuthType")  # type: ignore[attr-defined]
 
-        if auth_type not in ["NONE"] or is_intrinsic(self.FunctionUrlConfig):
+        if auth_type not in ["NONE"] or is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined, no-untyped-call]
             return None
 
         logical_id = f"{lambda_function.logical_id}UrlPublicPermissions"
-        lambda_permission_attributes = self.get_passthrough_resource_attributes()
-        lambda_permission = LambdaPermission(logical_id=logical_id, attributes=lambda_permission_attributes)
+        lambda_permission_attributes = self.get_passthrough_resource_attributes()  # type: ignore[no-untyped-call]
+        lambda_permission = LambdaPermission(logical_id=logical_id, attributes=lambda_permission_attributes)  # type: ignore[no-untyped-call]
         lambda_permission.Action = "lambda:InvokeFunctionUrl"
         lambda_permission.FunctionName = (
             lambda_alias.get_runtime_attr("arn") if lambda_alias else lambda_function.get_runtime_attr("name")
@@ -1064,33 +1064,33 @@ class SamApi(SamResourceMacro):
         # Implicit APIs. For Explicit APIs, customer is expected to set integration URI themselves.
         # In the future, we might rename and expose this property to customers so they can have SAM manage Explicit APIs
         # Swagger.
-        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),
-        "Name": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "StageName": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "Tags": PropertyType(False, is_type(dict)),
-        "DefinitionBody": PropertyType(False, is_type(dict)),
-        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "CacheClusterEnabled": PropertyType(False, is_type(bool)),
-        "CacheClusterSize": PropertyType(False, is_str()),
-        "Variables": PropertyType(False, is_type(dict)),
-        "EndpointConfiguration": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "MethodSettings": PropertyType(False, is_type(list)),
-        "BinaryMediaTypes": PropertyType(False, is_type(list)),
-        "MinimumCompressionSize": PropertyType(False, is_type(int)),
-        "Cors": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "Auth": PropertyType(False, is_type(dict)),
-        "GatewayResponses": PropertyType(False, is_type(dict)),
-        "AccessLogSetting": PropertyType(False, is_type(dict)),
-        "CanarySetting": PropertyType(False, is_type(dict)),
-        "TracingEnabled": PropertyType(False, is_type(bool)),
-        "OpenApiVersion": PropertyType(False, is_str()),
-        "Models": PropertyType(False, is_type(dict)),
-        "Domain": PropertyType(False, is_type(dict)),
-        "FailOnWarnings": PropertyType(False, is_type(bool)),
-        "Description": PropertyType(False, is_str()),
-        "Mode": PropertyType(False, is_str()),
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
-        "ApiKeySourceType": PropertyType(False, is_str()),
+        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Name": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "StageName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefinitionBody": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "CacheClusterEnabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CacheClusterSize": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Variables": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EndpointConfiguration": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "MethodSettings": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BinaryMediaTypes": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "MinimumCompressionSize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Cors": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "GatewayResponses": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AccessLogSetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CanarySetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TracingEnabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "OpenApiVersion": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Models": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Domain": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FailOnWarnings": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Mode": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ApiKeySourceType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
     referable_properties = {
@@ -1103,7 +1103,7 @@ class SamApi(SamResourceMacro):
     }
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the API Gateway RestApi, Deployment, and Stage to which this SAM Api corresponds.
 
         :param dict kwargs: already-converted resources that may need to be modified when converting this \
@@ -1114,47 +1114,47 @@ class SamApi(SamResourceMacro):
         resources = []
 
         intrinsics_resolver = kwargs["intrinsics_resolver"]
-        self.BinaryMediaTypes = intrinsics_resolver.resolve_parameter_refs(self.BinaryMediaTypes)
-        self.Domain = intrinsics_resolver.resolve_parameter_refs(self.Domain)
-        self.Auth = intrinsics_resolver.resolve_parameter_refs(self.Auth)
+        self.BinaryMediaTypes = intrinsics_resolver.resolve_parameter_refs(self.BinaryMediaTypes)  # type: ignore[has-type]
+        self.Domain = intrinsics_resolver.resolve_parameter_refs(self.Domain)  # type: ignore[has-type]
+        self.Auth = intrinsics_resolver.resolve_parameter_refs(self.Auth)  # type: ignore[has-type]
         redeploy_restapi_parameters = kwargs.get("redeploy_restapi_parameters")
         shared_api_usage_plan = kwargs.get("shared_api_usage_plan")
         template_conditions = kwargs.get("conditions")
         route53_record_set_groups = kwargs.get("route53_record_set_groups", {})
 
-        api_generator = ApiGenerator(
+        api_generator = ApiGenerator(  # type: ignore[no-untyped-call]
             self.logical_id,
-            self.CacheClusterEnabled,
-            self.CacheClusterSize,
-            self.Variables,
+            self.CacheClusterEnabled,  # type: ignore[attr-defined]
+            self.CacheClusterSize,  # type: ignore[attr-defined]
+            self.Variables,  # type: ignore[attr-defined]
             self.depends_on,
-            self.DefinitionBody,
-            self.DefinitionUri,
-            self.Name,
-            self.StageName,
+            self.DefinitionBody,  # type: ignore[attr-defined]
+            self.DefinitionUri,  # type: ignore[attr-defined]
+            self.Name,  # type: ignore[attr-defined]
+            self.StageName,  # type: ignore[attr-defined]
             shared_api_usage_plan,
             template_conditions,
-            tags=self.Tags,
-            endpoint_configuration=self.EndpointConfiguration,
-            method_settings=self.MethodSettings,
+            tags=self.Tags,  # type: ignore[attr-defined]
+            endpoint_configuration=self.EndpointConfiguration,  # type: ignore[attr-defined]
+            method_settings=self.MethodSettings,  # type: ignore[attr-defined]
             binary_media=self.BinaryMediaTypes,
-            minimum_compression_size=self.MinimumCompressionSize,
-            disable_execute_api_endpoint=self.DisableExecuteApiEndpoint,
-            cors=self.Cors,
+            minimum_compression_size=self.MinimumCompressionSize,  # type: ignore[attr-defined]
+            disable_execute_api_endpoint=self.DisableExecuteApiEndpoint,  # type: ignore[attr-defined]
+            cors=self.Cors,  # type: ignore[attr-defined]
             auth=self.Auth,
-            gateway_responses=self.GatewayResponses,
-            access_log_setting=self.AccessLogSetting,
-            canary_setting=self.CanarySetting,
-            tracing_enabled=self.TracingEnabled,
+            gateway_responses=self.GatewayResponses,  # type: ignore[attr-defined]
+            access_log_setting=self.AccessLogSetting,  # type: ignore[attr-defined]
+            canary_setting=self.CanarySetting,  # type: ignore[attr-defined]
+            tracing_enabled=self.TracingEnabled,  # type: ignore[attr-defined]
             resource_attributes=self.resource_attributes,
-            passthrough_resource_attributes=self.get_passthrough_resource_attributes(),
-            open_api_version=self.OpenApiVersion,
-            models=self.Models,
+            passthrough_resource_attributes=self.get_passthrough_resource_attributes(),  # type: ignore[no-untyped-call]
+            open_api_version=self.OpenApiVersion,  # type: ignore[attr-defined]
+            models=self.Models,  # type: ignore[attr-defined]
             domain=self.Domain,
-            fail_on_warnings=self.FailOnWarnings,
-            description=self.Description,
-            mode=self.Mode,
-            api_key_source_type=self.ApiKeySourceType,
+            fail_on_warnings=self.FailOnWarnings,  # type: ignore[attr-defined]
+            description=self.Description,  # type: ignore[attr-defined]
+            mode=self.Mode,  # type: ignore[attr-defined]
+            api_key_source_type=self.ApiKeySourceType,  # type: ignore[attr-defined]
         )
 
         (
@@ -1192,21 +1192,21 @@ class SamHttpApi(SamResourceMacro):
         # Implicit APIs. For Explicit APIs, this is managed by the DefaultDefinitionBody Plugin.
         # In the future, we might rename and expose this property to customers so they can have SAM manage Explicit APIs
         # Swagger.
-        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),
-        "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "Tags": PropertyType(False, is_type(dict)),
-        "DefinitionBody": PropertyType(False, is_type(dict)),
-        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "StageVariables": PropertyType(False, is_type(dict)),
-        "CorsConfiguration": PropertyType(False, one_of(is_type(bool), is_type(dict))),
-        "AccessLogSettings": PropertyType(False, is_type(dict)),
-        "DefaultRouteSettings": PropertyType(False, is_type(dict)),
-        "Auth": PropertyType(False, is_type(dict)),
-        "RouteSettings": PropertyType(False, is_type(dict)),
-        "Domain": PropertyType(False, is_type(dict)),
-        "FailOnWarnings": PropertyType(False, is_type(bool)),
-        "Description": PropertyType(False, is_str()),
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
+        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefinitionBody": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "StageVariables": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CorsConfiguration": PropertyType(False, one_of(is_type(bool), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "AccessLogSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefaultRouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Domain": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FailOnWarnings": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
     referable_properties = {
@@ -1215,7 +1215,7 @@ class SamHttpApi(SamResourceMacro):
     }
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the API GatewayV2 Api, Deployment, and Stage to which this SAM Api corresponds.
 
         :param dict kwargs: already-converted resources that may need to be modified when converting this \
@@ -1225,28 +1225,28 @@ class SamHttpApi(SamResourceMacro):
         """
         resources = []
         intrinsics_resolver = kwargs["intrinsics_resolver"]
-        self.CorsConfiguration = intrinsics_resolver.resolve_parameter_refs(self.CorsConfiguration)
-        self.Domain = intrinsics_resolver.resolve_parameter_refs(self.Domain)
+        self.CorsConfiguration = intrinsics_resolver.resolve_parameter_refs(self.CorsConfiguration)  # type: ignore[has-type]
+        self.Domain = intrinsics_resolver.resolve_parameter_refs(self.Domain)  # type: ignore[has-type]
 
-        api_generator = HttpApiGenerator(
+        api_generator = HttpApiGenerator(  # type: ignore[no-untyped-call]
             self.logical_id,
-            self.StageVariables,
+            self.StageVariables,  # type: ignore[attr-defined]
             self.depends_on,
-            self.DefinitionBody,
-            self.DefinitionUri,
-            self.StageName,
-            tags=self.Tags,
-            auth=self.Auth,
+            self.DefinitionBody,  # type: ignore[attr-defined]
+            self.DefinitionUri,  # type: ignore[attr-defined]
+            self.StageName,  # type: ignore[attr-defined]
+            tags=self.Tags,  # type: ignore[attr-defined]
+            auth=self.Auth,  # type: ignore[attr-defined]
             cors_configuration=self.CorsConfiguration,
-            access_log_settings=self.AccessLogSettings,
-            route_settings=self.RouteSettings,
-            default_route_settings=self.DefaultRouteSettings,
+            access_log_settings=self.AccessLogSettings,  # type: ignore[attr-defined]
+            route_settings=self.RouteSettings,  # type: ignore[attr-defined]
+            default_route_settings=self.DefaultRouteSettings,  # type: ignore[attr-defined]
             resource_attributes=self.resource_attributes,
-            passthrough_resource_attributes=self.get_passthrough_resource_attributes(),
+            passthrough_resource_attributes=self.get_passthrough_resource_attributes(),  # type: ignore[no-untyped-call]
             domain=self.Domain,
-            fail_on_warnings=self.FailOnWarnings,
-            description=self.Description,
-            disable_execute_api_endpoint=self.DisableExecuteApiEndpoint,
+            fail_on_warnings=self.FailOnWarnings,  # type: ignore[attr-defined]
+            description=self.Description,  # type: ignore[attr-defined]
+            disable_execute_api_endpoint=self.DisableExecuteApiEndpoint,  # type: ignore[attr-defined]
         )
 
         (
@@ -1277,31 +1277,31 @@ class SamSimpleTable(SamResourceMacro):
 
     resource_type = "AWS::Serverless::SimpleTable"
     property_types = {
-        "PrimaryKey": PropertyType(False, dict_of(is_str(), is_str())),
-        "ProvisionedThroughput": PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),
-        "TableName": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "Tags": PropertyType(False, is_type(dict)),
-        "SSESpecification": PropertyType(False, is_type(dict)),
+        "PrimaryKey": PropertyType(False, dict_of(is_str(), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "ProvisionedThroughput": PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "TableName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "SSESpecification": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
     attribute_type_conversions = {"String": "S", "Number": "N", "Binary": "B"}
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):
-        dynamodb_resources = self._construct_dynamodb_table()
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
+        dynamodb_resources = self._construct_dynamodb_table()  # type: ignore[no-untyped-call]
 
         return [dynamodb_resources]
 
-    def _construct_dynamodb_table(self):
-        dynamodb_table = DynamoDBTable(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)
+    def _construct_dynamodb_table(self):  # type: ignore[no-untyped-def]
+        dynamodb_table = DynamoDBTable(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)  # type: ignore[no-untyped-call]
 
-        if self.PrimaryKey:
-            if "Name" not in self.PrimaryKey or "Type" not in self.PrimaryKey:
-                raise InvalidResourceException(
+        if self.PrimaryKey:  # type: ignore[attr-defined]
+            if "Name" not in self.PrimaryKey or "Type" not in self.PrimaryKey:  # type: ignore[attr-defined]
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "'PrimaryKey' is missing required Property 'Name' or 'Type'."
                 )
             primary_key = {
-                "AttributeName": self.PrimaryKey["Name"],
-                "AttributeType": self._convert_attribute_type(self.PrimaryKey["Type"]),
+                "AttributeName": self.PrimaryKey["Name"],  # type: ignore[attr-defined]
+                "AttributeType": self._convert_attribute_type(self.PrimaryKey["Type"]),  # type: ignore[attr-defined, no-untyped-call]
             }
 
         else:
@@ -1310,26 +1310,26 @@ class SamSimpleTable(SamResourceMacro):
         dynamodb_table.AttributeDefinitions = [primary_key]
         dynamodb_table.KeySchema = [{"AttributeName": primary_key["AttributeName"], "KeyType": "HASH"}]
 
-        if self.ProvisionedThroughput:
-            dynamodb_table.ProvisionedThroughput = self.ProvisionedThroughput
+        if self.ProvisionedThroughput:  # type: ignore[attr-defined]
+            dynamodb_table.ProvisionedThroughput = self.ProvisionedThroughput  # type: ignore[attr-defined]
         else:
             dynamodb_table.BillingMode = "PAY_PER_REQUEST"
 
-        if self.SSESpecification:
-            dynamodb_table.SSESpecification = self.SSESpecification
+        if self.SSESpecification:  # type: ignore[attr-defined]
+            dynamodb_table.SSESpecification = self.SSESpecification  # type: ignore[attr-defined]
 
-        if self.TableName:
-            dynamodb_table.TableName = self.TableName
+        if self.TableName:  # type: ignore[attr-defined]
+            dynamodb_table.TableName = self.TableName  # type: ignore[attr-defined]
 
-        if bool(self.Tags):
-            dynamodb_table.Tags = get_tag_list(self.Tags)
+        if bool(self.Tags):  # type: ignore[attr-defined]
+            dynamodb_table.Tags = get_tag_list(self.Tags)  # type: ignore[attr-defined, no-untyped-call]
 
         return dynamodb_table
 
-    def _convert_attribute_type(self, attribute_type):
+    def _convert_attribute_type(self, attribute_type):  # type: ignore[no-untyped-def]
         if attribute_type in self.attribute_type_conversions:
             return self.attribute_type_conversions[attribute_type]
-        raise InvalidResourceException(self.logical_id, "Invalid 'Type' \"{actual}\".".format(actual=attribute_type))
+        raise InvalidResourceException(self.logical_id, "Invalid 'Type' \"{actual}\".".format(actual=attribute_type))  # type: ignore[no-untyped-call]
 
 
 class SamApplication(SamResourceMacro):
@@ -1342,45 +1342,45 @@ class SamApplication(SamResourceMacro):
 
     # The plugin will always insert the TemplateUrl parameter
     property_types = {
-        "Location": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "TemplateUrl": PropertyType(False, is_str()),
-        "Parameters": PropertyType(False, is_type(dict)),
-        "NotificationARNs": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "Tags": PropertyType(False, is_type(dict)),
-        "TimeoutInMinutes": PropertyType(False, is_type(int)),
+        "Location": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "TemplateUrl": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Parameters": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "NotificationARNs": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TimeoutInMinutes": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the stack with the proper parameters for this application"""
-        nested_stack = self._construct_nested_stack()
+        nested_stack = self._construct_nested_stack()  # type: ignore[no-untyped-call]
         return [nested_stack]
 
-    def _construct_nested_stack(self):
+    def _construct_nested_stack(self):  # type: ignore[no-untyped-def]
         """Constructs a AWS::CloudFormation::Stack resource"""
-        nested_stack = NestedStack(
-            self.logical_id, depends_on=self.depends_on, attributes=self.get_passthrough_resource_attributes()
+        nested_stack = NestedStack(  # type: ignore[no-untyped-call]
+            self.logical_id, depends_on=self.depends_on, attributes=self.get_passthrough_resource_attributes()  # type: ignore[no-untyped-call]
         )
-        nested_stack.Parameters = self.Parameters
-        nested_stack.NotificationARNs = self.NotificationARNs
-        application_tags = self._get_application_tags()
-        nested_stack.Tags = self._construct_tag_list(self.Tags, application_tags)
-        nested_stack.TimeoutInMinutes = self.TimeoutInMinutes
-        nested_stack.TemplateURL = self.TemplateUrl if self.TemplateUrl else ""
+        nested_stack.Parameters = self.Parameters  # type: ignore[attr-defined]
+        nested_stack.NotificationARNs = self.NotificationARNs  # type: ignore[attr-defined]
+        application_tags = self._get_application_tags()  # type: ignore[no-untyped-call]
+        nested_stack.Tags = self._construct_tag_list(self.Tags, application_tags)  # type: ignore[attr-defined, no-untyped-call]
+        nested_stack.TimeoutInMinutes = self.TimeoutInMinutes  # type: ignore[attr-defined]
+        nested_stack.TemplateURL = self.TemplateUrl if self.TemplateUrl else ""  # type: ignore[attr-defined]
 
         return nested_stack
 
-    def _get_application_tags(self):
+    def _get_application_tags(self):  # type: ignore[no-untyped-def]
         """Adds tags to the stack if this resource is using the serverless app repo"""
         application_tags = {}
-        if isinstance(self.Location, dict):
-            if self.APPLICATION_ID_KEY in self.Location.keys() and self.Location[self.APPLICATION_ID_KEY] is not None:
-                application_tags[self._SAR_APP_KEY] = self.Location[self.APPLICATION_ID_KEY]
+        if isinstance(self.Location, dict):  # type: ignore[attr-defined]
+            if self.APPLICATION_ID_KEY in self.Location.keys() and self.Location[self.APPLICATION_ID_KEY] is not None:  # type: ignore[attr-defined]
+                application_tags[self._SAR_APP_KEY] = self.Location[self.APPLICATION_ID_KEY]  # type: ignore[attr-defined]
             if (
-                self.SEMANTIC_VERSION_KEY in self.Location.keys()
-                and self.Location[self.SEMANTIC_VERSION_KEY] is not None
+                self.SEMANTIC_VERSION_KEY in self.Location.keys()  # type: ignore[attr-defined]
+                and self.Location[self.SEMANTIC_VERSION_KEY] is not None  # type: ignore[attr-defined]
             ):
-                application_tags[self._SAR_SEMVER_KEY] = self.Location[self.SEMANTIC_VERSION_KEY]
+                application_tags[self._SAR_SEMVER_KEY] = self.Location[self.SEMANTIC_VERSION_KEY]  # type: ignore[attr-defined]
         return application_tags
 
 
@@ -1389,13 +1389,13 @@ class SamLayerVersion(SamResourceMacro):
 
     resource_type = "AWS::Serverless::LayerVersion"
     property_types = {
-        "LayerName": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "Description": PropertyType(False, is_str()),
-        "ContentUri": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "CompatibleArchitectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
-        "LicenseInfo": PropertyType(False, is_str()),
-        "RetentionPolicy": PropertyType(False, is_str()),
+        "LayerName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ContentUri": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "CompatibleArchitectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "LicenseInfo": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RetentionPolicy": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
     RETAIN = "Retain"
@@ -1403,7 +1403,7 @@ class SamLayerVersion(SamResourceMacro):
     retention_policy_options = [RETAIN.lower(), DELETE.lower()]
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the Lambda layer to which this SAM Layer corresponds.
 
         :param dict kwargs: already-converted resources that may need to be modified when converting this \
@@ -1415,28 +1415,28 @@ class SamLayerVersion(SamResourceMacro):
 
         # Append any CFN resources:
         intrinsics_resolver = kwargs["intrinsics_resolver"]
-        resources.append(self._construct_lambda_layer(intrinsics_resolver))
+        resources.append(self._construct_lambda_layer(intrinsics_resolver))  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _construct_lambda_layer(self, intrinsics_resolver):
+    def _construct_lambda_layer(self, intrinsics_resolver):  # type: ignore[no-untyped-def]
         """Constructs and returns the Lambda function.
 
         :returns: a list containing the Lambda function and execution role resources
         :rtype: list
         """
         # Resolve intrinsics if applicable:
-        self.LayerName = self._resolve_string_parameter(intrinsics_resolver, self.LayerName, "LayerName")
-        self.LicenseInfo = self._resolve_string_parameter(intrinsics_resolver, self.LicenseInfo, "LicenseInfo")
-        self.Description = self._resolve_string_parameter(intrinsics_resolver, self.Description, "Description")
-        self.RetentionPolicy = self._resolve_string_parameter(
-            intrinsics_resolver, self.RetentionPolicy, "RetentionPolicy"
+        self.LayerName = self._resolve_string_parameter(intrinsics_resolver, self.LayerName, "LayerName")  # type: ignore[no-untyped-call, has-type]
+        self.LicenseInfo = self._resolve_string_parameter(intrinsics_resolver, self.LicenseInfo, "LicenseInfo")  # type: ignore[no-untyped-call, has-type]
+        self.Description = self._resolve_string_parameter(intrinsics_resolver, self.Description, "Description")  # type: ignore[no-untyped-call, has-type]
+        self.RetentionPolicy = self._resolve_string_parameter(  # type: ignore[no-untyped-call]
+            intrinsics_resolver, self.RetentionPolicy, "RetentionPolicy"  # type: ignore[has-type]
         )
 
         # If nothing defined, this will be set to Retain
-        retention_policy_value = self._get_retention_policy_value()
+        retention_policy_value = self._get_retention_policy_value()  # type: ignore[no-untyped-call]
 
-        attributes = self.get_passthrough_resource_attributes()
+        attributes = self.get_passthrough_resource_attributes()  # type: ignore[no-untyped-call]
         if attributes is None:
             attributes = {}
         if "DeletionPolicy" not in attributes:
@@ -1447,7 +1447,7 @@ class SamLayerVersion(SamResourceMacro):
         old_logical_id = self.logical_id
 
         # This is to prevent the passthrough resource attributes to be included for hashing
-        hash_dict = copy.deepcopy(self.to_dict())
+        hash_dict = copy.deepcopy(self.to_dict())  # type: ignore[no-untyped-call]
         if "DeletionPolicy" in hash_dict.get(old_logical_id):
             del hash_dict[old_logical_id]["DeletionPolicy"]
         if "UpdateReplacePolicy" in hash_dict.get(old_logical_id):
@@ -1455,10 +1455,10 @@ class SamLayerVersion(SamResourceMacro):
         if "Metadata" in hash_dict.get(old_logical_id):
             del hash_dict[old_logical_id]["Metadata"]
 
-        new_logical_id = logical_id_generator.LogicalIdGenerator(old_logical_id, hash_dict).gen()
+        new_logical_id = logical_id_generator.LogicalIdGenerator(old_logical_id, hash_dict).gen()  # type: ignore[no-untyped-call, no-untyped-call]
         self.logical_id = new_logical_id
 
-        lambda_layer = LambdaLayerVersion(self.logical_id, depends_on=self.depends_on, attributes=attributes)
+        lambda_layer = LambdaLayerVersion(self.logical_id, depends_on=self.depends_on, attributes=attributes)  # type: ignore[no-untyped-call]
 
         # Changing the LayerName property: when a layer is published, it is given an Arn
         # example: arn:aws:lambda:us-west-2:123456789012:layer:MyLayer:1
@@ -1474,26 +1474,26 @@ class SamLayerVersion(SamResourceMacro):
 
         lambda_layer.LayerName = self.LayerName
         lambda_layer.Description = self.Description
-        lambda_layer.Content = construct_s3_location_object(self.ContentUri, self.logical_id, "ContentUri")
+        lambda_layer.Content = construct_s3_location_object(self.ContentUri, self.logical_id, "ContentUri")  # type: ignore[attr-defined, no-untyped-call]
 
-        lambda_layer.CompatibleArchitectures = self.CompatibleArchitectures
-        self._validate_architectures(lambda_layer)
-        lambda_layer.CompatibleRuntimes = self.CompatibleRuntimes
+        lambda_layer.CompatibleArchitectures = self.CompatibleArchitectures  # type: ignore[attr-defined]
+        self._validate_architectures(lambda_layer)  # type: ignore[no-untyped-call]
+        lambda_layer.CompatibleRuntimes = self.CompatibleRuntimes  # type: ignore[attr-defined]
         lambda_layer.LicenseInfo = self.LicenseInfo
 
         return lambda_layer
 
-    def _get_retention_policy_value(self):
+    def _get_retention_policy_value(self):  # type: ignore[no-untyped-def]
         """
         Sets the deletion policy on this resource. The default is 'Retain'.
 
         :return: value for the DeletionPolicy attribute.
         """
 
-        if is_intrinsic(self.RetentionPolicy):
+        if is_intrinsic(self.RetentionPolicy):  # type: ignore[no-untyped-call]
             # RetentionPolicy attribute of AWS::Serverless::LayerVersion does set the DeletionPolicy
             # attribute. And DeletionPolicy attribute does not support intrinsic values.
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "'RetentionPolicy' does not accept intrinsic functions, "
                 "please use one of the following options: {}".format([self.RETAIN, self.DELETE]),
@@ -1506,12 +1506,12 @@ class SamLayerVersion(SamResourceMacro):
         if self.RetentionPolicy.lower() == self.DELETE.lower():
             return self.DELETE
         if self.RetentionPolicy.lower() not in self.retention_policy_options:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "'RetentionPolicy' must be one of the following options: {}.".format([self.RETAIN, self.DELETE]),
             )
 
-    def _validate_architectures(self, lambda_layer):
+    def _validate_architectures(self, lambda_layer):  # type: ignore[no-untyped-def]
         """Validate the values inside the CompatibleArchitectures field of a layer
 
         Parameters
@@ -1526,12 +1526,12 @@ class SamLayerVersion(SamResourceMacro):
         """
         architectures = lambda_layer.CompatibleArchitectures or [X86_64]
         # Intrinsics are not validated
-        if is_intrinsic(architectures):
+        if is_intrinsic(architectures):  # type: ignore[no-untyped-call]
             return
         for arq in architectures:
             # We validate the values only if we they're not intrinsics
-            if not is_intrinsic(arq) and not arq in [ARM64, X86_64]:
-                raise InvalidResourceException(
+            if not is_intrinsic(arq) and not arq in [ARM64, X86_64]:  # type: ignore[no-untyped-call]
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_layer.logical_id,
                     "CompatibleArchitectures needs to be a list of '{}' or '{}'".format(X86_64, ARM64),
                 )
@@ -1542,25 +1542,25 @@ class SamStateMachine(SamResourceMacro):
 
     resource_type = "AWS::Serverless::StateMachine"
     property_types = {
-        "Definition": PropertyType(False, is_type(dict)),
-        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),
-        "Logging": PropertyType(False, is_type(dict)),
-        "Role": PropertyType(False, is_str()),
-        "DefinitionSubstitutions": PropertyType(False, is_type(dict)),
-        "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),
-        "Name": PropertyType(False, is_str()),
-        "Type": PropertyType(False, is_str()),
-        "Tags": PropertyType(False, is_type(dict)),
-        "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),
-        "Tracing": PropertyType(False, is_type(dict)),
-        "PermissionsBoundary": PropertyType(False, is_str()),
+        "Definition": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Logging": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Role": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefinitionSubstitutions": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Type": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Tracing": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "PermissionsBoundary": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
-    event_resolver = ResourceTypeResolver(
+    event_resolver = ResourceTypeResolver(  # type: ignore[no-untyped-call]
         samtranslator.model.stepfunctions.events,
     )
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
         managed_policy_map = kwargs.get("managed_policy_map", {})
         intrinsics_resolver = kwargs["intrinsics_resolver"]
         event_resources = kwargs["event_resources"]
@@ -1570,43 +1570,43 @@ class SamStateMachine(SamResourceMacro):
             depends_on=self.depends_on,
             managed_policy_map=managed_policy_map,
             intrinsics_resolver=intrinsics_resolver,
-            definition=self.Definition,
-            definition_uri=self.DefinitionUri,
-            logging=self.Logging,
-            name=self.Name,
-            policies=self.Policies,
-            permissions_boundary=self.PermissionsBoundary,
-            definition_substitutions=self.DefinitionSubstitutions,
-            role=self.Role,
-            state_machine_type=self.Type,
-            tracing=self.Tracing,
-            events=self.Events,
+            definition=self.Definition,  # type: ignore[attr-defined]
+            definition_uri=self.DefinitionUri,  # type: ignore[attr-defined]
+            logging=self.Logging,  # type: ignore[attr-defined]
+            name=self.Name,  # type: ignore[attr-defined]
+            policies=self.Policies,  # type: ignore[attr-defined]
+            permissions_boundary=self.PermissionsBoundary,  # type: ignore[attr-defined]
+            definition_substitutions=self.DefinitionSubstitutions,  # type: ignore[attr-defined]
+            role=self.Role,  # type: ignore[attr-defined]
+            state_machine_type=self.Type,  # type: ignore[attr-defined]
+            tracing=self.Tracing,  # type: ignore[attr-defined]
+            events=self.Events,  # type: ignore[attr-defined]
             event_resources=event_resources,
             event_resolver=self.event_resolver,
-            tags=self.Tags,
+            tags=self.Tags,  # type: ignore[attr-defined]
             resource_attributes=self.resource_attributes,
-            passthrough_resource_attributes=self.get_passthrough_resource_attributes(),
+            passthrough_resource_attributes=self.get_passthrough_resource_attributes(),  # type: ignore[no-untyped-call]
         )
 
         resources = state_machine_generator.to_cloudformation()
         return resources
 
-    def resources_to_link(self, resources):
+    def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
         try:
-            return {"event_resources": self._event_resources_to_link(resources)}
+            return {"event_resources": self._event_resources_to_link(resources)}  # type: ignore[no-untyped-call]
         except InvalidEventException as e:
-            raise InvalidResourceException(self.logical_id, e.message)
+            raise InvalidResourceException(self.logical_id, e.message)  # type: ignore[no-untyped-call]
 
-    def _event_resources_to_link(self, resources):
+    def _event_resources_to_link(self, resources):  # type: ignore[no-untyped-def]
         event_resources = {}
-        if self.Events:
-            for logical_id, event_dict in self.Events.items():
+        if self.Events:  # type: ignore[attr-defined]
+            for logical_id, event_dict in self.Events.items():  # type: ignore[attr-defined]
                 try:
-                    event_source = self.event_resolver.resolve_resource_type(event_dict).from_dict(
+                    event_source = self.event_resolver.resolve_resource_type(event_dict).from_dict(  # type: ignore[no-untyped-call]
                         self.logical_id + logical_id, event_dict, logical_id
                     )
                 except (TypeError, AttributeError) as e:
-                    raise InvalidEventException(logical_id, "{}".format(e))
+                    raise InvalidEventException(logical_id, "{}".format(e))  # type: ignore[no-untyped-call]
                 event_resources[logical_id] = event_source.resources_to_link(resources)
         return event_resources
 
@@ -1624,13 +1624,13 @@ class SamConnector(SamResourceMacro):
 
     resource_type = "AWS::Serverless::Connector"
     property_types = {
-        "Source": PropertyType(True, dict_of(is_str(), any_type())),
-        "Destination": PropertyType(True, dict_of(is_str(), any_type())),
-        "Permissions": PropertyType(True, list_of(is_str())),
+        "Source": PropertyType(True, dict_of(is_str(), any_type())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Destination": PropertyType(True, dict_of(is_str(), any_type())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "Permissions": PropertyType(True, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
     }
 
-    @cw_timer
-    def to_cloudformation(self, **kwargs) -> List:
+    @cw_timer  # type: ignore[misc]
+    def to_cloudformation(self, **kwargs) -> List:  # type: ignore[no-untyped-def, type-arg]
         resource_resolver: ResourceResolver = kwargs["resource_resolver"]
         original_template = kwargs["original_template"]
 
@@ -1638,11 +1638,11 @@ class SamConnector(SamResourceMacro):
             destination = get_resource_reference(self.Destination, resource_resolver, self.Source)
             source = get_resource_reference(self.Source, resource_resolver, self.Destination)
         except ConnectorResourceError as e:
-            raise InvalidResourceException(self.logical_id, str(e))
+            raise InvalidResourceException(self.logical_id, str(e))  # type: ignore[no-untyped-call]
 
         profile = get_profile(source.resource_type, destination.resource_type)
         if not profile:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 f"Unable to create connector from {source.resource_type} to {destination.resource_type}; it's not supported or the template is invalid.",
             )
@@ -1656,14 +1656,14 @@ class SamConnector(SamResourceMacro):
         valid_permissions_str = ", ".join(profile_permissions)
 
         if not self.Permissions:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 f"'Permissions' cannot be empty; valid values are: {valid_permissions_str}.",
             )
 
         for permission in self.Permissions:
             if permission not in profile_permissions:
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     f"Unsupported 'Permissions' provided; valid values are: {valid_permissions_str}.",
                 )
@@ -1674,7 +1674,7 @@ class SamConnector(SamResourceMacro):
                 valid_permissions_combination_str = ", ".join(
                     " + ".join(permission) for permission in sorted_permissions_combinations
                 )
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
                     f"Unsupported 'Permissions' provided; valid combinations are: {valid_permissions_combination_str}.",
                 )
@@ -1692,7 +1692,7 @@ class SamConnector(SamResourceMacro):
         try:
             profile_properties = profile_replace(profile_properties, replacement)
         except ValueError as e:
-            raise InvalidResourceException(self.logical_id, str(e))
+            raise InvalidResourceException(self.logical_id, str(e))  # type: ignore[no-untyped-call]
 
         verify_profile_variables_replaced(profile_properties)
 
@@ -1744,12 +1744,12 @@ class SamConnector(SamResourceMacro):
         role_name = resource.role_name
         if not role_name:
             property_name = "Source" if source_policy else "Destination"
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, f"Unable to get IAM role name from '{property_name}' resource."
             )
 
         policy_document = self._get_policy_statements(profile)
-        policy = IAMManagedPolicy(f"{self.logical_id}Policy")
+        policy = IAMManagedPolicy(f"{self.logical_id}Policy")  # type: ignore[no-untyped-call]
         policy.PolicyDocument = policy_document
         policy.Roles = [role_name]
 
@@ -1779,14 +1779,14 @@ class SamConnector(SamResourceMacro):
         function_arn = lambda_function.arn
         if not function_arn:
             property_name = "Source" if source_policy else "Destination"
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, f"Unable to get Lambda function ARN from '{property_name}' resource."
             )
 
         lambda_permissions = []
         for name in profile["AccessCategories"].keys():
             if name in self.Permissions:
-                permission = LambdaPermission(f"{self.logical_id}{name}LambdaPermission")
+                permission = LambdaPermission(f"{self.logical_id}{name}LambdaPermission")  # type: ignore[no-untyped-call]
                 permissions = profile["AccessCategories"][name]
                 permission.Action = permissions["Action"]
                 permission.FunctionName = function_arn
@@ -1809,11 +1809,11 @@ class SamConnector(SamResourceMacro):
         topic_arn = sns_topic.arn
         if not topic_arn:
             property_name = "Source" if source_policy else "Destination"
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, f"Unable to get SNS topic ARN from '{property_name}' resource."
             )
 
-        topic_policy = SNSTopicPolicy(f"{self.logical_id}TopicPolicy")
+        topic_policy = SNSTopicPolicy(f"{self.logical_id}TopicPolicy")  # type: ignore[no-untyped-call]
         topic_policy.Topics = [topic_arn]
         topic_policy.PolicyDocument = self._get_policy_statements(profile)
 
@@ -1831,11 +1831,11 @@ class SamConnector(SamResourceMacro):
         queue_url = sqs_queue.queue_url
         if not queue_url:
             property_name = "Source" if source_policy else "Destination"
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, f"Unable to get SQS queue URL from '{property_name}' resource."
             )
 
-        queue_policy = SQSQueuePolicy(f"{self.logical_id}QueuePolicy")
+        queue_policy = SQSQueuePolicy(f"{self.logical_id}QueuePolicy")  # type: ignore[no-untyped-call]
         queue_policy.PolicyDocument = self._get_policy_statements(profile)
         queue_policy.Queues = [queue_url]
 
@@ -1878,7 +1878,7 @@ class SamConnector(SamResourceMacro):
             # Although as today the generated resources do not have any existing metadata,
             # To make it future proof, we still does a merge to avoid overwriting.
             try:
-                original_metadata = resource.get_resource_attribute("Metadata")
+                original_metadata = resource.get_resource_attribute("Metadata")  # type: ignore[no-untyped-call]
             except KeyError:
                 original_metadata = {}
-            resource.set_resource_attribute("Metadata", {**original_metadata, **metadata})
+            resource.set_resource_attribute("Metadata", {**original_metadata, **metadata})  # type: ignore[no-untyped-call]

--- a/samtranslator/model/sns.py
+++ b/samtranslator/model/sns.py
@@ -6,20 +6,20 @@ from samtranslator.model.intrinsics import ref
 class SNSSubscription(Resource):
     resource_type = "AWS::SNS::Subscription"
     property_types = {
-        "Endpoint": PropertyType(True, is_str()),
-        "Protocol": PropertyType(True, is_str()),
-        "TopicArn": PropertyType(True, is_str()),
-        "Region": PropertyType(False, is_str()),
-        "FilterPolicy": PropertyType(False, is_type(dict)),
+        "Endpoint": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Protocol": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TopicArn": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Region": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FilterPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
 
 class SNSTopicPolicy(Resource):
     resource_type = "AWS::SNS::TopicPolicy"
-    property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Topics": PropertyType(True, list_of(str))}
+    property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Topics": PropertyType(True, list_of(str))}  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
 
 
 class SNSTopic(Resource):
     resource_type = "AWS::SNS::Topic"
-    property_types = {"TopicName": PropertyType(False, is_str())}
-    runtime_attrs = {"arn": lambda self: ref(self.logical_id)}
+    property_types = {"TopicName": PropertyType(False, is_str())}  # type: ignore[no-untyped-call, no-untyped-call]
+    runtime_attrs = {"arn": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]

--- a/samtranslator/model/sqs.py
+++ b/samtranslator/model/sqs.py
@@ -9,20 +9,20 @@ class SQSQueue(Resource):
     resource_type = "AWS::SQS::Queue"
     property_types: Dict[str, PropertyType] = {}
     runtime_attrs = {
-        "queue_url": lambda self: ref(self.logical_id),
-        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),
+        "queue_url": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),  # type: ignore[no-untyped-call]
     }
 
 
 class SQSQueuePolicy(Resource):
     resource_type = "AWS::SQS::QueuePolicy"
-    property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Queues": PropertyType(True, list_of(str))}
-    runtime_attrs = {"arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+    property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Queues": PropertyType(True, list_of(str))}  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+    runtime_attrs = {"arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call]
 
 
 class SQSQueuePolicies:
     @staticmethod
-    def sns_topic_send_message_role_policy(topic_arn, queue_arn):
+    def sns_topic_send_message_role_policy(topic_arn, queue_arn):  # type: ignore[no-untyped-def]
         document = {
             "Version": "2012-10-17",
             "Statement": [
@@ -38,7 +38,7 @@ class SQSQueuePolicies:
         return document
 
     @staticmethod
-    def eventbridge_dlq_send_message_resource_based_policy(rule_arn, queue_arn):
+    def eventbridge_dlq_send_message_resource_based_policy(rule_arn, queue_arn):  # type: ignore[no-untyped-def]
         document = {
             "Version": "2012-10-17",
             "Statement": [

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -27,7 +27,7 @@ class EventSource(ResourceMacro):
     # TODO: Make `EventSource` an abstract class and not giving `principal` initial value.
     principal: str = None  # type: ignore
 
-    def _generate_logical_id(self, prefix, suffix, resource_type):
+    def _generate_logical_id(self, prefix, suffix, resource_type):  # type: ignore[no-untyped-def]
         """Helper utility to generate a logicial ID for a new resource
 
         :param string prefix: Prefix to use for the logical ID of the resource
@@ -42,11 +42,11 @@ class EventSource(ResourceMacro):
         if suffix.isalnum():
             logical_id = prefix + resource_type + suffix
         else:
-            generator = logical_id_generator.LogicalIdGenerator(prefix + resource_type, suffix)
-            logical_id = generator.gen()
+            generator = logical_id_generator.LogicalIdGenerator(prefix + resource_type, suffix)  # type: ignore[no-untyped-call]
+            logical_id = generator.gen()  # type: ignore[no-untyped-call]
         return logical_id
 
-    def _construct_role(self, resource, permissions_boundary=None, prefix=None, suffix=""):
+    def _construct_role(self, resource, permissions_boundary=None, prefix=None, suffix=""):  # type: ignore[no-untyped-def]
         """Constructs the IAM Role resource allowing the event service to invoke
         the StartExecution API of the state machine resource it is associated with.
 
@@ -58,14 +58,14 @@ class EventSource(ResourceMacro):
         :returns: the IAM Role resource
         :rtype: model.iam.IAMRole
         """
-        role_logical_id = self._generate_logical_id(prefix=prefix, suffix=suffix, resource_type="Role")
-        event_role = IAMRole(role_logical_id, attributes=resource.get_passthrough_resource_attributes())
-        event_role.AssumeRolePolicyDocument = IAMRolePolicies.construct_assume_role_policy_for_service_principal(
+        role_logical_id = self._generate_logical_id(prefix=prefix, suffix=suffix, resource_type="Role")  # type: ignore[no-untyped-call]
+        event_role = IAMRole(role_logical_id, attributes=resource.get_passthrough_resource_attributes())  # type: ignore[no-untyped-call]
+        event_role.AssumeRolePolicyDocument = IAMRolePolicies.construct_assume_role_policy_for_service_principal(  # type: ignore[no-untyped-call]
             self.principal
         )
         state_machine_arn = resource.get_runtime_attr("arn")
         event_role.Policies = [
-            IAMRolePolicies.step_functions_start_execution_role_policy(state_machine_arn, role_logical_id)
+            IAMRolePolicies.step_functions_start_execution_role_policy(state_machine_arn, role_logical_id)  # type: ignore[no-untyped-call]
         ]
 
         if permissions_boundary:
@@ -80,18 +80,18 @@ class Schedule(EventSource):
     resource_type = "Schedule"
     principal = "events.amazonaws.com"
     property_types = {
-        "Schedule": PropertyType(True, is_str()),
-        "Input": PropertyType(False, is_str()),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "State": PropertyType(False, is_str()),
-        "Name": PropertyType(False, is_str()),
-        "Description": PropertyType(False, is_str()),
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),
-        "RetryPolicy": PropertyType(False, is_type(dict)),
+        "Schedule": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Input": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RetryPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, resource, **kwargs):
+    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, resource, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the EventBridge Rule and IAM Role to which this Schedule event source corresponds.
 
         :param dict kwargs: no existing resources need to be modified
@@ -103,39 +103,39 @@ class Schedule(EventSource):
         permissions_boundary = kwargs.get("permissions_boundary")
 
         passthrough_resource_attributes = resource.get_passthrough_resource_attributes()
-        events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)
+        events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)  # type: ignore[no-untyped-call]
         resources.append(events_rule)
 
-        events_rule.ScheduleExpression = self.Schedule
+        events_rule.ScheduleExpression = self.Schedule  # type: ignore[attr-defined]
 
-        if self.State and self.Enabled is not None:
-            raise InvalidEventException(self.relative_id, "State and Enabled Properties cannot both be specified.")
+        if self.State and self.Enabled is not None:  # type: ignore[attr-defined, attr-defined]
+            raise InvalidEventException(self.relative_id, "State and Enabled Properties cannot both be specified.")  # type: ignore[no-untyped-call]
 
-        if self.State:
-            events_rule.State = self.State
+        if self.State:  # type: ignore[attr-defined]
+            events_rule.State = self.State  # type: ignore[attr-defined]
 
-        if self.Enabled is not None:
-            events_rule.State = "ENABLED" if self.Enabled else "DISABLED"
+        if self.Enabled is not None:  # type: ignore[attr-defined]
+            events_rule.State = "ENABLED" if self.Enabled else "DISABLED"  # type: ignore[attr-defined]
 
-        events_rule.Name = self.Name
-        events_rule.Description = self.Description
+        events_rule.Name = self.Name  # type: ignore[attr-defined]
+        events_rule.Description = self.Description  # type: ignore[attr-defined]
 
-        role = self._construct_role(resource, permissions_boundary)
+        role = self._construct_role(resource, permissions_boundary)  # type: ignore[no-untyped-call]
         resources.append(role)
 
-        source_arn = events_rule.get_runtime_attr("arn")
+        source_arn = events_rule.get_runtime_attr("arn")  # type: ignore[no-untyped-call]
         dlq_queue_arn = None
-        if self.DeadLetterConfig is not None:
-            EventBridgeRuleUtils.validate_dlq_config(self.logical_id, self.DeadLetterConfig)
-            dlq_queue_arn, dlq_resources = EventBridgeRuleUtils.get_dlq_queue_arn_and_resources(
+        if self.DeadLetterConfig is not None:  # type: ignore[attr-defined]
+            EventBridgeRuleUtils.validate_dlq_config(self.logical_id, self.DeadLetterConfig)  # type: ignore[attr-defined, no-untyped-call]
+            dlq_queue_arn, dlq_resources = EventBridgeRuleUtils.get_dlq_queue_arn_and_resources(  # type: ignore[no-untyped-call]
                 self, source_arn, passthrough_resource_attributes
             )
             resources.extend(dlq_resources)
-        events_rule.Targets = [self._construct_target(resource, role, dlq_queue_arn)]
+        events_rule.Targets = [self._construct_target(resource, role, dlq_queue_arn)]  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _construct_target(self, resource, role, dead_letter_queue_arn=None):
+    def _construct_target(self, resource, role, dead_letter_queue_arn=None):  # type: ignore[no-untyped-def]
         """Constructs the Target property for the EventBridge Rule.
 
         :returns: the Target property
@@ -146,14 +146,14 @@ class Schedule(EventSource):
             "Id": self.logical_id + "StepFunctionsTarget",
             "RoleArn": role.get_runtime_attr("arn"),
         }
-        if self.Input is not None:
-            target["Input"] = self.Input
+        if self.Input is not None:  # type: ignore[attr-defined]
+            target["Input"] = self.Input  # type: ignore[attr-defined]
 
-        if self.DeadLetterConfig is not None:
+        if self.DeadLetterConfig is not None:  # type: ignore[attr-defined]
             target["DeadLetterConfig"] = {"Arn": dead_letter_queue_arn}
 
-        if self.RetryPolicy is not None:
-            target["RetryPolicy"] = self.RetryPolicy
+        if self.RetryPolicy is not None:  # type: ignore[attr-defined]
+            target["RetryPolicy"] = self.RetryPolicy  # type: ignore[attr-defined]
 
         return target
 
@@ -164,17 +164,17 @@ class CloudWatchEvent(EventSource):
     resource_type = "CloudWatchEvent"
     principal = "events.amazonaws.com"
     property_types = {
-        "EventBusName": PropertyType(False, is_str()),
-        "Pattern": PropertyType(False, is_type(dict)),
-        "Input": PropertyType(False, is_str()),
-        "InputPath": PropertyType(False, is_str()),
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),
-        "RetryPolicy": PropertyType(False, is_type(dict)),
-        "State": PropertyType(False, is_str()),
+        "EventBusName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Pattern": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Input": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "InputPath": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RetryPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, resource, **kwargs):
+    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, resource, **kwargs):  # type: ignore[no-untyped-def]
         """Returns the CloudWatch Events/EventBridge Rule and IAM Role to which this
         CloudWatch Events/EventBridge event source corresponds.
 
@@ -187,32 +187,32 @@ class CloudWatchEvent(EventSource):
         permissions_boundary = kwargs.get("permissions_boundary")
 
         passthrough_resource_attributes = resource.get_passthrough_resource_attributes()
-        events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)
-        events_rule.EventBusName = self.EventBusName
-        events_rule.EventPattern = self.Pattern
+        events_rule = EventsRule(self.logical_id, attributes=passthrough_resource_attributes)  # type: ignore[no-untyped-call]
+        events_rule.EventBusName = self.EventBusName  # type: ignore[attr-defined]
+        events_rule.EventPattern = self.Pattern  # type: ignore[attr-defined]
 
-        if self.State:
-            events_rule.State = self.State
+        if self.State:  # type: ignore[attr-defined]
+            events_rule.State = self.State  # type: ignore[attr-defined]
 
         resources.append(events_rule)
 
-        role = self._construct_role(resource, permissions_boundary)
+        role = self._construct_role(resource, permissions_boundary)  # type: ignore[no-untyped-call]
         resources.append(role)
 
-        source_arn = events_rule.get_runtime_attr("arn")
+        source_arn = events_rule.get_runtime_attr("arn")  # type: ignore[no-untyped-call]
         dlq_queue_arn = None
-        if self.DeadLetterConfig is not None:
-            EventBridgeRuleUtils.validate_dlq_config(self.logical_id, self.DeadLetterConfig)
-            dlq_queue_arn, dlq_resources = EventBridgeRuleUtils.get_dlq_queue_arn_and_resources(
+        if self.DeadLetterConfig is not None:  # type: ignore[attr-defined]
+            EventBridgeRuleUtils.validate_dlq_config(self.logical_id, self.DeadLetterConfig)  # type: ignore[attr-defined, no-untyped-call]
+            dlq_queue_arn, dlq_resources = EventBridgeRuleUtils.get_dlq_queue_arn_and_resources(  # type: ignore[no-untyped-call]
                 self, source_arn, passthrough_resource_attributes
             )
             resources.extend(dlq_resources)
 
-        events_rule.Targets = [self._construct_target(resource, role, dlq_queue_arn)]
+        events_rule.Targets = [self._construct_target(resource, role, dlq_queue_arn)]  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _construct_target(self, resource, role, dead_letter_queue_arn=None):
+    def _construct_target(self, resource, role, dead_letter_queue_arn=None):  # type: ignore[no-untyped-def]
         """Constructs the Target property for the CloudWatch Events/EventBridge Rule.
 
         :returns: the Target property
@@ -223,17 +223,17 @@ class CloudWatchEvent(EventSource):
             "Id": self.logical_id + "StepFunctionsTarget",
             "RoleArn": role.get_runtime_attr("arn"),
         }
-        if self.Input is not None:
-            target["Input"] = self.Input
+        if self.Input is not None:  # type: ignore[attr-defined]
+            target["Input"] = self.Input  # type: ignore[attr-defined]
 
-        if self.InputPath is not None:
-            target["InputPath"] = self.InputPath
+        if self.InputPath is not None:  # type: ignore[attr-defined]
+            target["InputPath"] = self.InputPath  # type: ignore[attr-defined]
 
-        if self.DeadLetterConfig is not None:
+        if self.DeadLetterConfig is not None:  # type: ignore[attr-defined]
             target["DeadLetterConfig"] = {"Arn": dead_letter_queue_arn}
 
-        if self.RetryPolicy is not None:
-            target["RetryPolicy"] = self.RetryPolicy
+        if self.RetryPolicy is not None:  # type: ignore[attr-defined]
+            target["RetryPolicy"] = self.RetryPolicy  # type: ignore[attr-defined]
 
         return target
 
@@ -250,15 +250,15 @@ class Api(EventSource):
     resource_type = "Api"
     principal = "apigateway.amazonaws.com"
     property_types = {
-        "Path": PropertyType(True, is_str()),
-        "Method": PropertyType(True, is_str()),
+        "Path": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Method": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
         # Api Event sources must "always" be paired with a Serverless::Api
-        "RestApiId": PropertyType(True, is_str()),
-        "Stage": PropertyType(False, is_str()),
-        "Auth": PropertyType(False, is_type(dict)),
+        "RestApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Stage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
-    def resources_to_link(self, resources):
+    def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
         """
         If this API Event Source refers to an explicit API resource, resolve the reference and grab
         necessary data from the explicit API
@@ -273,7 +273,7 @@ class Api(EventSource):
         permitted_stage = "*"
         stage_suffix = "AllStages"
         explicit_api = None
-        rest_api_id = PushApi.get_rest_api_id_string(self.RestApiId)
+        rest_api_id = PushApi.get_rest_api_id_string(self.RestApiId)  # type: ignore[attr-defined, no-untyped-call]
         if isinstance(rest_api_id, str):
 
             if (
@@ -289,19 +289,19 @@ class Api(EventSource):
                 if isinstance(permitted_stage, str):
                     stage_suffix = permitted_stage
                 else:
-                    stage_suffix = "Stage"
+                    stage_suffix = "Stage"  # type: ignore[unreachable]
 
             else:
                 # RestApiId is a string, not an intrinsic, but we did not find a valid API resource for this ID
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "RestApiId property of Api event must reference a valid resource in the same template.",
                 )
 
         return {"explicit_api": explicit_api, "explicit_api_stage": {"suffix": stage_suffix}}
 
-    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)
-    def to_cloudformation(self, resource, **kwargs):
+    @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
+    def to_cloudformation(self, resource, **kwargs):  # type: ignore[no-untyped-def]
         """If the Api event source has a RestApi property, then simply return the IAM role resource
         allowing API Gateway to start the state machine execution. If no RestApi is provided, then
         additionally inject the path, method, and the x-amazon-apigateway-integration into the
@@ -320,20 +320,20 @@ class Api(EventSource):
         intrinsics_resolver = kwargs.get("intrinsics_resolver")
         permissions_boundary = kwargs.get("permissions_boundary")
 
-        if self.Method is not None:
+        if self.Method is not None:  # type: ignore[has-type]
             # Convert to lower case so that user can specify either GET or get
-            self.Method = self.Method.lower()
+            self.Method = self.Method.lower()  # type: ignore[has-type]
 
-        role = self._construct_role(resource, permissions_boundary)
+        role = self._construct_role(resource, permissions_boundary)  # type: ignore[no-untyped-call]
         resources.append(role)
 
         explicit_api = kwargs["explicit_api"]
         if explicit_api.get("__MANAGE_SWAGGER"):
-            self._add_swagger_integration(explicit_api, resource, role, intrinsics_resolver)
+            self._add_swagger_integration(explicit_api, resource, role, intrinsics_resolver)  # type: ignore[no-untyped-call]
 
         return resources
 
-    def _add_swagger_integration(self, api, resource, role, intrinsics_resolver):
+    def _add_swagger_integration(self, api, resource, role, intrinsics_resolver):  # type: ignore[no-untyped-def]
         """Adds the path and method for this Api event source to the Swagger body for the provided RestApi.
 
         :param model.apigateway.ApiGatewayRestApi rest_api: the RestApi to which the path and method should be added.
@@ -342,16 +342,16 @@ class Api(EventSource):
         if swagger_body is None:
             return
 
-        integration_uri = fnSub("arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution")
+        integration_uri = fnSub("arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution")  # type: ignore[no-untyped-call]
 
-        editor = SwaggerEditor(swagger_body)
+        editor = SwaggerEditor(swagger_body)  # type: ignore[no-untyped-call]
 
-        if editor.has_integration(self.Path, self.Method):
+        if editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined, no-untyped-call]
             # Cannot add the integration, if it is already present
-            raise InvalidEventException(
+            raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 'API method "{method}" defined multiple times for path "{path}".'.format(
-                    method=self.Method, path=self.Path
+                    method=self.Method, path=self.Path  # type: ignore[attr-defined]
                 ),
             )
 
@@ -359,18 +359,18 @@ class Api(EventSource):
         if CONDITION in resource.resource_attributes:
             condition = resource.resource_attributes[CONDITION]
 
-        editor.add_state_machine_integration(
-            self.Path,
+        editor.add_state_machine_integration(  # type: ignore[no-untyped-call]
+            self.Path,  # type: ignore[attr-defined]
             self.Method,
             integration_uri,
             role.get_runtime_attr("arn"),
-            self._generate_request_template(resource),
+            self._generate_request_template(resource),  # type: ignore[no-untyped-call]
             condition=condition,
         )
 
         # Note: Refactor and combine the section below with the Api eventsource for functions
-        if self.Auth:
-            method_authorizer = self.Auth.get("Authorizer")
+        if self.Auth:  # type: ignore[attr-defined]
+            method_authorizer = self.Auth.get("Authorizer")  # type: ignore[attr-defined]
             api_auth = api.get("Auth")
             api_auth = intrinsics_resolver.resolve_parameter_refs(api_auth)
 
@@ -379,63 +379,63 @@ class Api(EventSource):
 
                 if method_authorizer != "AWS_IAM":
                     if method_authorizer != "NONE" and not api_authorizers:
-                        raise InvalidEventException(
+                        raise InvalidEventException(  # type: ignore[no-untyped-call]
                             self.relative_id,
                             "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "
                             "because the related API does not define any Authorizers.".format(
-                                authorizer=method_authorizer, method=self.Method, path=self.Path
+                                authorizer=method_authorizer, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                             ),
                         )
 
                     if method_authorizer != "NONE" and not api_authorizers.get(method_authorizer):
-                        raise InvalidEventException(
+                        raise InvalidEventException(  # type: ignore[no-untyped-call]
                             self.relative_id,
                             "Unable to set Authorizer [{authorizer}] on API method [{method}] for path [{path}] "
                             "because it wasn't defined in the API's Authorizers.".format(
-                                authorizer=method_authorizer, method=self.Method, path=self.Path
+                                authorizer=method_authorizer, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                             ),
                         )
 
                     if method_authorizer == "NONE":
                         if not api_auth or not api_auth.get("DefaultAuthorizer"):
-                            raise InvalidEventException(
+                            raise InvalidEventException(  # type: ignore[no-untyped-call]
                                 self.relative_id,
                                 "Unable to set Authorizer on API method [{method}] for path [{path}] because 'NONE' "
                                 "is only a valid value when a DefaultAuthorizer on the API is specified.".format(
-                                    method=self.Method, path=self.Path
+                                    method=self.Method, path=self.Path  # type: ignore[attr-defined]
                                 ),
                             )
 
-            if self.Auth.get("AuthorizationScopes") and not isinstance(self.Auth.get("AuthorizationScopes"), list):
-                raise InvalidEventException(
+            if self.Auth.get("AuthorizationScopes") and not isinstance(self.Auth.get("AuthorizationScopes"), list):  # type: ignore[attr-defined]
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Unable to set Authorizer on API method [{method}] for path [{path}] because "
-                    "'AuthorizationScopes' must be a list of strings.".format(method=self.Method, path=self.Path),
+                    "'AuthorizationScopes' must be a list of strings.".format(method=self.Method, path=self.Path),  # type: ignore[attr-defined]
                 )
 
-            apikey_required_setting = self.Auth.get("ApiKeyRequired")
+            apikey_required_setting = self.Auth.get("ApiKeyRequired")  # type: ignore[attr-defined]
             apikey_required_setting_is_false = apikey_required_setting is not None and not apikey_required_setting
             if apikey_required_setting_is_false and (not api_auth or not api_auth.get("ApiKeyRequired")):
-                raise InvalidEventException(
+                raise InvalidEventException(  # type: ignore[no-untyped-call]
                     self.relative_id,
                     "Unable to set ApiKeyRequired [False] on API method [{method}] for path [{path}] "
                     "because the related API does not specify any ApiKeyRequired.".format(
-                        method=self.Method, path=self.Path
+                        method=self.Method, path=self.Path  # type: ignore[attr-defined]
                     ),
                 )
 
             if method_authorizer or apikey_required_setting is not None:
-                editor.add_auth_to_method(api=api, path=self.Path, method_name=self.Method, auth=self.Auth)
+                editor.add_auth_to_method(api=api, path=self.Path, method_name=self.Method, auth=self.Auth)  # type: ignore[attr-defined, attr-defined, no-untyped-call]
 
-            if self.Auth.get("ResourcePolicy"):
-                resource_policy = self.Auth.get("ResourcePolicy")
-                editor.add_resource_policy(resource_policy=resource_policy, path=self.Path, stage=self.Stage)
+            if self.Auth.get("ResourcePolicy"):  # type: ignore[attr-defined]
+                resource_policy = self.Auth.get("ResourcePolicy")  # type: ignore[attr-defined]
+                editor.add_resource_policy(resource_policy=resource_policy, path=self.Path, stage=self.Stage)  # type: ignore[attr-defined, attr-defined, no-untyped-call]
                 if resource_policy.get("CustomStatements"):
-                    editor.add_custom_statements(resource_policy.get("CustomStatements"))
+                    editor.add_custom_statements(resource_policy.get("CustomStatements"))  # type: ignore[no-untyped-call]
 
         api["DefinitionBody"] = editor.swagger
 
-    def _generate_request_template(self, resource):
+    def _generate_request_template(self, resource):  # type: ignore[no-untyped-def]
         """Generates the Body mapping request template for the Api. This allows for the input
         request to the Api to be passed as the execution input to the associated state machine resource.
 
@@ -446,7 +446,7 @@ class Api(EventSource):
         :rtype: dict
         """
         request_templates = {
-            "application/json": fnSub(
+            "application/json": fnSub(  # type: ignore[no-untyped-call]
                 json.dumps(
                     {
                         "input": "$util.escapeJavaScript($input.json('$'))",

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -5,9 +5,9 @@ from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.exceptions import InvalidEventException, InvalidResourceException
 from samtranslator.model.iam import IAMRolePolicies
 from samtranslator.model.resource_policies import ResourcePolicies
-from samtranslator.model.role_utils import construct_role_for_resource
+from samtranslator.model.role_utils import construct_role_for_resource  # type: ignore[attr-defined]
 from samtranslator.model.s3_utils.uri_parser import parse_s3_uri
-from samtranslator.model.stepfunctions import StepFunctionsStateMachine
+from samtranslator.model.stepfunctions import StepFunctionsStateMachine  # type: ignore[attr-defined]
 from samtranslator.model.intrinsics import fnJoin
 from samtranslator.model.tags.resource_tagging import get_tag_list
 
@@ -22,7 +22,7 @@ class StateMachineGenerator(object):
     _SUBSTITUTION_NAME_TEMPLATE = "definition_substitution_%s"
     _SUBSTITUTION_KEY_TEMPLATE = "${definition_substitution_%s}"
 
-    def __init__(
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         logical_id,
         depends_on,
@@ -94,8 +94,8 @@ class StateMachineGenerator(object):
         )
         self.substitution_counter = 1
 
-    @cw_timer(prefix="Generator", name="StateMachine")
-    def to_cloudformation(self):
+    @cw_timer(prefix="Generator", name="StateMachine")  # type: ignore[no-untyped-call]
+    def to_cloudformation(self):  # type: ignore[no-untyped-def]
         """
         Constructs and returns the State Machine resource and any additional resources associated with it.
 
@@ -109,27 +109,27 @@ class StateMachineGenerator(object):
             self.state_machine.DefinitionSubstitutions = self.definition_substitutions
 
         if self.definition and self.definition_uri:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Specify either 'Definition' or 'DefinitionUri' property and not both."
             )
         if self.definition:
             processed_definition = deepcopy(self.definition)
-            substitutions = self._replace_dynamic_values_with_substitutions(processed_definition)
+            substitutions = self._replace_dynamic_values_with_substitutions(processed_definition)  # type: ignore[no-untyped-call]
             if len(substitutions) > 0:
                 if self.state_machine.DefinitionSubstitutions:
                     self.state_machine.DefinitionSubstitutions.update(substitutions)
                 else:
                     self.state_machine.DefinitionSubstitutions = substitutions
-            self.state_machine.DefinitionString = self._build_definition_string(processed_definition)
+            self.state_machine.DefinitionString = self._build_definition_string(processed_definition)  # type: ignore[no-untyped-call]
         elif self.definition_uri:
-            self.state_machine.DefinitionS3Location = self._construct_definition_uri()
+            self.state_machine.DefinitionS3Location = self._construct_definition_uri()  # type: ignore[no-untyped-call]
         else:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Either 'Definition' or 'DefinitionUri' property must be specified."
             )
 
         if self.role and self.policies:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id, "Specify either 'Role' or 'Policies' property and not both."
             )
         if self.role:
@@ -138,24 +138,24 @@ class StateMachineGenerator(object):
             if not self.managed_policy_map:
                 raise Exception("Managed policy map is empty, but should not be.")
 
-            execution_role = self._construct_role()
+            execution_role = self._construct_role()  # type: ignore[no-untyped-call]
             self.state_machine.RoleArn = execution_role.get_runtime_attr("arn")
             resources.append(execution_role)
         else:
-            raise InvalidResourceException(self.logical_id, "Either 'Role' or 'Policies' property must be specified.")
+            raise InvalidResourceException(self.logical_id, "Either 'Role' or 'Policies' property must be specified.")  # type: ignore[no-untyped-call]
 
         self.state_machine.StateMachineName = self.name
         self.state_machine.StateMachineType = self.type
         self.state_machine.LoggingConfiguration = self.logging
         self.state_machine.TracingConfiguration = self.tracing
-        self.state_machine.Tags = self._construct_tag_list()
+        self.state_machine.Tags = self._construct_tag_list()  # type: ignore[no-untyped-call]
 
-        event_resources = self._generate_event_resources()
+        event_resources = self._generate_event_resources()  # type: ignore[no-untyped-call]
         resources.extend(event_resources)
 
         return resources
 
-    def _construct_definition_uri(self):
+    def _construct_definition_uri(self):  # type: ignore[no-untyped-def]
         """
         Constructs the State Machine's `DefinitionS3 property`_, from the SAM State Machines's DefinitionUri property.
 
@@ -165,13 +165,13 @@ class StateMachineGenerator(object):
         if isinstance(self.definition_uri, dict):
             if not self.definition_uri.get("Bucket", None) or not self.definition_uri.get("Key", None):
                 # DefinitionUri is a dictionary but does not contain Bucket or Key property
-                raise InvalidResourceException(
+                raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id, "'DefinitionUri' requires Bucket and Key properties to be specified."
                 )
             s3_pointer = self.definition_uri
         else:
             # DefinitionUri is a string
-            s3_pointer = parse_s3_uri(self.definition_uri)
+            s3_pointer = parse_s3_uri(self.definition_uri)  # type: ignore[no-untyped-call]
             if s3_pointer is None:
                 raise InvalidResourceException(
                     self.logical_id,
@@ -184,7 +184,7 @@ class StateMachineGenerator(object):
             definition_s3["Version"] = s3_pointer["Version"]
         return definition_s3
 
-    def _build_definition_string(self, definition_dict):
+    def _build_definition_string(self, definition_dict):  # type: ignore[no-untyped-def]
         """
         Builds a CloudFormation definition string from a definition dictionary. The definition string constructed is
         a Fn::Join intrinsic function to make it readable.
@@ -197,10 +197,10 @@ class StateMachineGenerator(object):
         # Indenting and then splitting the JSON-encoded string for readability of the state machine definition in the CloudFormation translated resource.
         # Separators are passed explicitly to maintain trailing whitespace consistency across Py2 and Py3
         definition_lines = json.dumps(definition_dict, sort_keys=True, indent=4, separators=(",", ": ")).split("\n")
-        definition_string = fnJoin("\n", definition_lines)
+        definition_string = fnJoin("\n", definition_lines)  # type: ignore[no-untyped-call]
         return definition_string
 
-    def _construct_role(self):
+    def _construct_role(self):  # type: ignore[no-untyped-def]
         """
         Constructs a State Machine execution role based on this SAM State Machine's Policies property.
 
@@ -209,9 +209,9 @@ class StateMachineGenerator(object):
         """
         policies = self.policies[:]
         if self.tracing and self.tracing.get("Enabled") is True:
-            policies.append(get_xray_managed_policy_name())
+            policies.append(get_xray_managed_policy_name())  # type: ignore[no-untyped-call]
 
-        state_machine_policies = ResourcePolicies(
+        state_machine_policies = ResourcePolicies(  # type: ignore[no-untyped-call]
             {"Policies": policies},
             # No support for policy templates in the "core"
             policy_template_processor=None,
@@ -221,14 +221,14 @@ class StateMachineGenerator(object):
             resource_logical_id=self.logical_id,
             attributes=self.passthrough_resource_attributes,
             managed_policy_map=self.managed_policy_map,
-            assume_role_policy_document=IAMRolePolicies.stepfunctions_assume_role_policy(),
+            assume_role_policy_document=IAMRolePolicies.stepfunctions_assume_role_policy(),  # type: ignore[no-untyped-call]
             resource_policies=state_machine_policies,
-            tags=self._construct_tag_list(),
+            tags=self._construct_tag_list(),  # type: ignore[no-untyped-call]
             permissions_boundary=self.permissions_boundary,
         )
         return execution_role
 
-    def _construct_tag_list(self):
+    def _construct_tag_list(self):  # type: ignore[no-untyped-def]
         """
         Transforms the SAM defined Tags into the form CloudFormation is expecting.
 
@@ -236,9 +236,9 @@ class StateMachineGenerator(object):
         :rtype: list
         """
         sam_tag = {self._SAM_KEY: self._SAM_VALUE}
-        return get_tag_list(sam_tag) + get_tag_list(self.tags)
+        return get_tag_list(sam_tag) + get_tag_list(self.tags)  # type: ignore[no-untyped-call]
 
-    def _generate_event_resources(self):
+    def _generate_event_resources(self):  # type: ignore[no-untyped-def]
         """Generates and returns the resources associated with this state machine's event sources.
 
         :returns: a list containing the state machine's event resources
@@ -258,12 +258,12 @@ class StateMachineGenerator(object):
                     for name, resource in self.event_resources[logical_id].items():
                         kwargs[name] = resource
                 except (TypeError, AttributeError) as e:
-                    raise InvalidEventException(logical_id, str(e))
+                    raise InvalidEventException(logical_id, str(e))  # type: ignore[no-untyped-call]
                 resources += eventsource.to_cloudformation(resource=self.state_machine, **kwargs)
 
         return resources
 
-    def _replace_dynamic_values_with_substitutions(self, input):
+    def _replace_dynamic_values_with_substitutions(self, input):  # type: ignore[no-untyped-def]
         """
         Replaces the CloudFormation instrinsic functions and dynamic references within the input with substitutions.
 
@@ -273,16 +273,16 @@ class StateMachineGenerator(object):
         :rtype: dict
         """
         substitution_map = {}
-        for path in self._get_paths_to_intrinsics(input):
+        for path in self._get_paths_to_intrinsics(input):  # type: ignore[no-untyped-call]
             location = input
             for step in path[:-1]:
                 location = location[step]
-            sub_name, sub_key = self._generate_substitution()
+            sub_name, sub_key = self._generate_substitution()  # type: ignore[no-untyped-call]
             substitution_map[sub_name] = location[path[-1]]
             location[path[-1]] = sub_key
         return substitution_map
 
-    def _get_paths_to_intrinsics(self, input, path=None):
+    def _get_paths_to_intrinsics(self, input, path=None):  # type: ignore[no-untyped-def]
         """
         Returns all paths to dynamic values within a dictionary
 
@@ -292,23 +292,23 @@ class StateMachineGenerator(object):
         """
         if path is None:
             path = []
-        dynamic_value_paths = []
+        dynamic_value_paths = []  # type: ignore[var-annotated]
         if isinstance(input, dict):
             iterator = input.items()
         elif isinstance(input, list):
-            iterator = enumerate(input)
+            iterator = enumerate(input)  # type: ignore[assignment]
         else:
             return dynamic_value_paths
 
-        for key, value in sorted(iterator, key=lambda item: item[0]):
-            if is_intrinsic(value) or is_dynamic_reference(value):
+        for key, value in sorted(iterator, key=lambda item: item[0]):  # type: ignore[no-any-return]
+            if is_intrinsic(value) or is_dynamic_reference(value):  # type: ignore[no-untyped-call, no-untyped-call]
                 dynamic_value_paths.append(path + [key])
             elif isinstance(value, (dict, list)):
-                dynamic_value_paths.extend(self._get_paths_to_intrinsics(value, path + [key]))
+                dynamic_value_paths.extend(self._get_paths_to_intrinsics(value, path + [key]))  # type: ignore[no-untyped-call]
 
         return dynamic_value_paths
 
-    def _generate_substitution(self):
+    def _generate_substitution(self):  # type: ignore[no-untyped-def]
         """
         Generates a name and key for a new substitution.
 

--- a/samtranslator/model/stepfunctions/resources.py
+++ b/samtranslator/model/stepfunctions/resources.py
@@ -6,19 +6,19 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class StepFunctionsStateMachine(Resource):
     resource_type = "AWS::StepFunctions::StateMachine"
     property_types = {
-        "Definition": PropertyType(False, is_type(dict)),
-        "DefinitionString": PropertyType(False, is_str()),
-        "DefinitionS3Location": PropertyType(False, is_type(dict)),
-        "LoggingConfiguration": PropertyType(False, is_type(dict)),
-        "RoleArn": PropertyType(True, is_str()),
-        "StateMachineName": PropertyType(False, is_str()),
-        "StateMachineType": PropertyType(False, is_str()),
-        "Tags": PropertyType(False, list_of(is_type(dict))),
-        "DefinitionSubstitutions": PropertyType(False, is_type(dict)),
-        "TracingConfiguration": PropertyType(False, is_type(dict)),
+        "Definition": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefinitionString": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DefinitionS3Location": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "LoggingConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RoleArn": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StateMachineName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "StateMachineType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "DefinitionSubstitutions": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TracingConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
     }
 
     runtime_attrs = {
-        "arn": lambda self: ref(self.logical_id),
-        "name": lambda self: fnGetAtt(self.logical_id, "Name"),
+        "arn": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
+        "name": lambda self: fnGetAtt(self.logical_id, "Name"),  # type: ignore[no-untyped-call]
     }

--- a/samtranslator/model/tags/resource_tagging.py
+++ b/samtranslator/model/tags/resource_tagging.py
@@ -3,7 +3,7 @@ _KEY = "Key"
 _VALUE = "Value"
 
 
-def get_tag_list(resource_tag_dict):
+def get_tag_list(resource_tag_dict):  # type: ignore[no-untyped-def]
     """
     Transforms the SAM defined Tags into the form CloudFormation is expecting.
 
@@ -23,7 +23,7 @@ def get_tag_list(resource_tag_dict):
     :param resource_tag_dict: Customer defined dictionary (SAM Example from above)
     :return: List of Tag Dictionaries (CloudFormation Equivalent from above)
     """
-    tag_list = []
+    tag_list = []  # type: ignore[var-annotated]
     if resource_tag_dict is None:
         return tag_list
 

--- a/samtranslator/model/types.py
+++ b/samtranslator/model/types.py
@@ -11,7 +11,7 @@ either a string or a list of strings, but do not validate whether the string(s) 
 import samtranslator.model.exceptions
 
 
-def is_type(valid_type):
+def is_type(valid_type):  # type: ignore[no-untyped-def]
     """Returns a validator function that succeeds only for inputs of the provided valid_type.
 
     :param type valid_type: the type that should be considered valid for the validator
@@ -19,7 +19,7 @@ def is_type(valid_type):
     :rtype: callable
     """
 
-    def validate(value, should_raise=True):
+    def validate(value, should_raise=True):  # type: ignore[no-untyped-def]
         if not isinstance(value, valid_type):
             if should_raise:
                 raise TypeError(
@@ -33,7 +33,7 @@ def is_type(valid_type):
     return validate
 
 
-def list_of(validate_item):
+def list_of(validate_item):  # type: ignore[no-untyped-def]
     """Returns a validator function that succeeds only if the input is a list, and each item in the list passes as input
     to the provided validator validate_item.
 
@@ -42,8 +42,8 @@ def list_of(validate_item):
     :rtype: callable
     """
 
-    def validate(value, should_raise=True):
-        validate_type = is_type(list)
+    def validate(value, should_raise=True):  # type: ignore[no-untyped-def]
+        validate_type = is_type(list)  # type: ignore[no-untyped-call]
         if not validate_type(value, should_raise=should_raise):
             return False
 
@@ -52,7 +52,7 @@ def list_of(validate_item):
                 validate_item(item)
             except TypeError as e:
                 if should_raise:
-                    samtranslator.model.exceptions.prepend(e, "list contained an invalid item")
+                    samtranslator.model.exceptions.prepend(e, "list contained an invalid item")  # type: ignore[no-untyped-call]
                     raise
                 return False
         return True
@@ -60,7 +60,7 @@ def list_of(validate_item):
     return validate
 
 
-def dict_of(validate_key, validate_item):
+def dict_of(validate_key, validate_item):  # type: ignore[no-untyped-def]
     """Returns a validator function that succeeds only if the input is a dict, and each key and value in the dict passes
     as input to the provided validators validate_key and validate_item, respectively.
 
@@ -70,8 +70,8 @@ def dict_of(validate_key, validate_item):
     :rtype: callable
     """
 
-    def validate(value, should_raise=True):
-        validate_type = is_type(dict)
+    def validate(value, should_raise=True):  # type: ignore[no-untyped-def]
+        validate_type = is_type(dict)  # type: ignore[no-untyped-call]
         if not validate_type(value, should_raise=should_raise):
             return False
 
@@ -80,7 +80,7 @@ def dict_of(validate_key, validate_item):
                 validate_key(key)
             except TypeError as e:
                 if should_raise:
-                    samtranslator.model.exceptions.prepend(e, "dict contained an invalid key")
+                    samtranslator.model.exceptions.prepend(e, "dict contained an invalid key")  # type: ignore[no-untyped-call]
                     raise
                 return False
 
@@ -88,7 +88,7 @@ def dict_of(validate_key, validate_item):
                 validate_item(item)
             except TypeError as e:
                 if should_raise:
-                    samtranslator.model.exceptions.prepend(e, "dict contained an invalid value")
+                    samtranslator.model.exceptions.prepend(e, "dict contained an invalid value")  # type: ignore[no-untyped-call]
                     raise
                 return False
         return True
@@ -96,7 +96,7 @@ def dict_of(validate_key, validate_item):
     return validate
 
 
-def one_of(*validators):
+def one_of(*validators):  # type: ignore[no-untyped-def]
     """Returns a validator function that succeeds only if the input passes at least one of the provided validators.
 
     :param callable validators: the validator functions
@@ -105,7 +105,7 @@ def one_of(*validators):
     :rtype: callable
     """
 
-    def validate(value, should_raise=True):
+    def validate(value, should_raise=True):  # type: ignore[no-untyped-def]
         if any(validate(value, should_raise=False) for validate in validators):
             return True
 
@@ -116,17 +116,17 @@ def one_of(*validators):
     return validate
 
 
-def is_str():
+def is_str():  # type: ignore[no-untyped-def]
     """Returns a validator function that succeeds for input of type str or unicode.
 
     :returns: a string validator
     :rtype: callable
     """
-    return is_type(str)
+    return is_type(str)  # type: ignore[no-untyped-call]
 
 
-def any_type():
-    def validate(value, should_raise=False):
+def any_type():  # type: ignore[no-untyped-def]
+    def validate(value, should_raise=False):  # type: ignore[no-untyped-def]
         return True
 
     return validate

--- a/samtranslator/model/update_policy.py
+++ b/samtranslator/model/update_policy.py
@@ -21,12 +21,12 @@ CodeDeploy resources.
 
 
 class UpdatePolicy(CodeDeployLambdaAliasUpdate):
-    def to_dict(self):
+    def to_dict(self):  # type: ignore[no-untyped-def]
         """
         :return: a dict that can be used as part of a cloudformation template
         """
         dict_with_nones = self._asdict()
         codedeploy_lambda_alias_update_dict = dict(
-            (k, v) for k, v in dict_with_nones.items() if v != ref(None) and v is not None
+            (k, v) for k, v in dict_with_nones.items() if v != ref(None) and v is not None  # type: ignore[no-untyped-call]
         )
         return {"CodeDeployLambdaAliasUpdate": codedeploy_lambda_alias_update_dict}

--- a/samtranslator/model/xray_utils.py
+++ b/samtranslator/model/xray_utils.py
@@ -1,10 +1,10 @@
 from samtranslator.translator.arn_generator import ArnGenerator
 
 
-def get_xray_managed_policy_name():
+def get_xray_managed_policy_name():  # type: ignore[no-untyped-def]
     # use previous (old) policy name for regular regions
     # for china and gov regions, use the newer policy name
-    partition_name = ArnGenerator.get_partition_name()
+    partition_name = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
     if partition_name == "aws":
         return "AWSXrayWriteOnlyAccess"
     return "AWSXRayDaemonWriteAccess"

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -31,7 +31,7 @@ class OpenApiEditor(object):
     _ALL_HTTP_METHODS = ["OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"]
     _DEFAULT_PATH = "$default"
 
-    def __init__(self, doc):
+    def __init__(self, doc):  # type: ignore[no-untyped-def]
         """
         Initialize the class with a swagger dictionary. This class creates a copy of the Swagger and performs all
         modifications on this copy.
@@ -39,10 +39,10 @@ class OpenApiEditor(object):
         :param dict doc: OpenApi document as a dictionary
         :raises InvalidDocumentException: If the input OpenApi document does not meet the basic OpenApi requirements.
         """
-        if not OpenApiEditor.is_valid(doc):
-            raise InvalidDocumentException(
+        if not OpenApiEditor.is_valid(doc):  # type: ignore[no-untyped-call]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                 [
-                    InvalidTemplateException(
+                    InvalidTemplateException(  # type: ignore[no-untyped-call]
                         "Invalid OpenApi document. Invalid values or missing keys for 'openapi' or 'paths' in 'DefinitionBody'."
                     )
                 ]
@@ -50,12 +50,12 @@ class OpenApiEditor(object):
 
         self._doc = copy.deepcopy(doc)
         self.paths = self._doc["paths"]
-        self.security_schemes = self._doc.get("components", Py27Dict()).get("securitySchemes", Py27Dict())
-        self.definitions = self._doc.get("definitions", Py27Dict())
+        self.security_schemes = self._doc.get("components", Py27Dict()).get("securitySchemes", Py27Dict())  # type: ignore[no-untyped-call]
+        self.definitions = self._doc.get("definitions", Py27Dict())  # type: ignore[no-untyped-call]
         self.tags = self._doc.get("tags", [])
-        self.info = self._doc.get("info", Py27Dict())
+        self.info = self._doc.get("info", Py27Dict())  # type: ignore[no-untyped-call]
 
-    def get_conditional_contents(self, item):
+    def get_conditional_contents(self, item):  # type: ignore[no-untyped-def]
         """
         Returns the contents of the given item.
         If a conditional block has been used inside the item, returns a list of the content
@@ -68,10 +68,10 @@ class OpenApiEditor(object):
         contents = [item]
         if isinstance(item, dict) and self._CONDITIONAL_IF in item:
             contents = item[self._CONDITIONAL_IF][1:]
-            contents = [content for content in contents if not is_intrinsic_no_value(content)]
+            contents = [content for content in contents if not is_intrinsic_no_value(content)]  # type: ignore[no-untyped-call]
         return contents
 
-    def has_path(self, path, method=None):
+    def has_path(self, path, method=None):  # type: ignore[no-untyped-def]
         """
         Returns True if this Swagger has the given path and optional method
         For paths with conditionals, only returns true if both items (true case, and false case) have the method.
@@ -83,14 +83,14 @@ class OpenApiEditor(object):
         if path not in self.paths:
             return False
 
-        method = self._normalize_method_name(method)
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
         if method:
-            for path_item in self.get_conditional_contents(self.paths.get(path)):
+            for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
                 if not path_item or method not in path_item:
                     return False
         return True
 
-    def is_integration_function_logical_id_match(self, path_name, method_name, logical_id):
+    def is_integration_function_logical_id_match(self, path_name, method_name, logical_id):  # type: ignore[no-untyped-def]
         """
         Returns True if the function logical id in a lambda integration matches the passed
         in logical_id.
@@ -101,18 +101,18 @@ class OpenApiEditor(object):
         :param method_name: name of the method
         :param logical_id: logical id to compare against
         """
-        if not self.has_integration(path_name, method_name):
+        if not self.has_integration(path_name, method_name):  # type: ignore[no-untyped-call]
             return False
-        method_name = self._normalize_method_name(method_name)
+        method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
 
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path_name, method_name, False):
-            integration = method_definition.get(self._X_APIGW_INTEGRATION, Py27Dict())
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path_name, method_name, False):  # type: ignore[no-untyped-call]
+            integration = method_definition.get(self._X_APIGW_INTEGRATION, Py27Dict())  # type: ignore[no-untyped-call]
 
             # Extract the integration uri out of a conditional if necessary
             uri = integration.get("uri")
             if not isinstance(uri, dict):
                 return False
-            for uri_content in self.get_conditional_contents(uri):
+            for uri_content in self.get_conditional_contents(uri):  # type: ignore[no-untyped-call]
                 arn = uri_content.get("Fn::Sub", "")
 
                 # Extract lambda integration (${LambdaName.Arn}) and split ".Arn" off from it
@@ -127,7 +127,7 @@ class OpenApiEditor(object):
 
         return True
 
-    def method_has_integration(self, method):
+    def method_has_integration(self, method):  # type: ignore[no-untyped-def]
         """
         Returns true if the given method contains a valid method definition.
         This uses the get_conditional_contents function to handle conditionals.
@@ -135,12 +135,12 @@ class OpenApiEditor(object):
         :param dict method: method dictionary
         :return: true if method has one or multiple integrations
         """
-        for method_definition in self.get_conditional_contents(method):
-            if self.method_definition_has_integration(method_definition):
+        for method_definition in self.get_conditional_contents(method):  # type: ignore[no-untyped-call]
+            if self.method_definition_has_integration(method_definition):  # type: ignore[no-untyped-call]
                 return True
         return False
 
-    def method_definition_has_integration(self, method_definition):
+    def method_definition_has_integration(self, method_definition):  # type: ignore[no-untyped-def]
         """
         Checks a method definition to make sure it has an apigw integration
 
@@ -151,7 +151,7 @@ class OpenApiEditor(object):
             return True
         return False
 
-    def has_integration(self, path, method):
+    def has_integration(self, path, method):  # type: ignore[no-untyped-def]
         """
         Checks if an API Gateway integration is already present at the given path/method.
         For paths with conditionals, it only returns True if both items (true case, false case) have the integration
@@ -160,19 +160,19 @@ class OpenApiEditor(object):
         :param string method: HTTP method
         :return: True, if an API Gateway integration is already present
         """
-        method = self._normalize_method_name(method)
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
 
-        if not self.has_path(path, method):
+        if not self.has_path(path, method):  # type: ignore[no-untyped-call]
             return False
 
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             method_definition = path_item.get(method)
-            if not (isinstance(method_definition, dict) and self.method_has_integration(method_definition)):
+            if not (isinstance(method_definition, dict) and self.method_has_integration(method_definition)):  # type: ignore[no-untyped-call]
                 return False
         # Integration present and non-empty
         return True
 
-    def add_path(self, path, method=None):
+    def add_path(self, path, method=None):  # type: ignore[no-untyped-def]
         """
         Adds the path/method combination to the Swagger, if not already present
 
@@ -180,20 +180,20 @@ class OpenApiEditor(object):
         :param string method: HTTP method
         :raises InvalidDocumentException: If the value of `path` in Swagger is not a dictionary
         """
-        method = self._normalize_method_name(method)
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
 
-        path_dict = self.paths.setdefault(path, Py27Dict())
+        path_dict = self.paths.setdefault(path, Py27Dict())  # type: ignore[no-untyped-call]
 
         if not isinstance(path_dict, dict):
             # Either customers has provided us an invalid Swagger, or this class has messed it somehow
-            raise InvalidDocumentException(
-                [InvalidTemplateException(f"Value of '{path}' path must be a dictionary according to Swagger spec.")]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                [InvalidTemplateException(f"Value of '{path}' path must be a dictionary according to Swagger spec.")]  # type: ignore[no-untyped-call]
             )
 
-        for path_item in self.get_conditional_contents(path_dict):
-            path_item.setdefault(method, Py27Dict())
+        for path_item in self.get_conditional_contents(path_dict):  # type: ignore[no-untyped-call]
+            path_item.setdefault(method, Py27Dict())  # type: ignore[no-untyped-call]
 
-    def add_lambda_integration(
+    def add_lambda_integration(  # type: ignore[no-untyped-def]
         self, path, method, integration_uri, method_auth_config=None, api_auth_config=None, condition=None
     ):
         """
@@ -204,23 +204,23 @@ class OpenApiEditor(object):
         :param string integration_uri: URI for the integration.
         """
 
-        method = self._normalize_method_name(method)
-        if self.has_integration(path, method):
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
+        if self.has_integration(path, method):  # type: ignore[no-untyped-call]
             # Not throwing an error- we will add lambda integrations to existing swagger if not present
             return
 
-        self.add_path(path, method)
+        self.add_path(path, method)  # type: ignore[no-untyped-call]
 
         # Wrap the integration_uri in a Condition if one exists on that function
         # This is necessary so CFN doesn't try to resolve the integration reference.
         if condition:
-            integration_uri = make_conditional(condition, integration_uri)
+            integration_uri = make_conditional(condition, integration_uri)  # type: ignore[no-untyped-call]
 
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             # create as Py27Dict and insert key one by one to preserve input order
             if path_item[method] is None:
-                path_item[method] = Py27Dict()
-            path_item[method][self._X_APIGW_INTEGRATION] = Py27Dict()
+                path_item[method] = Py27Dict()  # type: ignore[no-untyped-call]
+            path_item[method][self._X_APIGW_INTEGRATION] = Py27Dict()  # type: ignore[no-untyped-call]
             path_item[method][self._X_APIGW_INTEGRATION]["type"] = "aws_proxy"
             path_item[method][self._X_APIGW_INTEGRATION]["httpMethod"] = "POST"
             path_item[method][self._X_APIGW_INTEGRATION]["payloadFormatVersion"] = "2.0"
@@ -230,21 +230,21 @@ class OpenApiEditor(object):
                 path_item[method]["isDefaultRoute"] = True
 
             # If 'responses' key is *not* present, add it with an empty dict as value
-            path_item[method].setdefault("responses", Py27Dict())
+            path_item[method].setdefault("responses", Py27Dict())  # type: ignore[no-untyped-call]
 
             # If a condition is present, wrap all method contents up into the condition
             if condition:
-                path_item[method] = make_conditional(condition, path_item[method])
+                path_item[method] = make_conditional(condition, path_item[method])  # type: ignore[no-untyped-call]
 
-    def make_path_conditional(self, path, condition):
+    def make_path_conditional(self, path, condition):  # type: ignore[no-untyped-def]
         """
         Wrap entire API path definition in a CloudFormation if condition.
         :param path: path name
         :param condition: condition name
         """
-        self.paths[path] = make_conditional(condition, self.paths[path])
+        self.paths[path] = make_conditional(condition, self.paths[path])  # type: ignore[no-untyped-call]
 
-    def iter_on_path(self):
+    def iter_on_path(self):  # type: ignore[no-untyped-def]
         """
         Yields all the paths available in the Swagger. As a caller, if you add new paths to Swagger while iterating,
         they will not show up in this iterator
@@ -255,7 +255,7 @@ class OpenApiEditor(object):
         for path, _ in self.paths.items():
             yield path
 
-    def iter_on_method_definitions_for_path_at_method(
+    def iter_on_method_definitions_for_path_at_method(  # type: ignore[no-untyped-def]
         self, path_name, method_name, skip_methods_without_apigw_integration=True
     ):
         """
@@ -267,17 +267,17 @@ class OpenApiEditor(object):
         :param skip_methods_without_apigw_integration: if True, skips method definitions without apigw integration
         :yields dict: method definition
         """
-        normalized_method_name = self._normalize_method_name(method_name)
+        normalized_method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
 
-        for path_item in self.get_conditional_contents(self.paths.get(path_name)):
-            for method_definition in self.get_conditional_contents(path_item.get(normalized_method_name)):
+        for path_item in self.get_conditional_contents(self.paths.get(path_name)):  # type: ignore[no-untyped-call]
+            for method_definition in self.get_conditional_contents(path_item.get(normalized_method_name)):  # type: ignore[no-untyped-call]
                 if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
                     method_definition
-                ):
+                ):  # type: ignore[no-untyped-call]
                     continue
                 yield method_definition
 
-    def iter_on_all_methods_for_path(self, path_name, skip_methods_without_apigw_integration=True):
+    def iter_on_all_methods_for_path(self, path_name, skip_methods_without_apigw_integration=True):  # type: ignore[no-untyped-def]
         """
         Yields all the (method name, method definition) tuples for the path, including those inside conditionals.
 
@@ -285,17 +285,17 @@ class OpenApiEditor(object):
         :param skip_methods_without_apigw_integration: if True, skips method definitions without apigw integration
         :yields list of (method name, method definition) tuples
         """
-        for path_item in self.get_conditional_contents(self.paths.get(path_name)):
+        for path_item in self.get_conditional_contents(self.paths.get(path_name)):  # type: ignore[no-untyped-call]
             for method_name, method in path_item.items():
-                for method_definition in self.get_conditional_contents(method):
+                for method_definition in self.get_conditional_contents(method):  # type: ignore[no-untyped-call]
                     if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
                         method_definition
-                    ):
+                    ):  # type: ignore[no-untyped-call]
                         continue
-                    normalized_method_name = self._normalize_method_name(method_name)
+                    normalized_method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
                     yield normalized_method_name, method_definition
 
-    def add_timeout_to_method(self, api, path, method_name, timeout):
+    def add_timeout_to_method(self, api, path, method_name, timeout):  # type: ignore[no-untyped-def]
         """
         Adds a timeout to this path/method.
 
@@ -304,10 +304,10 @@ class OpenApiEditor(object):
         :param string method_name: Method name
         :param int timeout: Timeout amount, in milliseconds
         """
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
             method_definition[self._X_APIGW_INTEGRATION]["timeoutInMillis"] = timeout
 
-    def add_path_parameters_to_method(self, api, path, method_name, path_parameters):
+    def add_path_parameters_to_method(self, api, path, method_name, path_parameters):  # type: ignore[no-untyped-def]
         """
         Adds path parameters to this path + method
 
@@ -316,7 +316,7 @@ class OpenApiEditor(object):
         :param string method_name: Method name
         :param list path_parameters: list of strings of path parameters
         """
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
             # create path parameter list
             # add it here if it doesn't exist, merge with existing otherwise.
             method_definition.setdefault("parameters", [])
@@ -336,14 +336,14 @@ class OpenApiEditor(object):
                     existing_parameter["required"] = True
                 else:
                     # create as Py27Dict and insert keys one by one to preserve input order
-                    parameter = Py27Dict()
+                    parameter = Py27Dict()  # type: ignore[no-untyped-call]
                     param = Py27UniStr(param) if isinstance(param, str) else param
                     parameter["name"] = param
                     parameter["in"] = "path"
                     parameter["required"] = True
                     method_definition.get("parameters").append(parameter)
 
-    def add_payload_format_version_to_method(self, api, path, method_name, payload_format_version="2.0"):
+    def add_payload_format_version_to_method(self, api, path, method_name, payload_format_version="2.0"):  # type: ignore[no-untyped-def]
         """
         Adds a payload format version to this path/method.
 
@@ -352,21 +352,21 @@ class OpenApiEditor(object):
         :param string method_name: Method name
         :param string payload_format_version: payload format version sent to the integration
         """
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
             method_definition[self._X_APIGW_INTEGRATION]["payloadFormatVersion"] = payload_format_version
 
-    def add_authorizers_security_definitions(self, authorizers):
+    def add_authorizers_security_definitions(self, authorizers):  # type: ignore[no-untyped-def]
         """
         Add Authorizer definitions to the securityDefinitions part of Swagger.
 
         :param list authorizers: List of Authorizer configurations which get translated to securityDefinitions.
         """
-        self.security_schemes = self.security_schemes or Py27Dict()
+        self.security_schemes = self.security_schemes or Py27Dict()  # type: ignore[no-untyped-call]
 
         for authorizer_name, authorizer in authorizers.items():
             self.security_schemes[authorizer_name] = authorizer.generate_openapi()
 
-    def set_path_default_authorizer(self, path, default_authorizer, authorizers, api_authorizers):
+    def set_path_default_authorizer(self, path, default_authorizer, authorizers, api_authorizers):  # type: ignore[no-untyped-def]
         """
         Adds the default_authorizer to the security block for each method on this path unless an Authorizer
         was defined at the Function/Path/Method level. This is intended to be used to set the
@@ -378,35 +378,35 @@ class OpenApiEditor(object):
             authorizers param.
         :param list authorizers: List of Authorizer configurations defined on the related Api.
         """
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             for method_name, method in path_item.items():
-                normalized_method_name = self._normalize_method_name(method_name)
+                normalized_method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
                 # Excluding parameters section
                 if normalized_method_name == "parameters":
                     continue
                 if normalized_method_name != "options":
-                    normalized_method_name = self._normalize_method_name(method_name)
+                    normalized_method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
                     # It is possible that the method could have two definitions in a Fn::If block.
                     if normalized_method_name not in path_item:
-                        raise InvalidDocumentException(
+                        raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                             [
-                                InvalidTemplateException(
+                                InvalidTemplateException(  # type: ignore[no-untyped-call]
                                     f"Could not find {normalized_method_name} in {path} within DefinitionBody."
                                 )
                             ]
                         )
-                    for method_definition in self.get_conditional_contents(method):
+                    for method_definition in self.get_conditional_contents(method):  # type: ignore[no-untyped-call]
                         # check if there is any method_definition given by customer
                         if not method_definition:
-                            raise InvalidDocumentException(
+                            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                                 [
-                                    InvalidTemplateException(
+                                    InvalidTemplateException(  # type: ignore[no-untyped-call]
                                         f"Invalid method definition ({normalized_method_name}) for path: {path}"
                                     )
                                 ]
                             )
                         # If no integration given, then we don't need to process this definition (could be AWS::NoValue)
-                        if not self.method_definition_has_integration(method_definition):
+                        if not self.method_definition_has_integration(method_definition):  # type: ignore[no-untyped-call]
                             continue
                         existing_security = method_definition.get("security", [])
                         if existing_security:
@@ -415,7 +415,7 @@ class OpenApiEditor(object):
                         if authorizers:
                             authorizer_list.extend(authorizers.keys())
                         security_dict = {}
-                        security_dict[default_authorizer] = self._get_authorization_scopes(
+                        security_dict[default_authorizer] = self._get_authorization_scopes(  # type: ignore[no-untyped-call]
                             api_authorizers, default_authorizer
                         )
                         authorizer_security = [security_dict]
@@ -425,7 +425,7 @@ class OpenApiEditor(object):
                         if security:
                             method_definition["security"] = security
 
-    def add_auth_to_method(self, path, method_name, auth, api):
+    def add_auth_to_method(self, path, method_name, auth, api):  # type: ignore[no-untyped-def]
         """
         Adds auth settings for this path/method. Auth settings currently consist of Authorizers
         but this method will eventually include setting other auth settings such as Resource Policy, etc.
@@ -441,9 +441,9 @@ class OpenApiEditor(object):
         api_auth = api and api.get("Auth")
         authorizers = api_auth and api_auth.get("Authorizers")
         if method_authorizer:
-            self._set_method_authorizer(path, method_name, method_authorizer, authorizers, authorization_scopes)
+            self._set_method_authorizer(path, method_name, method_authorizer, authorizers, authorization_scopes)  # type: ignore[no-untyped-call]
 
-    def _set_method_authorizer(self, path, method_name, authorizer_name, authorizers, authorization_scopes=None):
+    def _set_method_authorizer(self, path, method_name, authorizer_name, authorizers, authorization_scopes=None):  # type: ignore[no-untyped-def]
         """
         Adds the authorizer_name to the security block for each method on this path.
         This is used to configure the authorizer for individual functions.
@@ -457,10 +457,10 @@ class OpenApiEditor(object):
         if authorization_scopes is None:
             authorization_scopes = []
 
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
             existing_security = method_definition.get("security", [])
 
-            security_dict = {}
+            security_dict = {}  # type: ignore[var-annotated]
             security_dict[authorizer_name] = []
 
             # Neither the NONE nor the AWS_IAM built-in authorizers support authorization scopes.
@@ -478,7 +478,7 @@ class OpenApiEditor(object):
             if security:
                 method_definition["security"] = security
 
-    def add_tags(self, tags):
+    def add_tags(self, tags):  # type: ignore[no-untyped-def]
         """
         Adds tags to the OpenApi definition using an ApiGateway extension for tag values.
 
@@ -487,9 +487,9 @@ class OpenApiEditor(object):
         for name, value in tags.items():
             # verify the tags definition is in the right format
             if not isinstance(self.tags, list):
-                raise InvalidDocumentException(
+                raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                     [
-                        InvalidTemplateException(
+                        InvalidTemplateException(  # type: ignore[no-untyped-call]
                             f"Tags in OpenApi DefinitionBody needs to be a list. {self.tags} is a {type(self.tags).__name__} not a list."
                         )
                     ]
@@ -501,12 +501,12 @@ class OpenApiEditor(object):
                 existing_tag[self._X_APIGW_TAG_VALUE] = value
             else:
                 # create as Py27Dict and insert key one by one to preserve input order
-                tag = Py27Dict()
+                tag = Py27Dict()  # type: ignore[no-untyped-call]
                 tag["name"] = name
                 tag[self._X_APIGW_TAG_VALUE] = value
                 self.tags.append(tag)
 
-    def add_endpoint_config(self, disable_execute_api_endpoint):
+    def add_endpoint_config(self, disable_execute_api_endpoint):  # type: ignore[no-untyped-def]
         """Add endpoint configuration to _X_APIGW_ENDPOINT_CONFIG header in open api definition
 
         Following this guide:
@@ -519,7 +519,7 @@ class OpenApiEditor(object):
 
         DISABLE_EXECUTE_API_ENDPOINT = "disableExecuteApiEndpoint"
 
-        servers_configurations = self._doc.get(self._SERVERS, [Py27Dict()])
+        servers_configurations = self._doc.get(self._SERVERS, [Py27Dict()])  # type: ignore[no-untyped-call]
         for config in servers_configurations:
             endpoint_configuration = config.get(self._X_APIGW_ENDPOINT_CONFIG, {})
             endpoint_configuration[DISABLE_EXECUTE_API_ENDPOINT] = disable_execute_api_endpoint
@@ -527,7 +527,7 @@ class OpenApiEditor(object):
 
         self._doc[self._SERVERS] = servers_configurations
 
-    def add_cors(
+    def add_cors(  # type: ignore[no-untyped-def]
         self,
         allow_origins,
         allow_headers=None,
@@ -565,7 +565,7 @@ class OpenApiEditor(object):
         cors_configuration = self._doc.get(self._X_APIGW_CORS, {})
 
         # intrinsics will not work if cors configuration is defined in open api and as a property to the HttpApi
-        if allow_origins and is_intrinsic(allow_origins):
+        if allow_origins and is_intrinsic(allow_origins):  # type: ignore[no-untyped-call]
             cors_configuration_string = json.dumps(allow_origins)
             for header in cors_headers:
                 # example: allowOrigins to AllowOrigins
@@ -590,7 +590,7 @@ class OpenApiEditor(object):
 
         self._doc[self._X_APIGW_CORS] = cors_configuration
 
-    def add_description(self, description):
+    def add_description(self, description):  # type: ignore[no-untyped-def]
         """Add description in open api definition, if it is not already defined
 
         :param string description: Description of the API
@@ -599,13 +599,13 @@ class OpenApiEditor(object):
             return
         self.info["description"] = description
 
-    def has_api_gateway_cors(self):
+    def has_api_gateway_cors(self):  # type: ignore[no-untyped-def]
         if self._doc.get(self._X_APIGW_CORS):
             return True
         return False
 
     @property
-    def openapi(self):
+    def openapi(self):  # type: ignore[no-untyped-def]
         """
         Returns a **copy** of the OpenApi specification as a dictionary.
 
@@ -619,7 +619,7 @@ class OpenApiEditor(object):
             self._doc["tags"] = self.tags
 
         if self.security_schemes:
-            self._doc.setdefault("components", Py27Dict())
+            self._doc.setdefault("components", Py27Dict())  # type: ignore[no-untyped-call]
             self._doc["components"]["securitySchemes"] = self.security_schemes
 
         if self.info:
@@ -628,7 +628,7 @@ class OpenApiEditor(object):
         return copy.deepcopy(self._doc)
 
     @staticmethod
-    def is_valid(data):
+    def is_valid(data):  # type: ignore[no-untyped-def]
         """
         Checks if the input data is a OpenApi document
 
@@ -638,29 +638,29 @@ class OpenApiEditor(object):
 
         if bool(data) and isinstance(data, dict) and isinstance(data.get("paths"), dict):
             if bool(data.get("openapi")):
-                return OpenApiEditor.safe_compare_regex_with_string(
-                    OpenApiEditor.get_openapi_version_3_regex(), data["openapi"]
+                return OpenApiEditor.safe_compare_regex_with_string(  # type: ignore[no-untyped-call]
+                    OpenApiEditor.get_openapi_version_3_regex(), data["openapi"]  # type: ignore[no-untyped-call]
                 )
         return False
 
     @staticmethod
-    def gen_skeleton():
+    def gen_skeleton():  # type: ignore[no-untyped-def]
         """
         Method to make an empty swagger file, with just some basic structure. Just enough to pass validator.
 
         :return dict: Dictionary of a skeleton swagger document
         """
         # create as Py27Dict and insert key one by one to preserve input order
-        skeleton = Py27Dict()
+        skeleton = Py27Dict()  # type: ignore[no-untyped-call]
         skeleton["openapi"] = "3.0.1"
-        skeleton["info"] = Py27Dict()
+        skeleton["info"] = Py27Dict()  # type: ignore[no-untyped-call]
         skeleton["info"]["version"] = "1.0"
-        skeleton["info"]["title"] = ref("AWS::StackName")
-        skeleton["paths"] = Py27Dict()
+        skeleton["info"]["title"] = ref("AWS::StackName")  # type: ignore[no-untyped-call]
+        skeleton["paths"] = Py27Dict()  # type: ignore[no-untyped-call]
         return skeleton
 
     @staticmethod
-    def _get_authorization_scopes(authorizers, default_authorizer):
+    def _get_authorization_scopes(authorizers, default_authorizer):  # type: ignore[no-untyped-def]
         """
         Returns auth scopes for an authorizer if present
         :param authorizers: authorizer definitions
@@ -675,7 +675,7 @@ class OpenApiEditor(object):
         return []
 
     @staticmethod
-    def _normalize_method_name(method):
+    def _normalize_method_name(method):  # type: ignore[no-untyped-def]
         """
         Returns a lower case, normalized version of HTTP Method. It also know how to handle API Gateway specific methods
         like "ANY"
@@ -694,16 +694,16 @@ class OpenApiEditor(object):
         return method
 
     @staticmethod
-    def get_openapi_version_3_regex():
+    def get_openapi_version_3_regex():  # type: ignore[no-untyped-def]
         openapi_version_3_regex = r"\A3(\.\d)(\.\d)?$"
         return openapi_version_3_regex
 
     @staticmethod
-    def safe_compare_regex_with_string(regex, data):
+    def safe_compare_regex_with_string(regex, data):  # type: ignore[no-untyped-def]
         return re.match(regex, str(data)) is not None
 
     @staticmethod
-    def get_path_without_trailing_slash(path):
+    def get_path_without_trailing_slash(path):  # type: ignore[no-untyped-def]
         sub = re.sub(r"{([a-zA-Z0-9._-]+|proxy\+)}", "*", path)
         if isinstance(path, Py27UniStr):
             return Py27UniStr(sub)

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -271,9 +271,7 @@ class OpenApiEditor(object):
 
         for path_item in self.get_conditional_contents(self.paths.get(path_name)):  # type: ignore[no-untyped-call]
             for method_definition in self.get_conditional_contents(path_item.get(normalized_method_name)):  # type: ignore[no-untyped-call]
-                if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
-                    method_definition
-                ):  # type: ignore[no-untyped-call]
+                if skip_methods_without_apigw_integration and not self.method_definition_has_integration(method_definition):  # type: ignore[no-untyped-call]
                     continue
                 yield method_definition
 
@@ -288,9 +286,7 @@ class OpenApiEditor(object):
         for path_item in self.get_conditional_contents(self.paths.get(path_name)):  # type: ignore[no-untyped-call]
             for method_name, method in path_item.items():
                 for method_definition in self.get_conditional_contents(method):  # type: ignore[no-untyped-call]
-                    if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
-                        method_definition
-                    ):  # type: ignore[no-untyped-call]
+                    if skip_methods_without_apigw_integration and not self.method_definition_has_integration(method_definition):  # type: ignore[no-untyped-call]
                         continue
                     normalized_method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
                     yield normalized_method_name, method_definition

--- a/samtranslator/parser/parser.py
+++ b/samtranslator/parser/parser.py
@@ -3,33 +3,33 @@ import logging
 from samtranslator.model.exceptions import InvalidDocumentException, InvalidTemplateException, InvalidResourceException
 from samtranslator.validator.validator import SamTemplateValidator
 from samtranslator.plugins import LifeCycleEvents
-from samtranslator.public.sdk.template import SamTemplate
+from samtranslator.public.sdk.template import SamTemplate  # type: ignore[attr-defined]
 
 LOG = logging.getLogger(__name__)
 
 
 class Parser:
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         pass
 
-    def parse(self, sam_template, parameter_values, sam_plugins):
-        self._validate(sam_template, parameter_values)
+    def parse(self, sam_template, parameter_values, sam_plugins):  # type: ignore[no-untyped-def]
+        self._validate(sam_template, parameter_values)  # type: ignore[no-untyped-call]
         sam_plugins.act(LifeCycleEvents.before_transform_template, sam_template)
 
     @staticmethod
-    def validate_datatypes(sam_template):
+    def validate_datatypes(sam_template):  # type: ignore[no-untyped-def]
         """Validates the datatype within the template"""
         if (
             "Resources" not in sam_template
             or not isinstance(sam_template["Resources"], dict)
             or not sam_template["Resources"]
         ):
-            raise InvalidDocumentException([InvalidTemplateException("'Resources' section is required")])
+            raise InvalidDocumentException([InvalidTemplateException("'Resources' section is required")])  # type: ignore[no-untyped-call, no-untyped-call]
 
         if not all(isinstance(sam_resource, dict) for sam_resource in sam_template["Resources"].values()):
-            raise InvalidDocumentException(
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                 [
-                    InvalidTemplateException(
+                    InvalidTemplateException(  # type: ignore[no-untyped-call]
                         "All 'Resources' must be Objects. If you're using YAML, this may be an indentation issue."
                     )
                 ]
@@ -42,9 +42,9 @@ class Parser:
             # `not isinstance(sam_resources.get("Properties"), dict)` as this would be a breaking change.
             # sam_resource.properties defaults to {} in SamTemplate init
             if not isinstance(sam_resource.properties, dict):
-                raise InvalidDocumentException(
+                raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                     [
-                        InvalidResourceException(
+                        InvalidResourceException(  # type: ignore[no-untyped-call]
                             resource_logical_id,
                             "All 'Resources' must be Objects and have a 'Properties' Object. If "
                             "you're using YAML, this may be an indentation issue.",
@@ -53,7 +53,7 @@ class Parser:
                 )
 
     # private methods
-    def _validate(self, sam_template, parameter_values):
+    def _validate(self, sam_template, parameter_values):  # type: ignore[no-untyped-def]
         """Validates the template and parameter values and raises exceptions if there's an issue
 
         :param dict sam_template: SAM template
@@ -62,11 +62,11 @@ class Parser:
         if parameter_values is None:
             raise ValueError("`parameter_values` argument is required")
 
-        Parser.validate_datatypes(sam_template)
+        Parser.validate_datatypes(sam_template)  # type: ignore[no-untyped-call]
 
         try:
-            validator = SamTemplateValidator()
-            validation_errors = validator.validate(sam_template)
+            validator = SamTemplateValidator()  # type: ignore[no-untyped-call]
+            validation_errors = validator.validate(sam_template)  # type: ignore[no-untyped-call]
             if validation_errors:
                 LOG.warning("Template schema validation reported the following errors: %s", validation_errors)
         except Exception as e:

--- a/samtranslator/plugins/__init__.py
+++ b/samtranslator/plugins/__init__.py
@@ -20,7 +20,7 @@ class BasePlugin(object):
     Base class for a NoOp plugin that implements all available hooks
     """
 
-    def __init__(self, name):
+    def __init__(self, name):  # type: ignore[no-untyped-def]
         """
         Initialize the plugin with given name. Name is always required to register a plugin
 
@@ -31,7 +31,7 @@ class BasePlugin(object):
 
         self.name = name
 
-    def on_before_transform_resource(self, logical_id, resource_type, resource_properties):
+    def on_before_transform_resource(self, logical_id, resource_type, resource_properties):  # type: ignore[no-untyped-def]
         """
         Hook method to execute on `before_transform_resource` life cycle event. Plugins are free to modify the
         whole template or properties of the resource.
@@ -56,7 +56,7 @@ class BasePlugin(object):
         # NoOp implementation
         pass
 
-    def on_before_transform_template(self, template_dict):
+    def on_before_transform_template(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Hook method to execute on "before_transform_template" life cycle event. Plugins are free to modify the
         whole template, inject new resources, or modify certain sections of the template.
@@ -74,7 +74,7 @@ class BasePlugin(object):
         """
         pass
 
-    def on_after_transform_template(self, template):
+    def on_after_transform_template(self, template):  # type: ignore[no-untyped-def]
         """
         Hook method to execute on "after_transform_template" life cycle event. Plugins may further modify
         the template. Warning: any changes made in this lifecycle action by a plugin will not be

--- a/samtranslator/plugins/api/default_definition_body_plugin.py
+++ b/samtranslator/plugins/api/default_definition_body_plugin.py
@@ -2,8 +2,8 @@ from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.plugins import BasePlugin
 from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.open_api.open_api import OpenApiEditor
-from samtranslator.public.sdk.resource import SamResourceType
-from samtranslator.public.sdk.template import SamTemplate
+from samtranslator.public.sdk.resource import SamResourceType  # type: ignore[attr-defined]
+from samtranslator.public.sdk.template import SamTemplate  # type: ignore[attr-defined]
 
 
 class DefaultDefinitionBodyPlugin(BasePlugin):
@@ -14,15 +14,15 @@ class DefaultDefinitionBodyPlugin(BasePlugin):
     to a minimum Swagger definition and sets `__MANAGE_SWAGGER: true`.
     """
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         """
         Initialize the plugin.
         """
 
-        super(DefaultDefinitionBodyPlugin, self).__init__(DefaultDefinitionBodyPlugin.__name__)
+        super(DefaultDefinitionBodyPlugin, self).__init__(DefaultDefinitionBodyPlugin.__name__)  # type: ignore[no-untyped-call]
 
-    @cw_timer(prefix="Plugin-DefaultDefinitionBody")
-    def on_before_transform_template(self, template_dict):
+    @cw_timer(prefix="Plugin-DefaultDefinitionBody")  # type: ignore[no-untyped-call]
+    def on_before_transform_template(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Hook method that gets called before the SAM template is processed.
         The template has passed the validation and is guaranteed to contain a non-empty "Resources" section.
@@ -41,9 +41,9 @@ class DefaultDefinitionBodyPlugin(BasePlugin):
                     # If "Properties" is not set in the template, set them here
                     if not api.properties:
                         template.set(logicalId, api)
-                    api.properties["DefinitionBody"] = OpenApiEditor.gen_skeleton()
+                    api.properties["DefinitionBody"] = OpenApiEditor.gen_skeleton()  # type: ignore[no-untyped-call]
 
                 if api_type is SamResourceType.Api.value:
-                    api.properties["DefinitionBody"] = SwaggerEditor.gen_skeleton()
+                    api.properties["DefinitionBody"] = SwaggerEditor.gen_skeleton()  # type: ignore[no-untyped-call]
 
                 api.properties["__MANAGE_SWAGGER"] = True

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -3,14 +3,14 @@ import copy
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.intrinsics import make_combined_condition
 from samtranslator.model.eventsources.push import Api
-from samtranslator.public.plugins import BasePlugin
-from samtranslator.public.exceptions import InvalidDocumentException, InvalidResourceException, InvalidEventException
-from samtranslator.public.sdk.resource import SamResourceType
-from samtranslator.public.sdk.template import SamTemplate
+from samtranslator.public.plugins import BasePlugin  # type: ignore[attr-defined]
+from samtranslator.public.exceptions import InvalidDocumentException, InvalidResourceException, InvalidEventException  # type: ignore[attr-defined, attr-defined, attr-defined]
+from samtranslator.public.sdk.resource import SamResourceType  # type: ignore[attr-defined]
+from samtranslator.public.sdk.template import SamTemplate  # type: ignore[attr-defined]
 from samtranslator.utils.py27hash_fix import Py27Dict
 
 
-class ImplicitApiPlugin(BasePlugin):
+class ImplicitApiPlugin(BasePlugin):  # type: ignore[misc]
     """
     This plugin provides Implicit API shorthand syntax in the SAM Spec.
     https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
@@ -32,7 +32,7 @@ class ImplicitApiPlugin(BasePlugin):
 
     """
 
-    def __init__(self, name):
+    def __init__(self, name):  # type: ignore[no-untyped-def]
         """
         Initialize the plugin
         """
@@ -44,15 +44,15 @@ class ImplicitApiPlugin(BasePlugin):
         self.api_conditions = {}
         self.api_deletion_policies = {}
         self.api_update_replace_policies = {}
-        self._setup_api_properties()
+        self._setup_api_properties()  # type: ignore[no-untyped-call]
 
-    def _setup_api_properties(self):
+    def _setup_api_properties(self):  # type: ignore[no-untyped-def]
         raise NotImplementedError(
             "Method _setup_api_properties() must be implemented in a subclass of ImplicitApiPlugin"
         )
 
-    @cw_timer(prefix="Plugin-ImplicitApi")
-    def on_before_transform_template(self, template_dict):
+    @cw_timer(prefix="Plugin-ImplicitApi")  # type: ignore[no-untyped-call]
+    def on_before_transform_template(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Hook method that gets called before the SAM template is processed.
         The template has pass the validation and is guaranteed to contain a non-empty "Resources" section.
@@ -72,14 +72,14 @@ class ImplicitApiPlugin(BasePlugin):
         # removing the "ServerlessRestApi" resource, we just restore what the author defined.
         self.existing_implicit_api_resource = copy.deepcopy(template.get(self.implicit_api_logical_id))
 
-        template.set(self.implicit_api_logical_id, self._generate_implicit_api_resource())
+        template.set(self.implicit_api_logical_id, self._generate_implicit_api_resource())  # type: ignore[no-untyped-call]
 
         errors = []
         for logicalId, resource in template.iterate(
             {SamResourceType.Function.value, SamResourceType.StateMachine.value}
         ):
 
-            api_events = self._get_api_events(resource)
+            api_events = self._get_api_events(resource)  # type: ignore[no-untyped-call]
             condition = resource.condition
             deletion_policy = resource.deletion_policy
             update_replace_policy = resource.update_replace_policy
@@ -87,23 +87,23 @@ class ImplicitApiPlugin(BasePlugin):
                 continue
 
             try:
-                self._process_api_events(
+                self._process_api_events(  # type: ignore[no-untyped-call]
                     resource, api_events, template, condition, deletion_policy, update_replace_policy
                 )
 
             except InvalidEventException as ex:
                 errors.append(InvalidResourceException(logicalId, ex.message))
 
-        self._maybe_add_condition_to_implicit_api(template_dict)
-        self._maybe_add_deletion_policy_to_implicit_api(template_dict)
-        self._maybe_add_update_replace_policy_to_implicit_api(template_dict)
-        self._maybe_add_conditions_to_implicit_api_paths(template)
-        self._maybe_remove_implicit_api(template)
+        self._maybe_add_condition_to_implicit_api(template_dict)  # type: ignore[no-untyped-call]
+        self._maybe_add_deletion_policy_to_implicit_api(template_dict)  # type: ignore[no-untyped-call]
+        self._maybe_add_update_replace_policy_to_implicit_api(template_dict)  # type: ignore[no-untyped-call]
+        self._maybe_add_conditions_to_implicit_api_paths(template)  # type: ignore[no-untyped-call]
+        self._maybe_remove_implicit_api(template)  # type: ignore[no-untyped-call]
 
         if len(errors) > 0:
             raise InvalidDocumentException(errors)
 
-    def _get_api_events(self, resource):
+    def _get_api_events(self, resource):  # type: ignore[no-untyped-def]
         """
         Method to return a dictionary of API Events on the resource
 
@@ -123,9 +123,9 @@ class ImplicitApiPlugin(BasePlugin):
             and isinstance(resource.properties.get("Events"), dict)
         ):
             # Resource structure is invalid.
-            return Py27Dict()
+            return Py27Dict()  # type: ignore[no-untyped-call]
 
-        api_events = Py27Dict()
+        api_events = Py27Dict()  # type: ignore[no-untyped-call]
         for event_id, event in resource.properties["Events"].items():
 
             if event and isinstance(event, dict) and event.get("Type") == self.api_event_type:
@@ -133,7 +133,7 @@ class ImplicitApiPlugin(BasePlugin):
 
         return api_events
 
-    def _process_api_events(
+    def _process_api_events(  # type: ignore[no-untyped-def]
         self, function, api_events, template, condition=None, deletion_policy=None, update_replace_policy=None
     ):
         """
@@ -149,7 +149,7 @@ class ImplicitApiPlugin(BasePlugin):
             "Method _setup_api_properties() must be implemented in a subclass of ImplicitApiPlugin"
         )
 
-    def _add_implicit_api_id_if_necessary(self, event_properties):
+    def _add_implicit_api_id_if_necessary(self, event_properties):  # type: ignore[no-untyped-def]
         """
         Events for implicit APIs will *not* have the RestApiId property. Absence of this property means this event
         is associated with the Serverless::Api ImplicitAPI resource. This method solifies this assumption by adding
@@ -161,7 +161,7 @@ class ImplicitApiPlugin(BasePlugin):
             "Method _setup_api_properties() must be implemented in a subclass of ImplicitApiPlugin"
         )
 
-    def _add_api_to_swagger(self, event_id, event_properties, template):
+    def _add_api_to_swagger(self, event_id, event_properties, template):  # type: ignore[no-untyped-def]
         """
         Adds the API path/method from the given event to the Swagger JSON of Serverless::Api resource this event
         refers to.
@@ -172,7 +172,7 @@ class ImplicitApiPlugin(BasePlugin):
         """
 
         # Need to grab the AWS::Serverless::Api resource for this API event and update its Swagger definition
-        api_id = self._get_api_id(event_properties)
+        api_id = self._get_api_id(event_properties)  # type: ignore[no-untyped-call]
 
         # As of right now, this is for backwards compatability. SAM fails if you have an event type "Api" but that
         # references "AWS::Serverless::HttpApi". If you do the opposite, SAM still outputs a valid template. Example of that
@@ -189,7 +189,7 @@ class ImplicitApiPlugin(BasePlugin):
         if isinstance(api_id, dict) or is_referencing_http_from_api_event:
             raise InvalidEventException(
                 event_id,
-                f"{self.api_id_property} must be a valid reference to an '{self._get_api_resource_type_name()}'"
+                f"{self.api_id_property} must be a valid reference to an '{self._get_api_resource_type_name()}'"  # type: ignore[no-untyped-call]
                 " resource in same template.",
             )
 
@@ -221,19 +221,19 @@ class ImplicitApiPlugin(BasePlugin):
         editor = self.editor(swagger)
         editor.add_path(path, method)
 
-        resource.properties["DefinitionBody"] = self._get_api_definition_from_editor(editor)
+        resource.properties["DefinitionBody"] = self._get_api_definition_from_editor(editor)  # type: ignore[no-untyped-call]
         template.set(api_id, resource)
 
-    def _get_api_id(self, event_properties):
+    def _get_api_id(self, event_properties):  # type: ignore[no-untyped-def]
         """
         Get API logical id from API event properties.
 
         Handles case where API id is not specified or is a reference to a logical id.
         """
         api_id = event_properties.get(self.api_id_property)
-        return Api.get_rest_api_id_string(api_id)
+        return Api.get_rest_api_id_string(api_id)  # type: ignore[no-untyped-call]
 
-    def _maybe_add_condition_to_implicit_api(self, template_dict):
+    def _maybe_add_condition_to_implicit_api(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Decides whether to add a condition to the implicit api resource.
         :param dict template_dict: SAM template dictionary
@@ -262,11 +262,11 @@ class ImplicitApiPlugin(BasePlugin):
                 # aggregate those conditions in order to conditionally create the Implicit Api. See RFC:
                 # https://github.com/awslabs/serverless-application-model/issues/758
                 implicit_api_resource["Condition"] = self.implicit_api_condition
-                self._add_combined_condition_to_template(
+                self._add_combined_condition_to_template(  # type: ignore[no-untyped-call]
                     template_dict, self.implicit_api_condition, all_resource_method_conditions
                 )
 
-    def _maybe_add_deletion_policy_to_implicit_api(self, template_dict):
+    def _maybe_add_deletion_policy_to_implicit_api(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Decides whether to add a deletion policy to the implicit api resource.
         :param dict template_dict: SAM template dictionary
@@ -277,14 +277,14 @@ class ImplicitApiPlugin(BasePlugin):
 
         # Add a deletion policy to the API resource if its resources contains DeletionPolicy.
         implicit_api_deletion_policies = self.api_deletion_policies.get(self.implicit_api_logical_id)
-        at_least_one_resource_method = len(implicit_api_deletion_policies) > 0
+        at_least_one_resource_method = len(implicit_api_deletion_policies) > 0  # type: ignore[arg-type]
         one_resource_method_contains_deletion_policy = False
         contains_retain = False
         contains_delete = False
         # If multiple functions with multiple different policies reference the Implicit Api,
         # we set DeletionPolicy to Retain if Retain is present in one of the functions,
         # else Delete if Delete is present
-        for iterated_policy in implicit_api_deletion_policies:
+        for iterated_policy in implicit_api_deletion_policies:  # type: ignore[union-attr]
             if iterated_policy:
                 one_resource_method_contains_deletion_policy = True
                 if iterated_policy == "Retain":
@@ -298,7 +298,7 @@ class ImplicitApiPlugin(BasePlugin):
             elif contains_delete:
                 implicit_api_resource["DeletionPolicy"] = "Delete"
 
-    def _maybe_add_update_replace_policy_to_implicit_api(self, template_dict):
+    def _maybe_add_update_replace_policy_to_implicit_api(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Decides whether to add an update replace policy to the implicit api resource.
         :param dict template_dict: SAM template dictionary
@@ -309,7 +309,7 @@ class ImplicitApiPlugin(BasePlugin):
 
         # Add a update replace policy to the API resource if its resources contains UpdateReplacePolicy.
         implicit_api_update_replace_policies = self.api_update_replace_policies.get(self.implicit_api_logical_id)
-        at_least_one_resource_method = len(implicit_api_update_replace_policies) > 0
+        at_least_one_resource_method = len(implicit_api_update_replace_policies) > 0  # type: ignore[arg-type]
         one_resource_method_contains_update_replace_policy = False
         contains_retain = False
         contains_snapshot = False
@@ -317,7 +317,7 @@ class ImplicitApiPlugin(BasePlugin):
         # If multiple functions with multiple different policies reference the Implicit Api,
         # we set UpdateReplacePolicy to Retain if Retain is present in one of the functions,
         # Snapshot if Snapshot is present, else Delete if Delete is present
-        for iterated_policy in implicit_api_update_replace_policies:
+        for iterated_policy in implicit_api_update_replace_policies:  # type: ignore[union-attr]
             if iterated_policy:
                 one_resource_method_contains_update_replace_policy = True
                 if iterated_policy == "Retain":
@@ -335,7 +335,7 @@ class ImplicitApiPlugin(BasePlugin):
             elif contains_delete:
                 implicit_api_resource["UpdateReplacePolicy"] = "Delete"
 
-    def _add_combined_condition_to_template(self, template_dict, condition_name, conditions_to_combine):
+    def _add_combined_condition_to_template(self, template_dict, condition_name, conditions_to_combine):  # type: ignore[no-untyped-def]
         """
         Add top-level template condition that combines the given list of conditions.
 
@@ -349,11 +349,11 @@ class ImplicitApiPlugin(BasePlugin):
             raise ValueError("conditions_to_combine must have at least 2 conditions")
 
         template_conditions = template_dict.setdefault("Conditions", {})
-        new_template_conditions = make_combined_condition(sorted(list(conditions_to_combine)), condition_name)
+        new_template_conditions = make_combined_condition(sorted(list(conditions_to_combine)), condition_name)  # type: ignore[no-untyped-call]
         for name, definition in new_template_conditions.items():
             template_conditions[name] = definition
 
-    def _maybe_add_conditions_to_implicit_api_paths(self, template):
+    def _maybe_add_conditions_to_implicit_api_paths(self, template):  # type: ignore[no-untyped-def]
         """
         Add conditions to implicit API paths if necessary.
 
@@ -380,16 +380,16 @@ class ImplicitApiPlugin(BasePlugin):
                     if len(all_method_conditions) == 1:
                         editor.make_path_conditional(path, all_method_conditions.pop())
                     else:
-                        path_condition_name = self._path_condition_name(api_id, path)
-                        self._add_combined_condition_to_template(
+                        path_condition_name = self._path_condition_name(api_id, path)  # type: ignore[no-untyped-call]
+                        self._add_combined_condition_to_template(  # type: ignore[no-untyped-call]
                             template.template_dict, path_condition_name, all_method_conditions
                         )
                         editor.make_path_conditional(path, path_condition_name)
 
-            api.properties["DefinitionBody"] = self._get_api_definition_from_editor(editor)  # TODO make static method
+            api.properties["DefinitionBody"] = self._get_api_definition_from_editor(editor)  # type: ignore[no-untyped-call] # TODO make static method
             template.set(api_id, api)
 
-    def _get_api_definition_from_editor(self, editor):
+    def _get_api_definition_from_editor(self, editor):  # type: ignore[no-untyped-def]
         """
         Required function that returns the api body from the respective editor
         """
@@ -397,7 +397,7 @@ class ImplicitApiPlugin(BasePlugin):
             "Method _setup_api_properties() must be implemented in a subclass of ImplicitApiPlugin"
         )
 
-    def _path_condition_name(self, api_id, path):
+    def _path_condition_name(self, api_id, path):  # type: ignore[no-untyped-def]
         """
         Generate valid condition logical id from the given API logical id and swagger resource path.
         """
@@ -407,7 +407,7 @@ class ImplicitApiPlugin(BasePlugin):
         path_logical_id = path.replace("/", "SLASH").replace("{", "OB").replace("}", "CB")
         return "{}{}PathCondition".format(api_id, path_logical_id)
 
-    def _maybe_remove_implicit_api(self, template):
+    def _maybe_remove_implicit_api(self, template):  # type: ignore[no-untyped-def]
         """
         Implicit API resource are tentatively added to the template for uniform handling of both Implicit & Explicit
         APIs. They need to removed from the template, if there are *no* API events attached to this resource.
@@ -427,7 +427,7 @@ class ImplicitApiPlugin(BasePlugin):
             else:
                 template.delete(self.implicit_api_logical_id)
 
-    def _generate_implicit_api_resource(self):
+    def _generate_implicit_api_resource(self):  # type: ignore[no-untyped-def]
         """
         Helper function implemented by child classes that create a new implicit API resource
         """
@@ -435,7 +435,7 @@ class ImplicitApiPlugin(BasePlugin):
             "Method _setup_api_properties() must be implemented in a subclass of ImplicitApiPlugin"
         )
 
-    def _get_api_resource_type_name(self):
+    def _get_api_resource_type_name(self):  # type: ignore[no-untyped-def]
         """
         Returns the type of API resource
         """

--- a/samtranslator/plugins/api/implicit_http_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_http_api_plugin.py
@@ -1,9 +1,9 @@
 from samtranslator.model.intrinsics import make_conditional
 from samtranslator.model.naming import GeneratedLogicalId
 from samtranslator.plugins.api.implicit_api_plugin import ImplicitApiPlugin
-from samtranslator.public.open_api import OpenApiEditor
-from samtranslator.public.exceptions import InvalidEventException
-from samtranslator.public.sdk.resource import SamResourceType, SamResource
+from samtranslator.public.open_api import OpenApiEditor  # type: ignore[attr-defined]
+from samtranslator.public.exceptions import InvalidEventException  # type: ignore[attr-defined]
+from samtranslator.public.sdk.resource import SamResourceType, SamResource  # type: ignore[attr-defined, attr-defined]
 
 
 class ImplicitHttpApiPlugin(ImplicitApiPlugin):
@@ -24,24 +24,24 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
                                              in OpenApi. Does **not** configure the API by any means.
     """
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         """
         Initializes the plugin
         """
-        super(ImplicitHttpApiPlugin, self).__init__(ImplicitHttpApiPlugin.__name__)
+        super(ImplicitHttpApiPlugin, self).__init__(ImplicitHttpApiPlugin.__name__)  # type: ignore[no-untyped-call]
 
-    def _setup_api_properties(self):
+    def _setup_api_properties(self):  # type: ignore[no-untyped-def]
         """
         Sets up properties that are distinct to this plugin
         """
-        self.implicit_api_logical_id = GeneratedLogicalId.implicit_http_api()
+        self.implicit_api_logical_id = GeneratedLogicalId.implicit_http_api()  # type: ignore[no-untyped-call]
         self.implicit_api_condition = "ServerlessHttpApiCondition"
         self.api_event_type = "HttpApi"
         self.api_type = SamResourceType.HttpApi.value
         self.api_id_property = "ApiId"
         self.editor = OpenApiEditor
 
-    def _process_api_events(
+    def _process_api_events(  # type: ignore[no-untyped-def]
         self, function, api_events, template, condition=None, deletion_policy=None, update_replace_policy=None
     ):
         """
@@ -66,9 +66,9 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
 
             if not event_properties:
                 event["Properties"] = event_properties
-            self._add_implicit_api_id_if_necessary(event_properties)
+            self._add_implicit_api_id_if_necessary(event_properties)  # type: ignore[no-untyped-call]
 
-            api_id = self._get_api_id(event_properties)
+            api_id = self._get_api_id(event_properties)  # type: ignore[no-untyped-call]
             path = event_properties.get("Path", "")
             method = event_properties.get("Method", "")
             # If no path and method specified, add the $default path and ANY method
@@ -101,15 +101,15 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
             api_dict_update_replace = self.api_update_replace_policies.setdefault(api_id, set())
             api_dict_update_replace.add(update_replace_policy)
 
-            self._add_api_to_swagger(logicalId, event_properties, template)
+            self._add_api_to_swagger(logicalId, event_properties, template)  # type: ignore[no-untyped-call]
             if "RouteSettings" in event_properties:
-                self._add_route_settings_to_api(logicalId, event_properties, template, condition)
+                self._add_route_settings_to_api(logicalId, event_properties, template, condition)  # type: ignore[no-untyped-call]
             api_events[logicalId] = event
 
         # We could have made changes to the Events structure. Write it back to function
         function.properties["Events"].update(api_events)
 
-    def _add_implicit_api_id_if_necessary(self, event_properties):
+    def _add_implicit_api_id_if_necessary(self, event_properties):  # type: ignore[no-untyped-def]
         """
         Events for implicit APIs will *not* have the RestApiId property. Absence of this property means this event
         is associated with the AWS::Serverless::Api ImplicitAPI resource.
@@ -120,25 +120,25 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
         if "ApiId" not in event_properties:
             event_properties["ApiId"] = {"Ref": self.implicit_api_logical_id}
 
-    def _generate_implicit_api_resource(self):
+    def _generate_implicit_api_resource(self):  # type: ignore[no-untyped-def]
         """
         Uses the implicit API in this file to generate an Implicit API resource
         """
-        return ImplicitHttpApiResource().to_dict()
+        return ImplicitHttpApiResource().to_dict()  # type: ignore[no-untyped-call]
 
-    def _get_api_definition_from_editor(self, editor):
+    def _get_api_definition_from_editor(self, editor):  # type: ignore[no-untyped-def]
         """
         Helper function to return the OAS definition from the editor
         """
         return editor.openapi
 
-    def _get_api_resource_type_name(self):
+    def _get_api_resource_type_name(self):  # type: ignore[no-untyped-def]
         """
         Returns the type of API resource
         """
         return "AWS::Serverless::HttpApi"
 
-    def _add_route_settings_to_api(self, event_id, event_properties, template, condition):
+    def _add_route_settings_to_api(self, event_id, event_properties, template, condition):  # type: ignore[no-untyped-def]
         """
         Adds the RouteSettings for this path/method from the given event to the RouteSettings configuration
         on the AWS::Serverless::HttpApi that this refers to.
@@ -149,7 +149,7 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
         :param string condition: Condition on this HttpApi event (if any)
         """
 
-        api_id = self._get_api_id(event_properties)
+        api_id = self._get_api_id(event_properties)  # type: ignore[no-untyped-call]
         resource = template.get(api_id)
 
         path = event_properties["Path"]
@@ -164,7 +164,7 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
         api_route_settings = resource.properties.get("RouteSettings", {})
         event_route_settings = event_properties.get("RouteSettings", {})
         if condition:
-            event_route_settings = make_conditional(condition, event_properties.get("RouteSettings", {}))
+            event_route_settings = make_conditional(condition, event_properties.get("RouteSettings", {}))  # type: ignore[no-untyped-call]
 
         # Merge event-level and api-level RouteSettings properties
         api_route_settings.setdefault(route, {})
@@ -173,13 +173,13 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
         template.set(api_id, resource)
 
 
-class ImplicitHttpApiResource(SamResource):
+class ImplicitHttpApiResource(SamResource):  # type: ignore[misc]
     """
     Returns a AWS::Serverless::HttpApi resource representing the Implicit APIs. The returned resource
     includes the empty OpenApi along with default values for other properties.
     """
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         open_api = OpenApiEditor.gen_skeleton()
 
         resource = {

--- a/samtranslator/plugins/api/implicit_rest_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_rest_api_plugin.py
@@ -1,8 +1,8 @@
 from samtranslator.model.naming import GeneratedLogicalId
 from samtranslator.plugins.api.implicit_api_plugin import ImplicitApiPlugin
-from samtranslator.public.swagger import SwaggerEditor
-from samtranslator.public.exceptions import InvalidEventException
-from samtranslator.public.sdk.resource import SamResourceType, SamResource
+from samtranslator.public.swagger import SwaggerEditor  # type: ignore[attr-defined]
+from samtranslator.public.exceptions import InvalidEventException  # type: ignore[attr-defined]
+from samtranslator.public.sdk.resource import SamResourceType, SamResource  # type: ignore[attr-defined, attr-defined]
 
 
 class ImplicitRestApiPlugin(ImplicitApiPlugin):
@@ -27,24 +27,24 @@ class ImplicitRestApiPlugin(ImplicitApiPlugin):
 
     """
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         """
         Initialize the plugin
         """
-        super(ImplicitRestApiPlugin, self).__init__(ImplicitRestApiPlugin.__name__)
+        super(ImplicitRestApiPlugin, self).__init__(ImplicitRestApiPlugin.__name__)  # type: ignore[no-untyped-call]
 
-    def _setup_api_properties(self):
+    def _setup_api_properties(self):  # type: ignore[no-untyped-def]
         """
         Sets up properties that are distinct to this plugin
         """
-        self.implicit_api_logical_id = GeneratedLogicalId.implicit_api()
+        self.implicit_api_logical_id = GeneratedLogicalId.implicit_api()  # type: ignore[no-untyped-call]
         self.implicit_api_condition = "ServerlessRestApiCondition"
         self.api_event_type = "Api"
         self.api_type = SamResourceType.Api.value
         self.api_id_property = "RestApiId"
         self.editor = SwaggerEditor
 
-    def _process_api_events(
+    def _process_api_events(  # type: ignore[no-untyped-def]
         self, function, api_events, template, condition=None, deletion_policy=None, update_replace_policy=None
     ):
         """
@@ -69,9 +69,9 @@ class ImplicitRestApiPlugin(ImplicitApiPlugin):
                     "Event 'Properties' must be an Object. If you're using YAML, this may be an indentation issue.",
                 )
 
-            self._add_implicit_api_id_if_necessary(event_properties)
+            self._add_implicit_api_id_if_necessary(event_properties)  # type: ignore[no-untyped-call]
 
-            api_id = self._get_api_id(event_properties)
+            api_id = self._get_api_id(event_properties)  # type: ignore[no-untyped-call]
             try:
                 path = event_properties["Path"]
                 method = event_properties["Method"]
@@ -99,14 +99,14 @@ class ImplicitRestApiPlugin(ImplicitApiPlugin):
             api_dict_update_replace = self.api_update_replace_policies.setdefault(api_id, set())
             api_dict_update_replace.add(update_replace_policy)
 
-            self._add_api_to_swagger(logicalId, event_properties, template)
+            self._add_api_to_swagger(logicalId, event_properties, template)  # type: ignore[no-untyped-call]
 
             api_events[logicalId] = event
 
         # We could have made changes to the Events structure. Write it back to function
         function.properties["Events"].update(api_events)
 
-    def _add_implicit_api_id_if_necessary(self, event_properties):
+    def _add_implicit_api_id_if_necessary(self, event_properties):  # type: ignore[no-untyped-def]
         """
         Events for implicit APIs will *not* have the RestApiId property. Absence of this property means this event
         is associated with the Serverless::Api ImplicitAPI resource. This method solifies this assumption by adding
@@ -117,32 +117,32 @@ class ImplicitRestApiPlugin(ImplicitApiPlugin):
         if "RestApiId" not in event_properties:
             event_properties["RestApiId"] = {"Ref": self.implicit_api_logical_id}
 
-    def _generate_implicit_api_resource(self):
+    def _generate_implicit_api_resource(self):  # type: ignore[no-untyped-def]
         """
         Uses the implicit API in this file to generate an Implicit API resource
         """
-        return ImplicitApiResource().to_dict()
+        return ImplicitApiResource().to_dict()  # type: ignore[no-untyped-call]
 
-    def _get_api_definition_from_editor(self, editor):
+    def _get_api_definition_from_editor(self, editor):  # type: ignore[no-untyped-def]
         """
         Helper function to return the OAS definition from the editor
         """
         return editor.swagger
 
-    def _get_api_resource_type_name(self):
+    def _get_api_resource_type_name(self):  # type: ignore[no-untyped-def]
         """
         Returns the type of API resource
         """
         return "AWS::Serverless::Api"
 
 
-class ImplicitApiResource(SamResource):
+class ImplicitApiResource(SamResource):  # type: ignore[misc]
     """
     Returns a AWS::Serverless::Api resource representing the Implicit APIs. The returned resource includes
     the empty swagger along with default values for other properties.
     """
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         swagger = SwaggerEditor.gen_skeleton()
 
         resource = {

--- a/samtranslator/plugins/exceptions.py
+++ b/samtranslator/plugins/exceptions.py
@@ -6,10 +6,10 @@ class InvalidPluginException(Exception):
         message -- explanation of the error
     """
 
-    def __init__(self, plugin_name, message):
+    def __init__(self, plugin_name, message):  # type: ignore[no-untyped-def]
         self._plugin_name = plugin_name
         self._message = message
 
     @property
-    def message(self):
+    def message(self):  # type: ignore[no-untyped-def]
         return "The {} plugin is invalid. {}".format(self._plugin_name, self._message)

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -1,7 +1,7 @@
 ﻿from typing import Dict, List
 
-from samtranslator.public.sdk.resource import SamResourceType
-from samtranslator.public.intrinsics import is_intrinsics
+from samtranslator.public.sdk.resource import SamResourceType  # type: ignore[attr-defined]
+from samtranslator.public.intrinsics import is_intrinsics  # type: ignore[attr-defined]
 from samtranslator.swagger.swagger import SwaggerEditor
 
 
@@ -86,7 +86,7 @@ class Globals(object):
     # unreleased_properties *must be* part of supported_properties too
     unreleased_properties: Dict[str, List[str]] = {}
 
-    def __init__(self, template):
+    def __init__(self, template):  # type: ignore[no-untyped-def]
         """
         Constructs an instance of this object
 
@@ -101,9 +101,9 @@ class Globals(object):
         self.template_globals = {}
 
         if self._KEYWORD in template:
-            self.template_globals = self._parse(template[self._KEYWORD])
+            self.template_globals = self._parse(template[self._KEYWORD])  # type: ignore[no-untyped-call]
 
-    def merge(self, resource_type, resource_properties):
+    def merge(self, resource_type, resource_properties):  # type: ignore[no-untyped-def]
         """
         Adds global properties to the resource, if necessary. This method is a no-op if there are no global properties
         for this resource type
@@ -122,7 +122,7 @@ class Globals(object):
         return global_props.merge(resource_properties)
 
     @classmethod
-    def del_section(cls, template):
+    def del_section(cls, template):  # type: ignore[no-untyped-def]
         """
         Helper method to delete the Globals section altogether from the template
 
@@ -134,7 +134,7 @@ class Globals(object):
             del template[cls._KEYWORD]
 
     @classmethod
-    def fix_openapi_definitions(cls, template):
+    def fix_openapi_definitions(cls, template):  # type: ignore[no-untyped-def]
         """
         Helper method to postprocess the resources to make sure the swagger doc version matches
         the one specified on the resource with flag OpenApiVersion.
@@ -157,8 +157,8 @@ class Globals(object):
                 if (
                     (cls._OPENAPIVERSION in properties)
                     and (cls._MANAGE_SWAGGER in properties)
-                    and SwaggerEditor.safe_compare_regex_with_string(
-                        SwaggerEditor.get_openapi_version_3_regex(), properties[cls._OPENAPIVERSION]
+                    and SwaggerEditor.safe_compare_regex_with_string(  # type: ignore[no-untyped-call]
+                        SwaggerEditor.get_openapi_version_3_regex(), properties[cls._OPENAPIVERSION]  # type: ignore[no-untyped-call]
                     )
                 ):
                     if not isinstance(properties[cls._OPENAPIVERSION], str):
@@ -170,7 +170,7 @@ class Globals(object):
                         if definition_body.get("swagger"):
                             del definition_body["swagger"]
 
-    def _parse(self, globals_dict):
+    def _parse(self, globals_dict):  # type: ignore[no-untyped-def]
         """
         Takes a SAM template as input and parses the Globals section
 
@@ -181,13 +181,13 @@ class Globals(object):
 
         globals = {}
         if not isinstance(globals_dict, dict):
-            raise InvalidGlobalsSectionException(self._KEYWORD, "It must be a non-empty dictionary")
+            raise InvalidGlobalsSectionException(self._KEYWORD, "It must be a non-empty dictionary")  # type: ignore[no-untyped-call]
 
         for section_name, properties in globals_dict.items():
-            resource_type = self._make_resource_type(section_name)
+            resource_type = self._make_resource_type(section_name)  # type: ignore[no-untyped-call]
 
             if resource_type not in self.supported_properties:
-                raise InvalidGlobalsSectionException(
+                raise InvalidGlobalsSectionException(  # type: ignore[no-untyped-call]
                     self._KEYWORD,
                     "'{section}' is not supported. "
                     "Must be one of the following values - {supported}".format(
@@ -196,7 +196,7 @@ class Globals(object):
                 )
 
             if not isinstance(properties, dict):
-                raise InvalidGlobalsSectionException(self._KEYWORD, "Value of ${section} must be a dictionary")
+                raise InvalidGlobalsSectionException(self._KEYWORD, "Value of ${section} must be a dictionary")  # type: ignore[no-untyped-call]
 
             supported = self.supported_properties[resource_type]
             supported_displayed = [
@@ -204,7 +204,7 @@ class Globals(object):
             ]
             for key, _ in properties.items():
                 if key not in supported:
-                    raise InvalidGlobalsSectionException(
+                    raise InvalidGlobalsSectionException(  # type: ignore[no-untyped-call]
                         self._KEYWORD,
                         "'{key}' is not a supported property of '{section}'. "
                         "Must be one of the following values - {supported}".format(
@@ -213,11 +213,11 @@ class Globals(object):
                     )
 
             # Store all Global properties in a map with key being the AWS::Serverless::* resource type
-            globals[resource_type] = GlobalProperties(properties)
+            globals[resource_type] = GlobalProperties(properties)  # type: ignore[no-untyped-call]
 
         return globals
 
-    def _make_resource_type(self, key):
+    def _make_resource_type(self, key):  # type: ignore[no-untyped-def]
         return self._RESOURCE_PREFIX + key
 
 
@@ -341,18 +341,18 @@ class GlobalProperties(object):
 
     """
 
-    def __init__(self, global_properties):
+    def __init__(self, global_properties):  # type: ignore[no-untyped-def]
         self.global_properties = global_properties
 
-    def merge(self, local_properties):
+    def merge(self, local_properties):  # type: ignore[no-untyped-def]
         """
         Merge Global & local level properties according to the above rules
 
         :return local_properties: Dictionary of local properties
         """
-        return self._do_merge(self.global_properties, local_properties)
+        return self._do_merge(self.global_properties, local_properties)  # type: ignore[no-untyped-call]
 
-    def _do_merge(self, global_value, local_value):
+    def _do_merge(self, global_value, local_value):  # type: ignore[no-untyped-def]
         """
         Actually perform the merge operation for the given inputs. This method is used as part of the recursion.
         Therefore input values can be of any type. So is the output.
@@ -362,25 +362,25 @@ class GlobalProperties(object):
         :return: Merged result
         """
 
-        token_global = self._token_of(global_value)
-        token_local = self._token_of(local_value)
+        token_global = self._token_of(global_value)  # type: ignore[no-untyped-call]
+        token_local = self._token_of(local_value)  # type: ignore[no-untyped-call]
 
         # The following statements codify the rules explained in the doctring above
         if token_global != token_local:
-            return self._prefer_local(global_value, local_value)
+            return self._prefer_local(global_value, local_value)  # type: ignore[no-untyped-call]
 
         if self.TOKEN.PRIMITIVE == token_global == token_local:
-            return self._prefer_local(global_value, local_value)
+            return self._prefer_local(global_value, local_value)  # type: ignore[no-untyped-call]
 
         if self.TOKEN.DICT == token_global == token_local:
-            return self._merge_dict(global_value, local_value)
+            return self._merge_dict(global_value, local_value)  # type: ignore[no-untyped-call]
 
         if self.TOKEN.LIST == token_global == token_local:
-            return self._merge_lists(global_value, local_value)
+            return self._merge_lists(global_value, local_value)  # type: ignore[no-untyped-call]
 
         raise TypeError("Unsupported type of objects. GlobalType={}, LocalType={}".format(token_global, token_local))
 
-    def _merge_lists(self, global_list, local_list):
+    def _merge_lists(self, global_list, local_list):  # type: ignore[no-untyped-def]
         """
         Merges the global list with the local list. List merging is simply a concatenation = global + local
 
@@ -391,7 +391,7 @@ class GlobalProperties(object):
 
         return global_list + local_list
 
-    def _merge_dict(self, global_dict, local_dict):
+    def _merge_dict(self, global_dict, local_dict):  # type: ignore[no-untyped-def]
         """
         Merges the two dictionaries together
 
@@ -407,7 +407,7 @@ class GlobalProperties(object):
 
             if key in global_dict:
                 # Both local & global contains the same key. Let's do a merge.
-                global_dict[key] = self._do_merge(global_dict[key], local_dict[key])
+                global_dict[key] = self._do_merge(global_dict[key], local_dict[key])  # type: ignore[no-untyped-call]
 
             else:
                 # Key is not in globals, just in local. Copy it over
@@ -415,7 +415,7 @@ class GlobalProperties(object):
 
         return global_dict
 
-    def _prefer_local(self, global_value, local_value):
+    def _prefer_local(self, global_value, local_value):  # type: ignore[no-untyped-def]
         """
         Literally returns the local value whatever it may be. This method is useful to provide a unified implementation
         for cases that don't require special handling.
@@ -426,7 +426,7 @@ class GlobalProperties(object):
         """
         return local_value
 
-    def _token_of(self, input):
+    def _token_of(self, input):  # type: ignore[no-untyped-def]
         """
         Returns the token type of the input.
 
@@ -465,10 +465,10 @@ class InvalidGlobalsSectionException(Exception):
         message -- explanation of the error
     """
 
-    def __init__(self, logical_id, message):
+    def __init__(self, logical_id, message):  # type: ignore[no-untyped-def]
         self._logical_id = logical_id
         self._message = message
 
     @property
-    def message(self):
+    def message(self):  # type: ignore[no-untyped-def]
         return "'{}' section is invalid. {}".format(self._logical_id, self._message)

--- a/samtranslator/plugins/globals/globals_plugin.py
+++ b/samtranslator/plugins/globals/globals_plugin.py
@@ -1,26 +1,26 @@
 from samtranslator.metrics.method_decorator import cw_timer
-from samtranslator.public.sdk.template import SamTemplate
-from samtranslator.public.plugins import BasePlugin
-from samtranslator.public.exceptions import InvalidDocumentException
+from samtranslator.public.sdk.template import SamTemplate  # type: ignore[attr-defined]
+from samtranslator.public.plugins import BasePlugin  # type: ignore[attr-defined]
+from samtranslator.public.exceptions import InvalidDocumentException  # type: ignore[attr-defined]
 
 from samtranslator.plugins.globals.globals import Globals, InvalidGlobalsSectionException
 
 _API_RESOURCE = "AWS::Serverless::Api"
 
 
-class GlobalsPlugin(BasePlugin):
+class GlobalsPlugin(BasePlugin):  # type: ignore[misc]
     """
     Plugin to process Globals section of a SAM template before the template is translated to CloudFormation.
     """
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         """
         Initialize the plugin
         """
         super(GlobalsPlugin, self).__init__(GlobalsPlugin.__name__)
 
-    @cw_timer(prefix="Plugin-Globals")
-    def on_before_transform_template(self, template_dict):
+    @cw_timer(prefix="Plugin-Globals")  # type: ignore[no-untyped-call]
+    def on_before_transform_template(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Hook method that runs before a template gets transformed. In this method, we parse and process Globals section
         from the template (if present).
@@ -28,19 +28,19 @@ class GlobalsPlugin(BasePlugin):
         :param dict template_dict: SAM template as a dictionary
         """
         try:
-            global_section = Globals(template_dict)
+            global_section = Globals(template_dict)  # type: ignore[no-untyped-call]
         except InvalidGlobalsSectionException as ex:
             raise InvalidDocumentException([ex])
 
         # For each resource in template, try and merge with Globals if necessary
         template = SamTemplate(template_dict)
         for logicalId, resource in template.iterate():
-            resource.properties = global_section.merge(resource.type, resource.properties)
+            resource.properties = global_section.merge(resource.type, resource.properties)  # type: ignore[no-untyped-call]
             template.set(logicalId, resource)
 
         # Remove the Globals section from template if necessary
-        Globals.del_section(template_dict)
+        Globals.del_section(template_dict)  # type: ignore[no-untyped-call]
 
         # If there was a global openApiVersion flag, check and convert swagger
         # to the right version
-        Globals.fix_openapi_definitions(template_dict)
+        Globals.fix_openapi_definitions(template_dict)  # type: ignore[no-untyped-call]

--- a/samtranslator/plugins/policies/policy_templates_plugin.py
+++ b/samtranslator/plugins/policies/policy_templates_plugin.py
@@ -17,7 +17,7 @@ class PolicyTemplatesForResourcePlugin(BasePlugin):
     _plugin_name = ""
     SUPPORTED_RESOURCE_TYPE = {"AWS::Serverless::Function", "AWS::Serverless::StateMachine"}
 
-    def __init__(self, policy_template_processor):
+    def __init__(self, policy_template_processor):  # type: ignore[no-untyped-def]
         """
         Initialize the plugin.
 
@@ -27,12 +27,12 @@ class PolicyTemplatesForResourcePlugin(BasePlugin):
 
         # Plugin name is the class name for easy disambiguation
         _plugin_name = PolicyTemplatesForResourcePlugin.__name__
-        super(PolicyTemplatesForResourcePlugin, self).__init__(_plugin_name)
+        super(PolicyTemplatesForResourcePlugin, self).__init__(_plugin_name)  # type: ignore[no-untyped-call]
 
         self._policy_template_processor = policy_template_processor
 
-    @cw_timer(prefix="Plugin-PolicyTemplates")
-    def on_before_transform_resource(self, logical_id, resource_type, resource_properties):
+    @cw_timer(prefix="Plugin-PolicyTemplates")  # type: ignore[no-untyped-call]
+    def on_before_transform_resource(self, logical_id, resource_type, resource_properties):  # type: ignore[no-untyped-def]
         """
         Hook method that gets called before "each" SAM resource gets processed
 
@@ -42,50 +42,50 @@ class PolicyTemplatesForResourcePlugin(BasePlugin):
         :return: Nothing
         """
 
-        if not self._is_supported(resource_type):
+        if not self._is_supported(resource_type):  # type: ignore[no-untyped-call]
             return
 
-        function_policies = ResourcePolicies(resource_properties, self._policy_template_processor)
+        function_policies = ResourcePolicies(resource_properties, self._policy_template_processor)  # type: ignore[no-untyped-call]
 
         if len(function_policies) == 0:
             # No policies to process
             return
 
         result = []
-        for policy_entry in function_policies.get():
+        for policy_entry in function_policies.get():  # type: ignore[no-untyped-call]
 
             if policy_entry.type is not PolicyTypes.POLICY_TEMPLATE:
                 # If we don't know the type, skip processing and pass to result as is.
                 result.append(policy_entry.data)
                 continue
 
-            if is_intrinsic_if(policy_entry.data):
+            if is_intrinsic_if(policy_entry.data):  # type: ignore[no-untyped-call]
                 # If policy is an intrinsic if, we need to process each sub-statement separately
-                processed_intrinsic_if = self._process_intrinsic_if_policy_template(logical_id, policy_entry)
+                processed_intrinsic_if = self._process_intrinsic_if_policy_template(logical_id, policy_entry)  # type: ignore[no-untyped-call]
                 result.append(processed_intrinsic_if)
                 continue
 
-            converted_policy = self._process_policy_template(logical_id, policy_entry.data)
+            converted_policy = self._process_policy_template(logical_id, policy_entry.data)  # type: ignore[no-untyped-call]
             result.append(converted_policy)
 
         # Save the modified policies list to the input
         resource_properties[ResourcePolicies.POLICIES_PROPERTY_NAME] = result
 
-    def _process_intrinsic_if_policy_template(self, logical_id, policy_entry):
+    def _process_intrinsic_if_policy_template(self, logical_id, policy_entry):  # type: ignore[no-untyped-def]
         intrinsic_if = policy_entry.data
         then_statement = intrinsic_if["Fn::If"][1]
         else_statement = intrinsic_if["Fn::If"][2]
 
         processed_then_statement = (
             then_statement
-            if is_intrinsic_no_value(then_statement)
-            else self._process_policy_template(logical_id, then_statement)
+            if is_intrinsic_no_value(then_statement)  # type: ignore[no-untyped-call]
+            else self._process_policy_template(logical_id, then_statement)  # type: ignore[no-untyped-call]
         )
 
         processed_else_statement = (
             else_statement
-            if is_intrinsic_no_value(else_statement)
-            else self._process_policy_template(logical_id, else_statement)
+            if is_intrinsic_no_value(else_statement)  # type: ignore[no-untyped-call]
+            else self._process_policy_template(logical_id, else_statement)  # type: ignore[no-untyped-call]
         )
 
         processed_intrinsic_if = {
@@ -94,7 +94,7 @@ class PolicyTemplatesForResourcePlugin(BasePlugin):
 
         return processed_intrinsic_if
 
-    def _process_policy_template(self, logical_id, template_data):
+    def _process_policy_template(self, logical_id, template_data):  # type: ignore[no-untyped-def]
 
         # We are processing policy templates. We know they have a particular structure:
         # {"templateName": { parameter_values_dict }}
@@ -107,13 +107,13 @@ class PolicyTemplatesForResourcePlugin(BasePlugin):
 
         except InsufficientParameterValues as ex:
             # Exception's message will give lot of specific details
-            raise InvalidResourceException(logical_id, str(ex))
+            raise InvalidResourceException(logical_id, str(ex))  # type: ignore[no-untyped-call]
         except InvalidParameterValues:
-            raise InvalidResourceException(
+            raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 logical_id, "Must specify valid parameter values for policy template '{}'".format(template_name)
             )
 
-    def _is_supported(self, resource_type):
+    def _is_supported(self, resource_type):  # type: ignore[no-untyped-def]
         """
         Is this resource supported by this plugin?
 

--- a/samtranslator/plugins/sam_plugins.py
+++ b/samtranslator/plugins/sam_plugins.py
@@ -45,7 +45,7 @@ class SamPlugins(object):
     set by the plugin. SAM translator will convert this into a nice error message and display to the user.
     """
 
-    def __init__(self, initial_plugins=None):
+    def __init__(self, initial_plugins=None):  # type: ignore[no-untyped-def]
         """
         Initialize the plugins class with an optional list of plugins
 
@@ -60,9 +60,9 @@ class SamPlugins(object):
             initial_plugins = [initial_plugins]
 
         for plugin in initial_plugins:
-            self.register(plugin)
+            self.register(plugin)  # type: ignore[no-untyped-call]
 
-    def register(self, plugin):
+    def register(self, plugin):  # type: ignore[no-untyped-def]
         """
         Register a plugin. New plugins are added to the end of the plugins list.
 
@@ -75,12 +75,12 @@ class SamPlugins(object):
         if not plugin or not isinstance(plugin, BasePlugin):
             raise ValueError("Plugin must be implemented as a subclass of BasePlugin class")
 
-        if self.is_registered(plugin.name):
+        if self.is_registered(plugin.name):  # type: ignore[no-untyped-call]
             raise ValueError("Plugin with name {} is already registered".format(plugin.name))
 
         self._plugins.append(plugin)
 
-    def is_registered(self, plugin_name):
+    def is_registered(self, plugin_name):  # type: ignore[no-untyped-def]
         """
         Checks if a plugin with given name is already registered
 
@@ -90,7 +90,7 @@ class SamPlugins(object):
 
         return plugin_name in [p.name for p in self._plugins]
 
-    def _get(self, plugin_name):
+    def _get(self, plugin_name):  # type: ignore[no-untyped-def]
         """
         Retrieves the plugin with given name
 
@@ -104,7 +104,7 @@ class SamPlugins(object):
 
         return None
 
-    def act(self, event, *args, **kwargs):
+    def act(self, event, *args, **kwargs):  # type: ignore[no-untyped-def]
         """
         Act on the specific life cycle event. The action here is to invoke the hook function on all registered plugins.
         *args and **kwargs will be passed directly to the plugin's hook functions
@@ -137,7 +137,7 @@ class SamPlugins(object):
                 LOG.exception("Plugin '%s' raised an exception: %s", plugin.name, ex)
                 raise ex
 
-    def __len__(self):
+    def __len__(self):  # type: ignore[no-untyped-def]
         """
         Returns the number of plugins registered with this class
 

--- a/samtranslator/policy_template_processor/exceptions.py
+++ b/samtranslator/policy_template_processor/exceptions.py
@@ -3,7 +3,7 @@ class TemplateNotFoundException(Exception):
     Exception raised when a template with given name is not found
     """
 
-    def __init__(self, template_name):
+    def __init__(self, template_name):  # type: ignore[no-untyped-def]
         super(TemplateNotFoundException, self).__init__(f"Template with name '{template_name}' is not found")
 
 
@@ -12,7 +12,7 @@ class InsufficientParameterValues(Exception):
     Exception raised when not every parameter in the template is given a value.
     """
 
-    def __init__(self, message):
+    def __init__(self, message):  # type: ignore[no-untyped-def]
         super(InsufficientParameterValues, self).__init__(message)
 
 
@@ -21,5 +21,5 @@ class InvalidParameterValues(Exception):
     Exception raised when parameter values passed to this template is invalid
     """
 
-    def __init__(self, message):
+    def __init__(self, message):  # type: ignore[no-untyped-def]
         super(InvalidParameterValues, self).__init__(message)

--- a/samtranslator/policy_template_processor/processor.py
+++ b/samtranslator/policy_template_processor/processor.py
@@ -48,7 +48,7 @@ class PolicyTemplatesProcessor(object):
     # ./policy_templates.json
     DEFAULT_POLICY_TEMPLATES_FILE = policy_templates_data.POLICY_TEMPLATES_FILE
 
-    def __init__(self, policy_templates_dict, schema=None):
+    def __init__(self, policy_templates_dict, schema=None):  # type: ignore[no-untyped-def]
         """
         Initialize the class
 
@@ -56,13 +56,13 @@ class PolicyTemplatesProcessor(object):
         :param dict schema: Dictionary containing the JSON Schema of policy templates
         :raises ValueError: If policy templates does not match up with the schema
         """
-        PolicyTemplatesProcessor._is_valid_templates_dict(policy_templates_dict, schema)
+        PolicyTemplatesProcessor._is_valid_templates_dict(policy_templates_dict, schema)  # type: ignore[no-untyped-call]
 
         self.policy_templates = {}
         for template_name, template_value_dict in policy_templates_dict["Templates"].items():
-            self.policy_templates[template_name] = Template.from_dict(template_name, template_value_dict)
+            self.policy_templates[template_name] = Template.from_dict(template_name, template_value_dict)  # type: ignore[no-untyped-call]
 
-    def has(self, template_name):
+    def has(self, template_name):  # type: ignore[no-untyped-def]
         """
         Is this template available?
 
@@ -71,7 +71,7 @@ class PolicyTemplatesProcessor(object):
         """
         return template_name in self.policy_templates
 
-    def get(self, template_name):
+    def get(self, template_name):  # type: ignore[no-untyped-def]
         """
         Get the template for the given name
 
@@ -81,7 +81,7 @@ class PolicyTemplatesProcessor(object):
         """
         return self.policy_templates.get(template_name, None)
 
-    def convert(self, template_name, parameter_values):
+    def convert(self, template_name, parameter_values):  # type: ignore[no-untyped-def]
         """
         Converts the given template to IAM-ready policy statement by substituting template parameters with the given
         values.
@@ -93,14 +93,14 @@ class PolicyTemplatesProcessor(object):
         :raises InsufficientParameterValues: If the parameter values don't have values for all required parameters
         """
 
-        if not self.has(template_name):
-            raise TemplateNotFoundException(template_name)
+        if not self.has(template_name):  # type: ignore[no-untyped-call]
+            raise TemplateNotFoundException(template_name)  # type: ignore[no-untyped-call]
 
-        template = self.get(template_name)
+        template = self.get(template_name)  # type: ignore[no-untyped-call]
         return template.to_statement(parameter_values)
 
     @staticmethod
-    def _is_valid_templates_dict(policy_templates_dict, schema=None):
+    def _is_valid_templates_dict(policy_templates_dict, schema=None):  # type: ignore[no-untyped-def]
         """
         Is this a valid policy template dictionary
 
@@ -111,7 +111,7 @@ class PolicyTemplatesProcessor(object):
         """
 
         if not schema:
-            schema = PolicyTemplatesProcessor._read_schema()
+            schema = PolicyTemplatesProcessor._read_schema()  # type: ignore[no-untyped-call]
 
         try:
             jsonschema.validate(policy_templates_dict, schema)
@@ -122,17 +122,17 @@ class PolicyTemplatesProcessor(object):
         return True
 
     @staticmethod
-    def get_default_policy_templates_json():
+    def get_default_policy_templates_json():  # type: ignore[no-untyped-def]
         """
         Reads and returns the default policy templates JSON data from file.
 
         :return dict: Dictionary containing data read from default policy templates JSON file
         """
 
-        return PolicyTemplatesProcessor._read_json(PolicyTemplatesProcessor.DEFAULT_POLICY_TEMPLATES_FILE)
+        return PolicyTemplatesProcessor._read_json(PolicyTemplatesProcessor.DEFAULT_POLICY_TEMPLATES_FILE)  # type: ignore[no-untyped-call]
 
     @staticmethod
-    def _read_schema():
+    def _read_schema():  # type: ignore[no-untyped-def]
         """
         Reads the JSON Schema at given file path
 
@@ -141,10 +141,10 @@ class PolicyTemplatesProcessor(object):
         :return dict: JSON Schema of the policy template
         """
 
-        return PolicyTemplatesProcessor._read_json(PolicyTemplatesProcessor.SCHEMA_LOCATION)
+        return PolicyTemplatesProcessor._read_json(PolicyTemplatesProcessor.SCHEMA_LOCATION)  # type: ignore[no-untyped-call]
 
     @staticmethod
-    def _read_json(filepath):
+    def _read_json(filepath):  # type: ignore[no-untyped-def]
         """
         Helper method to read a JSON file
         :param filepath: Path to the file

--- a/samtranslator/policy_template_processor/template.py
+++ b/samtranslator/policy_template_processor/template.py
@@ -10,7 +10,7 @@ class Template(object):
     Class representing a single policy template. It includes the name, parameters and template dictionary.
     """
 
-    def __init__(self, template_name, parameters, template_definition):
+    def __init__(self, template_name, parameters, template_definition):  # type: ignore[no-untyped-def]
         """
         Initialize a template. This performs the check to ensure all parameters are referenced in the template.
         For simplicity, this method assumes that inputs have already been validated against the JSON Schema. So no
@@ -21,13 +21,13 @@ class Template(object):
         :param template_definition: Template definition. Refer to JSON Schema for structure of this dict
         :raises ValueError: If one or more of the parameters are not referenced in the template definition
         """
-        Template.check_parameters_exist(parameters, template_definition)
+        Template.check_parameters_exist(parameters, template_definition)  # type: ignore[no-untyped-call]
 
         self.name = template_name
         self.parameters = parameters
         self.definition = template_definition
 
-    def to_statement(self, parameter_values):
+    def to_statement(self, parameter_values):  # type: ignore[no-untyped-def]
         """
         With the given values for each parameter, this method will return a policy statement that can be used
         directly with IAM.
@@ -39,10 +39,10 @@ class Template(object):
         :raises InsufficientParameterValues: If the parameter values don't have values for all required parameters
         """
 
-        missing = self.missing_parameter_values(parameter_values)
+        missing = self.missing_parameter_values(parameter_values)  # type: ignore[no-untyped-call]
         if len(missing) > 0:
             # str() of elements of list to prevent any `u` prefix from being displayed in user-facing error message
-            raise InsufficientParameterValues(
+            raise InsufficientParameterValues(  # type: ignore[no-untyped-call]
                 f"Following required parameters of template '{self.name}' don't have values: {[str(m) for m in missing]}"
             )
 
@@ -54,14 +54,14 @@ class Template(object):
         }
 
         # Only "Ref" is supported
-        supported_intrinsics = {RefAction.intrinsic_name: RefAction()}
+        supported_intrinsics = {RefAction.intrinsic_name: RefAction()}  # type: ignore[no-untyped-call]
 
-        resolver = IntrinsicsResolver(necessary_parameter_values, supported_intrinsics)
+        resolver = IntrinsicsResolver(necessary_parameter_values, supported_intrinsics)  # type: ignore[no-untyped-call]
         definition_copy = copy.deepcopy(self.definition)
 
-        return resolver.resolve_parameter_refs(definition_copy)
+        return resolver.resolve_parameter_refs(definition_copy)  # type: ignore[no-untyped-call]
 
-    def missing_parameter_values(self, parameter_values):
+    def missing_parameter_values(self, parameter_values):  # type: ignore[no-untyped-def]
         """
         Checks if the given input contains values for all parameters used by this template
 
@@ -70,13 +70,13 @@ class Template(object):
         :raises InvalidParameterValues: When parameter values is not a valid dictionary
         """
 
-        if not self._is_valid_parameter_values(parameter_values):
-            raise InvalidParameterValues("Parameter values are required to process a policy template")
+        if not self._is_valid_parameter_values(parameter_values):  # type: ignore[no-untyped-call]
+            raise InvalidParameterValues("Parameter values are required to process a policy template")  # type: ignore[no-untyped-call]
 
         return list(set(self.parameters.keys()) - set(parameter_values.keys()))
 
     @staticmethod
-    def _is_valid_parameter_values(parameter_values):
+    def _is_valid_parameter_values(parameter_values):  # type: ignore[no-untyped-def]
         """
         Checks if the given parameter values dictionary is valid
         :param dict parameter_values:
@@ -85,7 +85,7 @@ class Template(object):
         return parameter_values is not None and isinstance(parameter_values, dict)
 
     @staticmethod
-    def check_parameters_exist(parameters, template_definition):
+    def check_parameters_exist(parameters, template_definition):  # type: ignore[no-untyped-def]
         """
         Verify that every one of the parameters in the given list have been "Ref"ed in the template definition. This
         is a sanity check to prevent any mis-spelled properties etc. It also checks that parameters are used *only* with
@@ -99,7 +99,7 @@ class Template(object):
         pass
 
     @staticmethod
-    def from_dict(template_name, template_values_dict):
+    def from_dict(template_name, template_values_dict):  # type: ignore[no-untyped-def]
         """
         Parses the input and returns an instance of this class.
 
@@ -112,4 +112,4 @@ class Template(object):
         parameters = template_values_dict.get("Parameters", {})
         definition = template_values_dict.get("Definition", {})
 
-        return Template(template_name, parameters, definition)
+        return Template(template_name, parameters, definition)  # type: ignore[no-untyped-call]

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -10,7 +10,7 @@ class RegionConfiguration(object):
     """
 
     @classmethod
-    def is_apigw_edge_configuration_supported(cls):
+    def is_apigw_edge_configuration_supported(cls):  # type: ignore[no-untyped-def]
         """
         # API Gateway defaults to EDGE endpoint configuration in all regions in AWS partition. But for other partitions,
         # such as GovCloud, they don't support Edge.
@@ -18,7 +18,7 @@ class RegionConfiguration(object):
         :return: True, if API Gateway does not support Edge configuration
         """
 
-        return ArnGenerator.get_partition_name() not in [
+        return ArnGenerator.get_partition_name() not in [  # type: ignore[no-untyped-call]
             "aws-us-gov",
             "aws-iso",
             "aws-iso-b",
@@ -26,7 +26,7 @@ class RegionConfiguration(object):
         ]
 
     @classmethod
-    def is_service_supported(cls, service, region=None):
+    def is_service_supported(cls, service, region=None):  # type: ignore[no-untyped-def]
         """
         Not all services are supported in all regions.  This method returns whether a given
         service is supported in a given region.  If no region is specified, the current region
@@ -47,7 +47,7 @@ class RegionConfiguration(object):
             # need to handle when region is None so that it won't break
             if region is None:
                 if ArnGenerator.BOTO_SESSION_REGION_NAME is not None:
-                    region = ArnGenerator.BOTO_SESSION_REGION_NAME
+                    region = ArnGenerator.BOTO_SESSION_REGION_NAME  # type: ignore[unreachable]
                 else:
                     raise NoRegionFound("AWS Region cannot be found")
 

--- a/samtranslator/sdk/parameter.py
+++ b/samtranslator/sdk/parameter.py
@@ -9,7 +9,7 @@ class SamParameterValues(object):
     Class representing SAM parameter values.
     """
 
-    def __init__(self, parameter_values):
+    def __init__(self, parameter_values):  # type: ignore[no-untyped-def]
         """
         Initialize the object given the parameter values as a dictionary
 
@@ -18,7 +18,7 @@ class SamParameterValues(object):
 
         self.parameter_values = copy.deepcopy(parameter_values)
 
-    def add_default_parameter_values(self, sam_template):
+    def add_default_parameter_values(self, sam_template):  # type: ignore[no-untyped-def]
         """
         Method to read default values for template parameters and merge with user supplied values.
 
@@ -60,7 +60,7 @@ class SamParameterValues(object):
             if param_name not in self.parameter_values and isinstance(value, dict) and "Default" in value:
                 self.parameter_values[param_name] = value["Default"]
 
-    def add_pseudo_parameter_values(self, session=None):
+    def add_pseudo_parameter_values(self, session=None):  # type: ignore[no-untyped-def]
         """
         Add pseudo parameter values
         :return: parameter values that have pseudo parameter in it
@@ -76,4 +76,4 @@ class SamParameterValues(object):
             self.parameter_values["AWS::Region"] = session.region_name
 
         if "AWS::Partition" not in self.parameter_values:
-            self.parameter_values["AWS::Partition"] = ArnGenerator.get_partition_name(session.region_name)
+            self.parameter_values["AWS::Partition"] = ArnGenerator.get_partition_name(session.region_name)  # type: ignore[no-untyped-call]

--- a/samtranslator/sdk/resource.py
+++ b/samtranslator/sdk/resource.py
@@ -15,7 +15,7 @@ class SamResource(object):
     type = None
     properties: Dict[str, Any] = {}  # TODO: Replace `Any` with something more specific
 
-    def __init__(self, resource_dict):
+    def __init__(self, resource_dict):  # type: ignore[no-untyped-def]
         """
         Initialize the object given the resource as a dictionary
 
@@ -31,7 +31,7 @@ class SamResource(object):
         # Properties is *not* required. Ex: SimpleTable resource has no required properties
         self.properties = resource_dict.get("Properties", {})
 
-    def valid(self):
+    def valid(self):  # type: ignore[no-untyped-def]
         """
         Checks if the resource data is valid
 
@@ -42,28 +42,28 @@ class SamResource(object):
 
         if self.condition:
 
-            if not is_str()(self.condition, should_raise=False):
-                raise InvalidDocumentException([InvalidTemplateException("Every Condition member must be a string.")])
+            if not is_str()(self.condition, should_raise=False):  # type: ignore[no-untyped-call]
+                raise InvalidDocumentException([InvalidTemplateException("Every Condition member must be a string.")])  # type: ignore[no-untyped-call, no-untyped-call]
 
         if self.deletion_policy:
 
-            if not is_str()(self.deletion_policy, should_raise=False):
-                raise InvalidDocumentException(
-                    [InvalidTemplateException("Every DeletionPolicy member must be a string.")]
+            if not is_str()(self.deletion_policy, should_raise=False):  # type: ignore[no-untyped-call]
+                raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                    [InvalidTemplateException("Every DeletionPolicy member must be a string.")]  # type: ignore[no-untyped-call]
                 )
 
         if self.update_replace_policy:
 
-            if not is_str()(self.update_replace_policy, should_raise=False):
-                raise InvalidDocumentException(
-                    [InvalidTemplateException("Every UpdateReplacePolicy member must be a string.")]
+            if not is_str()(self.update_replace_policy, should_raise=False):  # type: ignore[no-untyped-call]
+                raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                    [InvalidTemplateException("Every UpdateReplacePolicy member must be a string.")]  # type: ignore[no-untyped-call]
                 )
 
-        return SamResourceType.has_value(self.type)
+        return SamResourceType.has_value(self.type)  # type: ignore[no-untyped-call]
 
-    def to_dict(self):
+    def to_dict(self):  # type: ignore[no-untyped-def]
 
-        if self.valid():
+        if self.valid():  # type: ignore[no-untyped-call]
             # Touch a resource dictionary ONLY if it is valid
             # Modify only Type & Properties section to preserve CloudFormation properties like DependsOn, Conditions etc
             self.resource_dict["Type"] = self.type
@@ -86,7 +86,7 @@ class SamResourceType(Enum):
     StateMachine = "AWS::Serverless::StateMachine"
 
     @classmethod
-    def has_value(cls, value):
+    def has_value(cls, value):  # type: ignore[no-untyped-def]
         """
         Checks if the given value belongs to the Enum
 

--- a/samtranslator/sdk/template.py
+++ b/samtranslator/sdk/template.py
@@ -10,7 +10,7 @@ class SamTemplate(object):
     Class representing the SAM template
     """
 
-    def __init__(self, template_dict):
+    def __init__(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Initialize with a template dictionary, that contains "Resources" dictionary
 
@@ -19,7 +19,7 @@ class SamTemplate(object):
         self.template_dict = template_dict
         self.resources = template_dict["Resources"]
 
-    def iterate(self, resource_types=None):
+    def iterate(self, resource_types=None):  # type: ignore[no-untyped-def]
         """
         Iterate over all resources within the SAM template, optionally filtering by type
 
@@ -30,15 +30,15 @@ class SamTemplate(object):
             resource_types = {}
         for logicalId, resource_dict in self.resources.items():
 
-            resource = SamResource(resource_dict)
-            needs_filter = resource.valid()
+            resource = SamResource(resource_dict)  # type: ignore[no-untyped-call]
+            needs_filter = resource.valid()  # type: ignore[no-untyped-call]
             if resource_types:
                 needs_filter = needs_filter and resource.type in resource_types
 
             if needs_filter:
                 yield logicalId, resource
 
-    def set(self, logicalId, resource):
+    def set(self, logicalId, resource):  # type: ignore[no-untyped-def]
         """
         Adds the resource to dictionary with given logical Id. It will overwrite, if the logicalId is already used.
 
@@ -48,11 +48,11 @@ class SamTemplate(object):
 
         resource_dict = resource
         if isinstance(resource, SamResource):
-            resource_dict = resource.to_dict()
+            resource_dict = resource.to_dict()  # type: ignore[no-untyped-call]
 
         self.resources[logicalId] = resource_dict
 
-    def get(self, logicalId):
+    def get(self, logicalId):  # type: ignore[no-untyped-def]
         """
         Gets the resource at the given logicalId if present
 
@@ -62,9 +62,9 @@ class SamTemplate(object):
         if logicalId not in self.resources:
             return None
 
-        return SamResource(self.resources.get(logicalId))
+        return SamResource(self.resources.get(logicalId))  # type: ignore[no-untyped-call]
 
-    def delete(self, logicalId):
+    def delete(self, logicalId):  # type: ignore[no-untyped-def]
         """
         Deletes a resource at the given ID
 
@@ -74,7 +74,7 @@ class SamTemplate(object):
         if logicalId in self.resources:
             del self.resources[logicalId]
 
-    def to_dict(self):
+    def to_dict(self):  # type: ignore[no-untyped-def]
         """
         Returns the template as a dictionary
 

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -337,9 +337,7 @@ class SwaggerEditor(object):
 
         for path_item in self.get_conditional_contents(self.paths.get(path_name)):  # type: ignore[no-untyped-call]
             for method_definition in self.get_conditional_contents(path_item.get(normalized_method_name)):  # type: ignore[no-untyped-call]
-                if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
-                    method_definition
-                ):  # type: ignore[no-untyped-call]
+                if skip_methods_without_apigw_integration and not self.method_definition_has_integration(method_definition):  # type: ignore[no-untyped-call]
                     continue
                 yield method_definition
 
@@ -364,9 +362,7 @@ class SwaggerEditor(object):
                             method_name, method_definition, path_name
                         ),
                     )
-                    if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
-                        method_definition
-                    ):  # type: ignore[no-untyped-call]
+                    if skip_methods_without_apigw_integration and not self.method_definition_has_integration(method_definition):  # type: ignore[no-untyped-call]
                         continue
                     normalized_method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
                     yield normalized_method_name, method_definition

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -38,7 +38,7 @@ class SwaggerEditor(object):
     _POLICY_TYPE_IP = "Ip"
     _POLICY_TYPE_VPC = "Vpc"
 
-    def __init__(self, doc):
+    def __init__(self, doc):  # type: ignore[no-untyped-def]
         """
         Initialize the class with a swagger dictionary. This class creates a copy of the Swagger and performs all
         modifications on this copy.
@@ -47,26 +47,26 @@ class SwaggerEditor(object):
         :raises InvalidDocumentException: If the input Swagger document does not meet the basic Swagger requirements.
         """
 
-        if not SwaggerEditor.is_valid(doc):
-            raise InvalidDocumentException([InvalidTemplateException("Invalid Swagger document")])
+        if not SwaggerEditor.is_valid(doc):  # type: ignore[no-untyped-call]
+            raise InvalidDocumentException([InvalidTemplateException("Invalid Swagger document")])  # type: ignore[no-untyped-call, no-untyped-call]
 
         self._doc = copy.deepcopy(doc)
         self.paths = self._doc["paths"]
-        self.security_definitions = self._doc.get("securityDefinitions", Py27Dict())
-        self.gateway_responses = self._doc.get(self._X_APIGW_GATEWAY_RESPONSES, Py27Dict())
-        self.resource_policy = self._doc.get(self._X_APIGW_POLICY, Py27Dict())
-        self.definitions = self._doc.get("definitions", Py27Dict())
+        self.security_definitions = self._doc.get("securityDefinitions", Py27Dict())  # type: ignore[no-untyped-call]
+        self.gateway_responses = self._doc.get(self._X_APIGW_GATEWAY_RESPONSES, Py27Dict())  # type: ignore[no-untyped-call]
+        self.resource_policy = self._doc.get(self._X_APIGW_POLICY, Py27Dict())  # type: ignore[no-untyped-call]
+        self.definitions = self._doc.get("definitions", Py27Dict())  # type: ignore[no-untyped-call]
 
         # https://swagger.io/specification/#path-item-object
         # According to swagger spec,
         # each path item object must be a dict (even it is empty).
         # We can do an early path validation on path item objects,
         # so we don't need to validate wherever we use them.
-        for path in self.iter_on_path():
-            for path_item in self.get_conditional_contents(self.paths.get(path)):
-                SwaggerEditor.validate_path_item_is_dict(path_item, path)
+        for path in self.iter_on_path():  # type: ignore[no-untyped-call]
+            for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
+                SwaggerEditor.validate_path_item_is_dict(path_item, path)  # type: ignore[no-untyped-call]
 
-    def get_conditional_contents(self, item):
+    def get_conditional_contents(self, item):  # type: ignore[no-untyped-def]
         """
         Returns the contents of the given item.
         If a conditional block has been used inside the item, returns a list of the content
@@ -79,10 +79,10 @@ class SwaggerEditor(object):
         contents = [item]
         if isinstance(item, dict) and self._CONDITIONAL_IF in item:
             contents = item[self._CONDITIONAL_IF][1:]
-            contents = [content for content in contents if not is_intrinsic_no_value(content)]
+            contents = [content for content in contents if not is_intrinsic_no_value(content)]  # type: ignore[no-untyped-call]
         return contents
 
-    def has_path(self, path, method=None):
+    def has_path(self, path, method=None):  # type: ignore[no-untyped-def]
         """
         Returns True if this Swagger has the given path and optional method
         For paths with conditionals, only returns true if both items (true case, and false case) have the method.
@@ -94,14 +94,14 @@ class SwaggerEditor(object):
         if path not in self.paths:
             return False
 
-        method = self._normalize_method_name(method)
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
         if method:
-            for path_item in self.get_conditional_contents(self.paths.get(path)):
+            for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
                 if method not in path_item:
                     return False
         return True
 
-    def method_has_integration(self, method):
+    def method_has_integration(self, method):  # type: ignore[no-untyped-def]
         """
         Returns true if the given method contains a valid method definition.
         This uses the get_conditional_contents function to handle conditionals.
@@ -109,12 +109,12 @@ class SwaggerEditor(object):
         :param dict method: method dictionary
         :return: true if method has one or multiple integrations
         """
-        for method_definition in self.get_conditional_contents(method):
-            if self.method_definition_has_integration(method_definition):
+        for method_definition in self.get_conditional_contents(method):  # type: ignore[no-untyped-call]
+            if self.method_definition_has_integration(method_definition):  # type: ignore[no-untyped-call]
                 return True
         return False
 
-    def method_definition_has_integration(self, method_definition):
+    def method_definition_has_integration(self, method_definition):  # type: ignore[no-untyped-def]
         """
         Checks a method definition to make sure it has an apigw integration
 
@@ -125,7 +125,7 @@ class SwaggerEditor(object):
             return True
         return False
 
-    def add_disable_execute_api_endpoint_extension(self, disable_execute_api_endpoint):
+    def add_disable_execute_api_endpoint_extension(self, disable_execute_api_endpoint):  # type: ignore[no-untyped-def]
         """Add endpoint configuration to _X_APIGW_ENDPOINT_CONFIG in open api definition as extension
         Following this guide:
         https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-endpoint-configuration.html
@@ -138,7 +138,7 @@ class SwaggerEditor(object):
         set_disable_api_endpoint = {DISABLE_EXECUTE_API_ENDPOINT: disable_execute_api_endpoint}
         self._doc[self._X_ENDPOINT_CONFIG].update(set_disable_api_endpoint)
 
-    def has_integration(self, path, method):
+    def has_integration(self, path, method):  # type: ignore[no-untyped-def]
         """
         Checks if an API Gateway integration is already present at the given path/method.
         For paths with conditionals, it only returns True if both items (true case, false case) have the integration
@@ -147,33 +147,33 @@ class SwaggerEditor(object):
         :param string method: HTTP method
         :return: True, if an API Gateway integration is already present
         """
-        method = self._normalize_method_name(method)
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
 
-        if not self.has_path(path, method):
+        if not self.has_path(path, method):  # type: ignore[no-untyped-call]
             return False
 
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             method_definition = path_item.get(method)
-            if not (isinstance(method_definition, dict) and self.method_has_integration(method_definition)):
+            if not (isinstance(method_definition, dict) and self.method_has_integration(method_definition)):  # type: ignore[no-untyped-call]
                 return False
         # Integration present and non-empty
         return True
 
-    def add_path(self, path, method=None):
+    def add_path(self, path, method=None):  # type: ignore[no-untyped-def]
         """
         Adds the path/method combination to the Swagger, if not already present
 
         :param string path: Path name
         :param string method: HTTP method
         """
-        method = self._normalize_method_name(method)
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
 
-        self.paths.setdefault(path, Py27Dict())
+        self.paths.setdefault(path, Py27Dict())  # type: ignore[no-untyped-call]
 
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
-            path_item.setdefault(method, Py27Dict())
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
+            path_item.setdefault(method, Py27Dict())  # type: ignore[no-untyped-call]
 
-    def add_lambda_integration(
+    def add_lambda_integration(  # type: ignore[no-untyped-def]
         self, path, method, integration_uri, method_auth_config=None, api_auth_config=None, condition=None
     ):
         """
@@ -184,32 +184,32 @@ class SwaggerEditor(object):
         :param string integration_uri: URI for the integration.
         """
 
-        method = self._normalize_method_name(method)
-        if self.has_integration(path, method):
-            raise InvalidDocumentException(
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
+        if self.has_integration(path, method):  # type: ignore[no-untyped-call]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                 [
-                    InvalidTemplateException(
+                    InvalidTemplateException(  # type: ignore[no-untyped-call]
                         "Lambda integration already exists on Path={}, Method={}".format(path, method)
                     )
                 ]
             )
 
-        self.add_path(path, method)
+        self.add_path(path, method)  # type: ignore[no-untyped-call]
 
         # Wrap the integration_uri in a Condition if one exists on that function
         # This is necessary so CFN doesn't try to resolve the integration reference.
         if condition:
-            integration_uri = make_conditional(condition, integration_uri)
+            integration_uri = make_conditional(condition, integration_uri)  # type: ignore[no-untyped-call]
 
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
-            path_item[method][self._X_APIGW_INTEGRATION] = Py27Dict()
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
+            path_item[method][self._X_APIGW_INTEGRATION] = Py27Dict()  # type: ignore[no-untyped-call]
             # insert key one by one to preserce input order
             path_item[method][self._X_APIGW_INTEGRATION]["type"] = "aws_proxy"
             path_item[method][self._X_APIGW_INTEGRATION]["httpMethod"] = "POST"
             path_item[method][self._X_APIGW_INTEGRATION]["uri"] = integration_uri
 
-            method_auth_config = method_auth_config or Py27Dict()
-            api_auth_config = api_auth_config or Py27Dict()
+            method_auth_config = method_auth_config or Py27Dict()  # type: ignore[no-untyped-call]
+            api_auth_config = api_auth_config or Py27Dict()  # type: ignore[no-untyped-call]
             if (
                 method_auth_config.get("Authorizer") == "AWS_IAM"
                 or api_auth_config.get("DefaultAuthorizer") == "AWS_IAM"
@@ -221,20 +221,20 @@ class SwaggerEditor(object):
                 api_invoke_role = api_auth_config.get("InvokeRole")
                 if not api_invoke_role and "InvokeRole" in api_auth_config:
                     api_invoke_role = "NONE"
-                credentials = self._generate_integration_credentials(
+                credentials = self._generate_integration_credentials(  # type: ignore[no-untyped-call]
                     method_invoke_role=method_invoke_role, api_invoke_role=api_invoke_role
                 )
                 if credentials and credentials != "NONE":
                     path_item[method][self._X_APIGW_INTEGRATION]["credentials"] = credentials
 
             # If 'responses' key is *not* present, add it with an empty dict as value
-            path_item[method].setdefault("responses", Py27Dict())
+            path_item[method].setdefault("responses", Py27Dict())  # type: ignore[no-untyped-call]
 
             # If a condition is present, wrap all method contents up into the condition
             if condition:
-                path_item[method] = make_conditional(condition, path_item[method])
+                path_item[method] = make_conditional(condition, path_item[method])  # type: ignore[no-untyped-call]
 
-    def add_state_machine_integration(
+    def add_state_machine_integration(  # type: ignore[no-untyped-def]
         self,
         path,
         method,
@@ -254,32 +254,32 @@ class SwaggerEditor(object):
         :param bool condition: Condition for the integration
         """
 
-        method = self._normalize_method_name(method)
-        if self.has_integration(path, method):
-            raise InvalidDocumentException(
-                [InvalidTemplateException("Integration already exists on Path={}, Method={}".format(path, method))]
+        method = self._normalize_method_name(method)  # type: ignore[no-untyped-call]
+        if self.has_integration(path, method):  # type: ignore[no-untyped-call]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                [InvalidTemplateException("Integration already exists on Path={}, Method={}".format(path, method))]  # type: ignore[no-untyped-call]
             )
 
-        self.add_path(path, method)
+        self.add_path(path, method)  # type: ignore[no-untyped-call]
 
         # Wrap the integration_uri in a Condition if one exists on that state machine
         # This is necessary so CFN doesn't try to resolve the integration reference.
         if condition:
-            integration_uri = make_conditional(condition, integration_uri)
+            integration_uri = make_conditional(condition, integration_uri)  # type: ignore[no-untyped-call]
 
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             # Responses
-            integration_responses = Py27Dict()
+            integration_responses = Py27Dict()  # type: ignore[no-untyped-call]
             # insert key one by one to preserce input order
-            integration_responses["200"] = Py27Dict({"statusCode": "200"})
-            integration_responses["400"] = Py27Dict({"statusCode": "400"})
+            integration_responses["200"] = Py27Dict({"statusCode": "200"})  # type: ignore[no-untyped-call]
+            integration_responses["400"] = Py27Dict({"statusCode": "400"})  # type: ignore[no-untyped-call]
 
-            default_method_responses = Py27Dict()
+            default_method_responses = Py27Dict()  # type: ignore[no-untyped-call]
             # insert key one by one to preserce input order
-            default_method_responses["200"] = Py27Dict({"description": "OK"})
-            default_method_responses["400"] = Py27Dict({"description": "Bad Request"})
+            default_method_responses["200"] = Py27Dict({"description": "OK"})  # type: ignore[no-untyped-call]
+            default_method_responses["400"] = Py27Dict({"description": "Bad Request"})  # type: ignore[no-untyped-call]
 
-            path_item[method][self._X_APIGW_INTEGRATION] = Py27Dict()
+            path_item[method][self._X_APIGW_INTEGRATION] = Py27Dict()  # type: ignore[no-untyped-call]
             # insert key one by one to preserce input order
             path_item[method][self._X_APIGW_INTEGRATION]["type"] = "aws"
             path_item[method][self._X_APIGW_INTEGRATION]["httpMethod"] = "POST"
@@ -295,22 +295,22 @@ class SwaggerEditor(object):
 
             # If a condition is present, wrap all method contents up into the condition
             if condition:
-                path_item[method] = make_conditional(condition, path_item[method])
+                path_item[method] = make_conditional(condition, path_item[method])  # type: ignore[no-untyped-call]
 
-    def make_path_conditional(self, path, condition):
+    def make_path_conditional(self, path, condition):  # type: ignore[no-untyped-def]
         """
         Wrap entire API path definition in a CloudFormation if condition.
         """
-        self.paths[path] = make_conditional(condition, self.paths[path])
+        self.paths[path] = make_conditional(condition, self.paths[path])  # type: ignore[no-untyped-call]
 
-    def _generate_integration_credentials(self, method_invoke_role=None, api_invoke_role=None):
-        return self._get_invoke_role(method_invoke_role or api_invoke_role)
+    def _generate_integration_credentials(self, method_invoke_role=None, api_invoke_role=None):  # type: ignore[no-untyped-def]
+        return self._get_invoke_role(method_invoke_role or api_invoke_role)  # type: ignore[no-untyped-call]
 
-    def _get_invoke_role(self, invoke_role):
+    def _get_invoke_role(self, invoke_role):  # type: ignore[no-untyped-def]
         CALLER_CREDENTIALS_ARN = "arn:aws:iam::*:user/*"
         return invoke_role if invoke_role and invoke_role != "CALLER_CREDENTIALS" else CALLER_CREDENTIALS_ARN
 
-    def iter_on_path(self):
+    def iter_on_path(self):  # type: ignore[no-untyped-def]
         """
         Yields all the paths available in the Swagger. As a caller, if you add new paths to Swagger while iterating,
         they will not show up in this iterator
@@ -321,7 +321,7 @@ class SwaggerEditor(object):
         for path, _ in self.paths.items():
             yield path
 
-    def iter_on_method_definitions_for_path_at_method(
+    def iter_on_method_definitions_for_path_at_method(  # type: ignore[no-untyped-def]
         self, path_name, method_name, skip_methods_without_apigw_integration=True
     ):
         """
@@ -333,17 +333,17 @@ class SwaggerEditor(object):
         :param skip_methods_without_apigw_integration: if True, skips method definitions without apigw integration
         :yields dict: method definition
         """
-        normalized_method_name = self._normalize_method_name(method_name)
+        normalized_method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
 
-        for path_item in self.get_conditional_contents(self.paths.get(path_name)):
-            for method_definition in self.get_conditional_contents(path_item.get(normalized_method_name)):
+        for path_item in self.get_conditional_contents(self.paths.get(path_name)):  # type: ignore[no-untyped-call]
+            for method_definition in self.get_conditional_contents(path_item.get(normalized_method_name)):  # type: ignore[no-untyped-call]
                 if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
                     method_definition
-                ):
+                ):  # type: ignore[no-untyped-call]
                     continue
                 yield method_definition
 
-    def iter_on_all_methods_for_path(self, path_name, skip_methods_without_apigw_integration=True):
+    def iter_on_all_methods_for_path(self, path_name, skip_methods_without_apigw_integration=True):  # type: ignore[no-untyped-def]
         """
         Yields all the (method name, method definition) tuples for the path, including those inside conditionals.
 
@@ -351,14 +351,14 @@ class SwaggerEditor(object):
         :param skip_methods_without_apigw_integration: if True, skips method definitions without apigw integration
         :yields list of (method name, method definition) tuples
         """
-        for path_item in self.get_conditional_contents(self.paths.get(path_name)):
+        for path_item in self.get_conditional_contents(self.paths.get(path_name)):  # type: ignore[no-untyped-call]
             for method_name, method in path_item.items():
                 # Excluding non-method sections
                 if method_name in SwaggerEditor._EXCLUDED_PATHS_FIELDS:
                     continue
 
-                for method_definition in self.get_conditional_contents(method):
-                    SwaggerEditor.validate_is_dict(
+                for method_definition in self.get_conditional_contents(method):  # type: ignore[no-untyped-call]
+                    SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
                         method_definition,
                         'Value of "{}" ({}) for path {} is not a valid dictionary.'.format(
                             method_name, method_definition, path_name
@@ -366,12 +366,12 @@ class SwaggerEditor(object):
                     )
                     if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
                         method_definition
-                    ):
+                    ):  # type: ignore[no-untyped-call]
                         continue
-                    normalized_method_name = self._normalize_method_name(method_name)
+                    normalized_method_name = self._normalize_method_name(method_name)  # type: ignore[no-untyped-call]
                     yield normalized_method_name, method_definition
 
-    def add_cors(
+    def add_cors(  # type: ignore[no-untyped-def]
         self, path, allowed_origins, allowed_headers=None, allowed_methods=None, max_age=None, allow_credentials=None
     ):
         """
@@ -398,18 +398,18 @@ class SwaggerEditor(object):
         :raises InvalidTemplateException: When values for one of the allowed_* variables is empty
         """
 
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             # Skip if Options is already present
-            method = self._normalize_method_name(self._OPTIONS_METHOD)
+            method = self._normalize_method_name(self._OPTIONS_METHOD)  # type: ignore[no-untyped-call]
             if method in path_item:
                 continue
 
             if not allowed_origins:
-                raise InvalidTemplateException("Invalid input. Value for AllowedOrigins is required")
+                raise InvalidTemplateException("Invalid input. Value for AllowedOrigins is required")  # type: ignore[no-untyped-call]
 
             if not allowed_methods:
                 # AllowMethods is not given. Let's try to generate the list from the given Swagger.
-                allowed_methods = self._make_cors_allowed_methods_for_path_item(path_item)
+                allowed_methods = self._make_cors_allowed_methods_for_path_item(path_item)  # type: ignore[no-untyped-call]
 
                 # APIGW expects the value to be a "string expression". Hence wrap in another quote. Ex: "'GET,POST,DELETE'"
                 allowed_methods = "'{}'".format(allowed_methods)
@@ -418,37 +418,37 @@ class SwaggerEditor(object):
                 allow_credentials = False
 
             # Add the Options method and the CORS response
-            path_item[self._OPTIONS_METHOD] = self._options_method_response_for_cors(
+            path_item[self._OPTIONS_METHOD] = self._options_method_response_for_cors(  # type: ignore[no-untyped-call]
                 allowed_origins, allowed_headers, allowed_methods, max_age, allow_credentials
             )
 
-    def add_binary_media_types(self, binary_media_types):
+    def add_binary_media_types(self, binary_media_types):  # type: ignore[no-untyped-def]
         """
         Args:
             binary_media_types: list
         """
 
-        def replace_recursively(bmt):
+        def replace_recursively(bmt):  # type: ignore[no-untyped-def]
             """replaces "~1" with "/" for the input binary_media_types recursively"""
             if isinstance(bmt, dict):
-                to_return = Py27Dict()
+                to_return = Py27Dict()  # type: ignore[no-untyped-call]
                 for k, v in bmt.items():
-                    to_return[Py27UniStr(k.replace("~1", "/"))] = replace_recursively(v)
+                    to_return[Py27UniStr(k.replace("~1", "/"))] = replace_recursively(v)  # type: ignore[no-untyped-call]
                 return to_return
             if isinstance(bmt, list):
-                return [replace_recursively(item) for item in bmt]
+                return [replace_recursively(item) for item in bmt]  # type: ignore[no-untyped-call]
             if isinstance(bmt, (Py27UniStr, str)):
                 return Py27UniStr(bmt.replace("~1", "/"))
             return bmt
 
-        bmt = replace_recursively(binary_media_types)
+        bmt = replace_recursively(binary_media_types)  # type: ignore[no-untyped-call]
         self._doc[self._X_APIGW_BINARY_MEDIA_TYPES] = bmt
 
     @staticmethod
     def _make_response_header_key(original_header_key: str) -> str:
         return "method.response.header." + original_header_key
 
-    def _options_method_response_for_cors(
+    def _options_method_response_for_cors(  # type: ignore[no-untyped-def]
         self, allowed_origins, allowed_headers=None, allowed_methods=None, max_age=None, allow_credentials=None
     ):
         """
@@ -476,14 +476,14 @@ class SwaggerEditor(object):
         MAX_AGE = "Access-Control-Max-Age"
         ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials"
 
-        response_parameters = Py27Dict(
+        response_parameters = Py27Dict(  # type: ignore[no-untyped-call]
             {
                 # AllowedOrigin is always required
                 self._make_response_header_key(ALLOW_ORIGIN): allowed_origins
             }
         )
 
-        response_headers = Py27Dict(
+        response_headers = Py27Dict(  # type: ignore[no-untyped-call]
             {
                 # Allow Origin is always required
                 ALLOW_ORIGIN: {"type": "string"}
@@ -513,25 +513,25 @@ class SwaggerEditor(object):
             response_headers[ALLOW_CREDENTIALS] = {"type": "string"}
 
         # construct snippet and insert key one by one to preserce input order
-        to_return = Py27Dict()
+        to_return = Py27Dict()  # type: ignore[no-untyped-call]
         to_return["summary"] = "CORS support"
         to_return["consumes"] = ["application/json"]
         to_return["produces"] = ["application/json"]
-        to_return[self._X_APIGW_INTEGRATION] = Py27Dict()
+        to_return[self._X_APIGW_INTEGRATION] = Py27Dict()  # type: ignore[no-untyped-call]
         to_return[self._X_APIGW_INTEGRATION]["type"] = "mock"
         to_return[self._X_APIGW_INTEGRATION]["requestTemplates"] = {"application/json": '{\n  "statusCode" : 200\n}\n'}
-        to_return[self._X_APIGW_INTEGRATION]["responses"] = Py27Dict()
-        to_return[self._X_APIGW_INTEGRATION]["responses"]["default"] = Py27Dict()
+        to_return[self._X_APIGW_INTEGRATION]["responses"] = Py27Dict()  # type: ignore[no-untyped-call]
+        to_return[self._X_APIGW_INTEGRATION]["responses"]["default"] = Py27Dict()  # type: ignore[no-untyped-call]
         to_return[self._X_APIGW_INTEGRATION]["responses"]["default"]["statusCode"] = "200"
         to_return[self._X_APIGW_INTEGRATION]["responses"]["default"]["responseParameters"] = response_parameters
         to_return[self._X_APIGW_INTEGRATION]["responses"]["default"]["responseTemplates"] = {"application/json": "{}\n"}
-        to_return["responses"] = Py27Dict()
-        to_return["responses"]["200"] = Py27Dict()
+        to_return["responses"] = Py27Dict()  # type: ignore[no-untyped-call]
+        to_return["responses"]["200"] = Py27Dict()  # type: ignore[no-untyped-call]
         to_return["responses"]["200"]["description"] = "Default response for CORS method"
         to_return["responses"]["200"]["headers"] = response_headers
         return to_return
 
-    def _make_cors_allowed_methods_for_path_item(self, path_item):
+    def _make_cors_allowed_methods_for_path_item(self, path_item):  # type: ignore[no-untyped-def]
         """
         Creates the value for Access-Control-Allow-Methods header for given path item. All HTTP methods defined for this
         path item will be included in the result. If the path item contains "ANY" method, then *all available* HTTP methods will
@@ -564,39 +564,39 @@ class SwaggerEditor(object):
         # Allow-Methods is comma separated string
         return ",".join(allow_methods)
 
-    def add_authorizers_security_definitions(self, authorizers):
+    def add_authorizers_security_definitions(self, authorizers):  # type: ignore[no-untyped-def]
         """
         Add Authorizer definitions to the securityDefinitions part of Swagger.
 
         :param list authorizers: List of Authorizer configurations which get translated to securityDefinitions.
         """
-        self.security_definitions = self.security_definitions or Py27Dict()
+        self.security_definitions = self.security_definitions or Py27Dict()  # type: ignore[no-untyped-call]
 
         for authorizer_name, authorizer in authorizers.items():
             self.security_definitions[authorizer_name] = authorizer.generate_swagger()
 
-    def add_awsiam_security_definition(self):
+    def add_awsiam_security_definition(self):  # type: ignore[no-untyped-def]
         """
         Adds AWS_IAM definition to the securityDefinitions part of Swagger.
         Note: this method is idempotent
         """
 
         # construct aws_iam_security_definition as Py27Dict and insert key one by one to preserce input order
-        aws_iam_security_definition = Py27Dict()
-        aws_iam_security_definition["AWS_IAM"] = Py27Dict()
+        aws_iam_security_definition = Py27Dict()  # type: ignore[no-untyped-call]
+        aws_iam_security_definition["AWS_IAM"] = Py27Dict()  # type: ignore[no-untyped-call]
         aws_iam_security_definition["AWS_IAM"]["x-amazon-apigateway-authtype"] = "awsSigv4"
         aws_iam_security_definition["AWS_IAM"]["type"] = "apiKey"
         aws_iam_security_definition["AWS_IAM"]["name"] = "Authorization"
         aws_iam_security_definition["AWS_IAM"]["in"] = "header"
 
-        self.security_definitions = self.security_definitions or Py27Dict()
+        self.security_definitions = self.security_definitions or Py27Dict()  # type: ignore[no-untyped-call]
 
         # Only add the security definition if it doesn't exist.  This helps ensure
         # that we minimize changes to the swagger in the case of user defined swagger
         if "AWS_IAM" not in self.security_definitions:
             self.security_definitions.update(aws_iam_security_definition)
 
-    def add_apikey_security_definition(self):
+    def add_apikey_security_definition(self):  # type: ignore[no-untyped-def]
         """
         Adds api_key definition to the securityDefinitions part of Swagger.
         Note: this method is idempotent
@@ -604,20 +604,20 @@ class SwaggerEditor(object):
 
         # construct api_key_security_definiton as py27 dict
         # and insert keys one by one to preserve input order
-        api_key_security_definition = Py27Dict()
-        api_key_security_definition["api_key"] = Py27Dict()
+        api_key_security_definition = Py27Dict()  # type: ignore[no-untyped-call]
+        api_key_security_definition["api_key"] = Py27Dict()  # type: ignore[no-untyped-call]
         api_key_security_definition["api_key"]["type"] = "apiKey"
         api_key_security_definition["api_key"]["name"] = "x-api-key"
         api_key_security_definition["api_key"]["in"] = "header"
 
-        self.security_definitions = self.security_definitions or Py27Dict()
+        self.security_definitions = self.security_definitions or Py27Dict()  # type: ignore[no-untyped-call]
 
         # Only add the security definition if it doesn't exist.  This helps ensure
         # that we minimize changes to the swagger in the case of user defined swagger
         if "api_key" not in self.security_definitions:
             self.security_definitions.update(api_key_security_definition)
 
-    def set_path_default_authorizer(
+    def set_path_default_authorizer(  # type: ignore[no-untyped-def]
         self, path, default_authorizer, authorizers, add_default_auth_to_preflight=True, api_authorizers=None
     ):
         """
@@ -634,7 +634,7 @@ class SwaggerEditor(object):
             authorizer to OPTIONS preflight requests.
         """
 
-        for method_name, method_definition in self.iter_on_all_methods_for_path(path):
+        for method_name, method_definition in self.iter_on_all_methods_for_path(path):  # type: ignore[no-untyped-call]
             if not (add_default_auth_to_preflight or method_name != "options"):
                 continue
             existing_security = method_definition.get("security", [])
@@ -649,7 +649,7 @@ class SwaggerEditor(object):
             # (e.g. sigv4 (AWS_IAM), api_key (API Key/Usage Plans), NONE (marker for ignoring default))
             # We want to ensure only a single Authorizer security entry exists while keeping everything else
             for security in existing_security:
-                SwaggerEditor.validate_is_dict(
+                SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
                     security,
                     "{} in Security for path {} method {} is not a valid dictionary.".format(
                         security, path, method_name
@@ -685,8 +685,8 @@ class SwaggerEditor(object):
 
             # No existing Authorizer found; use default
             else:
-                security_dict = Py27Dict()
-                security_dict[default_authorizer] = self._get_authorization_scopes(api_authorizers, default_authorizer)
+                security_dict = Py27Dict()  # type: ignore[no-untyped-call]
+                security_dict[default_authorizer] = self._get_authorization_scopes(api_authorizers, default_authorizer)  # type: ignore[no-untyped-call]
                 authorizer_security = [security_dict]
 
             security = existing_non_authorizer_security + authorizer_security
@@ -697,9 +697,9 @@ class SwaggerEditor(object):
                 # The first element of the method_definition['security'] should be AWS_IAM
                 # because authorizer_list = ['AWS_IAM'] is hardcoded above
                 if "AWS_IAM" in method_definition["security"][0]:
-                    self.add_awsiam_security_definition()
+                    self.add_awsiam_security_definition()  # type: ignore[no-untyped-call]
 
-    def set_path_default_apikey_required(self, path):
+    def set_path_default_apikey_required(self, path):  # type: ignore[no-untyped-def]
         """
         Add the ApiKey security as required for each method on this path unless ApiKeyRequired
         was defined at the Function/Path/Method level. This is intended to be used to set the
@@ -709,7 +709,7 @@ class SwaggerEditor(object):
         :param string path: Path name
         """
 
-        for method_name, method_definition in self.iter_on_all_methods_for_path(path):
+        for method_name, method_definition in self.iter_on_all_methods_for_path(path):  # type: ignore[no-untyped-call]
             existing_security = method_definition.get("security", [])
             apikey_security_names = set(["api_key", "api_key_false"])
             existing_non_apikey_security = []
@@ -720,7 +720,7 @@ class SwaggerEditor(object):
             # (e.g. sigv4 (AWS_IAM), authorizers, NONE (marker for ignoring default authorizer))
             # We want to ensure only a single ApiKey security entry exists while keeping everything else
             for security in existing_security:
-                SwaggerEditor.validate_is_dict(
+                SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
                     security,
                     "{} in Security for path {} method {} is not a valid dictionary.".format(
                         security, path, method_name
@@ -750,7 +750,7 @@ class SwaggerEditor(object):
 
             # No existing ApiKey setting found or it's already set to the default
             else:
-                security_dict = Py27Dict()
+                security_dict = Py27Dict()  # type: ignore[no-untyped-call]
                 security_dict["api_key"] = []
                 apikey_security = [security_dict]
 
@@ -759,7 +759,7 @@ class SwaggerEditor(object):
             if security != existing_security:
                 method_definition["security"] = security
 
-    def add_auth_to_method(self, path, method_name, auth, api):
+    def add_auth_to_method(self, path, method_name, auth, api):  # type: ignore[no-untyped-def]
         """
         Adds auth settings for this path/method. Auth settings currently consist of Authorizers and ApiKeyRequired
         but this method will eventually include setting other auth settings such as Resource Policy, etc.
@@ -775,13 +775,13 @@ class SwaggerEditor(object):
         api_auth = api and api.get("Auth")
         authorizers = api_auth and api_auth.get("Authorizers")
         if method_authorizer:
-            self._set_method_authorizer(path, method_name, method_authorizer, authorizers, method_scopes)
+            self._set_method_authorizer(path, method_name, method_authorizer, authorizers, method_scopes)  # type: ignore[no-untyped-call]
 
         method_apikey_required = auth and auth.get("ApiKeyRequired")
         if method_apikey_required is not None:
-            self._set_method_apikey_handling(path, method_name, method_apikey_required)
+            self._set_method_apikey_handling(path, method_name, method_apikey_required)  # type: ignore[no-untyped-call]
 
-    def _set_method_authorizer(self, path, method_name, authorizer_name, authorizers=None, method_scopes=None):
+    def _set_method_authorizer(self, path, method_name, authorizer_name, authorizers=None, method_scopes=None):  # type: ignore[no-untyped-def]
         """
         Adds the authorizer_name to the security block for each method on this path.
         This is used to configure the authorizer for individual functions.
@@ -792,12 +792,12 @@ class SwaggerEditor(object):
             authorizers param.
         """
         if authorizers is None:
-            authorizers = Py27Dict()
+            authorizers = Py27Dict()  # type: ignore[no-untyped-call]
 
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
             existing_security = method_definition.get("security", [])
 
-            security_dict = Py27Dict()
+            security_dict = Py27Dict()  # type: ignore[no-untyped-call]
             security_dict[authorizer_name] = []
             authorizer_security = [security_dict]
 
@@ -805,7 +805,7 @@ class SwaggerEditor(object):
             security = existing_security + authorizer_security
 
             if authorizer_name != "NONE" and authorizers:
-                method_auth_scopes = authorizers.get(authorizer_name, Py27Dict()).get("AuthorizationScopes")
+                method_auth_scopes = authorizers.get(authorizer_name, Py27Dict()).get("AuthorizationScopes")  # type: ignore[no-untyped-call]
                 if method_scopes is not None:
                     method_auth_scopes = method_scopes
                 if authorizers.get(authorizer_name) is not None and method_auth_scopes is not None:
@@ -817,9 +817,9 @@ class SwaggerEditor(object):
                 # The first element of the method_definition['security'] should be AWS_IAM
                 # because authorizer_list = ['AWS_IAM'] is hardcoded above
                 if "AWS_IAM" in method_definition["security"][0]:
-                    self.add_awsiam_security_definition()
+                    self.add_awsiam_security_definition()  # type: ignore[no-untyped-call]
 
-    def _set_method_apikey_handling(self, path, method_name, apikey_required):
+    def _set_method_apikey_handling(self, path, method_name, apikey_required):  # type: ignore[no-untyped-def]
         """
         Adds the apikey setting to the security block for each method on this path.
         This is used to configure the authorizer for individual functions.
@@ -828,20 +828,20 @@ class SwaggerEditor(object):
         :param string method_name: Method name
         :param bool apikey_required: Whether the apikey security is required
         """
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
             existing_security = method_definition.get("security", [])
 
             if apikey_required:
                 # We want to enable apikey required security
-                security_dict = Py27Dict()
+                security_dict = Py27Dict()  # type: ignore[no-untyped-call]
                 security_dict["api_key"] = []
                 apikey_security = [security_dict]
-                self.add_apikey_security_definition()
+                self.add_apikey_security_definition()  # type: ignore[no-untyped-call]
             else:
                 # The method explicitly does NOT require apikey and there is an API default
                 # so let's add a marker 'api_key_false' so that we don't incorrectly override
                 # with the api default
-                security_dict = Py27Dict()
+                security_dict = Py27Dict()  # type: ignore[no-untyped-call]
                 security_dict["api_key_false"] = []
                 apikey_security = [security_dict]
 
@@ -851,7 +851,7 @@ class SwaggerEditor(object):
             if security != existing_security:
                 method_definition["security"] = security
 
-    def add_request_validator_to_method(self, path, method_name, validate_body=False, validate_parameters=False):
+    def add_request_validator_to_method(self, path, method_name, validate_body=False, validate_parameters=False):  # type: ignore[no-untyped-def]
         """
         Adds request model body parameter for this path/method.
 
@@ -861,28 +861,28 @@ class SwaggerEditor(object):
         :param bool validate_parameters: Validate request
         """
 
-        validator_name = SwaggerEditor.get_validator_name(validate_body, validate_parameters)
+        validator_name = SwaggerEditor.get_validator_name(validate_body, validate_parameters)  # type: ignore[no-untyped-call]
 
         # Creating validator as py27 dict
         # and insert keys one by one to preserve input order
-        request_validator_definition = Py27Dict()
-        request_validator_definition[validator_name] = Py27Dict()
+        request_validator_definition = Py27Dict()  # type: ignore[no-untyped-call]
+        request_validator_definition[validator_name] = Py27Dict()  # type: ignore[no-untyped-call]
         request_validator_definition[validator_name]["validateRequestBody"] = validate_body
         request_validator_definition[validator_name]["validateRequestParameters"] = validate_parameters
 
         if not self._doc.get(self._X_APIGW_REQUEST_VALIDATORS):
-            self._doc[self._X_APIGW_REQUEST_VALIDATORS] = Py27Dict()
+            self._doc[self._X_APIGW_REQUEST_VALIDATORS] = Py27Dict()  # type: ignore[no-untyped-call]
 
         if not self._doc[self._X_APIGW_REQUEST_VALIDATORS].get(validator_name):
             # Adding only if the validator hasn't been defined already
             self._doc[self._X_APIGW_REQUEST_VALIDATORS].update(request_validator_definition)
 
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
-            set_validator_to_method = Py27Dict({self._X_APIGW_REQUEST_VALIDATOR: validator_name})
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
+            set_validator_to_method = Py27Dict({self._X_APIGW_REQUEST_VALIDATOR: validator_name})  # type: ignore[no-untyped-call]
             # Setting validator to the given method
             method_definition.update(set_validator_to_method)
 
-    def add_request_model_to_method(self, path, method_name, request_model):
+    def add_request_model_to_method(self, path, method_name, request_model):  # type: ignore[no-untyped-def]
         """
         Adds request model body parameter for this path/method.
 
@@ -893,14 +893,14 @@ class SwaggerEditor(object):
         model_name = request_model and request_model.get("Model").lower()
         model_required = request_model and request_model.get("Required")
 
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
             if self._doc.get("swagger") is not None:
 
                 existing_parameters = method_definition.get("parameters", [])
 
                 # construct parameter as py27 dict
                 # and insert keys one by one to preserve input order
-                parameter = Py27Dict()
+                parameter = Py27Dict()  # type: ignore[no-untyped-call]
                 parameter["in"] = "body"
                 parameter["name"] = model_name
                 parameter["schema"] = {"$ref": "#/definitions/{}".format(model_name)}
@@ -912,8 +912,8 @@ class SwaggerEditor(object):
 
                 method_definition["parameters"] = existing_parameters
 
-            elif self._doc.get("openapi") and SwaggerEditor.safe_compare_regex_with_string(
-                SwaggerEditor.get_openapi_version_3_regex(), self._doc["openapi"]
+            elif self._doc.get("openapi") and SwaggerEditor.safe_compare_regex_with_string(  # type: ignore[no-untyped-call]
+                SwaggerEditor.get_openapi_version_3_regex(), self._doc["openapi"]  # type: ignore[no-untyped-call]
             ):
                 method_definition["requestBody"] = {
                     "content": {"application/json": {"schema": {"$ref": "#/components/schemas/{}".format(model_name)}}}
@@ -922,18 +922,18 @@ class SwaggerEditor(object):
                 if model_required is not None:
                     method_definition["requestBody"]["required"] = model_required
 
-    def add_gateway_responses(self, gateway_responses):
+    def add_gateway_responses(self, gateway_responses):  # type: ignore[no-untyped-def]
         """
         Add Gateway Response definitions to Swagger.
 
         :param dict gateway_responses: Dictionary of GatewayResponse configuration which gets translated.
         """
-        self.gateway_responses = self.gateway_responses or Py27Dict()
+        self.gateway_responses = self.gateway_responses or Py27Dict()  # type: ignore[no-untyped-call]
 
         for response_type, response in gateway_responses.items():
             self.gateway_responses[response_type] = response.generate_swagger()
 
-    def add_models(self, models):
+    def add_models(self, models):  # type: ignore[no-untyped-def]
         """
         Add Model definitions to Swagger.
 
@@ -941,7 +941,7 @@ class SwaggerEditor(object):
         :return:
         """
 
-        self.definitions = self.definitions or Py27Dict()
+        self.definitions = self.definitions or Py27Dict()  # type: ignore[no-untyped-call]
 
         for model_name, schema in models.items():
 
@@ -949,14 +949,14 @@ class SwaggerEditor(object):
             model_properties = schema.get("properties")
 
             if not model_type:
-                raise InvalidDocumentException([InvalidTemplateException("'Models' schema is missing 'type'.")])
+                raise InvalidDocumentException([InvalidTemplateException("'Models' schema is missing 'type'.")])  # type: ignore[no-untyped-call, no-untyped-call]
 
             if not model_properties:
-                raise InvalidDocumentException([InvalidTemplateException("'Models' schema is missing 'properties'.")])
+                raise InvalidDocumentException([InvalidTemplateException("'Models' schema is missing 'properties'.")])  # type: ignore[no-untyped-call, no-untyped-call]
 
             self.definitions[model_name.lower()] = schema
 
-    def add_resource_policy(self, resource_policy, path, stage):
+    def add_resource_policy(self, resource_policy, path, stage):  # type: ignore[no-untyped-def]
         """
         Add resource policy definition to Swagger.
 
@@ -965,7 +965,7 @@ class SwaggerEditor(object):
         """
         if resource_policy is None:
             return
-        SwaggerEditor.validate_is_dict(resource_policy, "Resource Policy is not a valid dictionary.")
+        SwaggerEditor.validate_is_dict(resource_policy, "Resource Policy is not a valid dictionary.")  # type: ignore[no-untyped-call]
 
         aws_account_whitelist = resource_policy.get("AwsAccountWhitelist")
         aws_account_blacklist = resource_policy.get("AwsAccountBlacklist")
@@ -981,25 +981,25 @@ class SwaggerEditor(object):
         source_vpce_intrinsic_blacklist = resource_policy.get("IntrinsicVpceBlacklist")
 
         if aws_account_whitelist is not None:
-            resource_list = self._get_method_path_uri_list(path, stage)
-            self._add_iam_resource_policy_for_method(aws_account_whitelist, "Allow", resource_list)
+            resource_list = self._get_method_path_uri_list(path, stage)  # type: ignore[no-untyped-call]
+            self._add_iam_resource_policy_for_method(aws_account_whitelist, "Allow", resource_list)  # type: ignore[no-untyped-call]
 
         if aws_account_blacklist is not None:
-            resource_list = self._get_method_path_uri_list(path, stage)
-            self._add_iam_resource_policy_for_method(aws_account_blacklist, "Deny", resource_list)
+            resource_list = self._get_method_path_uri_list(path, stage)  # type: ignore[no-untyped-call]
+            self._add_iam_resource_policy_for_method(aws_account_blacklist, "Deny", resource_list)  # type: ignore[no-untyped-call]
 
         if ip_range_whitelist is not None:
-            resource_list = self._get_method_path_uri_list(path, stage)
-            self._add_ip_resource_policy_for_method(ip_range_whitelist, "NotIpAddress", resource_list)
+            resource_list = self._get_method_path_uri_list(path, stage)  # type: ignore[no-untyped-call]
+            self._add_ip_resource_policy_for_method(ip_range_whitelist, "NotIpAddress", resource_list)  # type: ignore[no-untyped-call]
 
         if ip_range_blacklist is not None:
-            resource_list = self._get_method_path_uri_list(path, stage)
-            self._add_ip_resource_policy_for_method(ip_range_blacklist, "IpAddress", resource_list)
+            resource_list = self._get_method_path_uri_list(path, stage)  # type: ignore[no-untyped-call]
+            self._add_ip_resource_policy_for_method(ip_range_blacklist, "IpAddress", resource_list)  # type: ignore[no-untyped-call]
 
-        if not SwaggerEditor._validate_list_property_is_resolved(source_vpc_blacklist):
-            raise InvalidDocumentException(
+        if not SwaggerEditor._validate_list_property_is_resolved(source_vpc_blacklist):  # type: ignore[no-untyped-call]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                 [
-                    InvalidTemplateException(
+                    InvalidTemplateException(  # type: ignore[no-untyped-call]
                         "SourceVpcBlacklist must be a list of strings. Use IntrinsicVpcBlacklist instead for values that use Intrinsic Functions"
                     )
                 ]
@@ -1011,13 +1011,13 @@ class SwaggerEditor(object):
             "IntrinsicVpcList": source_vpc_intrinsic_blacklist,
             "IntrinsicVpceList": source_vpce_intrinsic_blacklist,
         }
-        resource_list = self._get_method_path_uri_list(path, stage)
-        self._add_vpc_resource_policy_for_method(blacklist_dict, "StringEquals", resource_list)
+        resource_list = self._get_method_path_uri_list(path, stage)  # type: ignore[no-untyped-call]
+        self._add_vpc_resource_policy_for_method(blacklist_dict, "StringEquals", resource_list)  # type: ignore[no-untyped-call]
 
-        if not SwaggerEditor._validate_list_property_is_resolved(source_vpc_whitelist):
-            raise InvalidDocumentException(
+        if not SwaggerEditor._validate_list_property_is_resolved(source_vpc_whitelist):  # type: ignore[no-untyped-call]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                 [
-                    InvalidTemplateException(
+                    InvalidTemplateException(  # type: ignore[no-untyped-call]
                         "SourceVpcWhitelist must be a list of strings. Use IntrinsicVpcWhitelist instead for values that use Intrinsic Functions"
                     )
                 ]
@@ -1028,16 +1028,16 @@ class SwaggerEditor(object):
             "IntrinsicVpcList": source_vpc_intrinsic_whitelist,
             "IntrinsicVpceList": source_vpce_intrinsic_whitelist,
         }
-        self._add_vpc_resource_policy_for_method(whitelist_dict, "StringNotEquals", resource_list)
+        self._add_vpc_resource_policy_for_method(whitelist_dict, "StringNotEquals", resource_list)  # type: ignore[no-untyped-call]
 
         self._doc[self._X_APIGW_POLICY] = self.resource_policy
 
-    def add_custom_statements(self, custom_statements):
-        self._add_custom_statement(custom_statements)
+    def add_custom_statements(self, custom_statements):  # type: ignore[no-untyped-def]
+        self._add_custom_statement(custom_statements)  # type: ignore[no-untyped-call]
 
         self._doc[self._X_APIGW_POLICY] = self.resource_policy
 
-    def _add_iam_resource_policy_for_method(self, policy_list, effect, resource_list):
+    def _add_iam_resource_policy_for_method(self, policy_list, effect, resource_list):  # type: ignore[no-untyped-def]
         """
         This method generates a policy statement to grant/deny specific IAM users access to the API method and
         appends it to the swagger under `x-amazon-apigateway-policy`
@@ -1047,24 +1047,24 @@ class SwaggerEditor(object):
             return
 
         if effect not in ["Allow", "Deny"]:
-            raise InvalidDocumentException(
-                [InvalidTemplateException("Effect must be one of {}".format(["Allow", "Deny"]))]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                [InvalidTemplateException("Effect must be one of {}".format(["Allow", "Deny"]))]  # type: ignore[no-untyped-call]
             )
 
         if not isinstance(policy_list, (dict, list)):
-            raise InvalidDocumentException(
-                [InvalidTemplateException("Type of '{}' must be a list or dictionary".format(policy_list))]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                [InvalidTemplateException("Type of '{}' must be a list or dictionary".format(policy_list))]  # type: ignore[no-untyped-call]
             )
 
         if not isinstance(policy_list, list):
             policy_list = [policy_list]
 
         self.resource_policy["Version"] = "2012-10-17"
-        policy_statement = Py27Dict()
+        policy_statement = Py27Dict()  # type: ignore[no-untyped-call]
         policy_statement["Effect"] = effect
         policy_statement["Action"] = "execute-api:Invoke"
         policy_statement["Resource"] = resource_list
-        policy_statement["Principal"] = Py27Dict({"AWS": policy_list})
+        policy_statement["Principal"] = Py27Dict({"AWS": policy_list})  # type: ignore[no-untyped-call]
 
         if self.resource_policy.get("Statement") is None:
             self.resource_policy["Statement"] = policy_statement
@@ -1075,18 +1075,18 @@ class SwaggerEditor(object):
             statement.extend([policy_statement])
             self.resource_policy["Statement"] = statement
 
-    def _get_method_path_uri_list(self, path, stage):
+    def _get_method_path_uri_list(self, path, stage):  # type: ignore[no-untyped-def]
         """
         It turns out that APIGW doesn't like trailing slashes in paths (#665)
         and removes as a part of their behavior, but this isn't documented.
         The regex removes the trailing slash to ensure the permission works as intended
         """
         methods = []
-        for path_item in self.get_conditional_contents(self.paths.get(path)):
+        for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             methods += list(path_item.keys())
 
         uri_list = []
-        path = SwaggerEditor.get_path_without_trailing_slash(path)
+        path = SwaggerEditor.get_path_without_trailing_slash(path)  # type: ignore[no-untyped-call]
 
         for m in methods:
             method = "*" if (m.lower() == self._X_ANY_METHOD or m.lower() == "any") else m.upper()
@@ -1094,11 +1094,11 @@ class SwaggerEditor(object):
             resource = (
                 Py27UniStr(resource) if isinstance(method, Py27UniStr) or isinstance(path, Py27UniStr) else resource
             )
-            resource = fnSub(resource, {"__Stage__": stage})
+            resource = fnSub(resource, {"__Stage__": stage})  # type: ignore[no-untyped-call]
             uri_list.extend([resource])
         return uri_list
 
-    def _add_ip_resource_policy_for_method(self, ip_list, conditional, resource_list):
+    def _add_ip_resource_policy_for_method(self, ip_list, conditional, resource_list):  # type: ignore[no-untyped-def]
         """
         This method generates a policy statement to grant/deny specific IP address ranges access to the API method and
         appends it to the swagger under `x-amazon-apigateway-policy`
@@ -1111,18 +1111,18 @@ class SwaggerEditor(object):
             ip_list = [ip_list]
 
         if conditional not in ["IpAddress", "NotIpAddress"]:
-            raise InvalidDocumentException(
-                [InvalidTemplateException("Conditional must be one of {}".format(["IpAddress", "NotIpAddress"]))]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                [InvalidTemplateException("Conditional must be one of {}".format(["IpAddress", "NotIpAddress"]))]  # type: ignore[no-untyped-call]
             )
 
         self.resource_policy["Version"] = "2012-10-17"
-        allow_statement = Py27Dict()
+        allow_statement = Py27Dict()  # type: ignore[no-untyped-call]
         allow_statement["Effect"] = "Allow"
         allow_statement["Action"] = "execute-api:Invoke"
         allow_statement["Resource"] = resource_list
         allow_statement["Principal"] = "*"
 
-        deny_statement = Py27Dict()
+        deny_statement = Py27Dict()  # type: ignore[no-untyped-call]
         deny_statement["Effect"] = "Deny"
         deny_statement["Action"] = "execute-api:Invoke"
         deny_statement["Resource"] = resource_list
@@ -1141,7 +1141,7 @@ class SwaggerEditor(object):
                 statement.extend([deny_statement])
             self.resource_policy["Statement"] = statement
 
-    def _add_vpc_resource_policy_for_method(self, endpoint_dict, conditional, resource_list):
+    def _add_vpc_resource_policy_for_method(self, endpoint_dict, conditional, resource_list):  # type: ignore[no-untyped-def]
         """
         This method generates a policy statement to grant/deny specific VPC/VPCE access to the API method and
         appends it to the swagger under `x-amazon-apigateway-policy`
@@ -1149,11 +1149,11 @@ class SwaggerEditor(object):
         """
 
         if conditional not in ["StringNotEquals", "StringEquals"]:
-            raise InvalidDocumentException(
-                [InvalidTemplateException("Conditional must be one of {}".format(["StringNotEquals", "StringEquals"]))]
+            raise InvalidDocumentException(  # type: ignore[no-untyped-call]
+                [InvalidTemplateException("Conditional must be one of {}".format(["StringNotEquals", "StringEquals"]))]  # type: ignore[no-untyped-call]
             )
 
-        condition = Py27Dict()
+        condition = Py27Dict()  # type: ignore[no-untyped-call]
         string_endpoint_list = endpoint_dict.get("StringEndpointList")
         intrinsic_vpc_endpoint_list = endpoint_dict.get("IntrinsicVpcList")
         intrinsic_vpce_endpoint_list = endpoint_dict.get("IntrinsicVpceList")
@@ -1169,26 +1169,26 @@ class SwaggerEditor(object):
                 if re.match(vpc_regex, endpoint):
                     vpc_list.append(endpoint)
             if vpc_list:
-                condition.setdefault("aws:SourceVpc", []).extend(vpc_list)
+                condition.setdefault("aws:SourceVpc", []).extend(vpc_list)  # type: ignore[no-untyped-call]
             if vpce_list:
-                condition.setdefault("aws:SourceVpce", []).extend(vpce_list)
+                condition.setdefault("aws:SourceVpce", []).extend(vpce_list)  # type: ignore[no-untyped-call]
         if intrinsic_vpc_endpoint_list is not None:
-            condition.setdefault("aws:SourceVpc", []).extend(intrinsic_vpc_endpoint_list)
+            condition.setdefault("aws:SourceVpc", []).extend(intrinsic_vpc_endpoint_list)  # type: ignore[no-untyped-call]
         if intrinsic_vpce_endpoint_list is not None:
-            condition.setdefault("aws:SourceVpce", []).extend(intrinsic_vpce_endpoint_list)
+            condition.setdefault("aws:SourceVpce", []).extend(intrinsic_vpce_endpoint_list)  # type: ignore[no-untyped-call]
 
         # Skip writing to transformed template if both vpc and vpce endpoint lists are empty
         if (not condition.get("aws:SourceVpc", [])) and (not condition.get("aws:SourceVpce", [])):
             return
 
         self.resource_policy["Version"] = "2012-10-17"
-        allow_statement = Py27Dict()
+        allow_statement = Py27Dict()  # type: ignore[no-untyped-call]
         allow_statement["Effect"] = "Allow"
         allow_statement["Action"] = "execute-api:Invoke"
         allow_statement["Resource"] = resource_list
         allow_statement["Principal"] = "*"
 
-        deny_statement = Py27Dict()
+        deny_statement = Py27Dict()  # type: ignore[no-untyped-call]
         deny_statement["Effect"] = "Deny"
         deny_statement["Action"] = "execute-api:Invoke"
         deny_statement["Resource"] = resource_list
@@ -1207,7 +1207,7 @@ class SwaggerEditor(object):
                 statement.extend([deny_statement])
             self.resource_policy["Statement"] = statement
 
-    def _add_custom_statement(self, custom_statements):
+    def _add_custom_statement(self, custom_statements):  # type: ignore[no-untyped-def]
         if custom_statements is None:
             return
 
@@ -1227,7 +1227,7 @@ class SwaggerEditor(object):
                     statement.append(s)
             self.resource_policy["Statement"] = statement
 
-    def add_request_parameters_to_method(self, path, method_name, request_parameters):
+    def add_request_parameters_to_method(self, path, method_name, request_parameters):  # type: ignore[no-untyped-def]
         """
         Add Parameters to Swagger.
 
@@ -1237,7 +1237,7 @@ class SwaggerEditor(object):
         :return:
         """
 
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):  # type: ignore[no-untyped-call]
             existing_parameters = method_definition.get("parameters", [])
 
             for request_parameter in request_parameters:
@@ -1252,7 +1252,7 @@ class SwaggerEditor(object):
 
                 # create parameter as py27 dict
                 # and insert keys one by one to preserve input orders
-                parameter = Py27Dict()
+                parameter = Py27Dict()  # type: ignore[no-untyped-call]
                 parameter["in"] = location
                 parameter["name"] = name
                 parameter["required"] = request_parameter["Required"]
@@ -1270,7 +1270,7 @@ class SwaggerEditor(object):
             method_definition["parameters"] = existing_parameters
 
     @property
-    def swagger(self):
+    def swagger(self):  # type: ignore[no-untyped-def]
         """
         Returns a **copy** of the Swagger document as a dictionary.
 
@@ -1293,7 +1293,7 @@ class SwaggerEditor(object):
         return copy.deepcopy(self._doc)
 
     @staticmethod
-    def is_valid(data):
+    def is_valid(data):  # type: ignore[no-untyped-def]
         """
         Checks if the input data is a Swagger document
 
@@ -1305,13 +1305,13 @@ class SwaggerEditor(object):
             if bool(data.get("swagger")):
                 return True
             if bool(data.get("openapi")):
-                return SwaggerEditor.safe_compare_regex_with_string(
-                    SwaggerEditor.get_openapi_version_3_regex(), data["openapi"]
+                return SwaggerEditor.safe_compare_regex_with_string(  # type: ignore[no-untyped-call]
+                    SwaggerEditor.get_openapi_version_3_regex(), data["openapi"]  # type: ignore[no-untyped-call]
                 )
         return False
 
     @staticmethod
-    def validate_is_dict(obj, exception_message):
+    def validate_is_dict(obj, exception_message):  # type: ignore[no-untyped-def]
         """
         Throws exception if obj is not a dict
 
@@ -1320,10 +1320,10 @@ class SwaggerEditor(object):
         """
 
         if not isinstance(obj, dict):
-            raise InvalidDocumentException([InvalidTemplateException(exception_message)])
+            raise InvalidDocumentException([InvalidTemplateException(exception_message)])  # type: ignore[no-untyped-call, no-untyped-call]
 
     @staticmethod
-    def validate_path_item_is_dict(path_item, path):
+    def validate_path_item_is_dict(path_item, path):  # type: ignore[no-untyped-def]
         """
         Throws exception if path_item is not a dict
 
@@ -1331,27 +1331,27 @@ class SwaggerEditor(object):
         :param path: path name
         """
 
-        SwaggerEditor.validate_is_dict(
+        SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
             path_item, "Value of '{}' path must be a dictionary according to Swagger spec.".format(path)
         )
 
     @staticmethod
-    def gen_skeleton():
+    def gen_skeleton():  # type: ignore[no-untyped-def]
         """
         Method to make an empty swagger file, with just some basic structure. Just enough to pass validator.
 
         :return dict: Dictionary of a skeleton swagger document
         """
-        skeleton = Py27Dict()
+        skeleton = Py27Dict()  # type: ignore[no-untyped-call]
         skeleton["swagger"] = "2.0"
-        skeleton["info"] = Py27Dict()
+        skeleton["info"] = Py27Dict()  # type: ignore[no-untyped-call]
         skeleton["info"]["version"] = "1.0"
-        skeleton["info"]["title"] = ref("AWS::StackName")
-        skeleton["paths"] = Py27Dict()
+        skeleton["info"]["title"] = ref("AWS::StackName")  # type: ignore[no-untyped-call]
+        skeleton["paths"] = Py27Dict()  # type: ignore[no-untyped-call]
         return skeleton
 
     @staticmethod
-    def _get_authorization_scopes(authorizers, default_authorizer):
+    def _get_authorization_scopes(authorizers, default_authorizer):  # type: ignore[no-untyped-def]
         """
         Returns auth scopes for an authorizer if present
         :param authorizers: authorizer definitions
@@ -1366,7 +1366,7 @@ class SwaggerEditor(object):
         return []
 
     @staticmethod
-    def _normalize_method_name(method):
+    def _normalize_method_name(method):  # type: ignore[no-untyped-def]
         """
         Returns a lower case, normalized version of HTTP Method. It also know how to handle API Gateway specific methods
         like "ANY"
@@ -1385,21 +1385,21 @@ class SwaggerEditor(object):
         return method
 
     @staticmethod
-    def get_openapi_versions_supported_regex():
+    def get_openapi_versions_supported_regex():  # type: ignore[no-untyped-def]
         openapi_version_supported_regex = r"\A[2-3](\.\d)(\.\d)?$"
         return openapi_version_supported_regex
 
     @staticmethod
-    def get_openapi_version_3_regex():
+    def get_openapi_version_3_regex():  # type: ignore[no-untyped-def]
         openapi_version_3_regex = r"\A3(\.\d)(\.\d)?$"
         return openapi_version_3_regex
 
     @staticmethod
-    def safe_compare_regex_with_string(regex, data):
+    def safe_compare_regex_with_string(regex, data):  # type: ignore[no-untyped-def]
         return re.match(regex, str(data)) is not None
 
     @staticmethod
-    def get_path_without_trailing_slash(path):
+    def get_path_without_trailing_slash(path):  # type: ignore[no-untyped-def]
         # convert greedy paths to such as {greedy+}, {proxy+} to "*"
         sub = re.sub(r"{([a-zA-Z0-9._-]+|[a-zA-Z0-9._-]+\+|proxy\+)}", "*", path)
         if isinstance(path, Py27UniStr):
@@ -1407,7 +1407,7 @@ class SwaggerEditor(object):
         return sub
 
     @staticmethod
-    def get_validator_name(validate_body, validate_parameters):
+    def get_validator_name(validate_body, validate_parameters):  # type: ignore[no-untyped-def]
         """
         Get a readable path name to use as validator name
 
@@ -1427,7 +1427,7 @@ class SwaggerEditor(object):
         return "no-validation"
 
     @staticmethod
-    def _validate_list_property_is_resolved(property_list):
+    def _validate_list_property_is_resolved(property_list):  # type: ignore[no-untyped-def]
         """
         Validate if the values of a Property List are all of type string
 

--- a/samtranslator/third_party/py27hash/hash.py
+++ b/samtranslator/third_party/py27hash/hash.py
@@ -8,7 +8,7 @@ import ctypes
 import math
 
 
-def hash27(value):
+def hash27(value):  # type: ignore[no-untyped-def]
     """
     Wrapper call to Hash.hash()
 
@@ -19,7 +19,7 @@ def hash27(value):
         Python 2.7 hash
     """
 
-    return Hash.hash(value)
+    return Hash.hash(value)  # type: ignore[no-untyped-call]
 
 
 class Hash(object):
@@ -28,7 +28,7 @@ class Hash(object):
     """
 
     @staticmethod
-    def hash(value):
+    def hash(value):  # type: ignore[no-untyped-def]
         """
         Returns a Python 2.7 hash for a value.
 
@@ -40,18 +40,18 @@ class Hash(object):
         """
 
         if isinstance(value, tuple):
-            return Hash.thash(value)
+            return Hash.thash(value)  # type: ignore[no-untyped-call]
         if isinstance(value, float):
-            return Hash.fhash(value)
+            return Hash.fhash(value)  # type: ignore[no-untyped-call]
         if isinstance(value, int):
             return hash(value)
         if isinstance(value, ("".__class__, bytes)) or type(value).__name__ == "buffer":
-            return Hash.shash(value)
+            return Hash.shash(value)  # type: ignore[no-untyped-call]
 
         raise TypeError("unhashable type: '%s'" % (type(value).__name__))
 
     @staticmethod
-    def thash(value):
+    def thash(value):  # type: ignore[no-untyped-def]
         """
         Returns a Python 2.7 hash for a tuple.
 
@@ -73,7 +73,7 @@ class Hash(object):
         for y in value:
             length -= 1
 
-            y = Hash.hash(y)
+            y = Hash.hash(y)  # type: ignore[no-untyped-call]
             x = (x ^ y) * mult
             mult += 82520 + length + length
 
@@ -86,7 +86,7 @@ class Hash(object):
         return ctypes.c_long(x).value
 
     @staticmethod
-    def fhash(value):
+    def fhash(value):  # type: ignore[no-untyped-def]
         """
         Returns a Python 2.7 hash for a float.
 
@@ -123,7 +123,7 @@ class Hash(object):
         return ctypes.c_long(x).value
 
     @staticmethod
-    def shash(value):
+    def shash(value):  # type: ignore[no-untyped-def]
         """
         Returns a Python 2.7 hash for a string.
 
@@ -142,9 +142,9 @@ class Hash(object):
         if length == 0:
             return 0
 
-        x = Hash.ordinal(value[0]) << 7
+        x = Hash.ordinal(value[0]) << 7  # type: ignore[no-untyped-call]
         for c in value:
-            x = (1000003 * x) ^ Hash.ordinal(c)
+            x = (1000003 * x) ^ Hash.ordinal(c)  # type: ignore[no-untyped-call]
 
         x ^= length
         x &= 0xFFFFFFFFFFFFFFFF
@@ -155,7 +155,7 @@ class Hash(object):
         return ctypes.c_long(x).value
 
     @staticmethod
-    def ordinal(value):
+    def ordinal(value):  # type: ignore[no-untyped-def]
         """
         Converts value to an ordinal or returns the input value if it's an int.
 

--- a/samtranslator/translator/arn_generator.py
+++ b/samtranslator/translator/arn_generator.py
@@ -9,7 +9,7 @@ class ArnGenerator(object):
     BOTO_SESSION_REGION_NAME = None
 
     @classmethod
-    def generate_arn(cls, partition, service, resource, include_account_id=True):
+    def generate_arn(cls, partition, service, resource, include_account_id=True):  # type: ignore[no-untyped-def]
         if not service or not resource:
             raise RuntimeError("Could not construct ARN for resource.")
 
@@ -23,7 +23,7 @@ class ArnGenerator(object):
         return arn.format(partition, service, resource)
 
     @classmethod
-    def generate_aws_managed_policy_arn(cls, policy_name):
+    def generate_aws_managed_policy_arn(cls, policy_name):  # type: ignore[no-untyped-def]
         """
         Method to create an ARN of AWS Owned Managed Policy. This uses the right partition name to construct
         the ARN
@@ -31,10 +31,10 @@ class ArnGenerator(object):
         :param policy_name: Name of the policy
         :return: ARN Of the managed policy
         """
-        return "arn:{}:iam::aws:policy/{}".format(ArnGenerator.get_partition_name(), policy_name)
+        return "arn:{}:iam::aws:policy/{}".format(ArnGenerator.get_partition_name(), policy_name)  # type: ignore[no-untyped-call]
 
     @classmethod
-    def get_partition_name(cls, region=None):
+    def get_partition_name(cls, region=None):  # type: ignore[no-untyped-def]
         """
         Gets the name of the partition given the region name. If region name is not provided, this method will
         use Boto3 to get name of the region where this code is running.
@@ -53,7 +53,7 @@ class ArnGenerator(object):
             if ArnGenerator.BOTO_SESSION_REGION_NAME is None:
                 region = boto3.session.Session().region_name
             else:
-                region = ArnGenerator.BOTO_SESSION_REGION_NAME
+                region = ArnGenerator.BOTO_SESSION_REGION_NAME  # type: ignore[unreachable]
 
         # If region is still None, then we could not find the region. This will only happen
         # in the local context. When this is deployed, we will be able to find the region like

--- a/samtranslator/translator/logical_id_generator.py
+++ b/samtranslator/translator/logical_id_generator.py
@@ -9,7 +9,7 @@ class LogicalIdGenerator(object):
     #       given by this class
     HASH_LENGTH = 10
 
-    def __init__(self, prefix, data_obj=None, data_hash=None):
+    def __init__(self, prefix, data_obj=None, data_hash=None):  # type: ignore[no-untyped-def]
         """
         Generate logical IDs for resources that are stable, deterministic and platform independent
 
@@ -20,13 +20,13 @@ class LogicalIdGenerator(object):
 
         data_str = ""
         if data_obj:
-            data_str = self._stringify(data_obj)
+            data_str = self._stringify(data_obj)  # type: ignore[no-untyped-call]
 
         self._prefix = prefix
         self.data_str = data_str
         self.data_hash = data_hash
 
-    def gen(self):
+    def gen(self):  # type: ignore[no-untyped-def]
         """
         Generate stable LogicalIds based on the prefix and given data. This method ensures that the logicalId is
         deterministic and stable based on input prefix & data object. In other words:
@@ -44,10 +44,10 @@ class LogicalIdGenerator(object):
         :rtype string
         """
 
-        data_hash = self.get_hash()
+        data_hash = self.get_hash()  # type: ignore[no-untyped-call]
         return "{prefix}{hash}".format(prefix=self._prefix, hash=data_hash)
 
-    def get_hash(self, length=HASH_LENGTH):
+    def get_hash(self, length=HASH_LENGTH):  # type: ignore[no-untyped-def]
         """
         Generate and return a hash of data that can be used as suffix of logicalId
 
@@ -65,17 +65,17 @@ class LogicalIdGenerator(object):
         encoded_data_str = self.data_str
         if sys.version_info.major == 2:
             # In Py2, only unicode needs to be encoded.
-            if isinstance(self.data_str, unicode):  # pylint: disable=E0602
+            if isinstance(self.data_str, unicode):  # type: ignore[name-defined] # pylint: disable=E0602
                 encoded_data_str = self.data_str.encode("utf-8")
         else:
             # data_str should always be unicode on python 3
-            encoded_data_str = self.data_str.encode("utf-8")
+            encoded_data_str = self.data_str.encode("utf-8")  # type: ignore[assignment]
 
-        data_hash = hashlib.sha1(encoded_data_str).hexdigest()
+        data_hash = hashlib.sha1(encoded_data_str).hexdigest()  # type: ignore[arg-type]
 
         return data_hash[:length]
 
-    def _stringify(self, data):
+    def _stringify(self, data):  # type: ignore[no-untyped-def]
         """
         Stable, platform & language-independent stringification of a data with basic Python type.
 

--- a/samtranslator/translator/managed_policy_translator.py
+++ b/samtranslator/translator/managed_policy_translator.py
@@ -6,13 +6,13 @@ LOG = logging.getLogger(__name__)
 
 
 class ManagedPolicyLoader(object):
-    def __init__(self, iam_client):
+    def __init__(self, iam_client):  # type: ignore[no-untyped-def]
         self._iam_client = iam_client
         self._policy_map = None
         self.max_items = 1000
 
-    @cw_timer(prefix="External", name="IAM")
-    def _load_policies_from_iam(self):
+    @cw_timer(prefix="External", name="IAM")  # type: ignore[no-untyped-call]
+    def _load_policies_from_iam(self):  # type: ignore[no-untyped-def]
         LOG.info("Loading policies from IAM...")
 
         paginator = self._iam_client.get_paginator("list_policies")
@@ -22,7 +22,7 @@ class ManagedPolicyLoader(object):
         # Note(jfuss): boto3 PaginationConfig MaxItems does not control the number of items returned from the API
         # call. This is actually controlled by PageSize.
         page_iterator = paginator.paginate(Scope="AWS", PaginationConfig={"PageSize": self.max_items})
-        name_to_arn_map = {}
+        name_to_arn_map = {}  # type: ignore[var-annotated]
 
         for page in page_iterator:
             name_to_arn_map.update(map(lambda x: (x["PolicyName"], x["Arn"]), page["Policies"]))
@@ -30,7 +30,7 @@ class ManagedPolicyLoader(object):
         LOG.info("Finished loading policies from IAM.")
         self._policy_map = name_to_arn_map
 
-    def load(self):
+    def load(self):  # type: ignore[no-untyped-def]
         if self._policy_map is None:
             self._load_policies_from_iam()
         return self._policy_map

--- a/samtranslator/translator/transform.py
+++ b/samtranslator/translator/transform.py
@@ -3,7 +3,7 @@ from samtranslator.parser.parser import Parser
 from samtranslator.utils.py27hash_fix import to_py27_compatible_template, undo_mark_unicode_str_in_template
 
 
-def transform(input_fragment, parameter_values, managed_policy_loader, feature_toggle=None, passthrough_metadata=False):
+def transform(input_fragment, parameter_values, managed_policy_loader, feature_toggle=None, passthrough_metadata=False):  # type: ignore[no-untyped-def]
     """Translates the SAM manifest provided in the and returns the translation to CloudFormation.
 
     :param dict input_fragment: the SAM template to transform
@@ -12,14 +12,14 @@ def transform(input_fragment, parameter_values, managed_policy_loader, feature_t
     :rtype: dict
     """
 
-    sam_parser = Parser()
-    to_py27_compatible_template(input_fragment, parameter_values)
-    translator = Translator(managed_policy_loader.load(), sam_parser)
-    transformed = translator.translate(
+    sam_parser = Parser()  # type: ignore[no-untyped-call]
+    to_py27_compatible_template(input_fragment, parameter_values)  # type: ignore[no-untyped-call]
+    translator = Translator(managed_policy_loader.load(), sam_parser)  # type: ignore[no-untyped-call]
+    transformed = translator.translate(  # type: ignore[no-untyped-call]
         input_fragment,
         parameter_values=parameter_values,
         feature_toggle=feature_toggle,
         passthrough_metadata=passthrough_metadata,
     )
-    transformed = undo_mark_unicode_str_in_template(transformed)
+    transformed = undo_mark_unicode_str_in_template(transformed)  # type: ignore[no-untyped-call]
     return transformed

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -36,7 +36,7 @@ from samtranslator.model.eventsources.push import Api
 class Translator:
     """Translates SAM templates into CloudFormation templates"""
 
-    def __init__(self, managed_policy_map, sam_parser, plugins=None, boto_session=None, metrics=None):
+    def __init__(self, managed_policy_map, sam_parser, plugins=None, boto_session=None, metrics=None):  # type: ignore[no-untyped-def]
         """
         :param dict managed_policy_map: Map of managed policy names to the ARNs
         :param sam_parser: Instance of a SAM Parser
@@ -48,14 +48,14 @@ class Translator:
         self.sam_parser = sam_parser
         self.feature_toggle = None
         self.boto_session = boto_session
-        self.metrics = metrics if metrics else Metrics("ServerlessTransform", DummyMetricsPublisher())
-        MetricsMethodWrapperSingleton.set_instance(self.metrics)
+        self.metrics = metrics if metrics else Metrics("ServerlessTransform", DummyMetricsPublisher())  # type: ignore[no-untyped-call, no-untyped-call]
+        MetricsMethodWrapperSingleton.set_instance(self.metrics)  # type: ignore[no-untyped-call]
         self._translated_resouce_mapping = {}
 
         if self.boto_session:
             ArnGenerator.BOTO_SESSION_REGION_NAME = self.boto_session.region_name
 
-    def _get_function_names(self, resource_dict, intrinsics_resolver):
+    def _get_function_names(self, resource_dict, intrinsics_resolver):  # type: ignore[no-untyped-def]
         """
         :param resource_dict: AWS::Serverless::Function resource is provided as input
         :param intrinsics_resolver: to resolve intrinsics for function_name
@@ -71,7 +71,7 @@ class Translator:
                 item_properties = item.get("Properties", {})
                 if item.get("Type") == "Api" and item_properties.get("RestApiId"):
                     rest_api = item_properties.get("RestApiId")
-                    api_name = Api.get_rest_api_id_string(rest_api)
+                    api_name = Api.get_rest_api_id_string(rest_api)  # type: ignore[no-untyped-call]
                     if isinstance(api_name, str):
                         resource_dict_copy = copy.deepcopy(resource_dict)
                         function_name = intrinsics_resolver.resolve_parameter_refs(
@@ -83,7 +83,7 @@ class Translator:
                             )
         return self.function_names
 
-    def translate(self, sam_template, parameter_values, feature_toggle=None, passthrough_metadata=False):
+    def translate(self, sam_template, parameter_values, feature_toggle=None, passthrough_metadata=False):  # type: ignore[no-untyped-def]
         """Loads the SAM resources from the given SAM manifest, replaces them with their corresponding
         CloudFormation resources, and returns the resulting CloudFormation template.
 
@@ -101,39 +101,39 @@ class Translator:
         self.feature_toggle = (
             feature_toggle
             if feature_toggle
-            else FeatureToggle(FeatureToggleDefaultConfigProvider(), stage=None, account_id=None, region=None)
+            else FeatureToggle(FeatureToggleDefaultConfigProvider(), stage=None, account_id=None, region=None)  # type: ignore[no-untyped-call, no-untyped-call]
         )
         self.function_names = {}
         self.redeploy_restapi_parameters = {}
-        sam_parameter_values = SamParameterValues(parameter_values)
-        sam_parameter_values.add_default_parameter_values(sam_template)
-        sam_parameter_values.add_pseudo_parameter_values(self.boto_session)
+        sam_parameter_values = SamParameterValues(parameter_values)  # type: ignore[no-untyped-call]
+        sam_parameter_values.add_default_parameter_values(sam_template)  # type: ignore[no-untyped-call]
+        sam_parameter_values.add_pseudo_parameter_values(self.boto_session)  # type: ignore[no-untyped-call]
         parameter_values = sam_parameter_values.parameter_values
         # Create & Install plugins
-        sam_plugins = prepare_plugins(self.plugins, parameter_values)
+        sam_plugins = prepare_plugins(self.plugins, parameter_values)  # type: ignore[no-untyped-call]
 
         self.sam_parser.parse(sam_template=sam_template, parameter_values=parameter_values, sam_plugins=sam_plugins)
 
         template = copy.deepcopy(sam_template)
-        macro_resolver = ResourceTypeResolver(sam_resources)
-        intrinsics_resolver = IntrinsicsResolver(parameter_values)
+        macro_resolver = ResourceTypeResolver(sam_resources)  # type: ignore[no-untyped-call]
+        intrinsics_resolver = IntrinsicsResolver(parameter_values)  # type: ignore[no-untyped-call]
 
         # ResourceResolver is used by connector, its "resources" will be
         # updated in-place by other transforms so connector transform
         # can see the transformed resources.
         resource_resolver = ResourceResolver(template.get("Resources", {}))
-        mappings_resolver = IntrinsicsResolver(
-            template.get("Mappings", {}), {FindInMapAction.intrinsic_name: FindInMapAction()}
+        mappings_resolver = IntrinsicsResolver(  # type: ignore[no-untyped-call]
+            template.get("Mappings", {}), {FindInMapAction.intrinsic_name: FindInMapAction()}  # type: ignore[no-untyped-call]
         )
-        deployment_preference_collection = DeploymentPreferenceCollection()
-        supported_resource_refs = SupportedResourceReferences()
-        shared_api_usage_plan = SharedApiUsagePlan()
+        deployment_preference_collection = DeploymentPreferenceCollection()  # type: ignore[no-untyped-call]
+        supported_resource_refs = SupportedResourceReferences()  # type: ignore[no-untyped-call]
+        shared_api_usage_plan = SharedApiUsagePlan()  # type: ignore[no-untyped-call]
         document_errors = []
         changed_logical_ids = {}
-        route53_record_set_groups = {}
-        for logical_id, resource_dict in self._get_resources_to_iterate(sam_template, macro_resolver):
+        route53_record_set_groups = {}  # type: ignore[var-annotated]
+        for logical_id, resource_dict in self._get_resources_to_iterate(sam_template, macro_resolver):  # type: ignore[no-untyped-call]
             try:
-                macro = macro_resolver.resolve_resource_type(resource_dict).from_dict(
+                macro = macro_resolver.resolve_resource_type(resource_dict).from_dict(  # type: ignore[no-untyped-call]
                     logical_id, resource_dict, sam_plugins=sam_plugins
                 )
 
@@ -146,7 +146,7 @@ class Translator:
                 kwargs["resource_resolver"] = resource_resolver
                 kwargs["original_template"] = sam_template
                 # add the value of FunctionName property if the function is referenced with the api resource
-                self.redeploy_restapi_parameters["function_names"] = self._get_function_names(
+                self.redeploy_restapi_parameters["function_names"] = self._get_function_names(  # type: ignore[no-untyped-call]
                     resource_dict, intrinsics_resolver
                 )
                 kwargs["redeploy_restapi_parameters"] = self.redeploy_restapi_parameters
@@ -162,7 +162,7 @@ class Translator:
 
                 del template["Resources"][logical_id]
                 for resource in translated:
-                    if verify_unique_logical_id(resource, sam_template["Resources"]):
+                    if verify_unique_logical_id(resource, sam_template["Resources"]):  # type: ignore[no-untyped-call]
                         # For each generated resource, pass through existing metadata that may exist on the original SAM resource.
                         _r = resource.to_dict()
                         if resource_dict.get("Metadata") and passthrough_metadata:
@@ -171,47 +171,47 @@ class Translator:
                         template["Resources"].update(_r)
                     else:
                         document_errors.append(
-                            DuplicateLogicalIdException(logical_id, resource.logical_id, resource.resource_type)
+                            DuplicateLogicalIdException(logical_id, resource.logical_id, resource.resource_type)  # type: ignore[no-untyped-call]
                         )
             except (InvalidResourceException, InvalidEventException, InvalidTemplateException) as e:
-                document_errors.append(e)
+                document_errors.append(e)  # type: ignore[arg-type]
 
-        if deployment_preference_collection.any_enabled():
-            template["Resources"].update(deployment_preference_collection.get_codedeploy_application().to_dict())
-            if deployment_preference_collection.needs_resource_condition():
-                new_conditions = deployment_preference_collection.create_aggregate_deployment_condition()
+        if deployment_preference_collection.any_enabled():  # type: ignore[no-untyped-call]
+            template["Resources"].update(deployment_preference_collection.get_codedeploy_application().to_dict())  # type: ignore[no-untyped-call]
+            if deployment_preference_collection.needs_resource_condition():  # type: ignore[no-untyped-call]
+                new_conditions = deployment_preference_collection.create_aggregate_deployment_condition()  # type: ignore[no-untyped-call]
                 if new_conditions:
                     template.get("Conditions").update(new_conditions)
 
-            if not deployment_preference_collection.can_skip_service_role():
-                template["Resources"].update(deployment_preference_collection.get_codedeploy_iam_role().to_dict())
+            if not deployment_preference_collection.can_skip_service_role():  # type: ignore[no-untyped-call]
+                template["Resources"].update(deployment_preference_collection.get_codedeploy_iam_role().to_dict())  # type: ignore[no-untyped-call]
 
-            for logical_id in deployment_preference_collection.enabled_logical_ids():
+            for logical_id in deployment_preference_collection.enabled_logical_ids():  # type: ignore[no-untyped-call]
                 try:
                     template["Resources"].update(
-                        deployment_preference_collection.deployment_group(logical_id).to_dict()
+                        deployment_preference_collection.deployment_group(logical_id).to_dict()  # type: ignore[no-untyped-call]
                     )
                 except InvalidResourceException as e:
-                    document_errors.append(e)
+                    document_errors.append(e)  # type: ignore[arg-type]
 
         # Run the after-transform plugin target
         try:
             sam_plugins.act(LifeCycleEvents.after_transform_template, template)
         except (InvalidDocumentException, InvalidResourceException, InvalidTemplateException) as e:
-            document_errors.append(e)
+            document_errors.append(e)  # type: ignore[arg-type]
 
         # Cleanup
         if "Transform" in template:
             del template["Transform"]
 
         if len(document_errors) == 0:
-            template = intrinsics_resolver.resolve_sam_resource_id_refs(template, changed_logical_ids)
-            template = intrinsics_resolver.resolve_sam_resource_refs(template, supported_resource_refs)
+            template = intrinsics_resolver.resolve_sam_resource_id_refs(template, changed_logical_ids)  # type: ignore[no-untyped-call]
+            template = intrinsics_resolver.resolve_sam_resource_refs(template, supported_resource_refs)  # type: ignore[no-untyped-call]
             return template
-        raise InvalidDocumentException(document_errors)
+        raise InvalidDocumentException(document_errors)  # type: ignore[no-untyped-call]
 
     # private methods
-    def _get_resources_to_iterate(self, sam_template, macro_resolver):
+    def _get_resources_to_iterate(self, sam_template, macro_resolver):  # type: ignore[no-untyped-def]
         """
         Returns a list of resources to iterate, order them based on the following order:
 
@@ -257,7 +257,7 @@ class Translator:
         return functions + statemachines + apis + others + connectors
 
 
-def prepare_plugins(plugins, parameters=None):
+def prepare_plugins(plugins, parameters=None):  # type: ignore[no-untyped-def]
     """
     Creates & returns a plugins object with the given list of plugins installed. In addition to the given plugins,
     we will also install a few "required" plugins that are necessary to provide complete support for SAM template spec.
@@ -270,45 +270,45 @@ def prepare_plugins(plugins, parameters=None):
     if parameters is None:
         parameters = {}
     required_plugins = [
-        DefaultDefinitionBodyPlugin(),
-        make_implicit_rest_api_plugin(),
-        make_implicit_http_api_plugin(),
-        GlobalsPlugin(),
-        make_policy_template_for_function_plugin(),
+        DefaultDefinitionBodyPlugin(),  # type: ignore[no-untyped-call]
+        make_implicit_rest_api_plugin(),  # type: ignore[no-untyped-call]
+        make_implicit_http_api_plugin(),  # type: ignore[no-untyped-call]
+        GlobalsPlugin(),  # type: ignore[no-untyped-call]
+        make_policy_template_for_function_plugin(),  # type: ignore[no-untyped-call]
     ]
 
     plugins = [] if not plugins else plugins
 
     # If a ServerlessAppPlugin does not yet exist, create one and add to the beginning of the required plugins list.
     if not any(isinstance(plugin, ServerlessAppPlugin) for plugin in plugins):
-        required_plugins.insert(0, ServerlessAppPlugin(parameters=parameters))
+        required_plugins.insert(0, ServerlessAppPlugin(parameters=parameters))  # type: ignore[no-untyped-call]
 
     # Execute customer's plugins first before running SAM plugins. It is very important to retain this order because
     # other plugins will be dependent on this ordering.
-    return SamPlugins(plugins + required_plugins)
+    return SamPlugins(plugins + required_plugins)  # type: ignore[no-untyped-call]
 
 
-def make_implicit_rest_api_plugin():
+def make_implicit_rest_api_plugin():  # type: ignore[no-untyped-def]
     # This is necessary to prevent a circular dependency on imports when loading package
     from samtranslator.plugins.api.implicit_rest_api_plugin import ImplicitRestApiPlugin
 
-    return ImplicitRestApiPlugin()
+    return ImplicitRestApiPlugin()  # type: ignore[no-untyped-call]
 
 
-def make_implicit_http_api_plugin():
+def make_implicit_http_api_plugin():  # type: ignore[no-untyped-def]
     # This is necessary to prevent a circular dependency on imports when loading package
     from samtranslator.plugins.api.implicit_http_api_plugin import ImplicitHttpApiPlugin
 
-    return ImplicitHttpApiPlugin()
+    return ImplicitHttpApiPlugin()  # type: ignore[no-untyped-call]
 
 
-def make_policy_template_for_function_plugin():
+def make_policy_template_for_function_plugin():  # type: ignore[no-untyped-def]
     """
     Constructs an instance of policy templates processing plugin using default policy templates JSON data
 
     :return plugins.policies.policy_templates_plugin.PolicyTemplatesForResourcePlugin: Instance of the plugin
     """
 
-    policy_templates = PolicyTemplatesProcessor.get_default_policy_templates_json()
-    processor = PolicyTemplatesProcessor(policy_templates)
-    return PolicyTemplatesForResourcePlugin(processor)
+    policy_templates = PolicyTemplatesProcessor.get_default_policy_templates_json()  # type: ignore[no-untyped-call]
+    processor = PolicyTemplatesProcessor(policy_templates)  # type: ignore[no-untyped-call]
+    return PolicyTemplatesForResourcePlugin(processor)  # type: ignore[no-untyped-call]

--- a/samtranslator/translator/verify_logical_id.py
+++ b/samtranslator/translator/verify_logical_id.py
@@ -15,7 +15,7 @@ do_not_verify = {
 }
 
 
-def verify_unique_logical_id(resource, existing_resources):
+def verify_unique_logical_id(resource, existing_resources):  # type: ignore[no-untyped-def]
     # new resource logicalid exists in the template before transform
     if resource.logical_id is not None and resource.logical_id in existing_resources:
         # new resource logicalid is in  the do_not_resolve list

--- a/samtranslator/utils/cfn_dynamic_references.py
+++ b/samtranslator/utils/cfn_dynamic_references.py
@@ -1,7 +1,7 @@
 import re
 
 
-def is_dynamic_reference(input):
+def is_dynamic_reference(input):  # type: ignore[no-untyped-def]
     """
     Checks if the given input is a dynamic reference. Dynamic references follow the pattern '{{resolve:service-name:reference-key}}'
 

--- a/samtranslator/utils/py27hash_fix.py
+++ b/samtranslator/utils/py27hash_fix.py
@@ -21,7 +21,7 @@ unicode_string_type = str  # TODO: remove it, python 2 legacy code
 long_int_type = int  # TODO: remove it, python 2 legacy code
 
 
-def to_py27_compatible_template(template, parameter_values=None):
+def to_py27_compatible_template(template, parameter_values=None):  # type: ignore[no-untyped-def]
     """
     Convert an input template to a py27hash-compatible template. This function has to be run before any
     manipulation occurs for sake of keeping the same initial state. This function modifies the input template,
@@ -43,9 +43,9 @@ def to_py27_compatible_template(template, parameter_values=None):
     # Passing to parser for a simple validation. Validation is normally done within translator.translate(...).
     # However, becuase this conversion is done before translate and also requires the template to be valid, we
     # perform a simple validation here to just make sure the template is minimally safe for conversion.
-    Parser.validate_datatypes(template)
+    Parser.validate_datatypes(template)  # type: ignore[no-untyped-call]
 
-    if not _template_has_api_resource(template) and not _template_has_httpapi_resource_with_default_authorizer(
+    if not _template_has_api_resource(template) and not _template_has_httpapi_resource_with_default_authorizer(  # type: ignore[no-untyped-call, no-untyped-call]
         template
     ):
         # no need to convert when all of the following conditions are true:
@@ -55,20 +55,20 @@ def to_py27_compatible_template(template, parameter_values=None):
 
     if "Globals" in template and isinstance(template["Globals"], dict) and "Api" in template["Globals"]:
         # "Api" section under "Globals" could affect swagger generation for AWS::Serverless::Api resources
-        template["Globals"]["Api"] = _convert_to_py27_type(template["Globals"]["Api"])
+        template["Globals"]["Api"] = _convert_to_py27_type(template["Globals"]["Api"])  # type: ignore[no-untyped-call]
 
     if "Parameters" in template and isinstance(template["Parameters"], dict):
-        new_parameters_dict = Py27Dict()
+        new_parameters_dict = Py27Dict()  # type: ignore[no-untyped-call]
         for logical_id, param_dict in template["Parameters"].items():
             if isinstance(param_dict, dict) and "Default" in param_dict:
-                param_dict["Default"] = _convert_to_py27_type(param_dict["Default"])
+                param_dict["Default"] = _convert_to_py27_type(param_dict["Default"])  # type: ignore[no-untyped-call]
 
             # dict keys have to be Py27UniStr for correct serialization
             new_parameters_dict[Py27UniStr(logical_id)] = param_dict
         template["Parameters"] = new_parameters_dict
 
     if "Resources" in template and isinstance(template["Resources"], dict):
-        new_resources_dict = Py27Dict()
+        new_resources_dict = Py27Dict()  # type: ignore[no-untyped-call]
         for logical_id, resource_dict in template["Resources"].items():
             if isinstance(resource_dict, dict):
                 resource_type = resource_dict.get("Type")
@@ -79,27 +79,27 @@ def to_py27_compatible_template(template, parameter_values=None):
                         "AWS::Serverless::Api",
                         "AWS::Serverless::HttpApi",
                     ]:
-                        resource_dict["Properties"] = _convert_to_py27_type(resource_properties)
+                        resource_dict["Properties"] = _convert_to_py27_type(resource_properties)  # type: ignore[no-untyped-call]
                     elif resource_type in ["AWS::Serverless::Function", "AWS::Serverless::StateMachine"]:
                         # properties below could affect swagger generation
                         if "Condition" in resource_dict:
-                            resource_dict["Condition"] = _convert_to_py27_type(resource_dict["Condition"])
+                            resource_dict["Condition"] = _convert_to_py27_type(resource_dict["Condition"])  # type: ignore[no-untyped-call]
                         if "FunctionName" in resource_properties:
-                            resource_properties["FunctionName"] = _convert_to_py27_type(
+                            resource_properties["FunctionName"] = _convert_to_py27_type(  # type: ignore[no-untyped-call]
                                 resource_properties["FunctionName"]
                             )
                         if "Events" in resource_properties:
-                            resource_properties["Events"] = _convert_to_py27_type(resource_properties["Events"])
+                            resource_properties["Events"] = _convert_to_py27_type(resource_properties["Events"])  # type: ignore[no-untyped-call]
 
             new_resources_dict[Py27UniStr(logical_id)] = resource_dict
         template["Resources"] = new_resources_dict
 
     if parameter_values:
         for key, val in parameter_values.items():
-            parameter_values[key] = _convert_to_py27_type(val)
+            parameter_values[key] = _convert_to_py27_type(val)  # type: ignore[no-untyped-call]
 
 
-def undo_mark_unicode_str_in_template(template_dict):
+def undo_mark_unicode_str_in_template(template_dict):  # type: ignore[no-untyped-def]
     return json.loads(json.dumps(template_dict))
 
 
@@ -109,37 +109,37 @@ class Py27UniStr(unicode_string_type):
     To preserve the instance type in string operations, we need to override certain methods
     """
 
-    def __add__(self, other):
+    def __add__(self, other):  # type: ignore[no-untyped-def]
         return Py27UniStr(super(Py27UniStr, self).__add__(other))
 
-    def __repr__(self):
+    def __repr__(self):  # type: ignore[no-untyped-def]
         if sys.version_info.major >= 3:
             return "u" + super(Py27UniStr, self).encode("unicode_escape").decode("ascii").__repr__().replace(
                 "\\\\", "\\"
             )
         return super(Py27UniStr, self).__repr__()
 
-    def upper(self):
+    def upper(self):  # type: ignore[no-untyped-def]
         return Py27UniStr(super(Py27UniStr, self).upper())
 
-    def lower(self):
+    def lower(self):  # type: ignore[no-untyped-def]
         return Py27UniStr(super(Py27UniStr, self).lower())
 
-    def replace(self, __old, __new, __count=None):
+    def replace(self, __old, __new, __count=None):  # type: ignore[no-untyped-def]
         if __count:
             return Py27UniStr(super(Py27UniStr, self).replace(__old, __new, __count))
         return Py27UniStr(super(Py27UniStr, self).replace(__old, __new))
 
-    def split(self, sep=None, maxsplit=-1):
+    def split(self, sep=None, maxsplit=-1):  # type: ignore[no-untyped-def]
         return [Py27UniStr(s) for s in super(Py27UniStr, self).split(sep, maxsplit)]
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo):  # type: ignore[no-untyped-def]
         return self  # strings are immutable
 
-    def _get_py27_hash(self):
+    def _get_py27_hash(self):  # type: ignore[no-untyped-def]
         h = getattr(self, "_py27_hash", None)
         if h is None:
-            self._py27_hash = h = ctypes.c_size_t(Hash.hash(self)).value
+            self._py27_hash = h = ctypes.c_size_t(Hash.hash(self)).value  # type: ignore[no-untyped-call]
         return h
 
 
@@ -151,12 +151,12 @@ class Py27LongInt(long_int_type):
 
     PY2_MAX_INT = 9223372036854775807  # sys.maxint from Python2.7 Lambda runtime
 
-    def __repr__(self):
+    def __repr__(self):  # type: ignore[no-untyped-def]
         if sys.version_info.major >= 3 and self > Py27LongInt.PY2_MAX_INT:
             return super(Py27LongInt, self).__repr__() + "L"
         return super(Py27LongInt, self).__repr__()
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo):  # type: ignore[no-untyped-def]
         return self  # primitive types (ints) are immutable
 
 
@@ -171,7 +171,7 @@ class Py27Keys(object):
 
     DUMMY = ["dummy"]  # marker for deleted keys
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         super(Py27Keys, self).__init__()
         self.debug = False
         self.keyorder = {}
@@ -179,24 +179,24 @@ class Py27Keys(object):
         self.fill = 0  # increment count when a key is added, equivalent to ma_fill in dictobject.c
         self.mask = MINSIZE - 1  # Python2 default dict size
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo):  # type: ignore[no-untyped-def]
         # add keys in the py2 order -- we can't do a straigh-up deep copy of keyorder because
         # in py2 copy.deepcopy of a dict may result in reordering of the keys
-        ret = Py27Keys()
-        for k in self.keys():
+        ret = Py27Keys()  # type: ignore[no-untyped-call]
+        for k in self.keys():  # type: ignore[no-untyped-call]
             if k is self.DUMMY:
                 continue
-            ret.add(copy.deepcopy(k, memo))
+            ret.add(copy.deepcopy(k, memo))  # type: ignore[no-untyped-call]
         return ret
 
-    def _get_key_idx(self, k):
+    def _get_key_idx(self, k):  # type: ignore[no-untyped-def]
         """Gets insert location for k"""
 
         # Py27UniStr caches the hash to improve performance so use its method instead of always computing the hash
         if isinstance(k, Py27UniStr):
-            h = k._get_py27_hash()
+            h = k._get_py27_hash()  # type: ignore[no-untyped-call]
         else:
-            h = ctypes.c_size_t(Hash.hash(k)).value
+            h = ctypes.c_size_t(Hash.hash(k)).value  # type: ignore[no-untyped-call]
 
         i = h & self.mask
 
@@ -224,7 +224,7 @@ class Py27Keys(object):
             perturb >>= PERTURB_SHIFT
         return i
 
-    def _resize(self, request):
+    def _resize(self, request):  # type: ignore[no-untyped-def]
         """
         Resizes allocated size based
         """
@@ -241,20 +241,20 @@ class Py27Keys(object):
         # reinsert all the keys using original order
         for idx in sorted(oldkeyorder.keys()):
             if oldkeyorder[idx] is not self.DUMMY:
-                self.add(oldkeyorder[idx])
+                self.add(oldkeyorder[idx])  # type: ignore[no-untyped-call]
 
-    def remove(self, key):
+    def remove(self, key):  # type: ignore[no-untyped-def]
         """Removes key"""
-        i = self._get_key_idx(key)
+        i = self._get_key_idx(key)  # type: ignore[no-untyped-call]
         if i in self.keyorder:
             if self.keyorder[i] is not self.DUMMY:
                 self.keyorder[i] = self.DUMMY
                 self.size -= 1
 
-    def add(self, key):
+    def add(self, key):  # type: ignore[no-untyped-def]
         """Adds key"""
         start_size = self.size
-        i = self._get_key_idx(key)
+        i = self._get_key_idx(key)  # type: ignore[no-untyped-call]
         if i not in self.keyorder:
             # We are not replacing an existing key or a DUMMY key, increment fill
             self.size += 1
@@ -269,46 +269,46 @@ class Py27Keys(object):
         # Resize if 2/3 capacity
         if self.size > start_size and self.fill * 3 >= ((self.mask + 1) * 2):
             # Python2 dict increases size by a factor of 4 for small dict, and 2 for large dict
-            self._resize(self.size * (2 if self.size > 50000 else 4))
+            self._resize(self.size * (2 if self.size > 50000 else 4))  # type: ignore[no-untyped-call]
 
-    def keys(self):
+    def keys(self):  # type: ignore[no-untyped-def]
         """Return keys in Python2 order"""
         return [self.keyorder[key] for key in sorted(self.keyorder.keys()) if self.keyorder[key] is not self.DUMMY]
 
-    def __setstate__(self, state):
+    def __setstate__(self, state):  # type: ignore[no-untyped-def]
         """
         Overrides default pickling object to force re-adding all keys and match Python 2.7 deserialization logic.
 
         :param state: input state
         """
         self.__dict__ = state
-        keys = self.keys()
+        keys = self.keys()  # type: ignore[no-untyped-call]
 
         # Clear keys and re-add to match deserialization logic
-        self.__init__()
+        self.__init__()  # type: ignore[misc]
 
         for k in keys:
             if k == self.DUMMY:
                 continue
-            self.add(k)
+            self.add(k)  # type: ignore[no-untyped-call]
 
-    def __iter__(self):
+    def __iter__(self):  # type: ignore[no-untyped-def]
         """
         Default iterator
         """
-        return iter(self.keys())
+        return iter(self.keys())  # type: ignore[no-untyped-call]
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # type: ignore[no-untyped-def]
         if isinstance(other, Py27Keys):
-            return self.keys() == other.keys()
+            return self.keys() == other.keys()  # type: ignore[no-untyped-call]
         if isinstance(other, list):
-            return self.keys() == other
+            return self.keys() == other  # type: ignore[no-untyped-call]
         return False
 
-    def __len__(self):
-        return len(self.keys())
+    def __len__(self):  # type: ignore[no-untyped-def]
+        return len(self.keys())  # type: ignore[no-untyped-call]
 
-    def merge(self, other):
+    def merge(self, other):  # type: ignore[no-untyped-def]
         """
         Merge keys from an exisitng iterable into this key list.
         Equivalent to PyDict_Merge
@@ -321,50 +321,50 @@ class Py27Keys(object):
 
         # PyDict_Merge initial merge size is double the size of current + incoming dict
         if ((self.fill + len(other)) * 3) >= ((self.mask + 1) * 2):
-            self._resize((self.size + len(other)) * 2)
+            self._resize((self.size + len(other)) * 2)  # type: ignore[no-untyped-call]
 
         # Copy actual keys
         for k in other:
-            self.add(k)
+            self.add(k)  # type: ignore[no-untyped-call]
 
-    def copy(self):
+    def copy(self):  # type: ignore[no-untyped-def]
         """
         Makes a copy of self
         """
         # Copy creates a new object and merges keys in
-        new = Py27Keys()
-        new.merge(self.keys())
+        new = Py27Keys()  # type: ignore[no-untyped-call]
+        new.merge(self.keys())  # type: ignore[no-untyped-call, no-untyped-call]
         return new
 
-    def pop(self):
+    def pop(self):  # type: ignore[no-untyped-def]
         """
         Pops the top element from the sorted keys if it exists. Returns None otherwise.
         """
         if self.keyorder:
-            value = self.keys()[0]
-            self.remove(value)
+            value = self.keys()[0]  # type: ignore[no-untyped-call]
+            self.remove(value)  # type: ignore[no-untyped-call]
             return value
         return None
 
 
-class Py27Dict(dict):
+class Py27Dict(dict):  # type: ignore[type-arg]
     """
     Compatibility class to support Python2.7 style iteration in Python3.x
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         """
         Overrides dict logic to always call set item. This allows Python2.7 style iteration
         """
         super(Py27Dict, self).__init__()
 
         # Initialize iteration key list
-        self.keylist = Py27Keys()
+        self.keylist = Py27Keys()  # type: ignore[no-untyped-call]
 
         # Initialize base arguments
-        self.update(*args, **kwargs)
+        self.update(*args, **kwargs)  # type: ignore[no-untyped-call]
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo):  # type: ignore[no-untyped-def]
         cls = self.__class__
         result = cls.__new__(cls)
         for k, v in self.__dict__.items():
@@ -375,14 +375,14 @@ class Py27Dict(dict):
 
         return result
 
-    def __reduce__(self):
+    def __reduce__(self):  # type: ignore[no-untyped-def]
         """
         Method necessary to fully pickle Python 3 subclassed dict objects with attribute fields.
         """
         # pylint: disable = W0235
         return super(Py27Dict, self).__reduce__()
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value):  # type: ignore[no-untyped-def]
         """
         Override of __setitem__ to track keys and simulate Python2.7 dict
 
@@ -392,9 +392,9 @@ class Py27Dict(dict):
         value: Any
         """
         super(Py27Dict, self).__setitem__(key, value)
-        self.keylist.add(key)
+        self.keylist.add(key)  # type: ignore[no-untyped-call]
 
-    def __delitem__(self, key):
+    def __delitem__(self, key):  # type: ignore[no-untyped-def]
         """
         Override of __delitem__ to track kyes and simulate Python2.7 dict.
 
@@ -403,9 +403,9 @@ class Py27Dict(dict):
         key: hashable
         """
         super(Py27Dict, self).__delitem__(key)
-        self.keylist.remove(key)
+        self.keylist.remove(key)  # type: ignore[no-untyped-call]
 
-    def update(self, *args, **kwargs):
+    def update(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         """
         Overrides dict logic to always call set item. This allows Python2.7 style iteration.
 
@@ -418,7 +418,7 @@ class Py27Dict(dict):
             # Cast to dict if applicable. Otherwise, assume it's an iterable of (key, value) pairs
             if isinstance(arg, dict):
                 # Merge incoming keys into keylist
-                self.keylist.merge(arg.keys())
+                self.keylist.merge(arg.keys())  # type: ignore[no-untyped-call]
                 arg = arg.items()
 
             for k, v in arg:
@@ -427,14 +427,14 @@ class Py27Dict(dict):
         for k, v in dict(**kwargs).items():
             self[k] = v
 
-    def clear(self):
+    def clear(self):  # type: ignore[no-untyped-def]
         """
         Clears the dict along with its backing Python2.7 keylist.
         """
         super(Py27Dict, self).clear()
-        self.keylist = Py27Keys()
+        self.keylist = Py27Keys()  # type: ignore[no-untyped-call]
 
-    def copy(self):
+    def copy(self):  # type: ignore[no-untyped-def]
         """
         Copies the dict along with its backing Python2.7 keylist.
 
@@ -443,18 +443,18 @@ class Py27Dict(dict):
         Py27Dict
             copy of self
         """
-        new = Py27Dict()
+        new = Py27Dict()  # type: ignore[no-untyped-call]
 
         # First copy the keylist to the new object
-        new.keylist = self.keylist.copy()
+        new.keylist = self.keylist.copy()  # type: ignore[no-untyped-call]
 
         # Copy keys into backing dict
-        for k, v in self.items():
+        for k, v in self.items():  # type: ignore[no-untyped-call]
             new[k] = v
 
         return new
 
-    def pop(self, key, default=None):
+    def pop(self, key, default=None):  # type: ignore[no-untyped-def]
         """
         Pops the value at key from the dict if it exists, return default otherwise
 
@@ -471,10 +471,10 @@ class Py27Dict(dict):
             value of key if found or default
         """
         value = super(Py27Dict, self).pop(key, default)
-        self.keylist.remove(key)
+        self.keylist.remove(key)  # type: ignore[no-untyped-call]
         return value
 
-    def popitem(self):
+    def popitem(self):  # type: ignore[no-untyped-def]
         """
         Pops an element from the dict and returns the item.
 
@@ -484,15 +484,15 @@ class Py27Dict(dict):
             (key, value) pair of an element if found or None if dict is empty
         """
         if self:
-            key = self.keylist.pop()
+            key = self.keylist.pop()  # type: ignore[no-untyped-call]
             value = self[key] if key else None
 
-            del self[key]
+            del self[key]  # type: ignore[no-untyped-call]
             return key, value
 
         return None
 
-    def __iter__(self):
+    def __iter__(self):  # type: ignore[no-untyped-def]
         """
         Default iterator
 
@@ -500,9 +500,9 @@ class Py27Dict(dict):
         -------
         iterator
         """
-        return self.keylist.__iter__()
+        return self.keylist.__iter__()  # type: ignore[no-untyped-call]
 
-    def __str__(self):
+    def __str__(self):  # type: ignore[no-untyped-def]
         """
         Override to minic exact Python2.7 str(dict_obj)
 
@@ -527,7 +527,7 @@ class Py27Dict(dict):
         string += "}"
         return string
 
-    def __repr__(self):
+    def __repr__(self):  # type: ignore[no-untyped-def]
         """
         Create a string version of this Dict
 
@@ -535,9 +535,9 @@ class Py27Dict(dict):
         -------
         str
         """
-        return self.__str__()
+        return self.__str__()  # type: ignore[no-untyped-call]
 
-    def keys(self):
+    def keys(self):  # type: ignore[no-untyped-def]
         """
         Returns keys ordered using Python2.7 iteration alogrithm
 
@@ -546,9 +546,9 @@ class Py27Dict(dict):
         list
             list of keys
         """
-        return self.keylist.keys()
+        return self.keylist.keys()  # type: ignore[no-untyped-call]
 
-    def values(self):
+    def values(self):  # type: ignore[no-untyped-def]
         """
         Returns values ordered using Python2.7 iteration algorithm
 
@@ -557,9 +557,9 @@ class Py27Dict(dict):
         list
             list of values
         """
-        return [self[k] for k in self.keys()]
+        return [self[k] for k in self.keys()]  # type: ignore[no-untyped-call]
 
-    def items(self):
+    def items(self):  # type: ignore[no-untyped-def]
         """
         Returns items ordered using Python2.7 iteration algorithm
 
@@ -568,9 +568,9 @@ class Py27Dict(dict):
         list
             list of items
         """
-        return [(k, self[k]) for k in self.keys()]
+        return [(k, self[k]) for k in self.keys()]  # type: ignore[no-untyped-call]
 
-    def setdefault(self, key, default):
+    def setdefault(self, key, default):  # type: ignore[no-untyped-def]
         """
         Retruns the value of a key if the key exists. Otherwise inserts key with the default value
 
@@ -588,7 +588,7 @@ class Py27Dict(dict):
         return self[key]
 
 
-def _convert_to_py27_type(original):
+def _convert_to_py27_type(original):  # type: ignore[no-untyped-def]
     if isinstance(original, ("".__class__, bytes)):
         # these are strings, return the Py27UniStr instance of the string
         return Py27UniStr(original)
@@ -598,21 +598,21 @@ def _convert_to_py27_type(original):
         return Py27LongInt(original)
 
     if isinstance(original, list):
-        return [_convert_to_py27_type(item) for item in original]
+        return [_convert_to_py27_type(item) for item in original]  # type: ignore[no-untyped-call]
 
     if isinstance(original, dict):
         # Recursively convert dict items
         key_list = original.keys()
-        new_dict = Py27Dict()
+        new_dict = Py27Dict()  # type: ignore[no-untyped-call]
         for key in key_list:
-            new_dict[Py27UniStr(key)] = _convert_to_py27_type(original[key])
+            new_dict[Py27UniStr(key)] = _convert_to_py27_type(original[key])  # type: ignore[no-untyped-call]
         return new_dict
 
     # Anything else does not require conversion
     return original
 
 
-def _template_has_api_resource(template):
+def _template_has_api_resource(template):  # type: ignore[no-untyped-def]
     """
     Returns true if the template contains at lease one explicit or implicit AWS::Serverless::Api resource
     """
@@ -635,7 +635,7 @@ def _template_has_api_resource(template):
     return False
 
 
-def _template_has_httpapi_resource_with_default_authorizer(template):
+def _template_has_httpapi_resource_with_default_authorizer(template):  # type: ignore[no-untyped-def]
     """
     Returns true if the template contains at least one AWS::Serverless::HttpApi resource with DefaultAuthorizer configured
     """

--- a/samtranslator/validator/validator.py
+++ b/samtranslator/validator/validator.py
@@ -18,7 +18,7 @@ class SamTemplateValidator:
     # Example: "u'integer'" -> "'integer'"
     UNICODE_TYPE_REGEX = re.compile("u('[^']+')")
 
-    def __init__(self, schema=None):
+    def __init__(self, schema=None):  # type: ignore[no-untyped-def]
         """
         Constructor
 
@@ -28,7 +28,7 @@ class SamTemplateValidator:
             Path to a schema to use for validation, by default None, the default schema.json will be used
         """
         if not schema:
-            schema = self._read_json(sam_schema.SCHEMA_NEW_FILE)
+            schema = self._read_json(sam_schema.SCHEMA_NEW_FILE)  # type: ignore[no-untyped-call]
 
         # Helps resolve the $Ref to external files
         # For cross platform resolving, we have to load the sub schemas into
@@ -44,7 +44,7 @@ class SamTemplateValidator:
                     schema_content = f.read()
                 schema_store[sub_schema] = json.loads(schema_content)
 
-        resolver = jsonschema.RefResolver.from_schema(schema, store=schema_store)
+        resolver = jsonschema.RefResolver.from_schema(schema, store=schema_store)  # type: ignore[no-untyped-call]
 
         SAMValidator = jsonschema.validators.extend(
             jsonschema.Draft7Validator,
@@ -55,7 +55,7 @@ class SamTemplateValidator:
         self.validator = SAMValidator(schema, resolver=resolver)
 
     @staticmethod
-    def validate(template_dict, schema=None):
+    def validate(template_dict, schema=None):  # type: ignore[no-untyped-def]
         """
         Validates a SAM Template
 
@@ -77,11 +77,11 @@ class SamTemplateValidator:
         str
             Validation errors separated by commas ","
         """
-        validator = SamTemplateValidator(schema)
+        validator = SamTemplateValidator(schema)  # type: ignore[no-untyped-call]
 
-        return ", ".join(validator.get_errors(template_dict))
+        return ", ".join(validator.get_errors(template_dict))  # type: ignore[no-untyped-call]
 
-    def get_errors(self, template_dict):
+    def get_errors(self, template_dict):  # type: ignore[no-untyped-def]
         """
         Validates a SAM Template
 
@@ -104,17 +104,17 @@ class SamTemplateValidator:
 
         # Set of "[Path.To.Element] Error message"
         # To track error uniqueness, Dict instead of List, for speed
-        errors_set = {}
+        errors_set = {}  # type: ignore[var-annotated]
 
         for e in validation_errors:
-            self._process_error(e, errors_set)
+            self._process_error(e, errors_set)  # type: ignore[no-untyped-call]
 
         # To be consistent across python versions 2 and 3, we have to sort the final result
         # It seems that the validator is not receiving the properties in the same order between python 2 and 3
         # It thus returns errors in a different order
         return sorted(errors_set.keys())
 
-    def _process_error(self, error, errors_set):
+    def _process_error(self, error, errors_set):  # type: ignore[no-untyped-def]
         """
         Processes the validation errors recursively
         error is actually a tree of errors
@@ -136,7 +136,7 @@ class SamTemplateValidator:
             # [Path.To.Element] Error message
             error_path = ".".join([str(p) for p in error.absolute_path]) if error.absolute_path else "."
 
-            error_content = "[{}] {}".format(error_path, self._cleanup_error_message(error))
+            error_content = "[{}] {}".format(error_path, self._cleanup_error_message(error))  # type: ignore[no-untyped-call]
 
             if error_content not in errors_set:
                 # We set the value to None as we don't use it
@@ -145,9 +145,9 @@ class SamTemplateValidator:
 
         for context_error in error.context:
             # Each "context" item is also a validation error
-            self._process_error(context_error, errors_set)
+            self._process_error(context_error, errors_set)  # type: ignore[no-untyped-call]
 
-    def _cleanup_error_message(self, error):
+    def _cleanup_error_message(self, error):  # type: ignore[no-untyped-def]
         """
         Cleans an error message up to remove unecessary clutter or replace
         it with a more meaningful one
@@ -173,7 +173,7 @@ class SamTemplateValidator:
 
         return final_message
 
-    def _read_json(self, filepath):
+    def _read_json(self, filepath):  # type: ignore[no-untyped-def]
         """
         Returns the content of a JSON file
 
@@ -213,7 +213,7 @@ INTRINSIC_ATTR = {
 }
 
 
-def is_object(checker, instance):
+def is_object(checker, instance):  # type: ignore[no-untyped-def]
     """
     'object' type definition
     Overloaded to exclude intrinsic functions
@@ -230,10 +230,10 @@ def is_object(checker, instance):
     boolean
         True if an object, False otherwise
     """
-    return isinstance(instance, dict) and not has_intrinsic_attr(instance)
+    return isinstance(instance, dict) and not has_intrinsic_attr(instance)  # type: ignore[no-untyped-call]
 
 
-def is_intrinsic(checker, instance):
+def is_intrinsic(checker, instance):  # type: ignore[no-untyped-def]
     """
     'intrinsic' type definition
 
@@ -249,10 +249,10 @@ def is_intrinsic(checker, instance):
     [type]
         [description]
     """
-    return isinstance(instance, dict) and has_intrinsic_attr(instance)
+    return isinstance(instance, dict) and has_intrinsic_attr(instance)  # type: ignore[no-untyped-call]
 
 
-def has_intrinsic_attr(instance):
+def has_intrinsic_attr(instance):  # type: ignore[no-untyped-def]
     """
     Returns a value indicating whether the instance has an intrinsic attribute
     Only one attribute which must be one of the intrinsics

--- a/samtranslator/yaml_helper.py
+++ b/samtranslator/yaml_helper.py
@@ -5,13 +5,13 @@ from yaml import ScalarNode, SequenceNode
 # https://github.com/aws/aws-cli/blob/develop/awscli/customizations/cloudformation/yamlhelper.py
 
 
-def yaml_parse(yamlstr):
+def yaml_parse(yamlstr):  # type: ignore[no-untyped-def]
     """Parse a yaml string"""
-    yaml.SafeLoader.add_multi_constructor("!", intrinsics_multi_constructor)
+    yaml.SafeLoader.add_multi_constructor("!", intrinsics_multi_constructor)  # type: ignore[no-untyped-call]
     return yaml.safe_load(yamlstr)
 
 
-def intrinsics_multi_constructor(loader, tag_prefix, node):
+def intrinsics_multi_constructor(loader, tag_prefix, node):  # type: ignore[no-untyped-def]
     """
     YAML constructor to parse CloudFormation intrinsics.
     This will return a dictionary with key being the instrinsic name


### PR DESCRIPTION
### Description of changes
Use https://pypi.org/project/mypy-clean-slate/ to add ignore to all existing method. Enable `mypy --strict` so any future development must be typed.

### Description of how you validated changes
Trying to create a function without type and `make pr` failed.
Trying to cast return to `Any` and `make pr` also failed.

### Checklist

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
