### PR TITLE
chore: Make intrinsics helper functions typed

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -139,7 +139,7 @@ class SharedApiUsagePlan(object):
 
             if self.conditions:
                 self.conditions.add(condition)
-                or_condition = make_or_condition(self.conditions)  # type: ignore[no-untyped-call]
+                or_condition = make_or_condition(self.conditions)
                 template_conditions[SharedApiUsagePlan.SHARED_USAGE_PLAN_CONDITION_NAME] = or_condition
             else:
                 self.conditions.add(condition)
@@ -396,7 +396,7 @@ class ApiGenerator(object):
             generator = LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)  # type: ignore[no-untyped-call]
             stage_logical_id = generator.gen()  # type: ignore[no-untyped-call]
         stage = ApiGatewayStage(stage_logical_id, attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
-        stage.RestApiId = ref(self.logical_id)  # type: ignore[no-untyped-call]
+        stage.RestApiId = ref(self.logical_id)
         stage.update_deployment_ref(deployment.logical_id)  # type: ignore[no-untyped-call]
         stage.StageName = self.stage_name
         stage.CacheClusterEnabled = self.cache_cluster_enabled
@@ -503,9 +503,9 @@ class ApiGenerator(object):
             basepath_mapping = ApiGatewayBasePathMapping(  # type: ignore[no-untyped-call]
                 self.logical_id + "BasePathMapping", attributes=self.passthrough_resource_attributes
             )
-            basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))  # type: ignore[no-untyped-call]
-            basepath_mapping.RestApiId = ref(rest_api.logical_id)  # type: ignore[no-untyped-call]
-            basepath_mapping.Stage = ref(rest_api.logical_id + ".Stage")  # type: ignore[no-untyped-call]
+            basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
+            basepath_mapping.RestApiId = ref(rest_api.logical_id)
+            basepath_mapping.Stage = ref(rest_api.logical_id + ".Stage")
             basepath_resource_list.extend([basepath_mapping])
         else:
             for path in basepaths:
@@ -514,9 +514,9 @@ class ApiGenerator(object):
                 basepath_mapping = ApiGatewayBasePathMapping(  # type: ignore[no-untyped-call]
                     logical_id, attributes=self.passthrough_resource_attributes
                 )
-                basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))  # type: ignore[no-untyped-call]
-                basepath_mapping.RestApiId = ref(rest_api.logical_id)  # type: ignore[no-untyped-call]
-                basepath_mapping.Stage = ref(rest_api.logical_id + ".Stage")  # type: ignore[no-untyped-call]
+                basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
+                basepath_mapping.RestApiId = ref(rest_api.logical_id)
+                basepath_mapping.Stage = ref(rest_api.logical_id + ".Stage")
                 basepath_mapping.BasePath = path
                 basepath_resource_list.extend([basepath_mapping])
 
@@ -583,11 +583,11 @@ class ApiGenerator(object):
         if target_health is not None:
             alias_target["EvaluateTargetHealth"] = target_health
         if domain.get("EndpointConfiguration") == "REGIONAL":
-            alias_target["HostedZoneId"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalHostedZoneId")  # type: ignore[no-untyped-call]
-            alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")  # type: ignore[no-untyped-call]
+            alias_target["HostedZoneId"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalHostedZoneId")
+            alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")
         else:
             if route53.get("DistributionDomainName") is None:
-                route53["DistributionDomainName"] = fnGetAtt(self.domain.get("ApiDomainName"), "DistributionDomainName")  # type: ignore[no-untyped-call]
+                route53["DistributionDomainName"] = fnGetAtt(self.domain.get("ApiDomainName"), "DistributionDomainName")
             alias_target["HostedZoneId"] = "Z2FDTNDATAQYW2"
             alias_target["DNSName"] = route53.get("DistributionDomainName")
         return alias_target
@@ -630,7 +630,7 @@ class ApiGenerator(object):
                 self.logical_id, "Cors works only with inline Swagger specified in 'DefinitionBody' property."
             )
 
-        if isinstance(self.cors, str) or is_intrinsic(self.cors):  # type: ignore[no-untyped-call]
+        if isinstance(self.cors, str) or is_intrinsic(self.cors):
             # Just set Origin property. Others will be defaults
             properties = CorsProperties(AllowOrigin=self.cors)  # type: ignore[call-arg]
         elif isinstance(self.cors, dict):
@@ -793,8 +793,8 @@ class ApiGenerator(object):
             )
             api_stages = []
             api_stage = {}
-            api_stage["ApiId"] = ref(self.logical_id)  # type: ignore[no-untyped-call]
-            api_stage["Stage"] = ref(rest_api_stage.logical_id)  # type: ignore[no-untyped-call]
+            api_stage["ApiId"] = ref(self.logical_id)
+            api_stage["Stage"] = ref(rest_api_stage.logical_id)
             api_stages.append(api_stage)
             usage_plan.ApiStages = api_stages
 
@@ -815,8 +815,8 @@ class ApiGenerator(object):
                 ),
             )
             api_stage = {}
-            api_stage["ApiId"] = ref(self.logical_id)  # type: ignore[no-untyped-call]
-            api_stage["Stage"] = ref(rest_api_stage.logical_id)  # type: ignore[no-untyped-call]
+            api_stage["ApiId"] = ref(self.logical_id)
+            api_stage["Stage"] = ref(rest_api_stage.logical_id)
             if api_stage not in self.shared_api_usage_plan.api_stages_shared:
                 self.shared_api_usage_plan.api_stages_shared.append(api_stage)
             usage_plan.ApiStages = self.shared_api_usage_plan.api_stages_shared
@@ -856,8 +856,8 @@ class ApiGenerator(object):
             )
             api_key.Enabled = True
             stage_key = {}
-            stage_key["RestApiId"] = ref(self.logical_id)  # type: ignore[no-untyped-call]
-            stage_key["StageName"] = ref(rest_api_stage.logical_id)  # type: ignore[no-untyped-call]
+            stage_key["RestApiId"] = ref(self.logical_id)
+            stage_key["StageName"] = ref(rest_api_stage.logical_id)
             if stage_key not in self.shared_api_usage_plan.stage_keys_shared:
                 self.shared_api_usage_plan.stage_keys_shared.append(stage_key)
             api_key.StageKeys = self.shared_api_usage_plan.stage_keys_shared
@@ -873,8 +873,8 @@ class ApiGenerator(object):
             api_key.Enabled = True
             stage_keys = []
             stage_key = {}
-            stage_key["RestApiId"] = ref(self.logical_id)  # type: ignore[no-untyped-call]
-            stage_key["StageName"] = ref(rest_api_stage.logical_id)  # type: ignore[no-untyped-call]
+            stage_key["RestApiId"] = ref(self.logical_id)
+            stage_key["StageName"] = ref(rest_api_stage.logical_id)
             stage_keys.append(stage_key)
             api_key.StageKeys = stage_keys
         return api_key
@@ -903,9 +903,9 @@ class ApiGenerator(object):
             depends_on=[api_key.logical_id],
             attributes=resource_attributes,
         )
-        usage_plan_key.KeyId = ref(api_key.logical_id)  # type: ignore[no-untyped-call]
+        usage_plan_key.KeyId = ref(api_key.logical_id)
         usage_plan_key.KeyType = "API_KEY"
-        usage_plan_key.UsagePlanId = ref(usage_plan_logical_id)  # type: ignore[no-untyped-call]
+        usage_plan_key.UsagePlanId = ref(usage_plan_logical_id)
 
         return usage_plan_key
 
@@ -925,7 +925,7 @@ class ApiGenerator(object):
 
         # Make sure keys in the dict are recognized
         for responses_key, responses_value in self.gateway_responses.items():
-            if is_intrinsic(responses_value):  # type: ignore[no-untyped-call]
+            if is_intrinsic(responses_value):
                 # TODO: Add intrinsic support for this field.
                 raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     self.logical_id,
@@ -1108,7 +1108,7 @@ class ApiGenerator(object):
 
         partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
         resource = "${__ApiId__}/authorizers/*"
