### PR TITLE
feat: Add support to Fn::GetAtt X.Y when looking up IAM role in serve…

### DIFF
--- a/samtranslator/model/intrinsics.py
+++ b/samtranslator/model/intrinsics.py
@@ -217,12 +217,12 @@ def get_logical_id_from_intrinsic(input: Any) -> Optional[str]:
     if isinstance(v, str):
         return v
 
-    # Fn::GetAtt [<logical-id>, <attribute>]
+    # Fn::GetAtt: [<logical-id>, <attribute>]
     v = input.get("Fn::GetAtt")
     if isinstance(v, list) and len(v) == 2 and isinstance(v[0], str):
         return v[0]
 
-    # Fn::GetAtt <logical-id>.<attribute>
+    # Fn::GetAtt: <logical-id>.<attribute>
     if isinstance(v, str):
         tokens = v.split(".")
         if len(tokens) == 2:

--- a/samtranslator/model/intrinsics.py
+++ b/samtranslator/model/intrinsics.py
@@ -217,9 +217,15 @@ def get_logical_id_from_intrinsic(input: Any) -> Optional[str]:
     if isinstance(v, str):
         return v
 
-    # !GetAtt <logical-id>.<attribute>
+    # Fn::GetAtt [<logical-id>, <attribute>]
     v = input.get("Fn::GetAtt")
     if isinstance(v, list) and len(v) == 2 and isinstance(v[0], str):
         return v[0]
+
+    # Fn::GetAtt <logical-id>.<attribute>
+    if isinstance(v, str):
+        tokens = v.split(".")
+        if len(tokens) == 2:
+            return tokens[0]
 
     return None

--- a/tests/test_intrinsics.py
+++ b/tests/test_intrinsics.py
@@ -86,6 +86,7 @@ class TestIntrinsics(TestCase):
     @parameterized.expand(
         [
             ({"Fn::GetAtt": ["Foo", "Bar"]}, "Foo"),
+            ({"Fn::GetAtt": "Foo.Bar"}, "Foo"),
             ({"Ref": "Foo"}, "Foo"),
         ]
     )
@@ -95,12 +96,13 @@ class TestIntrinsics(TestCase):
     @parameterized.expand(
         [
             (None,),
-            ("Foo"),
+            ("Foo",),
             ({"Ref": True}),
             ({"Fn::GetAtt": "Foo"}),
             ({"Fn::GetAtt": ["Foo"]}),
             ({"Fn::GetAtt": [42, "Arn"]}),
             ({"Fn::If": ["Foo", "Bar"]}),
+            ({"Fn::GetAtt": "Foo.Bar.WhatEverThisIs"},),
         ]
     )
     def test_get_logical_id_from_intrinsic_error(self, input):

--- a/tests/translator/input/connector_sfn_to_sfn.yaml
+++ b/tests/translator/input/connector_sfn_to_sfn.yaml
@@ -8,7 +8,7 @@ Resources:
         States:
           TryDoSomething:
             Type: Task
-            Resource: arn:aws:states:::states:startExecution.sync:2
+            Resource: !Sub arn:${AWS::Partition}:states:::states:startExecution.sync:2
             Parameters:
               StateMachineArn: !Ref MyStateMachine
             End: True
@@ -39,3 +39,59 @@ Resources:
       Permissions:
         - Read
         - Write
+
+  StateMachineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action: [ 'sts:AssumeRole' ]
+            Effect: Allow
+            Principal:
+              Service: [ states.amazonaws.com ]
+
+  TriggerStateMachineWithoutRole:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: TriggerStateMachineWithoutRole
+      Role: !GetAtt StateMachineRole.Arn
+      Definition:
+        StartAt: Success
+        States:
+          Success:
+            Type: Succeed
+
+  TriggerStateMachineWithoutRole2:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: TriggerStateMachineWithoutRole
+      Role:
+        Fn::GetAtt: StateMachineRole.Arn
+      Definition:
+        StartAt: Success
+        States:
+          Success:
+            Type: Succeed
+
+  MyConnectorProvidingRole1:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source:
+        Id: TriggerStateMachineWithoutRole
+      Destination:
+        Id: MyStateMachine
+      Permissions:
+        - Write
+        - Read
+
+  MyConnectorProvidingRole2:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source:
+        Id: TriggerStateMachineWithoutRole2
+      Destination:
+        Id: MyStateMachine
+      Permissions:
+        - Write
+        - Read

