### PR TITLE
chore: Add --add-test-metadata option to yaml formatter

### DIFF
--- a/bin/json-format.py
+++ b/bin/json-format.py
@@ -17,8 +17,7 @@ class JSONFormatter(FileFormatter):
     def description() -> str:
         return "JSON file formatter"
 
-    @staticmethod
-    def format(input_str: str) -> str:
+    def format(self, input_str: str) -> str:
         """Opinionated format JSON file."""
         obj = json.loads(input_str)
         return json.dumps(obj, indent=2, sort_keys=True) + "\n"

--- a/bin/yaml-format.py
+++ b/bin/yaml-format.py
@@ -2,13 +2,14 @@
 """JSON file formatter (without prettier)."""
 import os
 import sys
+from textwrap import dedent
 
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, my_path + "/..")
 
 import re
 from io import StringIO
-from typing import Type
+from typing import Any, Dict, Type
 
 # We use ruamel.yaml for parsing yaml files because it can preserve comments
 from ruamel.yaml import YAML
@@ -27,10 +28,11 @@ class YAMLFormatter(FileFormatter):
     def description() -> str:
         return "YAML file formatter"
 
-    @staticmethod
-    def format(input_str: str) -> str:
+    def format(self, input_str: str) -> str:
         """Opinionated format YAML file."""
         obj = yaml.load(input_str)
+        if self.args.add_test_metadata:
+            self._add_test_metadata(obj)
         out_stream = StringIO()
         yaml.dump(
             obj,
@@ -40,12 +42,34 @@ class YAMLFormatter(FileFormatter):
         return re.sub(r"\n+$", "\n", out_stream.getvalue())
 
     @staticmethod
+    def _add_test_metadata(obj: Dict[str, Any]) -> None:
+        metadata = obj.get("Metadata", {})
+        if not metadata:
+            metadata = obj["Metadata"] = {}
+        sam_transform_test_value = metadata.get("SamTransformTest")
+        if sam_transform_test_value is not None and sam_transform_test_value is not True:
+            raise ValueError(f"Unexpected Metadata.SamTransformTest value {sam_transform_test_value}")
+        metadata["SamTransformTest"] = True
+
+    @staticmethod
     def decode_exception() -> Type[Exception]:
         return YAMLError
 
     @staticmethod
     def file_extension() -> str:
         return ".yaml"
+
+    @classmethod
+    def config_additional_args(cls) -> None:
+        cls.arg_parser.add_argument(
+            "--add-test-metadata",
+            action="store_true",
+            help=dedent(
+                """\
+                Add the testing metadata to yaml file if it doesn't exist:
+                "Metadata: SamTransformTest: true" """
+            ),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

<img width="500" alt="image" src="https://user-images.githubusercontent.com/3804518/202274042-44d7bad6-06ce-466d-bd7e-878d8e566f55.png">


### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