-        source_arn = fnSub(  # type: ignore[no-untyped-call]
+        source_arn = fnSub(
             ArnGenerator.generate_arn(partition=partition, service="execute-api", resource=resource),  # type: ignore[no-untyped-call]
             {"__ApiId__": api_id},
         )

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -172,7 +172,7 @@ class HttpApiGenerator(object):
             # if cors config is true add Origins as "'*'"
             properties = CorsProperties(AllowOrigins=[_CORS_WILDCARD])  # type: ignore[call-arg]
 
-        elif is_intrinsic(self.cors_configuration):  # type: ignore[no-untyped-call]
+        elif is_intrinsic(self.cors_configuration):
             # Just set Origin property. Intrinsics will be handledOthers will be defaults
             properties = CorsProperties(AllowOrigins=self.cors_configuration)  # type: ignore[call-arg]
 
@@ -344,9 +344,9 @@ class HttpApiGenerator(object):
             basepath_mapping = ApiGatewayV2ApiMapping(  # type: ignore[no-untyped-call]
                 self.logical_id + "ApiMapping", attributes=self.passthrough_resource_attributes
             )
-            basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))  # type: ignore[no-untyped-call]
-            basepath_mapping.ApiId = ref(http_api.logical_id)  # type: ignore[no-untyped-call]
-            basepath_mapping.Stage = ref(http_api.logical_id + ".Stage")  # type: ignore[no-untyped-call]
+            basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
+            basepath_mapping.ApiId = ref(http_api.logical_id)
+            basepath_mapping.Stage = ref(http_api.logical_id + ".Stage")
             basepath_resource_list.extend([basepath_mapping])
         else:
             for path in basepaths:
@@ -364,9 +364,9 @@ class HttpApiGenerator(object):
 
                 logical_id = "{}{}{}".format(self.logical_id, re.sub(r"[\-_/]+", "", path), "ApiMapping")
                 basepath_mapping = ApiGatewayV2ApiMapping(logical_id, attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
-                basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))  # type: ignore[no-untyped-call]
-                basepath_mapping.ApiId = ref(http_api.logical_id)  # type: ignore[no-untyped-call]
-                basepath_mapping.Stage = ref(http_api.logical_id + ".Stage")  # type: ignore[no-untyped-call]
+                basepath_mapping.DomainName = ref(self.domain.get("ApiDomainName"))
+                basepath_mapping.ApiId = ref(http_api.logical_id)
+                basepath_mapping.Stage = ref(http_api.logical_id + ".Stage")
                 basepath_mapping.ApiMappingKey = path
                 basepath_resource_list.extend([basepath_mapping])
         return basepath_resource_list
@@ -398,8 +398,8 @@ class HttpApiGenerator(object):
         if target_health is not None:
             alias_target["EvaluateTargetHealth"] = target_health
         if domain.get("EndpointConfiguration") == "REGIONAL":
-            alias_target["HostedZoneId"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalHostedZoneId")  # type: ignore[no-untyped-call]
-            alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")  # type: ignore[no-untyped-call]
+            alias_target["HostedZoneId"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalHostedZoneId")
+            alias_target["DNSName"] = fnGetAtt(self.domain.get("ApiDomainName"), "RegionalDomainName")
         else:
             raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
@@ -480,10 +480,10 @@ class HttpApiGenerator(object):
         if not default_authorizer:
             return
 
-        if is_intrinsic_no_value(default_authorizer):  # type: ignore[no-untyped-call]
+        if is_intrinsic_no_value(default_authorizer):
             return
 
-        if is_intrinsic(default_authorizer):  # type: ignore[no-untyped-call]
+        if is_intrinsic(default_authorizer):
             raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 "Unable to set DefaultAuthorizer because intrinsic functions are not supported for this field.",
@@ -603,7 +603,7 @@ class HttpApiGenerator(object):
             generator = LogicalIdGenerator(self.logical_id + "Stage", stage_name_prefix)  # type: ignore[no-untyped-call]
             stage_logical_id = generator.gen()  # type: ignore[no-untyped-call]
         stage = ApiGatewayV2Stage(stage_logical_id, attributes=self.passthrough_resource_attributes)  # type: ignore[no-untyped-call]
-        stage.ApiId = ref(self.logical_id)  # type: ignore[no-untyped-call]
+        stage.ApiId = ref(self.logical_id)
         stage.StageName = self.stage_name
         stage.StageVariables = self.stage_variables
         stage.AccessLogSettings = self.access_log_settings

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -27,7 +27,7 @@ class ApiGatewayRestApi(Resource):
         "ApiKeySourceType": PropertyType(False, is_str()),
     }
 
-    runtime_attrs = {"rest_api_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"rest_api_id": lambda self: ref(self.logical_id)}
 
 
 class ApiGatewayStage(Resource):
@@ -48,10 +48,10 @@ class ApiGatewayStage(Resource):
         "MethodSettings": PropertyType(False, is_type(list)),
     }
 
-    runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}
 
     def update_deployment_ref(self, deployment_logical_id):  # type: ignore[no-untyped-def]
-        self.DeploymentId = ref(deployment_logical_id)  # type: ignore[no-untyped-call]
+        self.DeploymentId = ref(deployment_logical_id)
 
 
 class ApiGatewayAccount(Resource):
@@ -70,7 +70,7 @@ class ApiGatewayDeployment(Resource):
         "StageName": PropertyType(False, is_str()),
     }
 
-    runtime_attrs = {"deployment_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"deployment_id": lambda self: ref(self.logical_id)}
 
     def make_auto_deployable(  # type: ignore[no-untyped-def]
         self, stage, openapi_version=None, swagger=None, domain=None, redeploy_restapi_parameters=None
@@ -201,7 +201,7 @@ class ApiGatewayUsagePlan(Resource):
         "Throttle": PropertyType(False, is_type(dict)),
         "UsagePlanName": PropertyType(False, is_str()),
     }
-    runtime_attrs = {"usage_plan_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"usage_plan_id": lambda self: ref(self.logical_id)}
 
 
 class ApiGatewayUsagePlanKey(Resource):
@@ -225,7 +225,7 @@ class ApiGatewayApiKey(Resource):
         "Value": PropertyType(False, is_str()),
     }
 
-    runtime_attrs = {"api_key_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"api_key_id": lambda self: ref(self.logical_id)}
 
 
 class ApiGatewayAuthorizer(object):
@@ -312,7 +312,7 @@ class ApiGatewayAuthorizer(object):
             swagger[APIGATEWAY_AUTHORIZER_KEY] = Py27Dict({"type": self._get_swagger_authorizer_type()})  # type: ignore[no-untyped-call, no-untyped-call]
             partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
             resource = "lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations"
-            authorizer_uri = fnSub(  # type: ignore[no-untyped-call]
+            authorizer_uri = fnSub(
                 ArnGenerator.generate_arn(  # type: ignore[no-untyped-call]
                     partition=partition, service="apigateway", resource=resource, include_account_id=False
                 ),

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -19,7 +19,7 @@ class ApiGatewayV2HttpApi(Resource):
         "CorsConfiguration": PropertyType(False, is_type(dict)),
     }
 
-    runtime_attrs = {"http_api_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"http_api_id": lambda self: ref(self.logical_id)}
 
 
 class ApiGatewayV2Stage(Resource):
@@ -37,7 +37,7 @@ class ApiGatewayV2Stage(Resource):
         "AutoDeploy": PropertyType(False, is_type(bool)),
     }
 
-    runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}
 
 
 class ApiGatewayV2DomainName(Resource):
@@ -218,7 +218,7 @@ class ApiGatewayV2Authorizer(object):
             # Generate the lambda arn
             partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
             resource = "lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations"
-            authorizer_uri = fnSub(  # type: ignore[no-untyped-call]
+            authorizer_uri = fnSub(
                 ArnGenerator.generate_arn(  # type: ignore[no-untyped-call]
                     partition=partition, service="apigateway", resource=resource, include_account_id=False
                 ),

--- a/samtranslator/model/cloudformation.py
+++ b/samtranslator/model/cloudformation.py
@@ -14,4 +14,4 @@ class NestedStack(Resource):
         "TimeoutInMinutes": PropertyType(False, is_type(int)),
     }
 
-    runtime_attrs = {"stack_id": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"stack_id": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/codedeploy.py
+++ b/samtranslator/model/codedeploy.py
@@ -7,7 +7,7 @@ class CodeDeployApplication(Resource):
     resource_type = "AWS::CodeDeploy::Application"
     property_types = {"ComputePlatform": PropertyType(False, one_of(is_str(), is_type(dict)))}
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id)}
 
 
 class CodeDeployDeploymentGroup(Resource):
@@ -22,4 +22,4 @@ class CodeDeployDeploymentGroup(Resource):
         "TriggerConfigurations": PropertyType(False, is_type(list)),
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -32,8 +32,8 @@ class CognitoUserPool(Resource):
     }
 
     runtime_attrs = {
-        "name": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
-        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),  # type: ignore[no-untyped-call]
-        "provider_name": lambda self: fnGetAtt(self.logical_id, "ProviderName"),  # type: ignore[no-untyped-call]
-        "provider_url": lambda self: fnGetAtt(self.logical_id, "ProviderURL"),  # type: ignore[no-untyped-call]
+        "name": lambda self: ref(self.logical_id),
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),
+        "provider_name": lambda self: fnGetAtt(self.logical_id, "ProviderName"),
+        "provider_url": lambda self: fnGetAtt(self.logical_id, "ProviderURL"),
     }

