### PR TITLE
chore: Make PropertyType and related validator typed

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -4,6 +4,7 @@ import inspect
 from typing import Any, Callable, Dict
 
 from samtranslator.model.exceptions import InvalidResourceException
+from samtranslator.model.types import Validator
 from samtranslator.plugins import LifeCycleEvents
 from samtranslator.model.tags.resource_tagging import get_tag_list
 
@@ -18,7 +19,12 @@ class PropertyType(object):
         raise an error when intrinsic function dictionary is supplied as value
     """
 
-    def __init__(self, required, validate=lambda value: True, supports_intrinsics=True):  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        required: bool,
+        validate: Validator = lambda value: True,
+        supports_intrinsics: bool = True,
+    ) -> None:
         self.required = required
         self.validate = validate
         self.supports_intrinsics = supports_intrinsics

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -13,18 +13,18 @@ from samtranslator.utils.py27hash_fix import Py27Dict, Py27UniStr
 class ApiGatewayRestApi(Resource):
     resource_type = "AWS::ApiGateway::RestApi"
     property_types = {
-        "Body": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BodyS3Location": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CloneFrom": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FailOnWarnings": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Parameters": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EndpointConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BinaryMediaTypes": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MinimumCompressionSize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Mode": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ApiKeySourceType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Body": PropertyType(False, is_type(dict)),
+        "BodyS3Location": PropertyType(False, is_type(dict)),
+        "CloneFrom": PropertyType(False, is_str()),
+        "Description": PropertyType(False, is_str()),
+        "FailOnWarnings": PropertyType(False, is_type(bool)),
+        "Name": PropertyType(False, is_str()),
+        "Parameters": PropertyType(False, is_type(dict)),
+        "EndpointConfiguration": PropertyType(False, is_type(dict)),
+        "BinaryMediaTypes": PropertyType(False, is_type(list)),
+        "MinimumCompressionSize": PropertyType(False, is_type(int)),
+        "Mode": PropertyType(False, is_str()),
+        "ApiKeySourceType": PropertyType(False, is_str()),
     }
 
     runtime_attrs = {"rest_api_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
@@ -33,19 +33,19 @@ class ApiGatewayRestApi(Resource):
 class ApiGatewayStage(Resource):
     resource_type = "AWS::ApiGateway::Stage"
     property_types = {
-        "AccessLogSetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CacheClusterEnabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CacheClusterSize": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CanarySetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ClientCertificateId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DeploymentId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RestApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StageName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "TracingEnabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Variables": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MethodSettings": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AccessLogSetting": PropertyType(False, is_type(dict)),
+        "CacheClusterEnabled": PropertyType(False, is_type(bool)),
+        "CacheClusterSize": PropertyType(False, is_str()),
+        "CanarySetting": PropertyType(False, is_type(dict)),
+        "ClientCertificateId": PropertyType(False, is_str()),
+        "DeploymentId": PropertyType(True, is_str()),
+        "Description": PropertyType(False, is_str()),
+        "RestApiId": PropertyType(True, is_str()),
+        "StageName": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "Tags": PropertyType(False, list_of(is_type(dict))),
+        "TracingEnabled": PropertyType(False, is_type(bool)),
+        "Variables": PropertyType(False, is_type(dict)),
+        "MethodSettings": PropertyType(False, is_type(list)),
     }
 
     runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
@@ -56,7 +56,7 @@ class ApiGatewayStage(Resource):
 
 class ApiGatewayAccount(Resource):
     resource_type = "AWS::ApiGateway::Account"
-    property_types = {"CloudWatchRoleArn": PropertyType(False, one_of(is_str(), is_type(dict)))}  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+    property_types = {"CloudWatchRoleArn": PropertyType(False, one_of(is_str(), is_type(dict)))}
 
 
 class ApiGatewayDeployment(Resource):
@@ -64,10 +64,10 @@ class ApiGatewayDeployment(Resource):
 
     resource_type = "AWS::ApiGateway::Deployment"
     property_types = {
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RestApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StageDescription": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StageName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),
+        "RestApiId": PropertyType(True, is_str()),
+        "StageDescription": PropertyType(False, is_type(dict)),
+        "StageName": PropertyType(False, is_str()),
     }
 
     runtime_attrs = {"deployment_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
@@ -171,35 +171,35 @@ class ApiGatewayResponse(object):
 class ApiGatewayDomainName(Resource):
     resource_type = "AWS::ApiGateway::DomainName"
     property_types = {
-        "RegionalCertificateArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DomainName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EndpointConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MutualTlsAuthentication": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SecurityPolicy": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CertificateArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "OwnershipVerificationCertificateArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RegionalCertificateArn": PropertyType(False, is_str()),
+        "DomainName": PropertyType(True, is_str()),
+        "EndpointConfiguration": PropertyType(False, is_type(dict)),
+        "MutualTlsAuthentication": PropertyType(False, is_type(dict)),
+        "SecurityPolicy": PropertyType(False, is_str()),
+        "CertificateArn": PropertyType(False, is_str()),
+        "OwnershipVerificationCertificateArn": PropertyType(False, is_str()),
     }
 
 
 class ApiGatewayBasePathMapping(Resource):
     resource_type = "AWS::ApiGateway::BasePathMapping"
     property_types = {
-        "BasePath": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DomainName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RestApiId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Stage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BasePath": PropertyType(False, is_str()),
+        "DomainName": PropertyType(True, is_str()),
+        "RestApiId": PropertyType(False, is_str()),
+        "Stage": PropertyType(False, is_str()),
     }
 
 
 class ApiGatewayUsagePlan(Resource):
     resource_type = "AWS::ApiGateway::UsagePlan"
     property_types = {
-        "ApiStages": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Quota": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, list_of(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Throttle": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "UsagePlanName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ApiStages": PropertyType(False, is_type(list)),
+        "Description": PropertyType(False, is_str()),
+        "Quota": PropertyType(False, is_type(dict)),
+        "Tags": PropertyType(False, list_of(dict)),
+        "Throttle": PropertyType(False, is_type(dict)),
+        "UsagePlanName": PropertyType(False, is_str()),
     }
     runtime_attrs = {"usage_plan_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
@@ -207,22 +207,22 @@ class ApiGatewayUsagePlan(Resource):
 class ApiGatewayUsagePlanKey(Resource):
     resource_type = "AWS::ApiGateway::UsagePlanKey"
     property_types = {
-        "KeyId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "KeyType": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "UsagePlanId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "KeyId": PropertyType(True, is_str()),
+        "KeyType": PropertyType(True, is_str()),
+        "UsagePlanId": PropertyType(True, is_str()),
     }
 
 
 class ApiGatewayApiKey(Resource):
     resource_type = "AWS::ApiGateway::ApiKey"
     property_types = {
-        "CustomerId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "GenerateDistinctId": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StageKeys": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Value": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "CustomerId": PropertyType(False, is_str()),
+        "Description": PropertyType(False, is_str()),
+        "Enabled": PropertyType(False, is_type(bool)),
+        "GenerateDistinctId": PropertyType(False, is_type(bool)),
+        "Name": PropertyType(False, is_str()),
+        "StageKeys": PropertyType(False, is_type(list)),
+        "Value": PropertyType(False, is_str()),
     }
 
     runtime_attrs = {"api_key_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -10,13 +10,13 @@ APIGATEWAY_AUTHORIZER_KEY = "x-amazon-apigateway-authorizer"
 class ApiGatewayV2HttpApi(Resource):
     resource_type = "AWS::ApiGatewayV2::Api"
     property_types = {
-        "Body": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BodyS3Location": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FailOnWarnings": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BasePath": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CorsConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Body": PropertyType(False, is_type(dict)),
+        "BodyS3Location": PropertyType(False, is_type(dict)),
+        "Description": PropertyType(False, is_str()),
+        "FailOnWarnings": PropertyType(False, is_type(bool)),
+        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
+        "BasePath": PropertyType(False, is_str()),
+        "CorsConfiguration": PropertyType(False, is_type(dict)),
     }
 
     runtime_attrs = {"http_api_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
@@ -25,16 +25,16 @@ class ApiGatewayV2HttpApi(Resource):
 class ApiGatewayV2Stage(Resource):
     resource_type = "AWS::ApiGatewayV2::Stage"
     property_types = {
-        "AccessLogSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefaultRouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ClientCertificateId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StageVariables": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "AutoDeploy": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AccessLogSettings": PropertyType(False, is_type(dict)),
+        "DefaultRouteSettings": PropertyType(False, is_type(dict)),
+        "RouteSettings": PropertyType(False, is_type(dict)),
+        "ClientCertificateId": PropertyType(False, is_str()),
+        "Description": PropertyType(False, is_str()),
+        "ApiId": PropertyType(True, is_str()),
+        "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "Tags": PropertyType(False, is_type(dict)),
+        "StageVariables": PropertyType(False, is_type(dict)),
+        "AutoDeploy": PropertyType(False, is_type(bool)),
     }
 
     runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
@@ -43,20 +43,20 @@ class ApiGatewayV2Stage(Resource):
 class ApiGatewayV2DomainName(Resource):
     resource_type = "AWS::ApiGatewayV2::DomainName"
     property_types = {
-        "DomainName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DomainNameConfigurations": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "MutualTlsAuthentication": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DomainName": PropertyType(True, is_str()),
+        "DomainNameConfigurations": PropertyType(False, list_of(is_type(dict))),
+        "MutualTlsAuthentication": PropertyType(False, is_type(dict)),
+        "Tags": PropertyType(False, is_type(dict)),
     }
 
 
 class ApiGatewayV2ApiMapping(Resource):
     resource_type = "AWS::ApiGatewayV2::ApiMapping"
     property_types = {
-        "ApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ApiMappingKey": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DomainName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Stage": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "ApiId": PropertyType(True, is_str()),
+        "ApiMappingKey": PropertyType(False, is_str()),
+        "DomainName": PropertyType(True, is_str()),
+        "Stage": PropertyType(True, is_str()),
     }
 
 

--- a/samtranslator/model/cloudformation.py
+++ b/samtranslator/model/cloudformation.py
@@ -7,11 +7,11 @@ class NestedStack(Resource):
     resource_type = "AWS::CloudFormation::Stack"
     # TODO: support passthrough parameters for stacks (Conditions, etc)
     property_types = {
-        "TemplateURL": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Parameters": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "NotificationARNs": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "TimeoutInMinutes": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TemplateURL": PropertyType(True, is_str()),
+        "Parameters": PropertyType(False, is_type(dict)),
+        "NotificationARNs": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "Tags": PropertyType(False, list_of(is_type(dict))),
+        "TimeoutInMinutes": PropertyType(False, is_type(int)),
     }
 
     runtime_attrs = {"stack_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]

--- a/samtranslator/model/codedeploy.py
+++ b/samtranslator/model/codedeploy.py
@@ -5,7 +5,7 @@ from samtranslator.model.types import is_type, one_of, is_str
 
 class CodeDeployApplication(Resource):
     resource_type = "AWS::CodeDeploy::Application"
-    property_types = {"ComputePlatform": PropertyType(False, one_of(is_str(), is_type(dict)))}  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+    property_types = {"ComputePlatform": PropertyType(False, one_of(is_str(), is_type(dict)))}
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
 
@@ -13,13 +13,13 @@ class CodeDeployApplication(Resource):
 class CodeDeployDeploymentGroup(Resource):
     resource_type = "AWS::CodeDeploy::DeploymentGroup"
     property_types = {
-        "AlarmConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ApplicationName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "AutoRollbackConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DeploymentConfigName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "DeploymentStyle": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ServiceRoleArn": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "TriggerConfigurations": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AlarmConfiguration": PropertyType(False, is_type(dict)),
+        "ApplicationName": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "AutoRollbackConfiguration": PropertyType(False, is_type(dict)),
+        "DeploymentConfigName": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "DeploymentStyle": PropertyType(False, is_type(dict)),
+        "ServiceRoleArn": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "TriggerConfigurations": PropertyType(False, is_type(list)),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]

--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -6,29 +6,29 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class CognitoUserPool(Resource):
     resource_type = "AWS::Cognito::UserPool"
     property_types = {
-        "AccountRecoverySetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "AdminCreateUserConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "AliasAttributes": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "AutoVerifiedAttributes": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "DeviceConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EmailConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EmailVerificationMessage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EmailVerificationSubject": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EnabledMfas": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "LambdaConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MfaConfiguration": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Policies": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Schema": PropertyType(False, list_of(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SmsAuthenticationMessage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SmsConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SmsVerificationMessage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "UserAttributeUpdateSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "UsernameAttributes": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "UsernameConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "UserPoolAddOns": PropertyType(False, list_of(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "UserPoolName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "UserPoolTags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "VerificationMessageTemplate": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AccountRecoverySetting": PropertyType(False, is_type(dict)),
+        "AdminCreateUserConfig": PropertyType(False, is_type(dict)),
+        "AliasAttributes": PropertyType(False, list_of(is_str())),
+        "AutoVerifiedAttributes": PropertyType(False, list_of(is_str())),
+        "DeviceConfiguration": PropertyType(False, is_type(dict)),
+        "EmailConfiguration": PropertyType(False, is_type(dict)),
+        "EmailVerificationMessage": PropertyType(False, is_str()),
+        "EmailVerificationSubject": PropertyType(False, is_str()),
+        "EnabledMfas": PropertyType(False, list_of(is_str())),
+        "LambdaConfig": PropertyType(False, is_type(dict)),
+        "MfaConfiguration": PropertyType(False, is_str()),
+        "Policies": PropertyType(False, is_type(dict)),
+        "Schema": PropertyType(False, list_of(dict)),
+        "SmsAuthenticationMessage": PropertyType(False, is_str()),
+        "SmsConfiguration": PropertyType(False, is_type(dict)),
+        "SmsVerificationMessage": PropertyType(False, is_str()),
+        "UserAttributeUpdateSettings": PropertyType(False, is_type(dict)),
+        "UsernameAttributes": PropertyType(False, list_of(is_str())),
+        "UsernameConfiguration": PropertyType(False, is_type(dict)),
+        "UserPoolAddOns": PropertyType(False, list_of(dict)),
+        "UserPoolName": PropertyType(False, is_str()),
+        "UserPoolTags": PropertyType(False, is_type(dict)),
+        "VerificationMessageTemplate": PropertyType(False, is_type(dict)),
     }
 
     runtime_attrs = {

--- a/samtranslator/model/dynamodb.py
+++ b/samtranslator/model/dynamodb.py
@@ -6,16 +6,16 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class DynamoDBTable(Resource):
     resource_type = "AWS::DynamoDB::Table"
     property_types = {
-        "AttributeDefinitions": PropertyType(True, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "GlobalSecondaryIndexes": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "KeySchema": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "LocalSecondaryIndexes": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "ProvisionedThroughput": PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "StreamSpecification": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "TableName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "SSESpecification": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BillingMode": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AttributeDefinitions": PropertyType(True, list_of(is_type(dict))),
+        "GlobalSecondaryIndexes": PropertyType(False, list_of(is_type(dict))),
+        "KeySchema": PropertyType(False, list_of(is_type(dict))),
+        "LocalSecondaryIndexes": PropertyType(False, list_of(is_type(dict))),
+        "ProvisionedThroughput": PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),
+        "StreamSpecification": PropertyType(False, is_type(dict)),
+        "TableName": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "Tags": PropertyType(False, list_of(is_type(dict))),
+        "SSESpecification": PropertyType(False, is_type(dict)),
+        "BillingMode": PropertyType(False, is_str()),
     }
 
     runtime_attrs = {

--- a/samtranslator/model/events.py
+++ b/samtranslator/model/events.py
@@ -6,14 +6,14 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class EventsRule(Resource):
     resource_type = "AWS::Events::Rule"
     property_types = {
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EventBusName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EventPattern": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RoleArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ScheduleExpression": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Targets": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),
+        "EventBusName": PropertyType(False, is_str()),
+        "EventPattern": PropertyType(False, is_type(dict)),
+        "Name": PropertyType(False, is_str()),
+        "RoleArn": PropertyType(False, is_str()),
+        "ScheduleExpression": PropertyType(False, is_str()),
+        "State": PropertyType(False, is_str()),
+        "Targets": PropertyType(False, list_of(is_type(dict))),
     }
 
     runtime_attrs = {"rule_id": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]

--- a/samtranslator/model/eventsources/cloudwatchlogs.py
+++ b/samtranslator/model/eventsources/cloudwatchlogs.py
@@ -13,7 +13,7 @@ class CloudWatchLogs(PushEventSource):
 
     resource_type = "CloudWatchLogs"
     principal = "logs.amazonaws.com"
-    property_types = {"LogGroupName": PropertyType(True, is_str()), "FilterPattern": PropertyType(True, is_str())}  # type: ignore[no-untyped-call, no-untyped-call]
+    property_types = {"LogGroupName": PropertyType(True, is_str()), "FilterPattern": PropertyType(True, is_str())}
 
     @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
     def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -29,27 +29,27 @@ class PullEventSource(ResourceMacro):
     resource_type: str = None  # type: ignore
     requires_stream_queue_broker = True
     property_types = {
-        "Stream": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Queue": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BatchSize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StartingPosition": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DestinationConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ParallelizationFactor": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Topics": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Broker": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Queues": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SourceAccessConfigurations": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SecretsManagerKmsKeyId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionResponseTypes": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "KafkaBootstrapServers": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FilterCriteria": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ConsumerGroupId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Stream": PropertyType(False, is_str()),
+        "Queue": PropertyType(False, is_str()),
+        "BatchSize": PropertyType(False, is_type(int)),
+        "StartingPosition": PropertyType(False, is_str()),
+        "Enabled": PropertyType(False, is_type(bool)),
+        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),
+        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
+        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),
+        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),
+        "DestinationConfig": PropertyType(False, is_type(dict)),
+        "ParallelizationFactor": PropertyType(False, is_type(int)),
+        "Topics": PropertyType(False, is_type(list)),
+        "Broker": PropertyType(False, is_str()),
+        "Queues": PropertyType(False, is_type(list)),
+        "SourceAccessConfigurations": PropertyType(False, is_type(list)),
+        "SecretsManagerKmsKeyId": PropertyType(False, is_str()),
+        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),
+        "FunctionResponseTypes": PropertyType(False, is_type(list)),
+        "KafkaBootstrapServers": PropertyType(False, is_type(list)),
+        "FilterCriteria": PropertyType(False, is_type(dict)),
+        "ConsumerGroupId": PropertyType(False, is_str()),
     }
 
     def get_policy_arn(self):  # type: ignore[no-untyped-def]

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -96,15 +96,15 @@ class Schedule(PushEventSource):
     resource_type = "Schedule"
     principal = "events.amazonaws.com"
     property_types = {
-        "Schedule": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RuleName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Input": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RetryPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Schedule": PropertyType(True, is_str()),
+        "RuleName": PropertyType(False, is_str()),
+        "Input": PropertyType(False, is_str()),
+        "Enabled": PropertyType(False, is_type(bool)),
+        "State": PropertyType(False, is_str()),
+        "Name": PropertyType(False, is_str()),
+        "Description": PropertyType(False, is_str()),
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),
+        "RetryPolicy": PropertyType(False, is_type(dict)),
     }
 
     @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
@@ -180,16 +180,16 @@ class CloudWatchEvent(PushEventSource):
     resource_type = "CloudWatchEvent"
     principal = "events.amazonaws.com"
     property_types = {
-        "EventBusName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RuleName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Pattern": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RetryPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Input": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "InputPath": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Target": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EventBusName": PropertyType(False, is_str()),
+        "RuleName": PropertyType(False, is_str()),
+        "Pattern": PropertyType(False, is_type(dict)),
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),
+        "RetryPolicy": PropertyType(False, is_type(dict)),
+        "Input": PropertyType(False, is_str()),
+        "InputPath": PropertyType(False, is_str()),
+        "Target": PropertyType(False, is_type(dict)),
+        "Enabled": PropertyType(False, is_type(bool)),
+        "State": PropertyType(False, is_str()),
     }
 
     @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
@@ -274,9 +274,9 @@ class S3(PushEventSource):
     resource_type = "S3"
     principal = "s3.amazonaws.com"
     property_types = {
-        "Bucket": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Events": PropertyType(True, one_of(is_str(), list_of(is_str())), False),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Filter": PropertyType(False, dict_of(is_str(), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "Bucket": PropertyType(True, is_str()),
+        "Events": PropertyType(True, one_of(is_str(), list_of(is_str())), False),
+        "Filter": PropertyType(False, dict_of(is_str(), is_str())),
     }
 
     def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
@@ -447,10 +447,10 @@ class SNS(PushEventSource):
     resource_type = "SNS"
     principal = "sns.amazonaws.com"
     property_types = {
-        "Topic": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Region": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FilterPolicy": PropertyType(False, dict_of(is_str(), list_of(one_of(is_str(), is_type(dict))))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "SqsSubscription": PropertyType(False, one_of(is_type(bool), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "Topic": PropertyType(True, is_str()),
+        "Region": PropertyType(False, is_str()),
+        "FilterPolicy": PropertyType(False, dict_of(is_str(), list_of(one_of(is_str(), is_type(dict))))),
+        "SqsSubscription": PropertyType(False, one_of(is_type(bool), is_type(dict))),
     }
 
     @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
@@ -562,14 +562,14 @@ class Api(PushEventSource):
     resource_type = "Api"
     principal = "apigateway.amazonaws.com"
     property_types = {
-        "Path": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Method": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Path": PropertyType(True, is_str()),
+        "Method": PropertyType(True, is_str()),
         # Api Event sources must "always" be paired with a Serverless::Api
-        "RestApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Stage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RequestModel": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RequestParameters": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RestApiId": PropertyType(True, is_str()),
+        "Stage": PropertyType(False, is_str()),
+        "Auth": PropertyType(False, is_type(dict)),
+        "RequestModel": PropertyType(False, is_type(dict)),
+        "RequestParameters": PropertyType(False, is_type(list)),
     }
 
     def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
@@ -932,7 +932,7 @@ class AlexaSkill(PushEventSource):
     resource_type = "AlexaSkill"
     principal = "alexa-appkit.amazon.com"
 
-    property_types = {"SkillId": PropertyType(False, is_str())}  # type: ignore[no-untyped-call, no-untyped-call]
+    property_types = {"SkillId": PropertyType(False, is_str())}
 
     @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
     def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
@@ -951,7 +951,7 @@ class IoTRule(PushEventSource):
     resource_type = "IoTRule"
     principal = "iot.amazonaws.com"
 
-    property_types = {"Sql": PropertyType(True, is_str()), "AwsIotSqlVersion": PropertyType(False, is_str())}  # type: ignore[no-untyped-call, no-untyped-call]
+    property_types = {"Sql": PropertyType(True, is_str()), "AwsIotSqlVersion": PropertyType(False, is_str())}
 
     @cw_timer(prefix=FUNCTION_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
     def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
@@ -998,8 +998,8 @@ class Cognito(PushEventSource):
     principal = "cognito-idp.amazonaws.com"
 
     property_types = {
-        "UserPool": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Trigger": PropertyType(True, one_of(is_str(), list_of(is_str())), False),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "UserPool": PropertyType(True, is_str()),
+        "Trigger": PropertyType(True, one_of(is_str(), list_of(is_str())), False),
     }
 
     def resources_to_link(self, resources):  # type: ignore[no-untyped-def]
@@ -1078,14 +1078,14 @@ class HttpApi(PushEventSource):
     resource_type = "HttpApi"
     principal = "apigateway.amazonaws.com"
     property_types = {
-        "Path": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Method": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ApiId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Stage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "TimeoutInMillis": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "PayloadFormatVersion": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Path": PropertyType(False, is_str()),
+        "Method": PropertyType(False, is_str()),
+        "ApiId": PropertyType(False, is_str()),
+        "Stage": PropertyType(False, is_str()),
+        "Auth": PropertyType(False, is_type(dict)),
+        "TimeoutInMillis": PropertyType(False, is_type(int)),
+        "RouteSettings": PropertyType(False, is_type(dict)),
+        "PayloadFormatVersion": PropertyType(False, is_str()),
     }
 
     def resources_to_link(self, resources):  # type: ignore[no-untyped-def]

--- a/samtranslator/model/iam.py
+++ b/samtranslator/model/iam.py
@@ -6,12 +6,12 @@ from samtranslator.model.intrinsics import ref, fnGetAtt
 class IAMRole(Resource):
     resource_type = "AWS::IAM::Role"
     property_types = {
-        "AssumeRolePolicyDocument": PropertyType(True, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ManagedPolicyArns": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Path": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Policies": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "PermissionsBoundary": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "AssumeRolePolicyDocument": PropertyType(True, is_type(dict)),
+        "ManagedPolicyArns": PropertyType(False, is_type(list)),
+        "Path": PropertyType(False, is_str()),
+        "Policies": PropertyType(False, is_type(list)),
+        "PermissionsBoundary": PropertyType(False, is_str()),
+        "Tags": PropertyType(False, list_of(is_type(dict))),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
@@ -20,13 +20,13 @@ class IAMRole(Resource):
 class IAMManagedPolicy(Resource):
     resource_type = "AWS::IAM::ManagedPolicy"
     property_types = {
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Groups": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "PolicyDocument": PropertyType(True, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ManagedPolicyName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Path": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Roles": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Users": PropertyType(False, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),
+        "Groups": PropertyType(False, is_str()),
+        "PolicyDocument": PropertyType(True, is_type(dict)),
+        "ManagedPolicyName": PropertyType(False, is_str()),
+        "Path": PropertyType(False, is_str()),
+        "Roles": PropertyType(False, is_type(list)),
+        "Users": PropertyType(False, list_of(is_str())),
     }
 
 

--- a/samtranslator/model/iot.py
+++ b/samtranslator/model/iot.py
@@ -5,6 +5,6 @@ from samtranslator.model.intrinsics import ref, fnGetAtt
 
 class IotTopicRule(Resource):
     resource_type = "AWS::IoT::TopicRule"
-    property_types = {"TopicRulePayload": PropertyType(False, is_type(dict))}  # type: ignore[no-untyped-call, no-untyped-call]
+    property_types = {"TopicRulePayload": PropertyType(False, is_type(dict))}
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -6,28 +6,28 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class LambdaFunction(Resource):
     resource_type = "AWS::Lambda::Function"
     property_types = {
-        "Code": PropertyType(True, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "PackageType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Handler": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MemorySize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Role": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Runtime": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Timeout": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "VpcConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Environment": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "TracingConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "KmsKeyArn": PropertyType(False, one_of(is_type(dict), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Layers": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "ReservedConcurrentExecutions": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FileSystemConfigs": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "CodeSigningConfigArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ImageConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Architectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "EphemeralStorage": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Code": PropertyType(True, is_type(dict)),
+        "PackageType": PropertyType(False, is_str()),
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),
+        "Description": PropertyType(False, is_str()),
+        "FunctionName": PropertyType(False, is_str()),
+        "Handler": PropertyType(False, is_str()),
+        "MemorySize": PropertyType(False, is_type(int)),
+        "Role": PropertyType(False, is_str()),
+        "Runtime": PropertyType(False, is_str()),
+        "Timeout": PropertyType(False, is_type(int)),
+        "VpcConfig": PropertyType(False, is_type(dict)),
+        "Environment": PropertyType(False, is_type(dict)),
+        "Tags": PropertyType(False, list_of(is_type(dict))),
+        "TracingConfig": PropertyType(False, is_type(dict)),
+        "KmsKeyArn": PropertyType(False, one_of(is_type(dict), is_str())),
+        "Layers": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "ReservedConcurrentExecutions": PropertyType(False, any_type()),
+        "FileSystemConfigs": PropertyType(False, list_of(is_type(dict))),
+        "CodeSigningConfigArn": PropertyType(False, is_str()),
+        "ImageConfig": PropertyType(False, is_type(dict)),
+        "Architectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "EphemeralStorage": PropertyType(False, is_type(dict)),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
@@ -36,9 +36,9 @@ class LambdaFunction(Resource):
 class LambdaVersion(Resource):
     resource_type = "AWS::Lambda::Version"
     property_types = {
-        "CodeSha256": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
+        "CodeSha256": PropertyType(False, is_str()),
+        "Description": PropertyType(False, is_str()),
+        "FunctionName": PropertyType(True, one_of(is_str(), is_type(dict))),
     }
 
     runtime_attrs = {
@@ -50,11 +50,11 @@ class LambdaVersion(Resource):
 class LambdaAlias(Resource):
     resource_type = "AWS::Lambda::Alias"
     property_types = {
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "FunctionVersion": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Description": PropertyType(False, is_str()),
+        "Name": PropertyType(False, is_str()),
+        "FunctionName": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "FunctionVersion": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),
     }
 
     runtime_attrs = {"arn": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
@@ -63,26 +63,26 @@ class LambdaAlias(Resource):
 class LambdaEventSourceMapping(Resource):
     resource_type = "AWS::Lambda::EventSourceMapping"
     property_types = {
-        "BatchSize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EventSourceArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DestinationConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ParallelizationFactor": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StartingPosition": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Topics": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Queues": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SourceAccessConfigurations": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionResponseTypes": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SelfManagedEventSource": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FilterCriteria": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "AmazonManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SelfManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "BatchSize": PropertyType(False, is_type(int)),
+        "Enabled": PropertyType(False, is_type(bool)),
+        "EventSourceArn": PropertyType(False, is_str()),
+        "FunctionName": PropertyType(True, is_str()),
+        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),
+        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
+        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),
+        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),
+        "DestinationConfig": PropertyType(False, is_type(dict)),
+        "ParallelizationFactor": PropertyType(False, is_type(int)),
+        "StartingPosition": PropertyType(False, is_str()),
+        "Topics": PropertyType(False, is_type(list)),
+        "Queues": PropertyType(False, is_type(list)),
+        "SourceAccessConfigurations": PropertyType(False, is_type(list)),
+        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),
+        "FunctionResponseTypes": PropertyType(False, is_type(list)),
+        "SelfManagedEventSource": PropertyType(False, is_type(dict)),
+        "FilterCriteria": PropertyType(False, is_type(dict)),
+        "AmazonManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),
+        "SelfManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
@@ -91,24 +91,24 @@ class LambdaEventSourceMapping(Resource):
 class LambdaPermission(Resource):
     resource_type = "AWS::Lambda::Permission"
     property_types = {
-        "Action": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Principal": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SourceAccount": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SourceArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EventSourceToken": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionUrlAuthType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Action": PropertyType(True, is_str()),
+        "FunctionName": PropertyType(True, is_str()),
+        "Principal": PropertyType(True, is_str()),
+        "SourceAccount": PropertyType(False, is_str()),
+        "SourceArn": PropertyType(False, is_str()),
+        "EventSourceToken": PropertyType(False, is_str()),
+        "FunctionUrlAuthType": PropertyType(False, is_str()),
     }
 
 
 class LambdaEventInvokeConfig(Resource):
     resource_type = "AWS::Lambda::EventInvokeConfig"
     property_types = {
-        "DestinationConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FunctionName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MaximumEventAgeInSeconds": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Qualifier": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "DestinationConfig": PropertyType(False, is_type(dict)),
+        "FunctionName": PropertyType(True, is_str()),
+        "MaximumEventAgeInSeconds": PropertyType(False, is_type(int)),
+        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
+        "Qualifier": PropertyType(True, is_str()),
     }
 
 
@@ -117,12 +117,12 @@ class LambdaLayerVersion(Resource):
 
     resource_type = "AWS::Lambda::LayerVersion"
     property_types = {
-        "Content": PropertyType(True, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "LayerName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CompatibleArchitectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "LicenseInfo": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Content": PropertyType(True, is_type(dict)),
+        "Description": PropertyType(False, is_str()),
+        "LayerName": PropertyType(False, is_str()),
+        "CompatibleArchitectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "LicenseInfo": PropertyType(False, is_str()),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
@@ -131,7 +131,7 @@ class LambdaLayerVersion(Resource):
 class LambdaUrl(Resource):
     resource_type = "AWS::Lambda::Url"
     property_types = {
-        "TargetFunctionArn": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "AuthType": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Cors": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "TargetFunctionArn": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "AuthType": PropertyType(True, is_str()),
+        "Cors": PropertyType(False, is_type(dict)),
     }

--- a/samtranslator/model/log.py
+++ b/samtranslator/model/log.py
@@ -6,9 +6,9 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class SubscriptionFilter(Resource):
     resource_type = "AWS::Logs::SubscriptionFilter"
     property_types = {
-        "LogGroupName": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FilterPattern": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DestinationArn": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "LogGroupName": PropertyType(True, is_str()),
+        "FilterPattern": PropertyType(True, is_str()),
+        "DestinationArn": PropertyType(True, is_str()),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]

--- a/samtranslator/model/route53.py
+++ b/samtranslator/model/route53.py
@@ -5,7 +5,7 @@ from samtranslator.model.types import is_type, is_str
 class Route53RecordSetGroup(Resource):
     resource_type = "AWS::Route53::RecordSetGroup"
     property_types = {
-        "HostedZoneId": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "HostedZoneName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RecordSets": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "HostedZoneId": PropertyType(False, is_str()),
+        "HostedZoneName": PropertyType(False, is_str()),
+        "RecordSets": PropertyType(False, is_type(list)),
     }

--- a/samtranslator/model/s3.py
+++ b/samtranslator/model/s3.py
@@ -6,26 +6,26 @@ from samtranslator.model.intrinsics import ref, fnGetAtt
 class S3Bucket(Resource):
     resource_type = "AWS::S3::Bucket"
     property_types = {
-        "AccessControl": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "AccelerateConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "AnalyticsConfigurations": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BucketEncryption": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BucketName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CorsConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "IntelligentTieringConfigurations": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "InventoryConfigurations": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "LifecycleConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "LoggingConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MetricsConfigurations": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "NotificationConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ObjectLockConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ObjectLockEnabled": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "OwnershipControls": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "PublicAccessBlockConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ReplicationConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "VersioningConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "WebsiteConfiguration": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AccessControl": PropertyType(False, any_type()),
+        "AccelerateConfiguration": PropertyType(False, any_type()),
+        "AnalyticsConfigurations": PropertyType(False, any_type()),
+        "BucketEncryption": PropertyType(False, any_type()),
+        "BucketName": PropertyType(False, is_str()),
+        "CorsConfiguration": PropertyType(False, any_type()),
+        "IntelligentTieringConfigurations": PropertyType(False, any_type()),
+        "InventoryConfigurations": PropertyType(False, any_type()),
+        "LifecycleConfiguration": PropertyType(False, any_type()),
+        "LoggingConfiguration": PropertyType(False, any_type()),
+        "MetricsConfigurations": PropertyType(False, any_type()),
+        "NotificationConfiguration": PropertyType(False, is_type(dict)),
+        "ObjectLockConfiguration": PropertyType(False, any_type()),
+        "ObjectLockEnabled": PropertyType(False, any_type()),
+        "OwnershipControls": PropertyType(False, any_type()),
+        "PublicAccessBlockConfiguration": PropertyType(False, is_type(dict)),
+        "ReplicationConfiguration": PropertyType(False, any_type()),
+        "Tags": PropertyType(False, is_type(list)),
+        "VersioningConfiguration": PropertyType(False, any_type()),
+        "WebsiteConfiguration": PropertyType(False, any_type()),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -76,42 +76,42 @@ class SamFunction(SamResourceMacro):
 
     resource_type = "AWS::Serverless::Function"
     property_types = {
-        "FunctionName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Handler": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Runtime": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CodeUri": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "ImageUri": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "PackageType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "InlineCode": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "DeadLetterQueue": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MemorySize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Timeout": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "VpcConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Role": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "AssumeRolePolicyDocument": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Policies": PropertyType(False, one_of(is_str(), is_type(dict), list_of(one_of(is_str(), is_type(dict))))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "PermissionsBoundary": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Environment": PropertyType(False, dict_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Tracing": PropertyType(False, one_of(is_type(dict), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "KmsKeyArn": PropertyType(False, one_of(is_type(dict), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "DeploymentPreference": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ReservedConcurrentExecutions": PropertyType(False, any_type()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Layers": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "EventInvokeConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EphemeralStorage": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "FunctionName": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "Handler": PropertyType(False, is_str()),
+        "Runtime": PropertyType(False, is_str()),
+        "CodeUri": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "ImageUri": PropertyType(False, is_str()),
+        "PackageType": PropertyType(False, is_str()),
+        "InlineCode": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "DeadLetterQueue": PropertyType(False, is_type(dict)),
+        "Description": PropertyType(False, is_str()),
+        "MemorySize": PropertyType(False, is_type(int)),
+        "Timeout": PropertyType(False, is_type(int)),
+        "VpcConfig": PropertyType(False, is_type(dict)),
+        "Role": PropertyType(False, is_str()),
+        "AssumeRolePolicyDocument": PropertyType(False, is_type(dict)),
+        "Policies": PropertyType(False, one_of(is_str(), is_type(dict), list_of(one_of(is_str(), is_type(dict))))),
+        "PermissionsBoundary": PropertyType(False, is_str()),
+        "Environment": PropertyType(False, dict_of(is_str(), is_type(dict))),
+        "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),
+        "Tags": PropertyType(False, is_type(dict)),
+        "Tracing": PropertyType(False, one_of(is_type(dict), is_str())),
+        "KmsKeyArn": PropertyType(False, one_of(is_type(dict), is_str())),
+        "DeploymentPreference": PropertyType(False, is_type(dict)),
+        "ReservedConcurrentExecutions": PropertyType(False, any_type()),
+        "Layers": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "EventInvokeConfig": PropertyType(False, is_type(dict)),
+        "EphemeralStorage": PropertyType(False, is_type(dict)),
         # Intrinsic functions in value of Alias property are not supported, yet
-        "AutoPublishAlias": PropertyType(False, one_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "AutoPublishCodeSha256": PropertyType(False, one_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "VersionDescription": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FileSystemConfigs": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "ImageConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CodeSigningConfigArn": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Architectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "FunctionUrlConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "AutoPublishAlias": PropertyType(False, one_of(is_str())),
+        "AutoPublishCodeSha256": PropertyType(False, one_of(is_str())),
+        "VersionDescription": PropertyType(False, is_str()),
+        "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),
+        "FileSystemConfigs": PropertyType(False, list_of(is_type(dict))),
+        "ImageConfig": PropertyType(False, is_type(dict)),
+        "CodeSigningConfigArn": PropertyType(False, is_str()),
+        "Architectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "FunctionUrlConfig": PropertyType(False, is_type(dict)),
     }
     event_resolver = ResourceTypeResolver(  # type: ignore[no-untyped-call]
         samtranslator.model.eventsources,
@@ -1064,33 +1064,33 @@ class SamApi(SamResourceMacro):
         # Implicit APIs. For Explicit APIs, customer is expected to set integration URI themselves.
         # In the future, we might rename and expose this property to customers so they can have SAM manage Explicit APIs
         # Swagger.
-        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Name": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "StageName": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefinitionBody": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "CacheClusterEnabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CacheClusterSize": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Variables": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "EndpointConfiguration": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "MethodSettings": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "BinaryMediaTypes": PropertyType(False, is_type(list)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "MinimumCompressionSize": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Cors": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "GatewayResponses": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "AccessLogSetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CanarySetting": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "TracingEnabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "OpenApiVersion": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Models": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Domain": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FailOnWarnings": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Mode": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ApiKeySourceType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),
+        "Name": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "StageName": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "Tags": PropertyType(False, is_type(dict)),
+        "DefinitionBody": PropertyType(False, is_type(dict)),
+        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "CacheClusterEnabled": PropertyType(False, is_type(bool)),
+        "CacheClusterSize": PropertyType(False, is_str()),
+        "Variables": PropertyType(False, is_type(dict)),
+        "EndpointConfiguration": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "MethodSettings": PropertyType(False, is_type(list)),
+        "BinaryMediaTypes": PropertyType(False, is_type(list)),
+        "MinimumCompressionSize": PropertyType(False, is_type(int)),
+        "Cors": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "Auth": PropertyType(False, is_type(dict)),
+        "GatewayResponses": PropertyType(False, is_type(dict)),
+        "AccessLogSetting": PropertyType(False, is_type(dict)),
+        "CanarySetting": PropertyType(False, is_type(dict)),
+        "TracingEnabled": PropertyType(False, is_type(bool)),
+        "OpenApiVersion": PropertyType(False, is_str()),
+        "Models": PropertyType(False, is_type(dict)),
+        "Domain": PropertyType(False, is_type(dict)),
+        "FailOnWarnings": PropertyType(False, is_type(bool)),
+        "Description": PropertyType(False, is_str()),
+        "Mode": PropertyType(False, is_str()),
+        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
+        "ApiKeySourceType": PropertyType(False, is_str()),
     }
 
     referable_properties = {
@@ -1192,21 +1192,21 @@ class SamHttpApi(SamResourceMacro):
         # Implicit APIs. For Explicit APIs, this is managed by the DefaultDefinitionBody Plugin.
         # In the future, we might rename and expose this property to customers so they can have SAM manage Explicit APIs
         # Swagger.
-        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefinitionBody": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "StageVariables": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "CorsConfiguration": PropertyType(False, one_of(is_type(bool), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "AccessLogSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefaultRouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RouteSettings": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Domain": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FailOnWarnings": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),
+        "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "Tags": PropertyType(False, is_type(dict)),
+        "DefinitionBody": PropertyType(False, is_type(dict)),
+        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "StageVariables": PropertyType(False, is_type(dict)),
+        "CorsConfiguration": PropertyType(False, one_of(is_type(bool), is_type(dict))),
+        "AccessLogSettings": PropertyType(False, is_type(dict)),
+        "DefaultRouteSettings": PropertyType(False, is_type(dict)),
+        "Auth": PropertyType(False, is_type(dict)),
+        "RouteSettings": PropertyType(False, is_type(dict)),
+        "Domain": PropertyType(False, is_type(dict)),
+        "FailOnWarnings": PropertyType(False, is_type(bool)),
+        "Description": PropertyType(False, is_str()),
+        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
     }
 
     referable_properties = {
@@ -1277,11 +1277,11 @@ class SamSimpleTable(SamResourceMacro):
 
     resource_type = "AWS::Serverless::SimpleTable"
     property_types = {
-        "PrimaryKey": PropertyType(False, dict_of(is_str(), is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "ProvisionedThroughput": PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "TableName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "SSESpecification": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "PrimaryKey": PropertyType(False, dict_of(is_str(), is_str())),
+        "ProvisionedThroughput": PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),
+        "TableName": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "Tags": PropertyType(False, is_type(dict)),
+        "SSESpecification": PropertyType(False, is_type(dict)),
     }
     attribute_type_conversions = {"String": "S", "Number": "N", "Binary": "B"}
 
@@ -1342,12 +1342,12 @@ class SamApplication(SamResourceMacro):
 
     # The plugin will always insert the TemplateUrl parameter
     property_types = {
-        "Location": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "TemplateUrl": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Parameters": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "NotificationARNs": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "TimeoutInMinutes": PropertyType(False, is_type(int)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Location": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "TemplateUrl": PropertyType(False, is_str()),
+        "Parameters": PropertyType(False, is_type(dict)),
+        "NotificationARNs": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "Tags": PropertyType(False, is_type(dict)),
+        "TimeoutInMinutes": PropertyType(False, is_type(int)),
     }
 
     @cw_timer
@@ -1389,13 +1389,13 @@ class SamLayerVersion(SamResourceMacro):
 
     resource_type = "AWS::Serverless::LayerVersion"
     property_types = {
-        "LayerName": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "ContentUri": PropertyType(True, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "CompatibleArchitectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "LicenseInfo": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RetentionPolicy": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "LayerName": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "Description": PropertyType(False, is_str()),
+        "ContentUri": PropertyType(True, one_of(is_str(), is_type(dict))),
+        "CompatibleArchitectures": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
+        "LicenseInfo": PropertyType(False, is_str()),
+        "RetentionPolicy": PropertyType(False, is_str()),
     }
 
     RETAIN = "Retain"
@@ -1542,18 +1542,18 @@ class SamStateMachine(SamResourceMacro):
 
     resource_type = "AWS::Serverless::StateMachine"
     property_types = {
-        "Definition": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Logging": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Role": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefinitionSubstitutions": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Type": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Tracing": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "PermissionsBoundary": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Definition": PropertyType(False, is_type(dict)),
+        "DefinitionUri": PropertyType(False, one_of(is_str(), is_type(dict))),
+        "Logging": PropertyType(False, is_type(dict)),
+        "Role": PropertyType(False, is_str()),
+        "DefinitionSubstitutions": PropertyType(False, is_type(dict)),
+        "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),
+        "Name": PropertyType(False, is_str()),
+        "Type": PropertyType(False, is_str()),
+        "Tags": PropertyType(False, is_type(dict)),
+        "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),
+        "Tracing": PropertyType(False, is_type(dict)),
+        "PermissionsBoundary": PropertyType(False, is_str()),
     }
     event_resolver = ResourceTypeResolver(  # type: ignore[no-untyped-call]
         samtranslator.model.stepfunctions.events,
@@ -1624,9 +1624,9 @@ class SamConnector(SamResourceMacro):
 
     resource_type = "AWS::Serverless::Connector"
     property_types = {
-        "Source": PropertyType(True, dict_of(is_str(), any_type())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Destination": PropertyType(True, dict_of(is_str(), any_type())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call, no-untyped-call]
-        "Permissions": PropertyType(True, list_of(is_str())),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+        "Source": PropertyType(True, dict_of(is_str(), any_type())),
+        "Destination": PropertyType(True, dict_of(is_str(), any_type())),
+        "Permissions": PropertyType(True, list_of(is_str())),
     }
 
     @cw_timer  # type: ignore[misc]

--- a/samtranslator/model/sns.py
+++ b/samtranslator/model/sns.py
@@ -6,20 +6,20 @@ from samtranslator.model.intrinsics import ref
 class SNSSubscription(Resource):
     resource_type = "AWS::SNS::Subscription"
     property_types = {
-        "Endpoint": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Protocol": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "TopicArn": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Region": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "FilterPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Endpoint": PropertyType(True, is_str()),
+        "Protocol": PropertyType(True, is_str()),
+        "TopicArn": PropertyType(True, is_str()),
+        "Region": PropertyType(False, is_str()),
+        "FilterPolicy": PropertyType(False, is_type(dict)),
     }
 
 
 class SNSTopicPolicy(Resource):
     resource_type = "AWS::SNS::TopicPolicy"
-    property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Topics": PropertyType(True, list_of(str))}  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+    property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Topics": PropertyType(True, list_of(str))}
 
 
 class SNSTopic(Resource):
     resource_type = "AWS::SNS::Topic"
-    property_types = {"TopicName": PropertyType(False, is_str())}  # type: ignore[no-untyped-call, no-untyped-call]
+    property_types = {"TopicName": PropertyType(False, is_str())}
     runtime_attrs = {"arn": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]

--- a/samtranslator/model/sqs.py
+++ b/samtranslator/model/sqs.py
@@ -16,7 +16,7 @@ class SQSQueue(Resource):
 
 class SQSQueuePolicy(Resource):
     resource_type = "AWS::SQS::QueuePolicy"
-    property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Queues": PropertyType(True, list_of(str))}  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
+    property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Queues": PropertyType(True, list_of(str))}
     runtime_attrs = {"arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call]
 
 

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -80,14 +80,14 @@ class Schedule(EventSource):
     resource_type = "Schedule"
     principal = "events.amazonaws.com"
     property_types = {
-        "Schedule": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Input": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Enabled": PropertyType(False, is_type(bool)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Name": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Description": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RetryPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Schedule": PropertyType(True, is_str()),
+        "Input": PropertyType(False, is_str()),
+        "Enabled": PropertyType(False, is_type(bool)),
+        "State": PropertyType(False, is_str()),
+        "Name": PropertyType(False, is_str()),
+        "Description": PropertyType(False, is_str()),
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),
+        "RetryPolicy": PropertyType(False, is_type(dict)),
     }
 
     @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
@@ -164,14 +164,14 @@ class CloudWatchEvent(EventSource):
     resource_type = "CloudWatchEvent"
     principal = "events.amazonaws.com"
     property_types = {
-        "EventBusName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RuleName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Pattern": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Input": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "InputPath": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DeadLetterConfig": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RetryPolicy": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "State": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "EventBusName": PropertyType(False, is_str()),
+        "RuleName": PropertyType(False, is_str()),
+        "Pattern": PropertyType(False, is_type(dict)),
+        "Input": PropertyType(False, is_str()),
+        "InputPath": PropertyType(False, is_str()),
+        "DeadLetterConfig": PropertyType(False, is_type(dict)),
+        "RetryPolicy": PropertyType(False, is_type(dict)),
+        "State": PropertyType(False, is_str()),
     }
 
     @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)  # type: ignore[no-untyped-call]
@@ -252,12 +252,12 @@ class Api(EventSource):
     resource_type = "Api"
     principal = "apigateway.amazonaws.com"
     property_types = {
-        "Path": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Method": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Path": PropertyType(True, is_str()),
+        "Method": PropertyType(True, is_str()),
         # Api Event sources must "always" be paired with a Serverless::Api
-        "RestApiId": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Stage": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Auth": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "RestApiId": PropertyType(True, is_str()),
+        "Stage": PropertyType(False, is_str()),
+        "Auth": PropertyType(False, is_type(dict)),
     }
 
     def resources_to_link(self, resources):  # type: ignore[no-untyped-def]

--- a/samtranslator/model/stepfunctions/resources.py
+++ b/samtranslator/model/stepfunctions/resources.py
@@ -6,16 +6,16 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 class StepFunctionsStateMachine(Resource):
     resource_type = "AWS::StepFunctions::StateMachine"
     property_types = {
-        "Definition": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefinitionString": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "DefinitionS3Location": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "LoggingConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "RoleArn": PropertyType(True, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StateMachineName": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "StateMachineType": PropertyType(False, is_str()),  # type: ignore[no-untyped-call, no-untyped-call]
-        "Tags": PropertyType(False, list_of(is_type(dict))),  # type: ignore[no-untyped-call, no-untyped-call, no-untyped-call]
-        "DefinitionSubstitutions": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
-        "TracingConfiguration": PropertyType(False, is_type(dict)),  # type: ignore[no-untyped-call, no-untyped-call]
+        "Definition": PropertyType(False, is_type(dict)),
+        "DefinitionString": PropertyType(False, is_str()),
+        "DefinitionS3Location": PropertyType(False, is_type(dict)),
+        "LoggingConfiguration": PropertyType(False, is_type(dict)),
+        "RoleArn": PropertyType(True, is_str()),
+        "StateMachineName": PropertyType(False, is_str()),
+        "StateMachineType": PropertyType(False, is_str()),
+        "Tags": PropertyType(False, list_of(is_type(dict))),
+        "DefinitionSubstitutions": PropertyType(False, is_type(dict)),
+        "TracingConfiguration": PropertyType(False, is_type(dict)),
     }
 
     runtime_attrs = {

--- a/samtranslator/sdk/resource.py
+++ b/samtranslator/sdk/resource.py
@@ -42,19 +42,19 @@ class SamResource(object):
 
         if self.condition:
 
-            if not is_str()(self.condition, should_raise=False):  # type: ignore[no-untyped-call]
+            if not is_str()(self.condition, should_raise=False):
                 raise InvalidDocumentException([InvalidTemplateException("Every Condition member must be a string.")])  # type: ignore[no-untyped-call, no-untyped-call]
 
         if self.deletion_policy:
 
-            if not is_str()(self.deletion_policy, should_raise=False):  # type: ignore[no-untyped-call]
+            if not is_str()(self.deletion_policy, should_raise=False):
                 raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                     [InvalidTemplateException("Every DeletionPolicy member must be a string.")]  # type: ignore[no-untyped-call]
                 )
 
         if self.update_replace_policy:
 
-            if not is_str()(self.update_replace_policy, should_raise=False):  # type: ignore[no-untyped-call]
+            if not is_str()(self.update_replace_policy, should_raise=False):
                 raise InvalidDocumentException(  # type: ignore[no-untyped-call]
                     [InvalidTemplateException("Every UpdateReplacePolicy member must be a string.")]  # type: ignore[no-untyped-call]
                 )


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