--- a/tests/translator/output/aws-cn/connector_sfn_to_sfn.json
+++ b/tests/translator/output/aws-cn/connector_sfn_to_sfn.json
@@ -103,6 +103,212 @@
       },
       "Type": "AWS::IAM::ManagedPolicy"
     },
+    "MyConnectorProvidingRole1Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "MyConnectorProvidingRole1": {
+            "Destination": {
+              "Type": "AWS::Serverless::StateMachine"
+            },
+            "Source": {
+              "Type": "AWS::Serverless::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "states:DescribeExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:DescribeRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StartExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "MyStateMachine"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StopExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:PutTargets",
+                "events:PutRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "StateMachineRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "MyConnectorProvidingRole2Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "MyConnectorProvidingRole2": {
+            "Destination": {
+              "Type": "AWS::Serverless::StateMachine"
+            },
+            "Source": {
+              "Type": "AWS::Serverless::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "states:DescribeExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:DescribeRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StartExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "MyStateMachine"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StopExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:PutTargets",
+                "events:PutRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "StateMachineRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
     "MyStateMachine": {
       "Properties": {
         "DefinitionString": {
@@ -187,6 +393,27 @@
       },
       "Type": "AWS::IAM::Role"
     },
+    "StateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::IAM::Role"
+    },
     "TriggerStateMachine": {
       "DependsOn": [
         "MyConnectorPolicy"
@@ -204,7 +431,7 @@
               "            \"Parameters\": {",
               "                \"StateMachineArn\": \"${definition_substitution_1}\"",
               "            },",
-              "            \"Resource\": \"arn:aws:states:::states:startExecution.sync:2\",",
+              "            \"Resource\": \"${definition_substitution_2}\",",
               "            \"Type\": \"Task\"",
               "        }",
               "    }",
@@ -215,6 +442,9 @@
         "DefinitionSubstitutions": {
           "definition_substitution_1": {
             "Ref": "MyStateMachine"
+          },
+          "definition_substitution_2": {
+            "Fn::Sub": "arn:${AWS::Partition}:states:::states:startExecution.sync:2"
           }
         },
         "RoleArn": {
@@ -283,6 +513,75 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "TriggerStateMachineWithoutRole": {
+      "DependsOn": [
+        "MyConnectorProvidingRole1Policy"
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"Success\",",
+              "    \"States\": {",
+              "        \"Success\": {",
+              "            \"Type\": \"Succeed\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "TriggerStateMachineWithoutRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "TriggerStateMachineWithoutRole2": {
+      "DependsOn": [
+        "MyConnectorProvidingRole2Policy"
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"Success\",",
+              "    \"States\": {",
+              "        \"Success\": {",
+              "            \"Type\": \"Succeed\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": "StateMachineRole.Arn"
+        },
+        "StateMachineName": "TriggerStateMachineWithoutRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/connector_sfn_to_sfn.json
+++ b/tests/translator/output/aws-us-gov/connector_sfn_to_sfn.json
@@ -103,6 +103,212 @@
       },
       "Type": "AWS::IAM::ManagedPolicy"
     },
+    "MyConnectorProvidingRole1Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "MyConnectorProvidingRole1": {
+            "Destination": {
+              "Type": "AWS::Serverless::StateMachine"
+            },
+            "Source": {
+              "Type": "AWS::Serverless::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "states:DescribeExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:DescribeRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StartExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "MyStateMachine"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StopExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:PutTargets",
+                "events:PutRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "StateMachineRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "MyConnectorProvidingRole2Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "MyConnectorProvidingRole2": {
+            "Destination": {
+              "Type": "AWS::Serverless::StateMachine"
+            },
+            "Source": {
+              "Type": "AWS::Serverless::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "states:DescribeExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:DescribeRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StartExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "MyStateMachine"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StopExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:PutTargets",
+                "events:PutRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "StateMachineRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
     "MyStateMachine": {
       "Properties": {
         "DefinitionString": {
@@ -187,6 +393,27 @@
       },
       "Type": "AWS::IAM::Role"
     },
+    "StateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::IAM::Role"
+    },
     "TriggerStateMachine": {
       "DependsOn": [
         "MyConnectorPolicy"
@@ -204,7 +431,7 @@
               "            \"Parameters\": {",
               "                \"StateMachineArn\": \"${definition_substitution_1}\"",
               "            },",
-              "            \"Resource\": \"arn:aws:states:::states:startExecution.sync:2\",",
+              "            \"Resource\": \"${definition_substitution_2}\",",
               "            \"Type\": \"Task\"",
               "        }",
               "    }",
@@ -215,6 +442,9 @@
         "DefinitionSubstitutions": {
           "definition_substitution_1": {
             "Ref": "MyStateMachine"
+          },
+          "definition_substitution_2": {
+            "Fn::Sub": "arn:${AWS::Partition}:states:::states:startExecution.sync:2"
           }
         },
         "RoleArn": {
@@ -283,6 +513,75 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "TriggerStateMachineWithoutRole": {
+      "DependsOn": [
+        "MyConnectorProvidingRole1Policy"
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"Success\",",
+              "    \"States\": {",
+              "        \"Success\": {",
+              "            \"Type\": \"Succeed\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "TriggerStateMachineWithoutRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "TriggerStateMachineWithoutRole2": {
+      "DependsOn": [
+        "MyConnectorProvidingRole2Policy"
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"Success\",",
+              "    \"States\": {",
+              "        \"Success\": {",
+              "            \"Type\": \"Succeed\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": "StateMachineRole.Arn"
+        },
+        "StateMachineName": "TriggerStateMachineWithoutRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
     }
   }
 }

--- a/tests/translator/output/connector_sfn_to_sfn.json
+++ b/tests/translator/output/connector_sfn_to_sfn.json
@@ -103,6 +103,212 @@
       },
       "Type": "AWS::IAM::ManagedPolicy"
     },
+    "MyConnectorProvidingRole1Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "MyConnectorProvidingRole1": {
+            "Destination": {
+              "Type": "AWS::Serverless::StateMachine"
+            },
+            "Source": {
+              "Type": "AWS::Serverless::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "states:DescribeExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:DescribeRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StartExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "MyStateMachine"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StopExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:PutTargets",
+                "events:PutRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "StateMachineRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "MyConnectorProvidingRole2Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "MyConnectorProvidingRole2": {
+            "Destination": {
+              "Type": "AWS::Serverless::StateMachine"
+            },
+            "Source": {
+              "Type": "AWS::Serverless::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "states:DescribeExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:DescribeRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StartExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Ref": "MyStateMachine"
+                }
+              ]
+            },
+            {
+              "Action": [
+                "states:StopExecution"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${DestinationName}:*",
+                    {
+                      "DestinationName": {
+                        "Fn::GetAtt": [
+                          "MyStateMachine",
+                          "Name"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "events:PutTargets",
+                "events:PutRule"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "StateMachineRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
     "MyStateMachine": {
       "Properties": {
         "DefinitionString": {
@@ -187,6 +393,27 @@
       },
       "Type": "AWS::IAM::Role"
     },
+    "StateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::IAM::Role"
+    },
     "TriggerStateMachine": {
       "DependsOn": [
         "MyConnectorPolicy"
@@ -204,7 +431,7 @@
               "            \"Parameters\": {",
               "                \"StateMachineArn\": \"${definition_substitution_1}\"",
               "            },",
-              "            \"Resource\": \"arn:aws:states:::states:startExecution.sync:2\",",
+              "            \"Resource\": \"${definition_substitution_2}\",",
               "            \"Type\": \"Task\"",
               "        }",
               "    }",
@@ -215,6 +442,9 @@
         "DefinitionSubstitutions": {
           "definition_substitution_1": {
             "Ref": "MyStateMachine"
+          },
+          "definition_substitution_2": {
+            "Fn::Sub": "arn:${AWS::Partition}:states:::states:startExecution.sync:2"
           }
         },
         "RoleArn": {
@@ -283,6 +513,75 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "TriggerStateMachineWithoutRole": {
+      "DependsOn": [
+        "MyConnectorProvidingRole1Policy"
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"Success\",",
+              "    \"States\": {",
+              "        \"Success\": {",
+              "            \"Type\": \"Succeed\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": "TriggerStateMachineWithoutRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "TriggerStateMachineWithoutRole2": {
+      "DependsOn": [
+        "MyConnectorProvidingRole2Policy"
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"Success\",",
+              "    \"States\": {",
+              "        \"Success\": {",
+              "            \"Type\": \"Succeed\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": "StateMachineRole.Arn"
+        },
+        "StateMachineName": "TriggerStateMachineWithoutRole",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
     }
   }
 }


### PR DESCRIPTION
…rless connector

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [x] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [x] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
