### PR TITLE
chore: Explicitly make our test yamls yaml 1.1

### DIFF
--- a/bin/yaml-format.py
+++ b/bin/yaml-format.py
@@ -17,6 +17,9 @@ from ruamel.yaml.error import YAMLError
 from bin._file_formatter import FileFormatter
 
 yaml = YAML()
+# We have pyyaml (5.4) to parse our yamls in this repo,
+# and pyyaml uses Yaml 1.1
+yaml.version = (1, 1)  # type: ignore
 
 
 class YAMLFormatter(FileFormatter):

--- a/tests/translator/input/alexa_skill.yaml
+++ b/tests/translator/input/alexa_skill.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/alexa_skill_with_skill_id.yaml
+++ b/tests/translator/input/alexa_skill_with_skill_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # "Kitchen Sink" test containing all supported policy templates. The idea is to know every one of them is
 # transformable and fail on any changes in the policy template definition without updating the test
 # Since this not about testing the transformation logic, we will keep the policy template parameter values as literal

--- a/tests/translator/input/api_cache.yaml
+++ b/tests/translator/input/api_cache.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_description.yaml
+++ b/tests/translator/input/api_description.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_endpoint_configuration.yaml
+++ b/tests/translator/input/api_endpoint_configuration.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   EndpointConfig:
     Type: String

--- a/tests/translator/input/api_endpoint_configuration_with_vpcendpoint.yaml
+++ b/tests/translator/input/api_endpoint_configuration_with_vpcendpoint.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   EndpointConfigType:
     Type: String

--- a/tests/translator/input/api_http_paths_with_if_condition.yaml
+++ b/tests/translator/input/api_http_paths_with_if_condition.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_http_paths_with_if_condition_no_value_else_case.yaml
+++ b/tests/translator/input/api_http_paths_with_if_condition_no_value_else_case.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_http_paths_with_if_condition_no_value_then_case.yaml
+++ b/tests/translator/input/api_http_paths_with_if_condition_no_value_then_case.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_request_model.yaml
+++ b/tests/translator/input/api_request_model.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_request_model_openapi_3.yaml
+++ b/tests/translator/input/api_request_model_openapi_3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_request_model_with_validator.yaml
+++ b/tests/translator/input/api_request_model_with_validator.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_request_model_with_validator_openapi_3.yaml
+++ b/tests/translator/input/api_request_model_with_validator_openapi_3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_rest_paths_with_if_condition_openapi.yaml
+++ b/tests/translator/input/api_rest_paths_with_if_condition_openapi.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_rest_paths_with_if_condition_openapi_no_value_else_case.yaml
+++ b/tests/translator/input/api_rest_paths_with_if_condition_openapi_no_value_else_case.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_rest_paths_with_if_condition_openapi_no_value_then_case.yaml
+++ b/tests/translator/input/api_rest_paths_with_if_condition_openapi_no_value_then_case.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_rest_paths_with_if_condition_swagger.yaml
+++ b/tests/translator/input/api_rest_paths_with_if_condition_swagger.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_rest_paths_with_if_condition_swagger_no_value_else_case.yaml
+++ b/tests/translator/input/api_rest_paths_with_if_condition_swagger_no_value_else_case.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_rest_paths_with_if_condition_swagger_no_value_then_case.yaml
+++ b/tests/translator/input/api_rest_paths_with_if_condition_swagger_no_value_then_case.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_swagger_integration_with_ref_intrinsic_api_id.yaml
+++ b/tests/translator/input/api_swagger_integration_with_ref_intrinsic_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_swagger_integration_with_string_api_id.yaml
+++ b/tests/translator/input/api_swagger_integration_with_string_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_access_log_setting.yaml
+++ b/tests/translator/input/api_with_access_log_setting.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     AccessLogSetting:

--- a/tests/translator/input/api_with_any_method_in_swagger.yaml
+++ b/tests/translator/input/api_with_any_method_in_swagger.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_apikey_default_override.yaml
+++ b/tests/translator/input/api_with_apikey_default_override.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_apikey_required.yaml
+++ b/tests/translator/input/api_with_apikey_required.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithoutAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_apikey_required_openapi_3.yaml
+++ b/tests/translator/input/api_with_apikey_required_openapi_3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithoutAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_apikey_source.yaml
+++ b/tests/translator/input/api_with_apikey_source.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithAuthSource:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_auth_all_maximum.yaml
+++ b/tests/translator/input/api_with_auth_all_maximum.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_auth_all_maximum_openapi_3.yaml
+++ b/tests/translator/input/api_with_auth_all_maximum_openapi_3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_auth_all_minimum.yaml
+++ b/tests/translator/input/api_with_auth_all_minimum.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithCognitoAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_auth_all_minimum_openapi.yaml
+++ b/tests/translator/input/api_with_auth_all_minimum_openapi.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     OpenApiVersion: 3.0.1

--- a/tests/translator/input/api_with_auth_and_conditions_all_max.yaml
+++ b/tests/translator/input/api_with_auth_and_conditions_all_max.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   PathCondition:
     Fn::Equals:

--- a/tests/translator/input/api_with_auth_no_default.yaml
+++ b/tests/translator/input/api_with_auth_no_default.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithCognitoAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_auth_with_default_scopes.yaml
+++ b/tests/translator/input/api_with_auth_with_default_scopes.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithCognitoAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_auth_with_default_scopes_openapi.yaml
+++ b/tests/translator/input/api_with_auth_with_default_scopes_openapi.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithCognitoAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_aws_account_blacklist.yaml
+++ b/tests/translator/input/api_with_aws_account_blacklist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_aws_account_whitelist.yaml
+++ b/tests/translator/input/api_with_aws_account_whitelist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_aws_iam_auth_overrides.yaml
+++ b/tests/translator/input/api_with_aws_iam_auth_overrides.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithAwsIamAuthNoCallerCredentials:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_basic_custom_domain.yaml
+++ b/tests/translator/input/api_with_basic_custom_domain.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   MyDomainName:
     Type: String

--- a/tests/translator/input/api_with_basic_custom_domain_http.yaml
+++ b/tests/translator/input/api_with_basic_custom_domain_http.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   MyDomainName:
     Type: String

--- a/tests/translator/input/api_with_basic_custom_domain_intrinsics.yaml
+++ b/tests/translator/input/api_with_basic_custom_domain_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   C1:
     Fn::Equals:

--- a/tests/translator/input/api_with_basic_custom_domain_intrinsics_http.yaml
+++ b/tests/translator/input/api_with_basic_custom_domain_intrinsics_http.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   C1:
     Fn::Equals:

--- a/tests/translator/input/api_with_binary_media_types.yaml
+++ b/tests/translator/input/api_with_binary_media_types.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   BMT:
     Type: String

--- a/tests/translator/input/api_with_binary_media_types_definition_body.yaml
+++ b/tests/translator/input/api_with_binary_media_types_definition_body.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   BMT:
     Type: String

--- a/tests/translator/input/api_with_canary_setting.yaml
+++ b/tests/translator/input/api_with_canary_setting.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     CanarySetting:

--- a/tests/translator/input/api_with_cors.yaml
+++ b/tests/translator/input/api_with_cors.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors: {Fn::Join: [',', [www.amazon.com, www.google.com]]}

--- a/tests/translator/input/api_with_cors_and_auth_no_preflight_auth.yaml
+++ b/tests/translator/input/api_with_cors_and_auth_no_preflight_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors: origins

--- a/tests/translator/input/api_with_cors_and_auth_preflight_auth.yaml
+++ b/tests/translator/input/api_with_cors_and_auth_preflight_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors: origins

--- a/tests/translator/input/api_with_cors_and_conditions_no_definitionbody.yaml
+++ b/tests/translator/input/api_with_cors_and_conditions_no_definitionbody.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Conditions:

--- a/tests/translator/input/api_with_cors_and_only_credentials_false.yaml
+++ b/tests/translator/input/api_with_cors_and_only_credentials_false.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors:

--- a/tests/translator/input/api_with_cors_and_only_headers.yaml
+++ b/tests/translator/input/api_with_cors_and_only_headers.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors:

--- a/tests/translator/input/api_with_cors_and_only_maxage.yaml
+++ b/tests/translator/input/api_with_cors_and_only_maxage.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors:

--- a/tests/translator/input/api_with_cors_and_only_methods.yaml
+++ b/tests/translator/input/api_with_cors_and_only_methods.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors:

--- a/tests/translator/input/api_with_cors_and_only_origins.yaml
+++ b/tests/translator/input/api_with_cors_and_only_origins.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     # If we skip AllowMethods, then SAM will auto generate a list of methods scoped to each path

--- a/tests/translator/input/api_with_cors_no_definitionbody.yaml
+++ b/tests/translator/input/api_with_cors_no_definitionbody.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Globals:

--- a/tests/translator/input/api_with_cors_openapi_3.yaml
+++ b/tests/translator/input/api_with_cors_openapi_3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors: {Fn::Join: [',', [www.amazon.com, www.google.com]]}

--- a/tests/translator/input/api_with_custom_domain_route53.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   DomainName:
     Type: String

--- a/tests/translator/input/api_with_custom_domain_route53_hosted_zone_name.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_hosted_zone_name.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   DomainName:
     Type: String

--- a/tests/translator/input/api_with_custom_domain_route53_hosted_zone_name_http.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_hosted_zone_name_http.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   DomainName:
     Type: String

--- a/tests/translator/input/api_with_custom_domain_route53_http.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_http.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   DomainName:
     Type: String

--- a/tests/translator/input/api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_multiple.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/api_with_default_aws_iam_auth.yaml
+++ b/tests/translator/input/api_with_default_aws_iam_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithAwsIamAuthAndDefaultInvokeRole:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_default_aws_iam_auth_and_no_auth_route.yaml
+++ b/tests/translator/input/api_with_default_aws_iam_auth_and_no_auth_route.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithAwsIamAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_disable_api_execute_endpoint.yaml
+++ b/tests/translator/input/api_with_disable_api_execute_endpoint.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_disable_api_execute_endpoint_openapi_3.yaml
+++ b/tests/translator/input/api_with_disable_api_execute_endpoint_openapi_3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_fail_on_warnings.yaml
+++ b/tests/translator/input/api_with_fail_on_warnings.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_gateway_responses.yaml
+++ b/tests/translator/input/api_with_gateway_responses.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_gateway_responses_all.yaml
+++ b/tests/translator/input/api_with_gateway_responses_all.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_gateway_responses_all_openapi_3.yaml
+++ b/tests/translator/input/api_with_gateway_responses_all_openapi_3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_gateway_responses_implicit.yaml
+++ b/tests/translator/input/api_with_gateway_responses_implicit.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Name: some api