--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -67,8 +67,8 @@ def get_event_source_mappings(event_source_id: str, function_id: str, resource_r
             properties = resource.get("Properties", {})
             # Not taking intrinsics as input to function as FunctionName could be a number of
             # formats, which would require parsing it anyway
-            resource_function_id = get_logical_id_from_intrinsic(properties.get("FunctionName"))  # type: ignore[no-untyped-call]
-            resource_event_source_id = get_logical_id_from_intrinsic(properties.get("EventSourceArn"))  # type: ignore[no-untyped-call]
+            resource_function_id = get_logical_id_from_intrinsic(properties.get("FunctionName"))
+            resource_event_source_id = get_logical_id_from_intrinsic(properties.get("EventSourceArn"))
             if (
                 resource_function_id
                 and resource_event_source_id
@@ -160,7 +160,7 @@ def _get_resource_role_property(
     if resource_type == "AWS::Events::Rule":
         for target in properties.get("Targets", []):
             target_arn = target.get("Arn")
-            target_logical_id = get_logical_id_from_intrinsic(target_arn)  # type: ignore[no-untyped-call]
+            target_logical_id = get_logical_id_from_intrinsic(target_arn)
             if (target_logical_id and target_logical_id == connecting_obj_id) or (
                 connecting_obj_arn and target_arn == connecting_obj_arn
             ):
@@ -175,26 +175,26 @@ def _get_resource_role_name(
     if not role:
         return None
 
-    logical_id = get_logical_id_from_intrinsic(role)  # type: ignore[no-untyped-call]
+    logical_id = get_logical_id_from_intrinsic(role)
     if not logical_id:
         return None
 
-    return ref(logical_id)  # type: ignore[no-untyped-call]
+    return ref(logical_id)
 
 
 def _get_resource_queue_url(logical_id: str, resource_type: str) -> Any:
     if resource_type == "AWS::SQS::Queue":
-        return ref(logical_id)  # type: ignore[no-untyped-call]
+        return ref(logical_id)
 
 
 def _get_resource_id(logical_id: str, resource_type: str) -> Any:
     if resource_type in ["AWS::ApiGateway::RestApi", "AWS::ApiGatewayV2::Api"]:
-        return ref(logical_id)  # type: ignore[no-untyped-call]
+        return ref(logical_id)
 
 
 def _get_resource_name(logical_id: str, resource_type: str) -> Any:
     if resource_type == "AWS::StepFunctions::StateMachine":
-        return fnGetAtt(logical_id, "Name")  # type: ignore[no-untyped-call]
+        return fnGetAtt(logical_id, "Name")
 
 
 def _get_resource_qualifier(resource_type: str) -> Any:
@@ -208,6 +208,6 @@ def _get_resource_arn(logical_id: str, resource_type: str) -> Any:
         # according to documentation, Ref returns ARNs for these two resource types
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#aws-resource-stepfunctions-statemachine-return-values
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html#aws-resource-sns-topic-return-values
-        return ref(logical_id)  # type: ignore[no-untyped-call]
+        return ref(logical_id)
     # For all other supported resources, we can typically use Fn::GetAtt LogicalId.Arn to obtain ARNs
-    return fnGetAtt(logical_id, "Arn")  # type: ignore[no-untyped-call]
+    return fnGetAtt(logical_id, "Arn")

--- a/samtranslator/model/dynamodb.py
+++ b/samtranslator/model/dynamodb.py
@@ -19,7 +19,7 @@ class DynamoDBTable(Resource):
     }
 
     runtime_attrs = {
-        "name": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
-        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),  # type: ignore[no-untyped-call]
-        "stream_arn": lambda self: fnGetAtt(self.logical_id, "StreamArn"),  # type: ignore[no-untyped-call]
+        "name": lambda self: ref(self.logical_id),
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),
+        "stream_arn": lambda self: fnGetAtt(self.logical_id, "StreamArn"),
     }

--- a/samtranslator/model/events.py
+++ b/samtranslator/model/events.py
@@ -16,4 +16,4 @@ class EventsRule(Resource):
         "Targets": PropertyType(False, list_of(is_type(dict))),
     }
 