--- a/tests/translator/input/api_with_gateway_responses_minimal.yaml
+++ b/tests/translator/input/api_with_gateway_responses_minimal.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_gateway_responses_string_status_code.yaml
+++ b/tests/translator/input/api_with_gateway_responses_string_status_code.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_identity_intrinsic.yaml
+++ b/tests/translator/input/api_with_identity_intrinsic.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 

--- a/tests/translator/input/api_with_if_conditional_with_resource_policy.yaml
+++ b/tests/translator/input/api_with_if_conditional_with_resource_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   C1:
     Fn::Equals:

--- a/tests/translator/input/api_with_incompatible_stage_name.yaml
+++ b/tests/translator/input/api_with_incompatible_stage_name.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HyphenFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_ip_range_blacklist.yaml
+++ b/tests/translator/input/api_with_ip_range_blacklist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_ip_range_whitelist.yaml
+++ b/tests/translator/input/api_with_ip_range_whitelist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_method_aws_iam_auth.yaml
+++ b/tests/translator/input/api_with_method_aws_iam_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithoutAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_method_settings.yaml
+++ b/tests/translator/input/api_with_method_settings.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     MethodSettings: [{LoggingLevel: INFO, MetricsEnabled: true, DataTraceEnabled: true,

--- a/tests/translator/input/api_with_minimum_compression_size.yaml
+++ b/tests/translator/input/api_with_minimum_compression_size.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     MinimumCompressionSize: 1024

--- a/tests/translator/input/api_with_mode.yaml
+++ b/tests/translator/input/api_with_mode.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_no_properties.yaml
+++ b/tests/translator/input/api_with_no_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_open_api_version.yaml
+++ b/tests/translator/input/api_with_open_api_version.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     OpenApiVersion: 3.0.1

--- a/tests/translator/input/api_with_open_api_version_2.yaml
+++ b/tests/translator/input/api_with_open_api_version_2.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     OpenApiVersion: '2.0'

--- a/tests/translator/input/api_with_openapi_definition_body_no_flag.yaml
+++ b/tests/translator/input/api_with_openapi_definition_body_no_flag.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Name: some api

--- a/tests/translator/input/api_with_path_parameters.yaml
+++ b/tests/translator/input/api_with_path_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_resource_policy.yaml
+++ b/tests/translator/input/api_with_resource_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ExplicitApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_resource_policy_global.yaml
+++ b/tests/translator/input/api_with_resource_policy_global.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   StageName:
     Type: String

--- a/tests/translator/input/api_with_resource_policy_global_implicit.yaml
+++ b/tests/translator/input/api_with_resource_policy_global_implicit.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_resource_refs.yaml
+++ b/tests/translator/input/api_with_resource_refs.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Test if resource references work for both Explicit API & Implicit API resources
 
 Resources:

--- a/tests/translator/input/api_with_security_definition_and_components.yaml
+++ b/tests/translator/input/api_with_security_definition_and_components.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   GetHtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_security_definition_and_no_components.yaml
+++ b/tests/translator/input/api_with_security_definition_and_no_components.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   GetHtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_security_definition_and_none_components.yaml
+++ b/tests/translator/input/api_with_security_definition_and_none_components.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   GetHtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_source_vpc_blacklist.yaml
+++ b/tests/translator/input/api_with_source_vpc_blacklist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_source_vpc_whitelist.yaml
+++ b/tests/translator/input/api_with_source_vpc_whitelist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   Vpc1:
     Type: String

--- a/tests/translator/input/api_with_stage_tags.yaml
+++ b/tests/translator/input/api_with_stage_tags.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   TagValueParam:
     Type: String

--- a/tests/translator/input/api_with_swagger_and_openapi_with_auth.yaml
+++ b/tests/translator/input/api_with_swagger_and_openapi_with_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Name: some api

--- a/tests/translator/input/api_with_swagger_authorizer_none.yaml
+++ b/tests/translator/input/api_with_swagger_authorizer_none.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithCognitoAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/api_with_usageplans.yaml
+++ b/tests/translator/input/api_with_usageplans.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_usageplans_intrinsics.yaml
+++ b/tests/translator/input/api_with_usageplans_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   C1:
     Fn::Equals:

--- a/tests/translator/input/api_with_usageplans_shared_attributes_three.yaml
+++ b/tests/translator/input/api_with_usageplans_shared_attributes_three.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_usageplans_shared_attributes_two.yaml
+++ b/tests/translator/input/api_with_usageplans_shared_attributes_two.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_usageplans_shared_no_side_effect_1.yaml
+++ b/tests/translator/input/api_with_usageplans_shared_no_side_effect_1.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_usageplans_shared_no_side_effect_2.yaml
+++ b/tests/translator/input/api_with_usageplans_shared_no_side_effect_2.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/api_with_xray_tracing.yaml
+++ b/tests/translator/input/api_with_xray_tracing.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/application_preparing_state.yaml
+++ b/tests/translator/input/application_preparing_state.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   PreparingApplication:
     Type: AWS::Serverless::Application

--- a/tests/translator/input/application_with_intrinsics.yaml
+++ b/tests/translator/input/application_with_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   ApplicationIdParam:
     Type: String

--- a/tests/translator/input/basic_application.yaml
+++ b/tests/translator/input/basic_application.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   TestCondition:
     Fn::Equals:

--- a/tests/translator/input/basic_function.yaml
+++ b/tests/translator/input/basic_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SomeParameter:
     Type: String

--- a/tests/translator/input/basic_function_with_tags.yaml
+++ b/tests/translator/input/basic_function_with_tags.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/basic_function_withimageuri.yaml
+++ b/tests/translator/input/basic_function_withimageuri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SomeParameter:
     Type: String

--- a/tests/translator/input/basic_layer.yaml
+++ b/tests/translator/input/basic_layer.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   TestCondition:
     Fn::Equals:

--- a/tests/translator/input/cloudwatch_logs_with_ref.yaml
+++ b/tests/translator/input/cloudwatch_logs_with_ref.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Example CloudWatch Logs + Lambda

--- a/tests/translator/input/cloudwatchevent.yaml
+++ b/tests/translator/input/cloudwatchevent.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/cloudwatchevent_intrinsics.yaml
+++ b/tests/translator/input/cloudwatchevent_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   PathA:
     Type: String

--- a/tests/translator/input/cloudwatchlog.yaml
+++ b/tests/translator/input/cloudwatchlog.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   TriggeredFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/cognito_userpool_with_event.yaml
+++ b/tests/translator/input/cognito_userpool_with_event.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   UserPool:
     Type: AWS::Cognito::UserPool

--- a/tests/translator/input/congito_userpool_with_sms_configuration.yaml
+++ b/tests/translator/input/congito_userpool_with_sms_configuration.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/connector_api_to_function.yaml
+++ b/tests/translator/input/connector_api_to_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyServerlessApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/connector_bucket_to_function.yaml
+++ b/tests/translator/input/connector_bucket_to_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/connector_dependson_replace.yaml
+++ b/tests/translator/input/connector_dependson_replace.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Stub resources

--- a/tests/translator/input/connector_esm_dependson.yaml
+++ b/tests/translator/input/connector_esm_dependson.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31-test
 Resources:
   MyFunction:

--- a/tests/translator/input/connector_function_to_s3.yaml
+++ b/tests/translator/input/connector_function_to_s3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/connector_function_to_sqs.yaml
+++ b/tests/translator/input/connector_function_to_sqs.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyRole:
     Type: AWS::IAM::Role

--- a/tests/translator/input/connector_function_to_table.yaml
+++ b/tests/translator/input/connector_function_to_table.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyRole:
     Type: AWS::IAM::Role

--- a/tests/translator/input/connector_hardcoded_lambda_arn.yaml
+++ b/tests/translator/input/connector_hardcoded_lambda_arn.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyTopic:
     Type: AWS::SNS::Topic

--- a/tests/translator/input/connector_hardcoded_props.yaml
+++ b/tests/translator/input/connector_hardcoded_props.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Intentionally not complete

--- a/tests/translator/input/connector_hardcoded_rolename.yaml
+++ b/tests/translator/input/connector_hardcoded_rolename.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   MyFunction:

--- a/tests/translator/input/connector_rule_to_eventbus.yaml
+++ b/tests/translator/input/connector_rule_to_eventbus.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   EventBus:
     Type: AWS::Events::EventBus

--- a/tests/translator/input/connector_rule_to_sfn.yaml
+++ b/tests/translator/input/connector_rule_to_sfn.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyNewEventsRule:
     Type: AWS::Events::Rule

--- a/tests/translator/input/connector_rule_to_sns.yaml
+++ b/tests/translator/input/connector_rule_to_sns.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyNewEventsRule:
     Type: AWS::Events::Rule

--- a/tests/translator/input/connector_sfn_to_function.yaml
+++ b/tests/translator/input/connector_sfn_to_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyStateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/connector_sfn_to_sfn.yaml
+++ b/tests/translator/input/connector_sfn_to_sfn.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   TriggerStateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/connector_sns_to_function.yaml
+++ b/tests/translator/input/connector_sns_to_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MySNSTopic:
     Type: AWS::SNS::Topic

--- a/tests/translator/input/connector_sns_to_sqs.yaml
+++ b/tests/translator/input/connector_sns_to_sqs.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MySNSTopic:
     Type: AWS::SNS::Topic

--- a/tests/translator/input/connector_sqs_to_function.yaml
+++ b/tests/translator/input/connector_sqs_to_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Queue:
     Type: AWS::SQS::Queue

--- a/tests/translator/input/connector_table_to_function.yaml
+++ b/tests/translator/input/connector_table_to_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyRole:
     Type: AWS::IAM::Role

--- a/tests/translator/input/connector_table_to_function_read.yaml
+++ b/tests/translator/input/connector_table_to_function_read.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/definition_body_intrinsics_support.yaml
+++ b/tests/translator/input/definition_body_intrinsics_support.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/depends_on.yaml
+++ b/tests/translator/input/depends_on.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # SAM template containing DependsOn property on resources. Output resources should
 # also have this property set
 Resources:

--- a/tests/translator/input/error_api_auth_invalid_path_item.yaml
+++ b/tests/translator/input/error_api_auth_invalid_path_item.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ExplicitApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_auth_null_path_item.yaml
+++ b/tests/translator/input/error_api_auth_null_path_item.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ExplicitApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_authorizer_property_indentity_header_with_invalid_type.yaml
+++ b/tests/translator/input/error_api_authorizer_property_indentity_header_with_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   AuthKeyName:
     Type: String

--- a/tests/translator/input/error_api_authorizer_property_indentity_with_invalid_type.yaml
+++ b/tests/translator/input/error_api_authorizer_property_indentity_with_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyLambdaFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_duplicate_methods_same_path.yaml
+++ b/tests/translator/input/error_api_duplicate_methods_same_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function1:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_event_import_vaule_reference.yaml
+++ b/tests/translator/input/error_api_event_import_vaule_reference.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   Api:
     Type: String

--- a/tests/translator/input/error_api_event_ref_http_api.yaml
+++ b/tests/translator/input/error_api_event_ref_http_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 
 Resources:

--- a/tests/translator/input/error_api_gateway_responses_nonnumeric_status_code.yaml
+++ b/tests/translator/input/error_api_gateway_responses_nonnumeric_status_code.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_gateway_responses_unknown_responseparameter.yaml
+++ b/tests/translator/input/error_api_gateway_responses_unknown_responseparameter.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_gateway_responses_unknown_responseparameter_property.yaml
+++ b/tests/translator/input/error_api_gateway_responses_unknown_responseparameter_property.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_invalid_auth.yaml
+++ b/tests/translator/input/error_api_invalid_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   NoAuthApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_auth_identity_cognito.yaml
+++ b/tests/translator/input/error_api_invalid_auth_identity_cognito.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ServerlessApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_auth_identity_lambda_request.yaml
+++ b/tests/translator/input/error_api_invalid_auth_identity_lambda_request.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ServerlessApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_definitionbody.yaml
+++ b/tests/translator/input/error_api_invalid_definitionbody.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   # Body has to be a dictionary
   ApiWithInvalidBodyType:

--- a/tests/translator/input/error_api_invalid_definitionuri.yaml
+++ b/tests/translator/input/error_api_invalid_definitionuri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Api:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_event_authorizer_type.yaml
+++ b/tests/translator/input/error_api_invalid_event_authorizer_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SignInFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_invalid_fail_on_warnings.yaml
+++ b/tests/translator/input/error_api_invalid_fail_on_warnings.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_openapi_path.yaml
+++ b/tests/translator/input/error_api_invalid_openapi_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiWithInvalidPath:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_openapi_path_with_empty_responses.yaml
+++ b/tests/translator/input/error_api_invalid_openapi_path_with_empty_responses.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiWithInvalidPath:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_openapi_path_with_string_responses.yaml
+++ b/tests/translator/input/error_api_invalid_openapi_path_with_string_responses.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiWithInvalidPath:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_path.yaml
+++ b/tests/translator/input/error_api_invalid_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiWithInvalidPath:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_request_model.yaml
+++ b/tests/translator/input/error_api_invalid_request_model.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
 
   NoModelsApi:

--- a/tests/translator/input/error_api_invalid_restapiid.yaml
+++ b/tests/translator/input/error_api_invalid_restapiid.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
 
   ValidFunction:

--- a/tests/translator/input/error_api_invalid_source_vpc_blacklist.yaml
+++ b/tests/translator/input/error_api_invalid_source_vpc_blacklist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/error_api_invalid_source_vpc_whitelist.yaml
+++ b/tests/translator/input/error_api_invalid_source_vpc_whitelist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/error_api_invalid_stagename.yaml
+++ b/tests/translator/input/error_api_invalid_stagename.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiWithEmptyStageName:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_invalid_usage_plan.yaml
+++ b/tests/translator/input/error_api_invalid_usage_plan.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithCognitoAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_mtls_configuration_invalid_field.yaml
+++ b/tests/translator/input/error_api_mtls_configuration_invalid_field.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_mtls_configuration_invalid_type.yaml
+++ b/tests/translator/input/error_api_mtls_configuration_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_no_cors_invalid_openapi_null_path.yaml
+++ b/tests/translator/input/error_api_no_cors_invalid_openapi_null_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiWithInvalidPath:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_no_cors_invalid_openapi_string_path.yaml
+++ b/tests/translator/input/error_api_no_cors_invalid_openapi_string_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiWithInvalidPath:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_request_model_with_intrinsics_validator.yaml
+++ b/tests/translator/input/error_api_request_model_with_intrinsics_validator.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   ValidateParametersBody:
     Type: String

--- a/tests/translator/input/error_api_request_model_with_strings_validator.yaml
+++ b/tests/translator/input/error_api_request_model_with_strings_validator.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   RequestValidator:
     Type: AWS::ApiGateway::RequestValidator

--- a/tests/translator/input/error_api_swagger_integration_with_condition_intrinsic_api_id.yaml
+++ b/tests/translator/input/error_api_swagger_integration_with_condition_intrinsic_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   TestCondition: !Equals [a, b]
 

--- a/tests/translator/input/error_api_swagger_integration_with_find_in_map_intrinsic_api_id.yaml
+++ b/tests/translator/input/error_api_swagger_integration_with_find_in_map_intrinsic_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Mappings:
   TestMap:
     TopLevel:

--- a/tests/translator/input/error_api_swagger_integration_with_getatt_intrinsic_api_id.yaml
+++ b/tests/translator/input/error_api_swagger_integration_with_getatt_intrinsic_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_swagger_integration_with_join_intrinsic_api_id.yaml
+++ b/tests/translator/input/error_api_swagger_integration_with_join_intrinsic_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_swagger_integration_with_select_intrinsic_api_id.yaml
+++ b/tests/translator/input/error_api_swagger_integration_with_select_intrinsic_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_swagger_integration_with_sub_intrinsic_api_id.yaml
+++ b/tests/translator/input/error_api_swagger_integration_with_sub_intrinsic_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_swagger_integration_with_transform_intrinsic_api_id.yaml
+++ b/tests/translator/input/error_api_swagger_integration_with_transform_intrinsic_api_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HtmlFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_with_cors_and_empty_allow_origin.yaml
+++ b/tests/translator/input/error_api_with_cors_and_empty_allow_origin.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors: {Fn::Join: [',', [www.amazon.com, www.google.com]]}

--- a/tests/translator/input/error_api_with_custom_domains_invalid.yaml
+++ b/tests/translator/input/error_api_with_custom_domains_invalid.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   MyDomainName:
     Type: String

--- a/tests/translator/input/error_api_with_custom_domains_route53_invalid.yaml
+++ b/tests/translator/input/error_api_with_custom_domains_route53_invalid.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_with_custom_domains_route53_invalid_type.yaml
+++ b/tests/translator/input/error_api_with_custom_domains_route53_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_api_with_disable_api_execute_endpoint_false.yaml
+++ b/tests/translator/input/error_api_with_disable_api_execute_endpoint_false.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_with_invalid_auth_scopes_openapi.yaml
+++ b/tests/translator/input/error_api_with_invalid_auth_scopes_openapi.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithCognitoAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_with_invalid_open_api_version.yaml
+++ b/tests/translator/input/error_api_with_invalid_open_api_version.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_with_invalid_open_api_version_type.yaml
+++ b/tests/translator/input/error_api_with_invalid_open_api_version_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_with_models_of_invalid_type.yaml
+++ b/tests/translator/input/error_api_with_models_of_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_api_with_usage_plan_invalid_parameter.yaml
+++ b/tests/translator/input/error_api_with_usage_plan_invalid_parameter.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     OpenApiVersion: 3.0.0

--- a/tests/translator/input/error_application_does_not_exist.yaml
+++ b/tests/translator/input/error_application_does_not_exist.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApplication:
     Type: AWS::Serverless::Application

--- a/tests/translator/input/error_application_no_access.yaml
+++ b/tests/translator/input/error_application_no_access.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   NoAccess:
     Type: AWS::Serverless::Application

--- a/tests/translator/input/error_application_preparing_timeout.yaml
+++ b/tests/translator/input/error_application_preparing_timeout.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApplication:
     Type: AWS::Serverless::Application

--- a/tests/translator/input/error_application_properties.yaml
+++ b/tests/translator/input/error_application_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   NormalApplication:
     Type: AWS::Serverless::Application

--- a/tests/translator/input/error_auto_publish_alias_empty_string.yaml
+++ b/tests/translator/input/error_auto_publish_alias_empty_string.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_cognito_trigger_invalid_type.yaml
+++ b/tests/translator/input/error_cognito_trigger_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   UserPool:
     Type: AWS::Cognito::UserPool

--- a/tests/translator/input/error_cognito_userpool_duplicate_trigger.yaml
+++ b/tests/translator/input/error_cognito_userpool_duplicate_trigger.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   UserPool:
     Type: AWS::Cognito::UserPool

--- a/tests/translator/input/error_cognito_userpool_not_string.yaml
+++ b/tests/translator/input/error_cognito_userpool_not_string.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   UserPool:
     Type: AWS::Cognito::UserPool

--- a/tests/translator/input/error_connector.yaml
+++ b/tests/translator/input/error_connector.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_consumer_group_id.yaml
+++ b/tests/translator/input/error_consumer_group_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   NotSupportedPullTrigger:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_cors_credentials_true_with_wildcard_origin.yaml
+++ b/tests/translator/input/error_cors_credentials_true_with_wildcard_origin.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors:

--- a/tests/translator/input/error_cors_credentials_true_without_explicit_origin.yaml
+++ b/tests/translator/input/error_cors_credentials_true_without_explicit_origin.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors:

--- a/tests/translator/input/error_cors_on_external_swagger.yaml
+++ b/tests/translator/input/error_cors_on_external_swagger.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ExplicitApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_default_authorizer_should_be_string_in_api.yaml
+++ b/tests/translator/input/error_default_authorizer_should_be_string_in_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 

--- a/tests/translator/input/error_depends_on_invalid_types.yaml
+++ b/tests/translator/input/error_depends_on_invalid_types.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Bucket1:
     Type: AWS::S3::Bucket

--- a/tests/translator/input/error_event_filtering.yaml
+++ b/tests/translator/input/error_event_filtering.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   WrongFilterName:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_existing_event_logical_id.yaml
+++ b/tests/translator/input/error_existing_event_logical_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/error_existing_permission_logical_id.yaml
+++ b/tests/translator/input/error_existing_permission_logical_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/error_existing_role_logical_id.yaml
+++ b/tests/translator/input/error_existing_role_logical_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   RestApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_api_invalid_properties.yaml
+++ b/tests/translator/input/error_function_api_invalid_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_fnsub_in_auto_publish_hash.yaml
+++ b/tests/translator/input/error_function_fnsub_in_auto_publish_hash.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Description: Dip Investigation
 Parameters:
   GitCommitInfo:

--- a/tests/translator/input/error_function_invalid_api_event.yaml
+++ b/tests/translator/input/error_function_invalid_api_event.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionApiInvalidProperties:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_invalid_autopublishalias.yaml
+++ b/tests/translator/input/error_function_invalid_autopublishalias.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   MyAlias:
     Type: String

--- a/tests/translator/input/error_function_invalid_codeuri.yaml
+++ b/tests/translator/input/error_function_invalid_codeuri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_invalid_event_api_ref.yaml
+++ b/tests/translator/input/error_function_invalid_event_api_ref.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionApiRestApiRefError:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_invalid_event_http_api_ref.yaml
+++ b/tests/translator/input/error_function_invalid_event_http_api_ref.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionApiHttpApiRefError:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_invalid_event_type.yaml
+++ b/tests/translator/input/error_function_invalid_event_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionApiTypeError:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_invalid_layer.yaml
+++ b/tests/translator/input/error_function_invalid_layer.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionWithLayersString:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_invalid_request_parameters.yaml
+++ b/tests/translator/input/error_function_invalid_request_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
 
   InvalidNameStringParameterFunction:

--- a/tests/translator/input/error_function_invalid_s3_event.yaml
+++ b/tests/translator/input/error_function_invalid_s3_event.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   EventsParam:
     Type: String

--- a/tests/translator/input/error_function_no_codeuri.yaml
+++ b/tests/translator/input/error_function_no_codeuri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_no_handler.yaml
+++ b/tests/translator/input/error_function_no_handler.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_no_imageuri.yaml
+++ b/tests/translator/input/error_function_no_imageuri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_no_runtime.yaml
+++ b/tests/translator/input/error_function_no_runtime.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_policy_template_invalid_value.yaml
+++ b/tests/translator/input/error_function_policy_template_invalid_value.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_policy_template_with_missing_parameter.yaml
+++ b/tests/translator/input/error_function_policy_template_with_missing_parameter.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_api_key_false.yaml
+++ b/tests/translator/input/error_function_with_api_key_false.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithoutAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_function_with_cwe_both_dlq_property_provided.yaml
+++ b/tests/translator/input/error_function_with_cwe_both_dlq_property_provided.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   TriggeredFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_cwe_invalid_dlq_type.yaml
+++ b/tests/translator/input/error_function_with_cwe_invalid_dlq_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   TriggeredFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_cwe_missing_dlq_property.yaml
+++ b/tests/translator/input/error_function_with_cwe_missing_dlq_property.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   TriggeredFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_deployment_preference_invalid_alarms.yaml
+++ b/tests/translator/input/error_function_with_deployment_preference_invalid_alarms.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   MyCondition:
     Fn::Equals:

--- a/tests/translator/input/error_function_with_deployment_preference_missing_alias.yaml
+++ b/tests/translator/input/error_function_with_deployment_preference_missing_alias.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_deployment_preference_passthrough_condition_with_invalid_values.yaml
+++ b/tests/translator/input/error_function_with_deployment_preference_passthrough_condition_with_invalid_values.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Tests unsupported intrinsic and invalid type in the PassthroughCondition property
 
 Mappings:

--- a/tests/translator/input/error_function_with_event_bridge_rule_dlq_intrinsic_function.yaml
+++ b/tests/translator/input/error_function_with_event_bridge_rule_dlq_intrinsic_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   Env:
     Type: String

--- a/tests/translator/input/error_function_with_event_dest_invalid.yaml
+++ b/tests/translator/input/error_function_with_event_dest_invalid.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SNSArn:
     Type: String

--- a/tests/translator/input/error_function_with_event_dest_type.yaml
+++ b/tests/translator/input/error_function_with_event_dest_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SNSArn:
     Type: String

--- a/tests/translator/input/error_function_with_function_url_config_with_invalid_cors_parameter.yaml
+++ b/tests/translator/input/error_function_with_function_url_config_with_invalid_cors_parameter.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_function_with_function_url_config_with_invalid_cors_parameter_data_type.yaml
+++ b/tests/translator/input/error_function_with_function_url_config_with_invalid_cors_parameter_data_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_function_with_function_url_config_with_no_authorization_type.yaml
+++ b/tests/translator/input/error_function_with_function_url_config_with_no_authorization_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_function_with_invalid_condition_name.yaml
+++ b/tests/translator/input/error_function_with_invalid_condition_name.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Conditions:

--- a/tests/translator/input/error_function_with_invalid_deployment_preference_hook_property.yaml
+++ b/tests/translator/input/error_function_with_invalid_deployment_preference_hook_property.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_invalid_dlq_property_type.yaml
+++ b/tests/translator/input/error_function_with_invalid_dlq_property_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Parameter:
   DeadLetterQueueType:

--- a/tests/translator/input/error_function_with_invalid_event_bridge_rule.yaml
+++ b/tests/translator/input/error_function_with_invalid_event_bridge_rule.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 
 Resources:

--- a/tests/translator/input/error_function_with_invalid_kms_type_for_self_managed_kafka.yaml
+++ b/tests/translator/input/error_function_with_invalid_kms_type_for_self_managed_kafka.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameter:
   SecretsManagerKmsKeyIdValue:

--- a/tests/translator/input/error_function_with_invalid_policy_statement.yaml
+++ b/tests/translator/input/error_function_with_invalid_policy_statement.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # When there are unknown policy templates, we will simply skip the entry
 
 Resources:

--- a/tests/translator/input/error_function_with_invalid_schedule_event.yaml
+++ b/tests/translator/input/error_function_with_invalid_schedule_event.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 
 Resources:

--- a/tests/translator/input/error_function_with_invalid_stream_eventsource_dest_type.yaml
+++ b/tests/translator/input/error_function_with_invalid_stream_eventsource_dest_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 

--- a/tests/translator/input/error_function_with_method_auth_and_no_api_auth.yaml
+++ b/tests/translator/input/error_function_with_method_auth_and_no_api_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_missing_on_failure_in_stream_event_destination_config.yaml
+++ b/tests/translator/input/error_function_with_missing_on_failure_in_stream_event_destination_config.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 

--- a/tests/translator/input/error_function_with_mq_kms_invalid_type.yaml
+++ b/tests/translator/input/error_function_with_mq_kms_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameter:
   SecretsManagerKmsKeyIdValue:
     Type: String

--- a/tests/translator/input/error_function_with_multiple_architectures.yaml
+++ b/tests/translator/input/error_function_with_multiple_architectures.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_function_with_no_alias_provisioned_concurrency.yaml
+++ b/tests/translator/input/error_function_with_no_alias_provisioned_concurrency.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   FnName:
     Type: String

--- a/tests/translator/input/error_function_with_schedue_dlq_intrinsic_function.yaml
+++ b/tests/translator/input/error_function_with_schedue_dlq_intrinsic_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   Env:
     Type: String

--- a/tests/translator/input/error_function_with_schedule_both_dlq_property_provided.yaml
+++ b/tests/translator/input/error_function_with_schedule_both_dlq_property_provided.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_schedule_invalid_dlq_type.yaml
+++ b/tests/translator/input/error_function_with_schedule_invalid_dlq_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_schedule_missing_dlq_property.yaml
+++ b/tests/translator/input/error_function_with_schedule_missing_dlq_property.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_function_with_unknown_architectures.yaml
+++ b/tests/translator/input/error_function_with_unknown_architectures.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_function_with_unknown_policy_template.yaml
+++ b/tests/translator/input/error_function_with_unknown_policy_template.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # When there are unknown policy templates, we will simply skip the entry
 
 Resources:

--- a/tests/translator/input/error_gateway_response_invalid_type_int.yaml
+++ b/tests/translator/input/error_gateway_response_invalid_type_int.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiResource:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_gateway_response_invalid_type_intrinsic.yaml
+++ b/tests/translator/input/error_gateway_response_invalid_type_intrinsic.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiResource:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_globals_api_with_stage_name.yaml
+++ b/tests/translator/input/error_globals_api_with_stage_name.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # For Implicit APIs, StageName is automatically set by SAM. Due to a limitation of the current architecture,
 # StageName **cannot** be overridden for Implicit APIs.
 #

--- a/tests/translator/input/error_globals_is_not_dict.yaml
+++ b/tests/translator/input/error_globals_is_not_dict.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals: [1, 2, 3]
 
 Resources:

--- a/tests/translator/input/error_globals_unsupported_property.yaml
+++ b/tests/translator/input/error_globals_unsupported_property.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Function:
     AutoPublishAlias: live

--- a/tests/translator/input/error_globals_unsupported_type.yaml
+++ b/tests/translator/input/error_globals_unsupported_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   NewType:
     Key: Value

--- a/tests/translator/input/error_http_api_def_body_uri.yaml
+++ b/tests/translator/input/error_http_api_def_body_uri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_http_api_event_invalid_api.yaml
+++ b/tests/translator/input/error_http_api_event_invalid_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_http_api_event_multiple_same_path.yaml
+++ b/tests/translator/input/error_http_api_event_multiple_same_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction2:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_http_api_invalid_auth.yaml
+++ b/tests/translator/input/error_http_api_invalid_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_http_api_invalid_basepath_type.yaml
+++ b/tests/translator/input/error_http_api_invalid_basepath_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_http_api_invalid_disable_execute_api_endpoint.yaml
+++ b/tests/translator/input/error_http_api_invalid_disable_execute_api_endpoint.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_http_api_invalid_event_authorizer_type.yaml
+++ b/tests/translator/input/error_http_api_invalid_event_authorizer_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SignInFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_http_api_invalid_lambda_auth.yaml
+++ b/tests/translator/input/error_http_api_invalid_lambda_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function1:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_http_api_invalid_openapi.yaml
+++ b/tests/translator/input/error_http_api_invalid_openapi.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_http_api_invalid_tags_format.yaml
+++ b/tests/translator/input/error_http_api_invalid_tags_format.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   condition:
     Fn::Equals:

--- a/tests/translator/input/error_http_api_null_method.yaml
+++ b/tests/translator/input/error_http_api_null_method.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   MyHttpApiGateway:

--- a/tests/translator/input/error_http_api_tags.yaml
+++ b/tests/translator/input/error_http_api_tags.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Api:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_http_api_tags_def_uri.yaml
+++ b/tests/translator/input/error_http_api_tags_def_uri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Api:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_http_api_with_cors_def_uri.yaml
+++ b/tests/translator/input/error_http_api_with_cors_def_uri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_http_api_with_disable_api_execute_endpoint_false.yaml
+++ b/tests/translator/input/error_http_api_with_disable_api_execute_endpoint_false.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ApiGatewayApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_httpapi_mtls_configuration_invalid_field.yaml
+++ b/tests/translator/input/error_httpapi_mtls_configuration_invalid_field.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_httpapi_mtls_configuration_invalid_type.yaml
+++ b/tests/translator/input/error_httpapi_mtls_configuration_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_implicit_http_api_auth_any_method.yaml
+++ b/tests/translator/input/error_implicit_http_api_auth_any_method.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SomeHttpApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/error_implicit_http_api_method.yaml
+++ b/tests/translator/input/error_implicit_http_api_method.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_implicit_http_api_path.yaml
+++ b/tests/translator/input/error_implicit_http_api_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_implicit_http_api_properties.yaml
+++ b/tests/translator/input/error_implicit_http_api_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_invalid_config_mq.yaml
+++ b/tests/translator/input/error_invalid_config_mq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_invalid_cors_dict.yaml
+++ b/tests/translator/input/error_invalid_cors_dict.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Cors:

--- a/tests/translator/input/error_invalid_document_empty_semantic_version.yaml
+++ b/tests/translator/input/error_invalid_document_empty_semantic_version.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   helloworld:
     Type: AWS::Serverless::Application

--- a/tests/translator/input/error_invalid_findinmap.yaml
+++ b/tests/translator/input/error_invalid_findinmap.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   ApplicationIdParam:
     Type: String

--- a/tests/translator/input/error_invalid_logical_id.yaml
+++ b/tests/translator/input/error_invalid_logical_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Bad-Function-Name-@#$%^&:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_invalid_method_definition.yaml
+++ b/tests/translator/input/error_invalid_method_definition.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Name: some api

--- a/tests/translator/input/error_invalid_properties.yaml
+++ b/tests/translator/input/error_invalid_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_invalid_resource_parameters.yaml
+++ b/tests/translator/input/error_invalid_resource_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   UnknownPropertyInResource:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_invalid_self_managed_kafka_config.yaml
+++ b/tests/translator/input/error_invalid_self_managed_kafka_config.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_invalid_template.yaml
+++ b/tests/translator/input/error_invalid_template.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # The error here is that this key should be "Resources" and not "Resource"
 Resource:
   Function:

--- a/tests/translator/input/error_layer_invalid_properties.yaml
+++ b/tests/translator/input/error_layer_invalid_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   DeletePolicy:
     Default: Keep

--- a/tests/translator/input/error_mappings_is_null.yaml
+++ b/tests/translator/input/error_mappings_is_null.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Mappings:
 
 Parameters:

--- a/tests/translator/input/error_missing_basic_auth_in_mq.yaml
+++ b/tests/translator/input/error_missing_basic_auth_in_mq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_missing_basic_auth_uri_in_mq.yaml
+++ b/tests/translator/input/error_missing_basic_auth_uri_in_mq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_missing_broker.yaml
+++ b/tests/translator/input/error_missing_broker.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_missing_kafka_bootstrap_server_for_self_managed_kafka.yaml
+++ b/tests/translator/input/error_missing_kafka_bootstrap_server_for_self_managed_kafka.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_missing_queue.yaml
+++ b/tests/translator/input/error_missing_queue.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/error_missing_sac_in_mq.yaml
+++ b/tests/translator/input/error_missing_sac_in_mq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_missing_source_access_configurations_for_self_managed_kafka.yaml
+++ b/tests/translator/input/error_missing_source_access_configurations_for_self_managed_kafka.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_missing_startingposition.yaml
+++ b/tests/translator/input/error_missing_startingposition.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   KinesisFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_missing_stream.yaml
+++ b/tests/translator/input/error_missing_stream.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_missing_topics_for_self_managed_kafka.yaml
+++ b/tests/translator/input/error_missing_topics_for_self_managed_kafka.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_multiple_auth_mechanism_self_managed_kafka_config.yaml
+++ b/tests/translator/input/error_multiple_auth_mechanism_self_managed_kafka_config.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_multiple_basic_auth_in_mq.yaml
+++ b/tests/translator/input/error_multiple_basic_auth_in_mq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_multiple_resource_errors.yaml
+++ b/tests/translator/input/error_multiple_resource_errors.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   BadDefinitionUriApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_multiple_topics_for_self_managed_kafka.yaml
+++ b/tests/translator/input/error_multiple_topics_for_self_managed_kafka.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/error_null_application_id.yaml
+++ b/tests/translator/input/error_null_application_id.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Application:
     Type: AWS::Serverless::Application

--- a/tests/translator/input/error_null_method_definition.yaml
+++ b/tests/translator/input/error_null_method_definition.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ExplicitApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_reserved_sam_tag.yaml
+++ b/tests/translator/input/error_reserved_sam_tag.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/error_resource_not_dict.yaml
+++ b/tests/translator/input/error_resource_not_dict.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_resource_policy_not_dict.yaml
+++ b/tests/translator/input/error_resource_policy_not_dict.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/error_resource_policy_not_dict_empty_api.yaml
+++ b/tests/translator/input/error_resource_policy_not_dict_empty_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Bad, bad resource policy
 Resources:

--- a/tests/translator/input/error_resource_properties_not_dict.yaml
+++ b/tests/translator/input/error_resource_properties_not_dict.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_s3_lambda_configuration_invalid_type.yaml
+++ b/tests/translator/input/error_s3_lambda_configuration_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   AppFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_s3_not_in_template.yaml
+++ b/tests/translator/input/error_s3_not_in_template.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/error_sns_intrinsics.yaml
+++ b/tests/translator/input/error_sns_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SnsSqsSubscription:
     Type: Boolean

--- a/tests/translator/input/error_state_machine_definition_string.yaml
+++ b/tests/translator/input/error_state_machine_definition_string.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_invalid_s3_object.yaml
+++ b/tests/translator/input/error_state_machine_invalid_s3_object.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_invalid_s3_string.yaml
+++ b/tests/translator/input/error_state_machine_invalid_s3_string.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_with_api_auth_none.yaml
+++ b/tests/translator/input/error_state_machine_with_api_auth_none.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_state_machine_with_cwe_both_dlq_property_provided.yaml
+++ b/tests/translator/input/error_state_machine_with_cwe_both_dlq_property_provided.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_with_cwe_invalid_dlq_type.yaml
+++ b/tests/translator/input/error_state_machine_with_cwe_invalid_dlq_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_with_cwe_missing_dlq_property.yaml
+++ b/tests/translator/input/error_state_machine_with_cwe_missing_dlq_property.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_with_eb_dlq_generated_intrinsic_function.yaml
+++ b/tests/translator/input/error_state_machine_with_eb_dlq_generated_intrinsic_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   Env:
     Type: String

--- a/tests/translator/input/error_state_machine_with_invalid_default_authorizer.yaml
+++ b/tests/translator/input/error_state_machine_with_invalid_default_authorizer.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_state_machine_with_invalid_schedule_event.yaml
+++ b/tests/translator/input/error_state_machine_with_invalid_schedule_event.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 
 Resources:

--- a/tests/translator/input/error_state_machine_with_no_api_authorizers.yaml
+++ b/tests/translator/input/error_state_machine_with_no_api_authorizers.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_state_machine_with_schedule_both_dlq_property_provided.yaml
+++ b/tests/translator/input/error_state_machine_with_schedule_both_dlq_property_provided.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_with_schedule_dlq_generated_intrinsic_function.yaml
+++ b/tests/translator/input/error_state_machine_with_schedule_dlq_generated_intrinsic_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   Env:
     Type: String

--- a/tests/translator/input/error_state_machine_with_schedule_invalid_dlq_type.yaml
+++ b/tests/translator/input/error_state_machine_with_schedule_invalid_dlq_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_with_schedule_missing_dlq_property.yaml
+++ b/tests/translator/input/error_state_machine_with_schedule_missing_dlq_property.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/error_state_machine_with_undefined_api_authorizer.yaml
+++ b/tests/translator/input/error_state_machine_with_undefined_api_authorizer.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/error_swagger_security_not_dict.yaml
+++ b/tests/translator/input/error_swagger_security_not_dict.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 transformId: AWS::Serverless-2016-10-31
 AWSTemplateFormatVersion: '2010-09-09'
 Resources:

--- a/tests/translator/input/error_swagger_security_not_dict_with_api_key_required.yaml
+++ b/tests/translator/input/error_swagger_security_not_dict_with_api_key_required.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 transformId: AWS::Serverless-2016-10-31
 AWSTemplateFormatVersion: '2010-09-09'
 Resources:

--- a/tests/translator/input/error_table_invalid_attributetype.yaml
+++ b/tests/translator/input/error_table_invalid_attributetype.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Table:
     Type: AWS::Serverless::SimpleTable

--- a/tests/translator/input/error_table_primary_key_missing_name.yaml
+++ b/tests/translator/input/error_table_primary_key_missing_name.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Table:
     Type: AWS::Serverless::SimpleTable

--- a/tests/translator/input/error_table_primary_key_missing_type.yaml
+++ b/tests/translator/input/error_table_primary_key_missing_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Table:
     Type: AWS::Serverless::SimpleTable

--- a/tests/translator/input/eventbridgerule.yaml
+++ b/tests/translator/input/eventbridgerule.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/eventbridgerule_schedule_properties.yaml
+++ b/tests/translator/input/eventbridgerule_schedule_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/eventbridgerule_with_dlq.yaml
+++ b/tests/translator/input/eventbridgerule_with_dlq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/eventbridgerule_with_retry_policy.yaml
+++ b/tests/translator/input/eventbridgerule_with_retry_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ScheduledFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/explicit_api.yaml
+++ b/tests/translator/input/explicit_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   MyStageName:
     Type: String

--- a/tests/translator/input/explicit_api_openapi_3.yaml
+++ b/tests/translator/input/explicit_api_openapi_3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   MyStageName:
     Type: String

--- a/tests/translator/input/explicit_api_with_invalid_events_config.yaml
+++ b/tests/translator/input/explicit_api_with_invalid_events_config.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # This is specifically testing a invalid SAM template, that is currently accepted by SAM, and some customers rely on this behavior.
 # We will eventually change the behavior to error on this invalid template, but until then, this test will guard against
 # inadvertently changing this behavior.

--- a/tests/translator/input/explicit_http_api.yaml
+++ b/tests/translator/input/explicit_http_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/explicit_http_api_default_path.yaml
+++ b/tests/translator/input/explicit_http_api_default_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   Function:

--- a/tests/translator/input/explicit_http_api_minimum.yaml
+++ b/tests/translator/input/explicit_http_api_minimum.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Api:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/function_concurrency.yaml
+++ b/tests/translator/input/function_concurrency.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   Concurrency:
     Type: Number

--- a/tests/translator/input/function_event_conditions.yaml
+++ b/tests/translator/input/function_event_conditions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   MyCondition:
     Fn::Equals:

--- a/tests/translator/input/function_managed_inline_policy.yaml
+++ b/tests/translator/input/function_managed_inline_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SomeManagedPolicyArn:
     Type: String

--- a/tests/translator/input/function_with_alias.yaml
+++ b/tests/translator/input/function_with_alias.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_alias_and_code_sha256.yaml
+++ b/tests/translator/input/function_with_alias_and_code_sha256.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   AutoPublishCodeSha256:
     Type: String

--- a/tests/translator/input/function_with_alias_and_event_sources.yaml
+++ b/tests/translator/input/function_with_alias_and_event_sources.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Testing Alias Invoke with ALL event sources supported by Lambda
 # We are looking to check if the event sources and their associated Lambda::Permission resources are
 # connect to the Alias and *not* the function

--- a/tests/translator/input/function_with_alias_intrinsics.yaml
+++ b/tests/translator/input/function_with_alias_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   AliasName:
     Type: String

--- a/tests/translator/input/function_with_amq.yaml
+++ b/tests/translator/input/function_with_amq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_amq_kms.yaml
+++ b/tests/translator/input/function_with_amq_kms.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_architectures.yaml
+++ b/tests/translator/input/function_with_architectures.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/function_with_auth_mechanism_for_self_managed_kafka.yaml
+++ b/tests/translator/input/function_with_auth_mechanism_for_self_managed_kafka.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/function_with_condition.yaml
+++ b/tests/translator/input/function_with_condition.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   TestCondition:
     Fn::Equals:

--- a/tests/translator/input/function_with_conditional_managed_policy.yaml
+++ b/tests/translator/input/function_with_conditional_managed_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   DummyCondition: !Equals ['', '']
 

--- a/tests/translator/input/function_with_conditional_managed_policy_and_ref_no_value.yaml
+++ b/tests/translator/input/function_with_conditional_managed_policy_and_ref_no_value.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   DummyCondition: !Equals ['', '']
 

--- a/tests/translator/input/function_with_conditional_policy_template.yaml
+++ b/tests/translator/input/function_with_conditional_policy_template.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   DummyCondition: !Equals ['', '']
 

--- a/tests/translator/input/function_with_conditional_policy_template_and_ref_no_value.yaml
+++ b/tests/translator/input/function_with_conditional_policy_template_and_ref_no_value.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   DummyCondition: !Equals ['', '']
 

--- a/tests/translator/input/function_with_custom_codedeploy_deployment_preference.yaml
+++ b/tests/translator/input/function_with_custom_codedeploy_deployment_preference.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Mappings:
   DeploymentPreferenceMap:
     prod:

--- a/tests/translator/input/function_with_custom_conditional_codedeploy_deployment_preference.yaml
+++ b/tests/translator/input/function_with_custom_conditional_codedeploy_deployment_preference.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Parameters:

--- a/tests/translator/input/function_with_deployment_and_custom_role.yaml
+++ b/tests/translator/input/function_with_deployment_and_custom_role.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Function:
     AutoPublishAlias: live

--- a/tests/translator/input/function_with_deployment_no_service_role_with_passthrough.yaml
+++ b/tests/translator/input/function_with_deployment_no_service_role_with_passthrough.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   Condition1:
     Fn::Equals:

--- a/tests/translator/input/function_with_deployment_no_service_role_without_passthrough.yaml
+++ b/tests/translator/input/function_with_deployment_no_service_role_without_passthrough.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   Condition1:
     Fn::Equals:

--- a/tests/translator/input/function_with_deployment_preference.yaml
+++ b/tests/translator/input/function_with_deployment_preference.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   FnName:
     Type: String

--- a/tests/translator/input/function_with_deployment_preference_alarms_intrinsic_if.yaml
+++ b/tests/translator/input/function_with_deployment_preference_alarms_intrinsic_if.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   MyCondition:
     Fn::Equals:

--- a/tests/translator/input/function_with_deployment_preference_all_parameters.yaml
+++ b/tests/translator/input/function_with_deployment_preference_all_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_deployment_preference_condition_with_passthrough.yaml
+++ b/tests/translator/input/function_with_deployment_preference_condition_with_passthrough.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   FnName:
     Type: String

--- a/tests/translator/input/function_with_deployment_preference_condition_without_passthrough.yaml
+++ b/tests/translator/input/function_with_deployment_preference_condition_without_passthrough.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   FnName:
     Type: String

--- a/tests/translator/input/function_with_deployment_preference_from_parameters.yaml
+++ b/tests/translator/input/function_with_deployment_preference_from_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   MyTrueParameter:
     Default: 'True'

--- a/tests/translator/input/function_with_deployment_preference_multiple_combinations.yaml
+++ b/tests/translator/input/function_with_deployment_preference_multiple_combinations.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_deployment_preference_multiple_combinations_conditions_with_passthrough.yaml
+++ b/tests/translator/input/function_with_deployment_preference_multiple_combinations_conditions_with_passthrough.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   Condition1:
     Fn::Equals:

--- a/tests/translator/input/function_with_deployment_preference_multiple_combinations_conditions_without_passthrough.yaml
+++ b/tests/translator/input/function_with_deployment_preference_multiple_combinations_conditions_without_passthrough.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   Condition1:
     Fn::Equals:

--- a/tests/translator/input/function_with_deployment_preference_passthrough_condition_with_supported_intrinsics.yaml
+++ b/tests/translator/input/function_with_deployment_preference_passthrough_condition_with_supported_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Tests supported intrinsics in the PassthroughCondition property
 
 Mappings:

--- a/tests/translator/input/function_with_disabled_deployment_preference.yaml
+++ b/tests/translator/input/function_with_disabled_deployment_preference.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_disabled_traffic_hook.yaml
+++ b/tests/translator/input/function_with_disabled_traffic_hook.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Template with preference that does not require a new CodeDeploy Service

--- a/tests/translator/input/function_with_dlq.yaml
+++ b/tests/translator/input/function_with_dlq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   MySnsDlqLambdaFunction:

--- a/tests/translator/input/function_with_ephemeral_storage.yaml
+++ b/tests/translator/input/function_with_ephemeral_storage.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   EphemeralStorageSizeRef:
     Type: Number

--- a/tests/translator/input/function_with_event_bridge_rule_state.yaml
+++ b/tests/translator/input/function_with_event_bridge_rule_state.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 
 Resources:

--- a/tests/translator/input/function_with_event_dest.yaml
+++ b/tests/translator/input/function_with_event_dest.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SQSArn:
     Type: String

--- a/tests/translator/input/function_with_event_dest_basic.yaml
+++ b/tests/translator/input/function_with_event_dest_basic.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SNSArn:
     Type: String

--- a/tests/translator/input/function_with_event_dest_conditional.yaml
+++ b/tests/translator/input/function_with_event_dest_conditional.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SQSArn:
     Type: String

--- a/tests/translator/input/function_with_event_filtering.yaml
+++ b/tests/translator/input/function_with_event_filtering.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FilteredEventsFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_event_schedule_state.yaml
+++ b/tests/translator/input/function_with_event_schedule_state.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Parameters:
   ScheduleState:

--- a/tests/translator/input/function_with_event_source_mapping.yaml
+++ b/tests/translator/input/function_with_event_source_mapping.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 

--- a/tests/translator/input/function_with_file_system_config.yaml
+++ b/tests/translator/input/function_with_file_system_config.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Description: SAM + Lambda + EFS
 
 Parameters:

--- a/tests/translator/input/function_with_function_url_config.yaml
+++ b/tests/translator/input/function_with_function_url_config.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/function_with_function_url_config_and_autopublishalias.yaml
+++ b/tests/translator/input/function_with_function_url_config_and_autopublishalias.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/function_with_function_url_config_conditions.yaml
+++ b/tests/translator/input/function_with_function_url_config_conditions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Conditions:
   MyCondition:

--- a/tests/translator/input/function_with_function_url_config_with_iam_authorization_type.yaml
+++ b/tests/translator/input/function_with_function_url_config_with_iam_authorization_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/function_with_function_url_config_with_intrinsics.yaml
+++ b/tests/translator/input/function_with_function_url_config_with_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   AuthorizationTypeRef:

--- a/tests/translator/input/function_with_function_url_config_without_cors_config.yaml
+++ b/tests/translator/input/function_with_function_url_config_without_cors_config.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/function_with_global_layers.yaml
+++ b/tests/translator/input/function_with_global_layers.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Function:
     Layers:

--- a/tests/translator/input/function_with_intrinsic_architecture.yaml
+++ b/tests/translator/input/function_with_intrinsic_architecture.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   ArchitectureRef:
     Type: String

--- a/tests/translator/input/function_with_kmskeyarn.yaml
+++ b/tests/translator/input/function_with_kmskeyarn.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionWithKeyArn:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_layers.yaml
+++ b/tests/translator/input/function_with_layers.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalLayerFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_many_layers.yaml
+++ b/tests/translator/input/function_with_many_layers.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ManyLayersFunc:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_mq_virtual_host.yaml
+++ b/tests/translator/input/function_with_mq_virtual_host.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MQFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_msk.yaml
+++ b/tests/translator/input/function_with_msk.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 

--- a/tests/translator/input/function_with_msk_with_intrinsics.yaml
+++ b/tests/translator/input/function_with_msk_with_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   StartingPositionValue:

--- a/tests/translator/input/function_with_null_events.yaml
+++ b/tests/translator/input/function_with_null_events.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionWithNullEvents:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_permissions_boundary.yaml
+++ b/tests/translator/input/function_with_permissions_boundary.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_policy_templates.yaml
+++ b/tests/translator/input/function_with_policy_templates.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   FunctionNameParam:
     Type: String

--- a/tests/translator/input/function_with_request_parameters.yaml
+++ b/tests/translator/input/function_with_request_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
 
   Api:

--- a/tests/translator/input/function_with_resource_refs.yaml
+++ b/tests/translator/input/function_with_resource_refs.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Test to verify that resource references available on the Function are properly resolved
 # Currently supported references are:
 #    - Alias

--- a/tests/translator/input/function_with_self_managed_kafka.yaml
+++ b/tests/translator/input/function_with_self_managed_kafka.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/function_with_signing_profile.yaml
+++ b/tests/translator/input/function_with_signing_profile.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
 
   FunctionWithSigningProfile:

--- a/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
+++ b/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyAwesomeFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/function_with_vpc_permission_for_self_managed_kafka.yaml
+++ b/tests/translator/input/function_with_vpc_permission_for_self_managed_kafka.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters: {}
 Resources:

--- a/tests/translator/input/global_handle_path_level_parameter.yaml
+++ b/tests/translator/input/global_handle_path_level_parameter.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Name: some api

--- a/tests/translator/input/globals_for_api.yaml
+++ b/tests/translator/input/globals_for_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Name: some api

--- a/tests/translator/input/globals_for_function.yaml
+++ b/tests/translator/input/globals_for_function.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Function:
     CodeUri: s3://global-bucket/global.zip

--- a/tests/translator/input/globals_for_simpletable.yaml
+++ b/tests/translator/input/globals_for_simpletable.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   SimpleTable:
     SSESpecification:

--- a/tests/translator/input/http_api_custom_iam_auth.yaml
+++ b/tests/translator/input/http_api_custom_iam_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # This test-case tests what happens when an AWS_IAM authorizer is defined on an HttpApi but not enabled anywhere else.
 # While the defined authorizer isn't really a true Iam authorizer (it's just a poorly-named OAuth authorizer) this shouldn't cause an error.
 Resources:

--- a/tests/translator/input/http_api_def_uri.yaml
+++ b/tests/translator/input/http_api_def_uri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   HttpApi:
     DefaultRouteSettings:

--- a/tests/translator/input/http_api_description.yaml
+++ b/tests/translator/input/http_api_description.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApi:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/http_api_existing_openapi.yaml
+++ b/tests/translator/input/http_api_existing_openapi.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   Timeout:
     Default: 15000

--- a/tests/translator/input/http_api_existing_openapi_conditions.yaml
+++ b/tests/translator/input/http_api_existing_openapi_conditions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   condition:
     Fn::Equals:

--- a/tests/translator/input/http_api_explicit_stage.yaml
+++ b/tests/translator/input/http_api_explicit_stage.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   CorsParam:
     Type: String

--- a/tests/translator/input/http_api_global_iam_auth_enabled.yaml
+++ b/tests/translator/input/http_api_global_iam_auth_enabled.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   HttpApi:
     Auth:

--- a/tests/translator/input/http_api_global_iam_auth_enabled_with_existing_conflicting_authorizer.yaml
+++ b/tests/translator/input/http_api_global_iam_auth_enabled_with_existing_conflicting_authorizer.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # This test-case tests what happens when an AWS_IAM authorizer is defined on an HttpApi and also enabled globally.
 # In this case the defined authorizer should NOT be overwritten.
 Globals:

--- a/tests/translator/input/http_api_lambda_auth.yaml
+++ b/tests/translator/input/http_api_lambda_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/http_api_lambda_auth_full.yaml
+++ b/tests/translator/input/http_api_lambda_auth_full.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/http_api_local_iam_auth_enabled.yaml
+++ b/tests/translator/input/http_api_local_iam_auth_enabled.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   HttpApi:
     Auth:

--- a/tests/translator/input/http_api_local_iam_auth_enabled_with_existing_conflicting_authorizer.yaml
+++ b/tests/translator/input/http_api_local_iam_auth_enabled_with_existing_conflicting_authorizer.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # This test-case tests what happens when an AWS_IAM authorizer is defined on an HttpApi and also enabled locally.
 # In this case the defined authorizer should NOT be overwritten.
 Resources:

--- a/tests/translator/input/http_api_multiple_authorizers.yaml
+++ b/tests/translator/input/http_api_multiple_authorizers.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/http_api_with_cors.yaml
+++ b/tests/translator/input/http_api_with_cors.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   C1:
     Fn::Equals:

--- a/tests/translator/input/http_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/http_api_with_custom_domain_route53_multiple.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi1:
     Type: AWS::Serverless::HttpApi

--- a/tests/translator/input/http_api_with_null_path.yaml
+++ b/tests/translator/input/http_api_with_null_path.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: A template to test for API condition handling with a mix of explicit

--- a/tests/translator/input/implicit_and_explicit_api_with_conditions.yaml
+++ b/tests/translator/input/implicit_and_explicit_api_with_conditions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: A template to test for API condition handling with a mix of explicit

--- a/tests/translator/input/implicit_api.yaml
+++ b/tests/translator/input/implicit_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   RestApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/implicit_api_deletion_policy_precedence.yaml
+++ b/tests/translator/input/implicit_api_deletion_policy_precedence.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   RestApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/implicit_api_with_auth_and_conditions_max.yaml
+++ b/tests/translator/input/implicit_api_with_auth_and_conditions_max.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/implicit_api_with_many_conditions.yaml
+++ b/tests/translator/input/implicit_api_with_many_conditions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: A template to test for implicit API condition handling.

--- a/tests/translator/input/implicit_api_with_serverless_rest_api_resource.yaml
+++ b/tests/translator/input/implicit_api_with_serverless_rest_api_resource.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   RestApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/implicit_http_api.yaml
+++ b/tests/translator/input/implicit_http_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HttpApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/implicit_http_api_auth_and_simple_case.yaml
+++ b/tests/translator/input/implicit_http_api_auth_and_simple_case.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   RestApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/implicit_http_api_with_many_conditions.yaml
+++ b/tests/translator/input/implicit_http_api_with_many_conditions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: A template to test for implicit HttpApi condition handling.

--- a/tests/translator/input/inline_precedence.yaml
+++ b/tests/translator/input/inline_precedence.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/intrinsic_functions.yaml
+++ b/tests/translator/input/intrinsic_functions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # SAM template using intrinsic function on every property that supports it.
 # Translator should handle it properly
 Parameters:

--- a/tests/translator/input/iot_rule.yaml
+++ b/tests/translator/input/iot_rule.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # File: sam.yml
 # Version: 0.9
 

--- a/tests/translator/input/kinesis_intrinsics.yaml
+++ b/tests/translator/input/kinesis_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   IntValue:
     Type: Number

--- a/tests/translator/input/layer_deletion_policy_precedence.yaml
+++ b/tests/translator/input/layer_deletion_policy_precedence.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalLayer:
     Type: AWS::Serverless::LayerVersion

--- a/tests/translator/input/layers_all_properties.yaml
+++ b/tests/translator/input/layers_all_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   LayerDeleteParam:
     Type: String

--- a/tests/translator/input/layers_with_intrinsics.yaml
+++ b/tests/translator/input/layers_with_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   CompatibleArchitecturesList:
     Type: CommaDelimitedList

--- a/tests/translator/input/mixed_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/mixed_api_with_custom_domain_route53_multiple.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >

--- a/tests/translator/input/no_implicit_api_with_serverless_rest_api_resource.yaml
+++ b/tests/translator/input/no_implicit_api_with_serverless_rest_api_resource.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/resource_with_invalid_type.yaml
+++ b/tests/translator/input/resource_with_invalid_type.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionInvalid:
     Type:

--- a/tests/translator/input/s3.yaml
+++ b/tests/translator/input/s3.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_create_remove.yaml
+++ b/tests/translator/input/s3_create_remove.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_existing_lambda_notification_configuration.yaml
+++ b/tests/translator/input/s3_existing_lambda_notification_configuration.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_existing_other_notification_configuration.yaml
+++ b/tests/translator/input/s3_existing_other_notification_configuration.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_filter.yaml
+++ b/tests/translator/input/s3_filter.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_intrinsics.yaml
+++ b/tests/translator/input/s3_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   EventsParam:
     Type: String

--- a/tests/translator/input/s3_multiple_events_same_bucket.yaml
+++ b/tests/translator/input/s3_multiple_events_same_bucket.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_multiple_functions.yaml
+++ b/tests/translator/input/s3_multiple_functions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   FunctionOne:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_with_condition.yaml
+++ b/tests/translator/input/s3_with_condition.yaml
@@ -1,8 +1,10 @@
+%YAML 1.1
+---
 Conditions:
   MyCondition:
     Fn::Equals:
-    - yes
-    - no
+    - true
+    - false
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_with_dependsOn.yaml
+++ b/tests/translator/input/s3_with_dependsOn.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   Topic:
     Type: AWS::SNS::Topic

--- a/tests/translator/input/self_managed_kafka_with_intrinsics.yaml
+++ b/tests/translator/input/self_managed_kafka_with_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   BatchSizeValue:
     Type: Number

--- a/tests/translator/input/simple_table_ref_parameter_intrinsic.yaml
+++ b/tests/translator/input/simple_table_ref_parameter_intrinsic.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   ReadCapacity:
     Type: Number

--- a/tests/translator/input/simple_table_with_extra_tags.yaml
+++ b/tests/translator/input/simple_table_with_extra_tags.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   TagValueParam:
     Type: String

--- a/tests/translator/input/simple_table_with_table_name.yaml
+++ b/tests/translator/input/simple_table_with_table_name.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   MySimpleTableParameter:
     Type: String

--- a/tests/translator/input/simpletable.yaml
+++ b/tests/translator/input/simpletable.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalTable:
     Type: AWS::Serverless::SimpleTable

--- a/tests/translator/input/simpletable_with_sse.yaml
+++ b/tests/translator/input/simpletable_with_sse.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   TableWithSSE:
     Type: AWS::Serverless::SimpleTable

--- a/tests/translator/input/sns.yaml
+++ b/tests/translator/input/sns.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SaveNotificationFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/sns_existing_other_subscription.yaml
+++ b/tests/translator/input/sns_existing_other_subscription.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SaveNotificationFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/sns_existing_sqs.yaml
+++ b/tests/translator/input/sns_existing_sqs.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SaveNotificationFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/sns_intrinsics.yaml
+++ b/tests/translator/input/sns_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SnsRegion:
     Type: String

--- a/tests/translator/input/sns_outside_sqs.yaml
+++ b/tests/translator/input/sns_outside_sqs.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SaveNotificationFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/sns_sqs.yaml
+++ b/tests/translator/input/sns_sqs.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SaveNotificationFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/sns_topic_outside_template.yaml
+++ b/tests/translator/input/sns_topic_outside_template.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Parameters:
   SNSTopicArn:
     Type: String

--- a/tests/translator/input/sqs.yaml
+++ b/tests/translator/input/sqs.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   SQSFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_api_auth_default_scopes.yaml
+++ b/tests/translator/input/state_machine_with_api_auth_default_scopes.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApiWithCognitoAuth:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/state_machine_with_api_authorizer.yaml
+++ b/tests/translator/input/state_machine_with_api_authorizer.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/state_machine_with_api_authorizer_maximum.yaml
+++ b/tests/translator/input/state_machine_with_api_authorizer_maximum.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/state_machine_with_api_resource_policy.yaml
+++ b/tests/translator/input/state_machine_with_api_resource_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ExplicitApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/state_machine_with_condition.yaml
+++ b/tests/translator/input/state_machine_with_condition.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   TestCondition:
     Fn::Equals:

--- a/tests/translator/input/state_machine_with_condition_and_events.yaml
+++ b/tests/translator/input/state_machine_with_condition_and_events.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Conditions:
   TestCondition:
     Fn::Equals:

--- a/tests/translator/input/state_machine_with_cwe.yaml
+++ b/tests/translator/input/state_machine_with_cwe.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_definition_S3_object.yaml
+++ b/tests/translator/input/state_machine_with_definition_S3_object.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_definition_S3_string.yaml
+++ b/tests/translator/input/state_machine_with_definition_S3_string.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_definition_substitutions.yaml
+++ b/tests/translator/input/state_machine_with_definition_substitutions.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_eb_dlq.yaml
+++ b/tests/translator/input/state_machine_with_eb_dlq.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_eb_dlq_generated.yaml
+++ b/tests/translator/input/state_machine_with_eb_dlq_generated.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_eb_retry_policy.yaml
+++ b/tests/translator/input/state_machine_with_eb_retry_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_event_schedule_state.yaml
+++ b/tests/translator/input/state_machine_with_event_schedule_state.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 
 Resources:

--- a/tests/translator/input/state_machine_with_explicit_api.yaml
+++ b/tests/translator/input/state_machine_with_explicit_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/tests/translator/input/state_machine_with_express_logging.yaml
+++ b/tests/translator/input/state_machine_with_express_logging.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_implicit_api.yaml
+++ b/tests/translator/input/state_machine_with_implicit_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_implicit_api_globals.yaml
+++ b/tests/translator/input/state_machine_with_implicit_api_globals.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Globals:
   Api:
     Auth:

--- a/tests/translator/input/state_machine_with_inline_definition.yaml
+++ b/tests/translator/input/state_machine_with_inline_definition.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_inline_definition_intrinsics.yaml
+++ b/tests/translator/input/state_machine_with_inline_definition_intrinsics.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_inline_policies.yaml
+++ b/tests/translator/input/state_machine_with_inline_policies.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_managed_policy.yaml
+++ b/tests/translator/input/state_machine_with_managed_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_null_events.yaml
+++ b/tests/translator/input/state_machine_with_null_events.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_permissions_boundary.yaml
+++ b/tests/translator/input/state_machine_with_permissions_boundary.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_role.yaml
+++ b/tests/translator/input/state_machine_with_role.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_sam_policy_templates.yaml
+++ b/tests/translator/input/state_machine_with_sam_policy_templates.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StarterLambda:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_schedule.yaml
+++ b/tests/translator/input/state_machine_with_schedule.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_schedule_dlq_retry_policy.yaml
+++ b/tests/translator/input/state_machine_with_schedule_dlq_retry_policy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_standard_logging.yaml
+++ b/tests/translator/input/state_machine_with_standard_logging.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_tags.yaml
+++ b/tests/translator/input/state_machine_with_tags.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/state_machine_with_xray_policies.yaml
+++ b/tests/translator/input/state_machine_with_xray_policies.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/state_machine_with_xray_role.yaml
+++ b/tests/translator/input/state_machine_with_xray_role.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/input/streams.yaml
+++ b/tests/translator/input/streams.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   KinesisFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/translate_convert_metadata.yaml
+++ b/tests/translator/input/translate_convert_metadata.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/unsupported_resources.yaml
+++ b/tests/translator/input/unsupported_resources.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   # These resources are NOT errors from the eye of translator.
   # Translator will simply ignore resources with unknown type in order to accept non-SAM resources

--- a/tests/translator/input/version_deletion_policy_precedence.yaml
+++ b/tests/translator/input/version_deletion_policy_precedence.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/validator/input/api/error_accesslogsetting.yaml
+++ b/tests/validator/input/api/error_accesslogsetting.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   ApiAccessLogSettingEmpty:

--- a/tests/validator/input/api/error_auth.yaml
+++ b/tests/validator/input/api/error_auth.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Auth

--- a/tests/validator/input/api/error_auth_cognito.yaml
+++ b/tests/validator/input/api/error_auth_cognito.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Auth Cognito authorizer tests
 Transform: AWS::Serverless-2016-10-31
 Resources:

--- a/tests/validator/input/api/error_auth_lambda.yaml
+++ b/tests/validator/input/api/error_auth_lambda.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   MyApi:

--- a/tests/validator/input/api/error_auth_lambdarequest_identity.yaml
+++ b/tests/validator/input/api/error_auth_lambdarequest_identity.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   MyApi:

--- a/tests/validator/input/api/error_auth_lambdatoken_identity.yaml
+++ b/tests/validator/input/api/error_auth_lambdatoken_identity.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   MyApi:

--- a/tests/validator/input/api/error_auth_resourcepolicy.yaml
+++ b/tests/validator/input/api/error_auth_resourcepolicy.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # ResourcePolicy

--- a/tests/validator/input/api/error_auth_usageplan.yaml
+++ b/tests/validator/input/api/error_auth_usageplan.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # UsagePlan

--- a/tests/validator/input/api/error_binarymediatypes.yaml
+++ b/tests/validator/input/api/error_binarymediatypes.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # BinaryMediaTypes is empty

--- a/tests/validator/input/api/error_cachecluster.yaml
+++ b/tests/validator/input/api/error_cachecluster.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # CacheClusterEnabled empty

--- a/tests/validator/input/api/error_canarysetting.yaml
+++ b/tests/validator/input/api/error_canarysetting.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # CanarySetting is empty

--- a/tests/validator/input/api/error_cors.yaml
+++ b/tests/validator/input/api/error_cors.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Cors is empty

--- a/tests/validator/input/api/error_definitionbody.yaml
+++ b/tests/validator/input/api/error_definitionbody.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # DefinitionBody is empty

--- a/tests/validator/input/api/error_definitionuri.yaml
+++ b/tests/validator/input/api/error_definitionuri.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # DefinitionUri is empty

--- a/tests/validator/input/api/error_description.yaml
+++ b/tests/validator/input/api/error_description.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Description is empty

--- a/tests/validator/input/api/error_domain.yaml
+++ b/tests/validator/input/api/error_domain.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Domain

--- a/tests/validator/input/api/error_endpointconfiguration.yaml
+++ b/tests/validator/input/api/error_endpointconfiguration.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # EndpointConfiguration

--- a/tests/validator/input/api/error_gatewayresponses.yaml
+++ b/tests/validator/input/api/error_gatewayresponses.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # GatewayResponses

--- a/tests/validator/input/api/error_methodsettings.yaml
+++ b/tests/validator/input/api/error_methodsettings.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # MethodSettings

--- a/tests/validator/input/api/error_minimumcompressionsize.yaml
+++ b/tests/validator/input/api/error_minimumcompressionsize.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # MinimumCompressionSize not integer

--- a/tests/validator/input/api/error_models.yaml
+++ b/tests/validator/input/api/error_models.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Models is empty

--- a/tests/validator/input/api/error_name.yaml
+++ b/tests/validator/input/api/error_name.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Name is empty

--- a/tests/validator/input/api/error_openapiversion.yaml
+++ b/tests/validator/input/api/error_openapiversion.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   ApiOpenApiVersionEmpty:

--- a/tests/validator/input/api/error_properties.yaml
+++ b/tests/validator/input/api/error_properties.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   ApiPropertiesMissing:

--- a/tests/validator/input/api/error_resource_attributes.yaml
+++ b/tests/validator/input/api/error_resource_attributes.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   ApiConditionEmpty:

--- a/tests/validator/input/api/error_stagename.yaml
+++ b/tests/validator/input/api/error_stagename.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # StageName missing

--- a/tests/validator/input/api/error_tags.yaml
+++ b/tests/validator/input/api/error_tags.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Tags is empty

--- a/tests/validator/input/api/error_tracingenabled.yaml
+++ b/tests/validator/input/api/error_tracingenabled.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # TracingEnabled is empty

--- a/tests/validator/input/api/error_variables.yaml
+++ b/tests/validator/input/api/error_variables.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   # Variables is empty

--- a/tests/validator/input/api/success_auth_cognito.yaml
+++ b/tests/validator/input/api/success_auth_cognito.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   MyApi:

--- a/tests/validator/input/api/success_auth_lambdarequest.yaml
+++ b/tests/validator/input/api/success_auth_lambdarequest.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   MyApi:

--- a/tests/validator/input/api/success_complete_api.yaml
+++ b/tests/validator/input/api/success_complete_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Complete API
 Transform: AWS::Serverless-2016-10-31
 Resources:

--- a/tests/validator/input/api/success_minimal_api.yaml
+++ b/tests/validator/input/api/success_minimal_api.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Minimal valid API
 Transform: AWS::Serverless-2016-10-31
 Resources:

--- a/tests/validator/input/api/success_resource_attributes.yaml
+++ b/tests/validator/input/api/success_resource_attributes.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   ApiCondition:

--- a/tests/validator/input/root/error_awstemplateformatversion_unknown.yaml
+++ b/tests/validator/input/root/error_awstemplateformatversion_unknown.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # AWSTemplateFormatVersion has an unknown value
 AWSTemplateFormatVersion: '2021-01-26'
 Transform: AWS::Serverless-2016-10-31

--- a/tests/validator/input/root/error_empty_template.yaml
+++ b/tests/validator/input/root/error_empty_template.yaml
@@ -1,2 +1,3 @@
-null
+%YAML 1.1
+--- null
 ...

--- a/tests/validator/input/root/error_minimal_template_with_parameters.yaml
+++ b/tests/validator/input/root/error_minimal_template_with_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Smallest possible API template
 Transform: AWS::Serverless-2016-10-31
 Parameters:

--- a/tests/validator/input/root/error_resources.yaml
+++ b/tests/validator/input/root/error_resources.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 Transform: AWS::Serverless-2016-10-31
 Resources:
   EmptyResource:

--- a/tests/validator/input/root/error_resources_empty.yaml
+++ b/tests/validator/input/root/error_resources_empty.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Resources is present but empty
 Transform: AWS::Serverless-2016-10-31
 Resources:

--- a/tests/validator/input/root/error_resources_missing.yaml
+++ b/tests/validator/input/root/error_resources_missing.yaml
@@ -1,2 +1,4 @@
+%YAML 1.1
+---
 # Resources is missing
 Transform: AWS::Serverless-2016-10-31

--- a/tests/validator/input/root/error_resources_not_object.yaml
+++ b/tests/validator/input/root/error_resources_not_object.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Resources is present but not an object
 Transform: AWS::Serverless-2016-10-31
 Resources: 3

--- a/tests/validator/input/root/error_transform_empty.yaml
+++ b/tests/validator/input/root/error_transform_empty.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Transform is empty
 Transform:
 Resources:

--- a/tests/validator/input/root/success_minimal_template.yaml
+++ b/tests/validator/input/root/success_minimal_template.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Smallest possible API template
 Transform: AWS::Serverless-2016-10-31
 Resources:

--- a/tests/validator/input/root/success_minimal_template_with_parameters.yaml
+++ b/tests/validator/input/root/success_minimal_template_with_parameters.yaml
@@ -1,3 +1,5 @@
+%YAML 1.1
+---
 # Smallest possible API template
 Transform: AWS::Serverless-2016-10-31
 Parameters:


### PR DESCRIPTION
…rse them

### Issue #, if available

The formatter used 1.2 so output yaml 1.2 files in the end. However, in our dev.txt, we use pyyaml which is a 1.1 yaml parser. It could cause some issues. Here we make formatter parse/output yaml in 1.1 mode, and make our test files yaml version explicit.

**Note, this only affect our testing code, our translator main code doesn't deal with yaml.**

All files are reverted to ones before the previous format #2578 and re-formatted with 1.1

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