-    runtime_attrs = {"rule_id": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
+    runtime_attrs = {"rule_id": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}

--- a/samtranslator/model/eventsources/cloudwatchlogs.py
+++ b/samtranslator/model/eventsources/cloudwatchlogs.py
@@ -40,7 +40,7 @@ class CloudWatchLogs(PushEventSource):
         resource = "log-group:${__LogGroupName__}:*"
         partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
 
-        return fnSub(  # type: ignore[no-untyped-call]
+        return fnSub(
             ArnGenerator.generate_arn(partition=partition, service="logs", resource=resource),  # type: ignore[no-untyped-call]
             {"__LogGroupName__": self.LogGroupName},  # type: ignore[attr-defined]
         )

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -190,7 +190,7 @@ class PullEventSource(ResourceMacro):
                     role.Policies.append(destination_config_policy)
 
     def _validate_filter_criteria(self):  # type: ignore[no-untyped-def]
-        if not self.FilterCriteria or is_intrinsic(self.FilterCriteria):  # type: ignore[attr-defined, no-untyped-call]
+        if not self.FilterCriteria or is_intrinsic(self.FilterCriteria):  # type: ignore[attr-defined]
             return
         if self.resource_type not in self.RESOURCE_TYPES_WITH_EVENT_FILTERING:
             raise InvalidEventException(  # type: ignore[no-untyped-call]
@@ -446,7 +446,7 @@ class SelfManagedKafka(PullEventSource):
                 "No {} URI property specified in SourceAccessConfigurations for self managed kafka event.".format(msg),
             )
 
-        if not isinstance(config.get("URI"), str) and not is_intrinsic(config.get("URI")):  # type: ignore[no-untyped-call]
+        if not isinstance(config.get("URI"), str) and not is_intrinsic(config.get("URI")):
             raise InvalidEventException(  # type: ignore[no-untyped-call]
                 self.relative_id,
                 "Wrong Type for {} URI property specified in SourceAccessConfigurations for self managed kafka event.".format(

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -312,7 +312,7 @@ class S3(PushEventSource):
 
         resources = []
 
-        source_account = ref("AWS::AccountId")  # type: ignore[no-untyped-call]
+        source_account = ref("AWS::AccountId")
         permission = self._construct_permission(function, source_account=source_account)  # type: ignore[no-untyped-call]
         if CONDITION in permission.resource_attributes:
             self._depend_on_lambda_permissions_using_tag(bucket, permission)  # type: ignore[no-untyped-call]
@@ -389,7 +389,7 @@ class S3(PushEventSource):
         dep_tag = {
             "sam:ConditionalDependsOn:"
             + permission.logical_id: {
-                "Fn::If": [permission.resource_attributes[CONDITION], ref(permission.logical_id), "no dependency"]  # type: ignore[no-untyped-call]
+                "Fn::If": [permission.resource_attributes[CONDITION], ref(permission.logical_id), "no dependency"]
             }
         }
         properties["Tags"] = tags + get_tag_list(dep_tag)  # type: ignore[no-untyped-call]
@@ -411,7 +411,7 @@ class S3(PushEventSource):
             lambda_event = copy.deepcopy(base_event_mapping)
             lambda_event["Event"] = event_type
             if CONDITION in function.resource_attributes:
-                lambda_event = make_conditional(function.resource_attributes[CONDITION], lambda_event)  # type: ignore[no-untyped-call]
+                lambda_event = make_conditional(function.resource_attributes[CONDITION], lambda_event)
             event_mappings.append(lambda_event)
 
         properties = bucket.get("Properties", None)
@@ -679,7 +679,7 @@ class Api(PushEventSource):
         # RestApiId can be a simple string or intrinsic function like !Ref. Using Fn::Sub will handle both cases
         resource = "${__ApiId__}/" + "${__Stage__}/" + method + path
         partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
-        source_arn = fnSub(  # type: ignore[no-untyped-call]
+        source_arn = fnSub(
             ArnGenerator.generate_arn(partition=partition, service="execute-api", resource=resource),  # type: ignore[no-untyped-call]
             {"__ApiId__": api_id, "__Stage__": stage},
         )
@@ -797,7 +797,7 @@ class Api(PushEventSource):
                             model=method_model, method=self.Method, path=self.Path  # type: ignore[attr-defined]
                         ),
                     )
-                if not is_intrinsic(api_models) and not isinstance(api_models, dict):  # type: ignore[no-untyped-call]
+                if not is_intrinsic(api_models) and not isinstance(api_models, dict):
                     raise InvalidEventException(  # type: ignore[no-untyped-call]
                         self.relative_id,
                         "Unable to set RequestModel [{model}] on API method [{method}] for path [{path}] "
@@ -965,11 +965,11 @@ class IoTRule(PushEventSource):
         resource = "rule/${RuleName}"
 
         partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
-        source_arn = fnSub(  # type: ignore[no-untyped-call]
+        source_arn = fnSub(
             ArnGenerator.generate_arn(partition=partition, service="iot", resource=resource),  # type: ignore[no-untyped-call]
-            {"RuleName": ref(self.logical_id)},  # type: ignore[no-untyped-call]
+            {"RuleName": ref(self.logical_id)},
         )
-        source_account = fnSub("${AWS::AccountId}")  # type: ignore[no-untyped-call]
+        source_account = fnSub("${AWS::AccountId}")
 
         resources.append(self._construct_permission(function, source_arn=source_arn, source_account=source_account))  # type: ignore[no-untyped-call]
         resources.append(self._construct_iot_rule(function))  # type: ignore[no-untyped-call]
@@ -1033,7 +1033,7 @@ class Cognito(PushEventSource):
         userpool_id = kwargs["userpool_id"]
 
         resources = []
-        source_arn = fnGetAtt(userpool_id, "Arn")  # type: ignore[no-untyped-call]
+        source_arn = fnGetAtt(userpool_id, "Arn")
         lambda_permission = self._construct_permission(  # type: ignore[no-untyped-call]
             function, source_arn=source_arn, prefix=function.logical_id + "Cognito"
         )
@@ -1175,7 +1175,7 @@ class HttpApi(PushEventSource):
 
         # ApiId can be a simple string or intrinsic function like !Ref. Using Fn::Sub will handle both cases
         resource = "${__ApiId__}/" + "${__Stage__}/" + method + path
-        source_arn = fnSub(  # type: ignore[no-untyped-call]
+        source_arn = fnSub(
             ArnGenerator.generate_arn(partition="${AWS::Partition}", service="execute-api", resource=resource),  # type: ignore[no-untyped-call]
             {"__ApiId__": api_id, "__Stage__": stage},
         )
@@ -1301,14 +1301,14 @@ def _build_apigw_integration_uri(function, partition):  # type: ignore[no-untype
         "arn:"
         + partition
         + ":apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/"
-        + make_shorthand(function_arn)  # type: ignore[no-untyped-call]
+        + make_shorthand(function_arn)
         + "/invocations"
     )
     # function_arn is always of the form {"Fn::GetAtt": ["<function_logical_id>", "Arn"]}.
     # We only want to check if the function logical id is a Py27UniStr instance.
     if function_arn.get("Fn::GetAtt") and isinstance(function_arn["Fn::GetAtt"][0], Py27UniStr):
         arn = Py27UniStr(arn)
-    return Py27Dict(fnSub(arn))  # type: ignore[no-untyped-call, no-untyped-call]
+    return Py27Dict(fnSub(arn))
 
 
 def _check_valid_authorizer_types(  # type: ignore[no-untyped-def]

--- a/samtranslator/model/iam.py
+++ b/samtranslator/model/iam.py
@@ -14,7 +14,7 @@ class IAMRole(Resource):
         "Tags": PropertyType(False, list_of(is_type(dict))),
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
 
 
 class IAMManagedPolicy(Resource):

--- a/samtranslator/model/intrinsics.py
+++ b/samtranslator/model/intrinsics.py
@@ -1,40 +1,43 @@
-def fnGetAtt(logical_name, attribute_name):  # type: ignore[no-untyped-def]
+from typing import Any, Dict, Iterable, List, Union, Optional
+
+
+def fnGetAtt(logical_name: str, attribute_name: str) -> Dict[str, List[str]]:
     return {"Fn::GetAtt": [logical_name, attribute_name]}
 
 
-def ref(logical_name):  # type: ignore[no-untyped-def]
+def ref(logical_name: str) -> Dict[str, str]:
     return {"Ref": logical_name}
 
 
-def fnJoin(delimiter, values):  # type: ignore[no-untyped-def]
+def fnJoin(delimiter: str, values: List[str]) -> Dict[str, List[Any]]:
     return {"Fn::Join": [delimiter, values]}
 
 
-def fnSub(string, variables=None):  # type: ignore[no-untyped-def]
+def fnSub(string: str, variables: Optional[Dict[str, Any]] = None) -> Dict[str, Union[str, List[Any]]]:
     if variables:
         return {"Fn::Sub": [string, variables]}
     return {"Fn::Sub": string}
 
 
-def fnOr(argument_list):  # type: ignore[no-untyped-def]
+def fnOr(argument_list: List[Any]) -> Dict[str, List[Any]]:
     return {"Fn::Or": argument_list}
 
 
-def fnAnd(argument_list):  # type: ignore[no-untyped-def]
+def fnAnd(argument_list: List[Any]) -> Dict[str, List[Any]]:
     return {"Fn::And": argument_list}
 
 
-def make_conditional(condition, true_data, false_data=None):  # type: ignore[no-untyped-def]
+def make_conditional(condition: str, true_data: Any, false_data: Optional[Any] = None) -> Dict[str, List[Any]]:
     if false_data is None:
         false_data = {"Ref": "AWS::NoValue"}
     return {"Fn::If": [condition, true_data, false_data]}
 
 
-def make_not_conditional(condition):  # type: ignore[no-untyped-def]
+def make_not_conditional(condition: str) -> Dict[str, List[Dict[str, str]]]:
     return {"Fn::Not": [{"Condition": condition}]}
 
 
-def make_condition_or_list(conditions_list):  # type: ignore[no-untyped-def]
+def make_condition_or_list(conditions_list: Iterable[Any]) -> List[Dict[str, Any]]:
     condition_or_list = []
     for condition in conditions_list:
         c = {"Condition": condition}
@@ -42,19 +45,19 @@ def make_condition_or_list(conditions_list):  # type: ignore[no-untyped-def]
     return condition_or_list
 
 
-def make_or_condition(conditions_list):  # type: ignore[no-untyped-def]
-    or_list = make_condition_or_list(conditions_list)  # type: ignore[no-untyped-call]
-    condition = fnOr(or_list)  # type: ignore[no-untyped-call]
+def make_or_condition(conditions_list: Iterable[Any]) -> Dict[str, List[Dict[str, Any]]]:
+    or_list = make_condition_or_list(conditions_list)
+    condition = fnOr(or_list)
     return condition
 
 
-def make_and_condition(conditions_list):  # type: ignore[no-untyped-def]
-    and_list = make_condition_or_list(conditions_list)  # type: ignore[no-untyped-call]
-    condition = fnAnd(and_list)  # type: ignore[no-untyped-call]
+def make_and_condition(conditions_list: Iterable[Any]) -> Dict[str, List[Dict[str, Any]]]:
+    and_list = make_condition_or_list(conditions_list)
+    condition = fnAnd(and_list)
     return condition
 
 
-def calculate_number_of_conditions(conditions_length, max_conditions):  # type: ignore[no-untyped-def]
+def calculate_number_of_conditions(conditions_length: int, max_conditions: int) -> int:
     """
     Every condition can hold up to max_conditions, which (as of writing this) is 10.
     Every time a condition is created, (max_conditions) are used and 1 new one is added to the conditions list.
@@ -73,7 +76,9 @@ def calculate_number_of_conditions(conditions_length, max_conditions):  # type: 
     return num_conditions
 
 
-def make_combined_condition(conditions_list, condition_name):  # type: ignore[no-untyped-def]
+def make_combined_condition(
+    conditions_list: List[str], condition_name: str
+) -> Optional[Dict[str, Dict[str, List[Dict[str, Any]]]]]:
     """
     Makes a combined condition using Fn::Or. Since Fn::Or only accepts up to 10 conditions,
     this method optionally creates multiple conditions. These conditions are named based on
@@ -94,7 +99,7 @@ def make_combined_condition(conditions_list, condition_name):  # type: ignore[no
     conditions = {}
     conditions_length = len(conditions_list)
     # Get number of conditions needed, then minus one to use them as 0-based indices
-    zero_based_num_conditions = calculate_number_of_conditions(conditions_length, max_conditions) - 1  # type: ignore[no-untyped-call]
+    zero_based_num_conditions = calculate_number_of_conditions(conditions_length, max_conditions) - 1
 
     while len(conditions_list) > 1:
         new_condition_name = condition_name
@@ -102,14 +107,14 @@ def make_combined_condition(conditions_list, condition_name):  # type: ignore[no
         if zero_based_num_conditions > 0:
             new_condition_name = "{}{}".format(condition_name, zero_based_num_conditions)
             zero_based_num_conditions -= 1
-        new_condition_content = make_or_condition(conditions_list[:max_conditions])  # type: ignore[no-untyped-call]
+        new_condition_content = make_or_condition(conditions_list[:max_conditions])
         conditions_list = conditions_list[max_conditions:]
         conditions_list.append(new_condition_name)
         conditions[new_condition_name] = new_condition_content
     return conditions
 
 
-def make_shorthand(intrinsic_dict):  # type: ignore[no-untyped-def]
+def make_shorthand(intrinsic_dict: Dict[str, Any]) -> str:
     """
     Converts a given intrinsics dictionary into a short-hand notation that Fn::Sub can use. Only Ref and Fn::GetAtt
     support shorthands.
@@ -130,7 +135,7 @@ def make_shorthand(intrinsic_dict):  # type: ignore[no-untyped-def]
     raise NotImplementedError("Shorthanding is only supported for Ref and Fn::GetAtt")
 
 
-def is_intrinsic(input):  # type: ignore[no-untyped-def]
+def is_intrinsic(input: Any) -> bool:
     """
     Checks if the given input is an intrinsic function dictionary. Intrinsic function is a dictionary with single
     key that is the name of the intrinsics.
@@ -141,13 +146,13 @@ def is_intrinsic(input):  # type: ignore[no-untyped-def]
 
     if input is not None and isinstance(input, dict) and len(input) == 1:
 
-        key = list(input.keys())[0]
+        key: str = list(input.keys())[0]
         return key == "Ref" or key == "Condition" or key.startswith("Fn::")
 
     return False
 
 
-def is_intrinsic_if(input):  # type: ignore[no-untyped-def]
+def is_intrinsic_if(input: Any) -> bool:
     """
     Is the given input an intrinsic if? Intrinsic function 'if' is a dictionary with single
     key - if
@@ -156,14 +161,14 @@ def is_intrinsic_if(input):  # type: ignore[no-untyped-def]
     :return: True, if yes
     """
 
-    if not is_intrinsic(input):  # type: ignore[no-untyped-call]
+    if not is_intrinsic(input):
         return False
 
-    key = list(input.keys())[0]
+    key: str = list(input.keys())[0]
     return key == "Fn::If"
 
 
-def validate_intrinsic_if_items(items):  # type: ignore[no-untyped-def]
+def validate_intrinsic_if_items(items: Any) -> None:
     """
     Validates Fn::If items
 
@@ -181,7 +186,7 @@ def validate_intrinsic_if_items(items):  # type: ignore[no-untyped-def]
         raise ValueError("Fn::If requires 3 arguments")
 
 
-def is_intrinsic_no_value(input):  # type: ignore[no-untyped-def]
+def is_intrinsic_no_value(input: Any) -> bool:
     """
     Is the given input an intrinsic Ref: AWS::NoValue? Intrinsic function is a dictionary with single
     key - Ref and value - AWS::NoValue
@@ -190,21 +195,21 @@ def is_intrinsic_no_value(input):  # type: ignore[no-untyped-def]
     :return: True, if yes
     """
 
-    if not is_intrinsic(input):  # type: ignore[no-untyped-call]
+    if not is_intrinsic(input):
         return False
 
-    key = list(input.keys())[0]
+    key: str = list(input.keys())[0]
     return key == "Ref" and input["Ref"] == "AWS::NoValue"
 
 
-def get_logical_id_from_intrinsic(input):  # type: ignore[no-untyped-def]
+def get_logical_id_from_intrinsic(input: Any) -> Optional[str]:
     """
     Verify if input is an Fn:GetAtt or Ref intrinsic
 
     :param input: Input value to check if it is an intrinsic
     :return: logical id if yes, return input for any other intrinsic function
     """
-    if not is_intrinsic(input):  # type: ignore[no-untyped-call]
+    if not is_intrinsic(input):
         return None
 
     # !Ref <logical-id>

--- a/samtranslator/model/iot.py
+++ b/samtranslator/model/iot.py
@@ -7,4 +7,4 @@ class IotTopicRule(Resource):
     resource_type = "AWS::IoT::TopicRule"
     property_types = {"TopicRulePayload": PropertyType(False, is_type(dict))}
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -30,7 +30,7 @@ class LambdaFunction(Resource):
         "EphemeralStorage": PropertyType(False, is_type(dict)),
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
 
 
 class LambdaVersion(Resource):
@@ -42,8 +42,8 @@ class LambdaVersion(Resource):
     }
 
     runtime_attrs = {
-        "arn": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
-        "version": lambda self: fnGetAtt(self.logical_id, "Version"),  # type: ignore[no-untyped-call]
+        "arn": lambda self: ref(self.logical_id),
+        "version": lambda self: fnGetAtt(self.logical_id, "Version"),
     }
 
 
@@ -57,7 +57,7 @@ class LambdaAlias(Resource):
         "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),
     }
 
-    runtime_attrs = {"arn": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"arn": lambda self: ref(self.logical_id)}
 
 
 class LambdaEventSourceMapping(Resource):
@@ -85,7 +85,7 @@ class LambdaEventSourceMapping(Resource):
         "SelfManagedKafkaEventSourceConfig": PropertyType(False, is_type(dict)),
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id)}
 
 
 class LambdaPermission(Resource):
@@ -125,7 +125,7 @@ class LambdaLayerVersion(Resource):
         "LicenseInfo": PropertyType(False, is_str()),
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
 
 
 class LambdaUrl(Resource):

--- a/samtranslator/model/log.py
+++ b/samtranslator/model/log.py
@@ -11,4 +11,4 @@ class SubscriptionFilter(Resource):
         "DestinationArn": PropertyType(True, is_str()),
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}

--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -182,7 +182,7 @@ class DeploymentPreferenceCollection(object):
         except ValueError as e:
             raise InvalidResourceException(function_logical_id, str(e))  # type: ignore[no-untyped-call]
 
-        deployment_group.ApplicationName = ref(CODEDEPLOY_APPLICATION_LOGICAL_ID)  # type: ignore[no-untyped-call]
+        deployment_group.ApplicationName = ref(CODEDEPLOY_APPLICATION_LOGICAL_ID)
         deployment_group.AutoRollbackConfiguration = {
             "Enabled": True,
             "Events": ["DEPLOYMENT_FAILURE", "DEPLOYMENT_STOP_ON_ALARM", "DEPLOYMENT_STOP_ON_REQUEST"],
@@ -194,7 +194,7 @@ class DeploymentPreferenceCollection(object):
 
         deployment_group.DeploymentStyle = {"DeploymentType": "BLUE_GREEN", "DeploymentOption": "WITH_TRAFFIC_CONTROL"}
 
-        deployment_group.ServiceRoleArn = fnGetAtt(CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID, "Arn")  # type: ignore[no-untyped-call]
+        deployment_group.ServiceRoleArn = fnGetAtt(CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID, "Arn")
         if deployment_preference.role:
             deployment_group.ServiceRoleArn = deployment_preference.role
 
@@ -225,13 +225,13 @@ class DeploymentPreferenceCollection(object):
         ValueError
             If Alarms is in the wrong format
         """
-        if not preference_alarms or is_intrinsic_no_value(preference_alarms):  # type: ignore[no-untyped-call]
+        if not preference_alarms or is_intrinsic_no_value(preference_alarms):
             return None
 
-        if is_intrinsic_if(preference_alarms):  # type: ignore[no-untyped-call]
+        if is_intrinsic_if(preference_alarms):
             processed_alarms = copy.deepcopy(preference_alarms)
             alarms_list = processed_alarms.get("Fn::If")
-            validate_intrinsic_if_items(alarms_list)  # type: ignore[no-untyped-call]
+            validate_intrinsic_if_items(alarms_list)
             alarms_list[1] = self._build_alarm_configuration(alarms_list[1])  # type: ignore[no-untyped-call]
             alarms_list[2] = self._build_alarm_configuration(alarms_list[2])  # type: ignore[no-untyped-call]
             return processed_alarms
@@ -260,7 +260,7 @@ class DeploymentPreferenceCollection(object):
         if not isinstance(alarms, list):
             raise ValueError("Alarms must be a list")
 
-        if len(alarms) == 0 or is_intrinsic_no_value(alarms[0]):  # type: ignore[no-untyped-call]
+        if len(alarms) == 0 or is_intrinsic_no_value(alarms[0]):
             return {}
 
         return {
@@ -273,21 +273,21 @@ class DeploymentPreferenceCollection(object):
             for i, v in enumerate(value):
                 value[i] = self._replace_deployment_types(v)  # type: ignore[no-untyped-call]
             return value
-        if is_intrinsic(value):  # type: ignore[no-untyped-call]
+        if is_intrinsic(value):
             for (k, v) in value.items():
                 value[k] = self._replace_deployment_types(v, k)  # type: ignore[no-untyped-call]
             return value
         if value in CODEDEPLOY_PREDEFINED_CONFIGURATIONS_LIST:
             if key == "Fn::Sub":  # Don't nest a "Sub" in a "Sub"
                 return ["CodeDeployDefault.Lambda${ConfigName}", {"ConfigName": value}]
-            return fnSub("CodeDeployDefault.Lambda${ConfigName}", {"ConfigName": value})  # type: ignore[no-untyped-call]
+            return fnSub("CodeDeployDefault.Lambda${ConfigName}", {"ConfigName": value})
         return value
 
     def update_policy(self, function_logical_id):  # type: ignore[no-untyped-def]
         deployment_preference = self.get(function_logical_id)  # type: ignore[no-untyped-call]
 
         return UpdatePolicy(
-            ref(CODEDEPLOY_APPLICATION_LOGICAL_ID),  # type: ignore[no-untyped-call]
+            ref(CODEDEPLOY_APPLICATION_LOGICAL_ID),
             self.deployment_group(function_logical_id).get_runtime_attr("name"),  # type: ignore[no-untyped-call]
             deployment_preference.pre_traffic_hook,
             deployment_preference.post_traffic_hook,

--- a/samtranslator/model/resource_policies.py
+++ b/samtranslator/model/resource_policies.py
@@ -125,11 +125,11 @@ class ResourcePolicies(object):
             return PolicyTypes.MANAGED_POLICY
 
         # Handle the special case for 'if' intrinsic function
-        if is_intrinsic_if(policy):  # type: ignore[no-untyped-call]
+        if is_intrinsic_if(policy):
             return self._get_type_from_intrinsic_if(policy)  # type: ignore[no-untyped-call]
 
         # Intrinsic functions are treated as managed policies by default
-        if is_intrinsic(policy):  # type: ignore[no-untyped-call]
+        if is_intrinsic(policy):
             return PolicyTypes.MANAGED_POLICY
 
         # Policy statement is a dictionary with the key "Statement" in it
@@ -169,7 +169,7 @@ class ResourcePolicies(object):
         intrinsic_if_value = policy["Fn::If"]
 
         try:
-            validate_intrinsic_if_items(intrinsic_if_value)  # type: ignore[no-untyped-call]
+            validate_intrinsic_if_items(intrinsic_if_value)
         except ValueError as e:
             raise InvalidTemplateException(e)  # type: ignore[no-untyped-call]
 
@@ -182,10 +182,10 @@ class ResourcePolicies(object):
         if if_data_type == else_data_type:
             return if_data_type
 
-        if is_intrinsic_no_value(if_data):  # type: ignore[no-untyped-call]
+        if is_intrinsic_no_value(if_data):
             return else_data_type
 
-        if is_intrinsic_no_value(else_data):  # type: ignore[no-untyped-call]
+        if is_intrinsic_no_value(else_data):
             return if_data_type
 
         raise InvalidTemplateException(  # type: ignore[no-untyped-call]

--- a/samtranslator/model/role_utils/role_constructor.py
+++ b/samtranslator/model/role_utils/role_constructor.py
@@ -43,20 +43,20 @@ def construct_role_for_resource(  # type: ignore[no-untyped-def]
     for index, policy_entry in enumerate(resource_policies.get()):
         if policy_entry.type is PolicyTypes.POLICY_STATEMENT:
 
-            if is_intrinsic_if(policy_entry.data):  # type: ignore[no-untyped-call]
+            if is_intrinsic_if(policy_entry.data):
 
                 intrinsic_if = policy_entry.data
                 then_statement = intrinsic_if["Fn::If"][1]
                 else_statement = intrinsic_if["Fn::If"][2]
 
-                if not is_intrinsic_no_value(then_statement):  # type: ignore[no-untyped-call]
+                if not is_intrinsic_no_value(then_statement):
                     then_statement = {
                         "PolicyName": execution_role.logical_id + "Policy" + str(index),
                         "PolicyDocument": then_statement,
                     }
                     intrinsic_if["Fn::If"][1] = then_statement
 
-                if not is_intrinsic_no_value(else_statement):  # type: ignore[no-untyped-call]
+                if not is_intrinsic_no_value(else_statement):
                     else_statement = {
                         "PolicyName": execution_role.logical_id + "Policy" + str(index),
                         "PolicyDocument": else_statement,

--- a/samtranslator/model/s3.py
+++ b/samtranslator/model/s3.py
@@ -28,4 +28,4 @@ class S3Bucket(Resource):
         "WebsiteConfiguration": PropertyType(False, any_type()),
     }
 
-    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call, no-untyped-call]
+    runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -280,7 +280,7 @@ class SamFunction(SamResourceMacro):
             if policy is not None:
                 policy_document.append(policy)
 
-        lambda_event_invoke_config.FunctionName = ref(function_name)  # type: ignore[no-untyped-call]
+        lambda_event_invoke_config.FunctionName = ref(function_name)
         if alias_name:
             lambda_event_invoke_config.Qualifier = alias_name
         else:
@@ -333,7 +333,7 @@ class SamFunction(SamResourceMacro):
                 if combined_condition:
                     resource.set_resource_attribute("Condition", combined_condition)  # type: ignore[union-attr]
                 if property_condition:
-                    destination["Destination"] = make_conditional(  # type: ignore[no-untyped-call]
+                    destination["Destination"] = make_conditional(
                         property_condition, resource.get_runtime_attr("arn"), dest_arn  # type: ignore[union-attr]
                     )
                 else:
@@ -359,8 +359,8 @@ class SamFunction(SamResourceMacro):
         if property_condition is None:
             return resource_condition
 
-        and_condition = make_and_condition([{"Condition": resource_condition}, {"Condition": property_condition}])  # type: ignore[no-untyped-call]
-        condition_name = self._make_gen_condition_name(resource_condition + "AND" + property_condition, self.logical_id)  # type: ignore[no-untyped-call]
+        and_condition = make_and_condition([{"Condition": resource_condition}, {"Condition": property_condition}])
+        condition_name = self._make_gen_condition_name(resource_condition + "AND" + property_condition, self.logical_id)
         conditions[condition_name] = and_condition
 
         return condition_name
@@ -381,23 +381,23 @@ class SamFunction(SamResourceMacro):
         """
         if destination is None:
             return None, None
-        if is_intrinsic_if(destination):  # type: ignore[no-untyped-call]
+        if is_intrinsic_if(destination):
             dest_list = destination.get("Fn::If")
-            if is_intrinsic_no_value(dest_list[1]) and is_intrinsic_no_value(dest_list[2]):  # type: ignore[no-untyped-call]
+            if is_intrinsic_no_value(dest_list[1]) and is_intrinsic_no_value(dest_list[2]):
                 return None, None
-            if is_intrinsic_no_value(dest_list[1]):  # type: ignore[no-untyped-call]
+            if is_intrinsic_no_value(dest_list[1]):
                 return dest_list[0], dest_list[2]
-            if is_intrinsic_no_value(dest_list[2]):  # type: ignore[no-untyped-call]
+            if is_intrinsic_no_value(dest_list[2]):
                 condition = dest_list[0]
-                not_condition = self._make_gen_condition_name("NOT" + condition, logical_id)  # type: ignore[no-untyped-call]
-                conditions[not_condition] = make_not_conditional(condition)  # type: ignore[no-untyped-call]
+                not_condition = self._make_gen_condition_name("NOT" + condition, logical_id)
+                conditions[not_condition] = make_not_conditional(condition)
                 return not_condition, dest_list[1]
         return None, None
 
-    def _make_gen_condition_name(self, name, hash_input):  # type: ignore[no-untyped-def]
+    def _make_gen_condition_name(self, name: str, hash_input: str) -> str:
         # Make sure the property name is not over 255 characters (CFN limit)
         hash_digest = logical_id_generator.LogicalIdGenerator("", hash_input).gen()  # type: ignore[no-untyped-call, no-untyped-call]
-        condition_name = name + hash_digest
+        condition_name: str = name + hash_digest
         if len(condition_name) > 255:
             return input(condition_name)[:255]
         return condition_name
@@ -599,13 +599,13 @@ class SamFunction(SamResourceMacro):
 
         architectures = [X86_64] if lambda_function.Architectures is None else lambda_function.Architectures
 
-        if is_intrinsic(architectures):  # type: ignore[no-untyped-call]
+        if is_intrinsic(architectures):
             return
 
         if (
             not isinstance(architectures, list)
             or len(architectures) != 1
-            or (not is_intrinsic(architectures[0]) and (architectures[0] not in [X86_64, ARM64]))  # type: ignore[no-untyped-call]
+            or (not is_intrinsic(architectures[0]) and (architectures[0] not in [X86_64, ARM64]))
         ):
             raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 lambda_function.logical_id,
@@ -928,7 +928,7 @@ class SamFunction(SamResourceMacro):
             return True
         if processed_property_value in [False, "false", "False"]:
             return False
-        if is_intrinsic(processed_property_value):  # type: ignore[no-untyped-call] # couldn't resolve intrinsic
+        if is_intrinsic(processed_property_value):  # couldn't resolve intrinsic
             raise InvalidResourceException(  # type: ignore[no-untyped-call]
                 self.logical_id,
                 f"Unsupported intrinsic: the only intrinsic functions supported for "
@@ -975,11 +975,11 @@ class SamFunction(SamResourceMacro):
         self._validate_cors_config_parameter(lambda_function)  # type: ignore[no-untyped-call]
 
     def _validate_url_auth_type(self, lambda_function):  # type: ignore[no-untyped-def]
-        if is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined, no-untyped-call]
+        if is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined]
             return
 
         auth_type = self.FunctionUrlConfig.get("AuthType")  # type: ignore[attr-defined]
-        if auth_type and is_intrinsic(auth_type):  # type: ignore[no-untyped-call]
+        if auth_type and is_intrinsic(auth_type):
             return
 
         if not auth_type or auth_type not in ["AWS_IAM", "NONE"]:
@@ -989,7 +989,7 @@ class SamFunction(SamResourceMacro):
             )
 
     def _validate_cors_config_parameter(self, lambda_function):  # type: ignore[no-untyped-def]
-        if is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined, no-untyped-call]
+        if is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined]
             return
 
         cors_property_data_type = {
@@ -1003,7 +1003,7 @@ class SamFunction(SamResourceMacro):
 
         cors = self.FunctionUrlConfig.get("Cors")  # type: ignore[attr-defined]
 
-        if not cors or is_intrinsic(cors):  # type: ignore[no-untyped-call]
+        if not cors or is_intrinsic(cors):
             return
 
         for prop_name, prop_value in cors.items():
@@ -1013,7 +1013,7 @@ class SamFunction(SamResourceMacro):
                     "{} is not a valid property for configuring Cors.".format(prop_name),
                 )
             prop_type = cors_property_data_type.get(prop_name)
-            if not is_intrinsic(prop_value) and not isinstance(prop_value, prop_type):  # type: ignore[arg-type, no-untyped-call]
+            if not is_intrinsic(prop_value) and not isinstance(prop_value, prop_type):  # type: ignore[arg-type]
                 raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_function.logical_id,
                     "{} must be of type {}.".format(prop_name, str(prop_type).split("'")[1]),
@@ -1039,7 +1039,7 @@ class SamFunction(SamResourceMacro):
         """
         auth_type = self.FunctionUrlConfig.get("AuthType")  # type: ignore[attr-defined]
 
-        if auth_type not in ["NONE"] or is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined, no-untyped-call]
+        if auth_type not in ["NONE"] or is_intrinsic(self.FunctionUrlConfig):  # type: ignore[attr-defined]
             return None
 
         logical_id = f"{lambda_function.logical_id}UrlPublicPermissions"
@@ -1490,7 +1490,7 @@ class SamLayerVersion(SamResourceMacro):
         :return: value for the DeletionPolicy attribute.
         """
 
-        if is_intrinsic(self.RetentionPolicy):  # type: ignore[no-untyped-call]
+        if is_intrinsic(self.RetentionPolicy):
             # RetentionPolicy attribute of AWS::Serverless::LayerVersion does set the DeletionPolicy
             # attribute. And DeletionPolicy attribute does not support intrinsic values.
             raise InvalidResourceException(  # type: ignore[no-untyped-call]
@@ -1526,11 +1526,11 @@ class SamLayerVersion(SamResourceMacro):
         """
         architectures = lambda_layer.CompatibleArchitectures or [X86_64]
         # Intrinsics are not validated
-        if is_intrinsic(architectures):  # type: ignore[no-untyped-call]
+        if is_intrinsic(architectures):
             return
         for arq in architectures:
             # We validate the values only if we they're not intrinsics
-            if not is_intrinsic(arq) and not arq in [ARM64, X86_64]:  # type: ignore[no-untyped-call]
+            if not is_intrinsic(arq) and not arq in [ARM64, X86_64]:
                 raise InvalidResourceException(  # type: ignore[no-untyped-call]
                     lambda_layer.logical_id,
                     "CompatibleArchitectures needs to be a list of '{}' or '{}'".format(X86_64, ARM64),

--- a/samtranslator/model/sns.py
+++ b/samtranslator/model/sns.py
@@ -22,4 +22,4 @@ class SNSTopicPolicy(Resource):
 class SNSTopic(Resource):
     resource_type = "AWS::SNS::Topic"
     property_types = {"TopicName": PropertyType(False, is_str())}
-    runtime_attrs = {"arn": lambda self: ref(self.logical_id)}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"arn": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/sqs.py
+++ b/samtranslator/model/sqs.py
@@ -9,15 +9,15 @@ class SQSQueue(Resource):
     resource_type = "AWS::SQS::Queue"
     property_types: Dict[str, PropertyType] = {}
     runtime_attrs = {
-        "queue_url": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
-        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),  # type: ignore[no-untyped-call]
+        "queue_url": lambda self: ref(self.logical_id),
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),
     }
 
 
 class SQSQueuePolicy(Resource):
     resource_type = "AWS::SQS::QueuePolicy"
     property_types = {"PolicyDocument": PropertyType(True, is_type(dict)), "Queues": PropertyType(True, list_of(str))}
-    runtime_attrs = {"arn": lambda self: fnGetAtt(self.logical_id, "Arn")}  # type: ignore[no-untyped-call]
+    runtime_attrs = {"arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
 
 
 class SQSQueuePolicies:

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -344,7 +344,7 @@ class Api(EventSource):
         if swagger_body is None:
             return
 
-        integration_uri = fnSub("arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution")  # type: ignore[no-untyped-call]
+        integration_uri = fnSub("arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution")
 
         editor = SwaggerEditor(swagger_body)  # type: ignore[no-untyped-call]
 
@@ -448,7 +448,7 @@ class Api(EventSource):
         :rtype: dict
         """
         request_templates = {
-            "application/json": fnSub(  # type: ignore[no-untyped-call]
+            "application/json": fnSub(
                 json.dumps(
                     {
                         "input": "$util.escapeJavaScript($input.json('$'))",

--- a/samtranslator/model/stepfunctions/generators.py
+++ b/samtranslator/model/stepfunctions/generators.py
@@ -197,7 +197,7 @@ class StateMachineGenerator(object):
         # Indenting and then splitting the JSON-encoded string for readability of the state machine definition in the CloudFormation translated resource.
         # Separators are passed explicitly to maintain trailing whitespace consistency across Py2 and Py3
         definition_lines = json.dumps(definition_dict, sort_keys=True, indent=4, separators=(",", ": ")).split("\n")
-        definition_string = fnJoin("\n", definition_lines)  # type: ignore[no-untyped-call]
+        definition_string = fnJoin("\n", definition_lines)
         return definition_string
 
     def _construct_role(self):  # type: ignore[no-untyped-def]

--- a/samtranslator/model/stepfunctions/resources.py
+++ b/samtranslator/model/stepfunctions/resources.py
@@ -19,6 +19,6 @@ class StepFunctionsStateMachine(Resource):
     }
 
     runtime_attrs = {
-        "arn": lambda self: ref(self.logical_id),  # type: ignore[no-untyped-call]
-        "name": lambda self: fnGetAtt(self.logical_id, "Name"),  # type: ignore[no-untyped-call]
+        "arn": lambda self: ref(self.logical_id),
+        "name": lambda self: fnGetAtt(self.logical_id, "Name"),
     }

--- a/samtranslator/model/update_policy.py
+++ b/samtranslator/model/update_policy.py
@@ -27,6 +27,9 @@ class UpdatePolicy(CodeDeployLambdaAliasUpdate):
         """
         dict_with_nones = self._asdict()
         codedeploy_lambda_alias_update_dict = dict(
-            (k, v) for k, v in dict_with_nones.items() if v != ref(None) and v is not None  # type: ignore[no-untyped-call]
+            # Type ignore next line. `ref(None)` is not a typical usage of `ref()`.
+            (k, v)
+            for k, v in dict_with_nones.items()
+            if v != ref(None) and v is not None  # type: ignore
         )
         return {"CodeDeployLambdaAliasUpdate": codedeploy_lambda_alias_update_dict}

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -68,7 +68,7 @@ class OpenApiEditor(object):
         contents = [item]
         if isinstance(item, dict) and self._CONDITIONAL_IF in item:
             contents = item[self._CONDITIONAL_IF][1:]
-            contents = [content for content in contents if not is_intrinsic_no_value(content)]  # type: ignore[no-untyped-call]
+            contents = [content for content in contents if not is_intrinsic_no_value(content)]
         return contents
 
     def has_path(self, path, method=None):  # type: ignore[no-untyped-def]
@@ -214,7 +214,7 @@ class OpenApiEditor(object):
         # Wrap the integration_uri in a Condition if one exists on that function
         # This is necessary so CFN doesn't try to resolve the integration reference.
         if condition:
-            integration_uri = make_conditional(condition, integration_uri)  # type: ignore[no-untyped-call]
+            integration_uri = make_conditional(condition, integration_uri)
 
         for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             # create as Py27Dict and insert key one by one to preserve input order
@@ -234,7 +234,7 @@ class OpenApiEditor(object):
 
             # If a condition is present, wrap all method contents up into the condition
             if condition:
-                path_item[method] = make_conditional(condition, path_item[method])  # type: ignore[no-untyped-call]
+                path_item[method] = make_conditional(condition, path_item[method])
 
     def make_path_conditional(self, path, condition):  # type: ignore[no-untyped-def]
         """
@@ -242,7 +242,7 @@ class OpenApiEditor(object):
         :param path: path name
         :param condition: condition name
         """
-        self.paths[path] = make_conditional(condition, self.paths[path])  # type: ignore[no-untyped-call]
+        self.paths[path] = make_conditional(condition, self.paths[path])
 
     def iter_on_path(self):  # type: ignore[no-untyped-def]
         """
@@ -561,7 +561,7 @@ class OpenApiEditor(object):
         cors_configuration = self._doc.get(self._X_APIGW_CORS, {})
 
         # intrinsics will not work if cors configuration is defined in open api and as a property to the HttpApi
-        if allow_origins and is_intrinsic(allow_origins):  # type: ignore[no-untyped-call]
+        if allow_origins and is_intrinsic(allow_origins):
             cors_configuration_string = json.dumps(allow_origins)
             for header in cors_headers:
                 # example: allowOrigins to AllowOrigins
@@ -651,7 +651,7 @@ class OpenApiEditor(object):
         skeleton["openapi"] = "3.0.1"
         skeleton["info"] = Py27Dict()
         skeleton["info"]["version"] = "1.0"
-        skeleton["info"]["title"] = ref("AWS::StackName")  # type: ignore[no-untyped-call]
+        skeleton["info"]["title"] = ref("AWS::StackName")
         skeleton["paths"] = Py27Dict()
         return skeleton
 

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -349,8 +349,11 @@ class ImplicitApiPlugin(BasePlugin):  # type: ignore[misc]
             raise ValueError("conditions_to_combine must have at least 2 conditions")
 
         template_conditions = template_dict.setdefault("Conditions", {})
-        new_template_conditions = make_combined_condition(sorted(list(conditions_to_combine)), condition_name)  # type: ignore[no-untyped-call]
-        for name, definition in new_template_conditions.items():
+        new_template_conditions = make_combined_condition(sorted(list(conditions_to_combine)), condition_name)
+        # make_combined_condition() won't return None if `conditions_to_combine` has at least 2 elements,
+        # which is checked above.
+        # TODO: refactor the code to make the length check in one place only.
+        for name, definition in new_template_conditions.items():  # type: ignore
             template_conditions[name] = definition
 
     def _maybe_add_conditions_to_implicit_api_paths(self, template):  # type: ignore[no-untyped-def]

--- a/samtranslator/plugins/api/implicit_http_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_http_api_plugin.py
@@ -164,7 +164,7 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin):
         api_route_settings = resource.properties.get("RouteSettings", {})
         event_route_settings = event_properties.get("RouteSettings", {})
         if condition:
-            event_route_settings = make_conditional(condition, event_properties.get("RouteSettings", {}))  # type: ignore[no-untyped-call]
+            event_route_settings = make_conditional(condition, event_properties.get("RouteSettings", {}))
 
         # Merge event-level and api-level RouteSettings properties
         api_route_settings.setdefault(route, {})

--- a/samtranslator/plugins/policies/policy_templates_plugin.py
+++ b/samtranslator/plugins/policies/policy_templates_plugin.py
@@ -59,7 +59,7 @@ class PolicyTemplatesForResourcePlugin(BasePlugin):
                 result.append(policy_entry.data)
                 continue
 
-            if is_intrinsic_if(policy_entry.data):  # type: ignore[no-untyped-call]
+            if is_intrinsic_if(policy_entry.data):
                 # If policy is an intrinsic if, we need to process each sub-statement separately
                 processed_intrinsic_if = self._process_intrinsic_if_policy_template(logical_id, policy_entry)  # type: ignore[no-untyped-call]
                 result.append(processed_intrinsic_if)
@@ -78,13 +78,13 @@ class PolicyTemplatesForResourcePlugin(BasePlugin):
 
         processed_then_statement = (
             then_statement
-            if is_intrinsic_no_value(then_statement)  # type: ignore[no-untyped-call]
+            if is_intrinsic_no_value(then_statement)
             else self._process_policy_template(logical_id, then_statement)  # type: ignore[no-untyped-call]
         )
 
         processed_else_statement = (
             else_statement
-            if is_intrinsic_no_value(else_statement)  # type: ignore[no-untyped-call]
+            if is_intrinsic_no_value(else_statement)
             else self._process_policy_template(logical_id, else_statement)  # type: ignore[no-untyped-call]
         )
 

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -81,7 +81,7 @@ class SwaggerEditor(object):
         contents = [item]
         if isinstance(item, dict) and self._CONDITIONAL_IF in item:
             contents = item[self._CONDITIONAL_IF][1:]
-            contents = [content for content in contents if not is_intrinsic_no_value(content)]  # type: ignore[no-untyped-call]
+            contents = [content for content in contents if not is_intrinsic_no_value(content)]
         return contents
 
     def has_path(self, path, method=None):  # type: ignore[no-untyped-def]
@@ -215,7 +215,7 @@ class SwaggerEditor(object):
         # Wrap the integration_uri in a Condition if one exists on that function
         # This is necessary so CFN doesn't try to resolve the integration reference.
         if condition:
-            integration_uri = make_conditional(condition, integration_uri)  # type: ignore[no-untyped-call]
+            integration_uri = make_conditional(condition, integration_uri)
 
         for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             path_item[method][self._X_APIGW_INTEGRATION] = Py27Dict()
@@ -248,7 +248,7 @@ class SwaggerEditor(object):
 
             # If a condition is present, wrap all method contents up into the condition
             if condition:
-                path_item[method] = make_conditional(condition, path_item[method])  # type: ignore[no-untyped-call]
+                path_item[method] = make_conditional(condition, path_item[method])
 
     def add_state_machine_integration(  # type: ignore[no-untyped-def]
         self,
@@ -281,7 +281,7 @@ class SwaggerEditor(object):
         # Wrap the integration_uri in a Condition if one exists on that state machine
         # This is necessary so CFN doesn't try to resolve the integration reference.
         if condition:
-            integration_uri = make_conditional(condition, integration_uri)  # type: ignore[no-untyped-call]
+            integration_uri = make_conditional(condition, integration_uri)
 
         for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
             # Responses
@@ -311,13 +311,13 @@ class SwaggerEditor(object):
 
             # If a condition is present, wrap all method contents up into the condition
             if condition:
-                path_item[method] = make_conditional(condition, path_item[method])  # type: ignore[no-untyped-call]
+                path_item[method] = make_conditional(condition, path_item[method])
 
     def make_path_conditional(self, path, condition):  # type: ignore[no-untyped-def]
         """
         Wrap entire API path definition in a CloudFormation if condition.
         """
-        self.paths[path] = make_conditional(condition, self.paths[path])  # type: ignore[no-untyped-call]
+        self.paths[path] = make_conditional(condition, self.paths[path])
 
     def _generate_integration_credentials(self, method_invoke_role=None, api_invoke_role=None):  # type: ignore[no-untyped-def]
         return self._get_invoke_role(method_invoke_role or api_invoke_role)  # type: ignore[no-untyped-call]
@@ -1106,7 +1106,7 @@ class SwaggerEditor(object):
             resource = (
                 Py27UniStr(resource) if isinstance(method, Py27UniStr) or isinstance(path, Py27UniStr) else resource
             )
-            resource = fnSub(resource, {"__Stage__": stage})  # type: ignore[no-untyped-call]
+            resource = fnSub(resource, {"__Stage__": stage})
             uri_list.extend([resource])
         return uri_list
 
@@ -1361,7 +1361,7 @@ class SwaggerEditor(object):
         skeleton["swagger"] = "2.0"
         skeleton["info"] = Py27Dict()
         skeleton["info"]["version"] = "1.0"
-        skeleton["info"]["title"] = ref("AWS::StackName")  # type: ignore[no-untyped-call]
+        skeleton["info"]["title"] = ref("AWS::StackName")
         skeleton["paths"] = Py27Dict()
         return skeleton
 


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
