### PR TITLE
chore: Add Test Metadata to Integration Test Template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,13 @@ black:
 	black setup.py samtranslator/* tests/* integration/* bin/*.py
 	bin/json-format.py --write tests
 	bin/yaml-format.py --write tests
+	bin/yaml-format.py --write integration --add-test-metadata
 
 black-check:
 	black --check setup.py samtranslator/* tests/* integration/* bin/*.py
 	bin/json-format.py --check tests
 	bin/yaml-format.py --check tests
+	bin/yaml-format.py --check integration --add-test-metadata
 
 lint:
 	# mypy performs type check

--- a/bin/yaml-format.py
+++ b/bin/yaml-format.py
@@ -30,9 +30,12 @@ class YAMLFormatter(FileFormatter):
 
     def format(self, input_str: str) -> str:
         """Opinionated format YAML file."""
-        obj = yaml.load(input_str)
         if self.args.add_test_metadata:
-            self._add_test_metadata(obj)
+            # Since formatting integration test templates cause failure,
+            # temporary workaround to add test metadata to integration test templates
+            return input_str + "\n\nMetadata:\n  SamTransformTest: true\n\n"
+
+        obj = yaml.load(input_str)
         out_stream = StringIO()
         yaml.dump(
             obj,

--- a/bin/yaml-format.py
+++ b/bin/yaml-format.py
@@ -33,7 +33,9 @@ class YAMLFormatter(FileFormatter):
         if self.args.add_test_metadata:
             # Since formatting integration test templates cause failure,
             # temporary workaround to add test metadata to integration test templates
-            return input_str + "\n\nMetadata:\n  SamTransformTest: true\n\n"
+            if "SamTransformTest" in input_str:
+                return input_str
+            return input_str + "\nMetadata:\n  SamTransformTest: true\n\n"
 
         obj = yaml.load(input_str)
         out_stream = StringIO()

--- a/integration/resources/code/template.yaml
+++ b/integration/resources/code/template.yaml
@@ -6,3 +6,7 @@ Resources:
 Outputs:
   TableName:
     Value: !Ref MyTable
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/all_policy_templates.yaml
+++ b/integration/resources/templates/combination/all_policy_templates.yaml
@@ -207,3 +207,8 @@ Resources:
             EndpointConfigName: name
         - EcsRunTaskPolicy:
             TaskDefinition: name
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_authorizer_apikey.yaml
+++ b/integration/resources/templates/combination/api_with_authorizer_apikey.yaml
@@ -114,3 +114,8 @@ Outputs:
       Description: "Authorizer Function Arn"
       Value:
         Fn::GetAtt: MyLambdaAuthFunction.Arn
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
@@ -74,3 +74,7 @@ Outputs:
       Description: "API endpoint URL for Prod environment"
       Value:
         Fn::Sub: 'https://${MyApiWithAwsIamAuthNoCallerCredentials}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_authorizers_max.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_max.yaml
@@ -194,3 +194,7 @@ Outputs:
       Description: "Authorizer Function Arn"
       Value:
         Fn::GetAtt: LambdaAuthInvokeRole.Arn
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_authorizers_max_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_max_openapi.yaml
@@ -243,3 +243,8 @@ Outputs:
       Description: "ID of the API Key"
       Value:
         Ref: MyFirstApiKey
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_authorizers_min.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_min.yaml
@@ -128,3 +128,7 @@ Outputs:
       Description: "Cognito User Pool Arn"
       Value:
         Fn::GetAtt: MyCognitoUserPool.Arn
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_binary_media_types.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types.yaml
@@ -20,3 +20,8 @@ Resources:
         - {"Fn::Join": ["~1", ["image", "png"]]}
         - {"Ref": "ImageType"}
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body.yaml
@@ -44,3 +44,8 @@ Resources:
                 passthroughBehavior: "when_no_match"
                 requestParameters:
                   integration.request.path.proxy: "method.request.path.proxy"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
@@ -75,3 +75,8 @@ Outputs:
     Description: MyLambda Function ARN
     Value:
       Fn::GetAtt: MyLambda.Arn
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_cors.yaml
+++ b/integration/resources/templates/combination/api_with_cors.yaml
@@ -44,3 +44,7 @@ Outputs:
     Description: URL of your API endpoint
     Value:
       Fn::Sub: 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_cors_only_headers.yaml
+++ b/integration/resources/templates/combination/api_with_cors_only_headers.yaml
@@ -46,3 +46,7 @@ Outputs:
     Description: URL of your API endpoint
     Value:
       Fn::Sub: 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_cors_only_max_age.yaml
+++ b/integration/resources/templates/combination/api_with_cors_only_max_age.yaml
@@ -46,3 +46,7 @@ Outputs:
     Description: URL of your API endpoint
     Value:
       Fn::Sub: 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_cors_only_methods.yaml
+++ b/integration/resources/templates/combination/api_with_cors_only_methods.yaml
@@ -46,3 +46,7 @@ Outputs:
     Description: URL of your API endpoint
     Value:
       Fn::Sub: 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_cors_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_cors_openapi.yaml
@@ -44,3 +44,7 @@ Outputs:
     Description: URL of your API endpoint
     Value:
       Fn::Sub: 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_cors_shorthand.yaml
+++ b/integration/resources/templates/combination/api_with_cors_shorthand.yaml
@@ -45,3 +45,7 @@ Outputs:
     Description: URL of your API endpoint
     Value:
       Fn::Sub: 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_custom_domains_edge.yaml
+++ b/integration/resources/templates/combination/api_with_custom_domains_edge.yaml
@@ -46,3 +46,7 @@ Resources:
           HostedZoneId:
             Ref: HostedZoneId
           IpV6: true
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_custom_domains_regional.yaml
+++ b/integration/resources/templates/combination/api_with_custom_domains_regional.yaml
@@ -50,3 +50,7 @@ Resources:
           Properties:
             Method: Post
             Path: /post
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_custom_domains_regional_ownership_verification.yaml
+++ b/integration/resources/templates/combination/api_with_custom_domains_regional_ownership_verification.yaml
@@ -54,3 +54,8 @@ Resources:
           Properties:
             Method: Post
             Path: /post
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_disable_execute_api_endpoint.yaml
+++ b/integration/resources/templates/combination/api_with_disable_execute_api_endpoint.yaml
@@ -37,3 +37,7 @@ Outputs:
     Description: "API endpoint URL for Prod environment"
     Value:
       Fn::Sub: 'https://${RestApiGateway}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_disable_execute_api_endpoint_openapi_3.yaml
+++ b/integration/resources/templates/combination/api_with_disable_execute_api_endpoint_openapi_3.yaml
@@ -38,3 +38,7 @@ Outputs:
     Description: "API endpoint URL for Prod environment"
     Value:
       Fn::Sub: 'https://${RestApiGateway}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_endpoint_configuration.yaml
+++ b/integration/resources/templates/combination/api_with_endpoint_configuration.yaml
@@ -19,3 +19,8 @@ Resources:
       }
       DefinitionUri: ${definitionuri}
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_endpoint_configuration_dict.yaml
+++ b/integration/resources/templates/combination/api_with_endpoint_configuration_dict.yaml
@@ -15,3 +15,8 @@ Resources:
         Type: REGIONAL
       DefinitionUri: ${definitionuri}
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_fail_on_warnings.yaml
+++ b/integration/resources/templates/combination/api_with_fail_on_warnings.yaml
@@ -32,3 +32,8 @@ Resources:
               Ref: RestApiGateway
             Method: GET
             Path: /
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_gateway_responses.yaml
+++ b/integration/resources/templates/combination/api_with_gateway_responses.yaml
@@ -37,3 +37,7 @@ Outputs:
       Description: "API endpoint URL for Prod environment"
       Value:
         Fn::Sub: 'https://${MyApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_method_settings.yaml
+++ b/integration/resources/templates/combination/api_with_method_settings.yaml
@@ -11,3 +11,8 @@ Resources:
         "ResourcePath": "/*",
         "HttpMethod": "*"
     }]
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_request_models.yaml
+++ b/integration/resources/templates/combination/api_with_request_models.yaml
@@ -39,3 +39,7 @@ Outputs:
     Description: "API endpoint URL for Prod environment"
     Value:
       Fn::Sub: 'https://${MyApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_request_models_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_request_models_openapi.yaml
@@ -40,3 +40,7 @@ Outputs:
     Description: "API endpoint URL for Prod environment"
     Value:
       Fn::Sub: 'https://${MyApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_request_parameters_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_request_parameters_openapi.yaml
@@ -45,3 +45,8 @@ Resources:
           Properties:
             Path: /two
             Method: get
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_resource_policies.yaml
+++ b/integration/resources/templates/combination/api_with_resource_policies.yaml
@@ -60,3 +60,7 @@ Outputs:
     Description: URL of your API endpoint
     Value:
       Fn::Sub: 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/'
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_resource_policies_aws_account.yaml
+++ b/integration/resources/templates/combination/api_with_resource_policies_aws_account.yaml
@@ -31,3 +31,7 @@ Outputs:
     Description: "Partition"
     Value: 
       Ref: AWS::Partition
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_resource_refs.yaml
+++ b/integration/resources/templates/combination/api_with_resource_refs.yaml
@@ -20,3 +20,8 @@ Outputs:
     Value:
       Ref: MyApi.Deployment
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/api_with_usage_plan.yaml
+++ b/integration/resources/templates/combination/api_with_usage_plan.yaml
@@ -153,3 +153,7 @@ Outputs:
     Value:
       Ref: ServerlessApiKey
   
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_bucket_to_function_write.yaml
+++ b/integration/resources/templates/combination/connector_bucket_to_function_write.yaml
@@ -93,3 +93,7 @@ Resources:
       Permissions:
         - Write
   
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_event_rule_to_eb_custom_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_eb_custom_write.yaml
@@ -102,3 +102,8 @@ Resources:
         Id: VerificationQueue
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_event_rule_to_eb_default_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_eb_default_write.yaml
@@ -103,3 +103,8 @@ Resources:
         Id: VerificationQueue
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_event_rule_to_lambda_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_lambda_write.yaml
@@ -83,3 +83,8 @@ Resources:
         Id: Function
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_event_rule_to_sfn_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_sfn_write.yaml
@@ -91,3 +91,8 @@ Resources:
         Id: StateMachine
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_event_rule_to_sns_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_sns_write.yaml
@@ -81,3 +81,8 @@ Resources:
         Id: VerificationQueue
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_event_rule_to_sqs_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_sqs_write.yaml
@@ -61,3 +61,8 @@ Resources:
         Id: Queue
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_bucket_read.yaml
+++ b/integration/resources/templates/combination/connector_function_to_bucket_read.yaml
@@ -44,3 +44,7 @@ Resources:
         Id: Bucket
       Permissions:
         - Read
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_bucket_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_bucket_write.yaml
@@ -46,3 +46,7 @@ Resources:
         Id: Bucket
       Permissions:
         - Write
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_eventbus_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_eventbus_write.yaml
@@ -57,3 +57,7 @@ Resources:
         Id: EventBus
       Permissions:
         - Write
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_function.yaml
+++ b/integration/resources/templates/combination/connector_function_to_function.yaml
@@ -71,3 +71,8 @@ Resources:
         Id: MyFunction2
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_queue_read.yaml
+++ b/integration/resources/templates/combination/connector_function_to_queue_read.yaml
@@ -43,3 +43,7 @@ Resources:
         Id: Queue
       Permissions:
         - Read
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_queue_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_queue_write.yaml
@@ -44,3 +44,7 @@ Resources:
         Id: Queue
       Permissions:
         - Write
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_sfn_read.yaml
+++ b/integration/resources/templates/combination/connector_function_to_sfn_read.yaml
@@ -53,3 +53,7 @@ Resources:
         Id: StateMachine
       Permissions:
         - Read
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_sfn_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_sfn_write.yaml
@@ -52,3 +52,8 @@ Resources:
         Id: StateMachine
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_table_read.yaml
+++ b/integration/resources/templates/combination/connector_function_to_table_read.yaml
@@ -55,3 +55,8 @@ Resources:
         Id: MyTable
       Permissions:
         - Read
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_table_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_table_write.yaml
@@ -41,3 +41,8 @@ Resources:
         Id: MyTable
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_function_to_topic_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_topic_write.yaml
@@ -45,3 +45,7 @@ Resources:
         Id: Topic
       Permissions:
         - Write
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_httpapi_to_function.yaml
+++ b/integration/resources/templates/combination/connector_httpapi_to_function.yaml
@@ -125,3 +125,8 @@ Resources:
         Id: ConnectedFunction
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_restapi_to_function.yaml
+++ b/integration/resources/templates/combination/connector_restapi_to_function.yaml
@@ -143,3 +143,8 @@ Resources:
         Id: ConnectedFunction
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_bucket_read.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_bucket_read.yaml
@@ -29,3 +29,7 @@ Resources:
         Id: Bucket
       Permissions:
         - Read
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_bucket_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_bucket_write.yaml
@@ -30,3 +30,7 @@ Resources:
         Id: Bucket
       Permissions:
         - Write
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_eb_custom_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_eb_custom_write.yaml
@@ -36,3 +36,8 @@ Resources:
         Arn: !GetAtt CustomEventBus.Arn
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_eb_default_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_eb_default_write.yaml
@@ -31,3 +31,8 @@ Resources:
         Arn: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_function_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_function_write.yaml
@@ -35,3 +35,8 @@ Resources:
         Id: MyFunction
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_sfn_async.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_sfn_async.yaml
@@ -39,3 +39,8 @@ Resources:
       Permissions:
         - Read
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_sfn_sync.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_sfn_sync.yaml
@@ -39,3 +39,8 @@ Resources:
       Permissions:
         - Read
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_sns_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_sns_write.yaml
@@ -29,3 +29,8 @@ Resources:
         Id: MyTopic
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_sqs_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_sqs_write.yaml
@@ -29,3 +29,8 @@ Resources:
         Id: MyQueue
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_table_read.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_table_read.yaml
@@ -39,3 +39,8 @@ Resources:
         Id: MyTable
       Permissions:
         - Read
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sfn_to_table_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_table_write.yaml
@@ -39,3 +39,8 @@ Resources:
         Id: MyTable
       Permissions:
         - Write
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sns_to_function_write.yaml
+++ b/integration/resources/templates/combination/connector_sns_to_function_write.yaml
@@ -84,3 +84,8 @@ Resources:
       Permissions:
         - Write
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_sqs_to_function.yaml
+++ b/integration/resources/templates/combination/connector_sqs_to_function.yaml
@@ -80,3 +80,7 @@ Resources:
       Permissions:
         - Read
         - Write
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_table_to_function_read.yaml
+++ b/integration/resources/templates/combination/connector_table_to_function_read.yaml
@@ -104,3 +104,7 @@ Resources:
         Id: Table
       Permissions:
         - Write
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/connector_topic_to_queue_write.yaml
+++ b/integration/resources/templates/combination/connector_topic_to_queue_write.yaml
@@ -84,3 +84,7 @@ Resources:
         Id: Queue
       Permissions:
         - Read
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/depends_on.yaml
+++ b/integration/resources/templates/combination/depends_on.yaml
@@ -49,3 +49,8 @@ Resources:
         -
           Ref: "LambdaRole"
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_alias.yaml
+++ b/integration/resources/templates/combination/function_with_alias.yaml
@@ -6,3 +6,8 @@ Resources:
       Runtime: nodejs14.x
       CodeUri: ${codeuri}
       AutoPublishAlias: Live
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
+++ b/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
@@ -104,3 +104,8 @@ Resources:
       - KeyType: HASH
         AttributeName: id
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_alias_globals.yaml
+++ b/integration/resources/templates/combination/function_with_alias_globals.yaml
@@ -19,3 +19,8 @@ Resources:
       Runtime: nodejs14.x
       CodeUri: ${codeuri}
       AutoPublishAlias: Live
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_alias_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_alias_intrinsics.yaml
@@ -27,3 +27,8 @@ Resources:
         Key:
           # Even though the entire Sub won't be resolved, translator will substitute ${Key} with value passed at runtime
           Fn::Sub: "${CodeKey}"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_all_event_types.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types.yaml
@@ -140,3 +140,8 @@ Resources:
         WriteCapacityUnits: 5
       StreamSpecification:
         StreamViewType: NEW_IMAGE
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
@@ -129,3 +129,7 @@ Resources:
         WriteCapacityUnits: 5
       StreamSpecification:
         StreamViewType: NEW_IMAGE
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_api.yaml
+++ b/integration/resources/templates/combination/function_with_api.yaml
@@ -31,3 +31,8 @@ Resources:
             Method: post
             RestApiId:
               Ref: ExistingRestApi
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_application.yaml
+++ b/integration/resources/templates/combination/function_with_application.yaml
@@ -31,3 +31,7 @@ Resources:
     Condition: FalseCondition
     Properties:
       Location: ${templateurl}
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_cloudwatch_log.yaml
+++ b/integration/resources/templates/combination/function_with_cloudwatch_log.yaml
@@ -18,3 +18,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 7
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_custom_code_deploy.yaml
+++ b/integration/resources/templates/combination/function_with_custom_code_deploy.yaml
@@ -61,3 +61,7 @@ Resources:
         TimeBasedLinear:
           LinearInterval: 1
           LinearPercentage: 50
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_cwe_dlq_and_retry_policy.yaml
+++ b/integration/resources/templates/combination/function_with_cwe_dlq_and_retry_policy.yaml
@@ -44,3 +44,8 @@ Outputs:
       Fn::GetAtt:
         - "MyDeadLetterQueue"
         - "Arn"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_cwe_dlq_generated.yaml
+++ b/integration/resources/templates/combination/function_with_cwe_dlq_generated.yaml
@@ -44,3 +44,8 @@ Outputs:
     Value:
       Ref: MyDlq
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_deployment_alarms_and_hooks.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_alarms_and_hooks.yaml
@@ -126,3 +126,7 @@ Resources:
      Handler: index.handler
      Runtime: nodejs14.x
      CodeUri: ${codeuri}
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_deployment_basic.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_basic.yaml
@@ -43,3 +43,8 @@ Resources:
                   - "lambda:InvokeFunction"
                   - "s3:Get*"
                   - "sns:Publish"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_deployment_default_role_managed_policy.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_default_role_managed_policy.yaml
@@ -8,3 +8,8 @@ Resources:
       AutoPublishAlias: Live
       DeploymentPreference:
         Type: Canary10Percent5Minutes
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_deployment_disabled.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_disabled.yaml
@@ -57,3 +57,8 @@ Resources:
                   - "lambda:InvokeFunction"
                   - "s3:Get*"
                   - "sns:Publish"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_deployment_globals.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_globals.yaml
@@ -48,3 +48,8 @@ Resources:
                   - "lambda:InvokeFunction"
                   - "s3:Get*"
                   - "sns:Publish"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_dynamodb.yaml
+++ b/integration/resources/templates/combination/function_with_dynamodb.yaml
@@ -40,3 +40,8 @@ Resources:
 
 
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_file_system_config.yaml
+++ b/integration/resources/templates/combination/function_with_file_system_config.yaml
@@ -63,3 +63,8 @@ Resources:
       GroupDescription: "my test group"
       VpcId:
         Ref: PreCreatedVpc
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_http_api.yaml
+++ b/integration/resources/templates/combination/function_with_http_api.yaml
@@ -35,3 +35,7 @@ Outputs:
     Description: "API endpoint URL for Prod environment"
     Value:
       Fn::Sub: "https://${MyApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_http_api_default_path.yaml
+++ b/integration/resources/templates/combination/function_with_http_api_default_path.yaml
@@ -37,3 +37,7 @@ Outputs:
     Description: "API endpoint URL for Prod environment"
     Value:
       Fn::Sub: "https://${MyApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_implicit_api_and_conditions.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_api_and_conditions.yaml
@@ -223,3 +223,7 @@ Resources:
           Properties:
             Path: /sub9
             Method: post
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_implicit_http_api.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_http_api.yaml
@@ -18,3 +18,7 @@ Outputs:
     Description: "API endpoint URL for Prod environment"
     Value:
       Fn::Sub: "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_kinesis.yaml
+++ b/integration/resources/templates/combination/function_with_kinesis.yaml
@@ -25,3 +25,8 @@ Resources:
     Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: 1
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_kinesis_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_kinesis_intrinsics.yaml
@@ -80,3 +80,8 @@ Resources:
     Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: 1
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_layer.yaml
+++ b/integration/resources/templates/combination/function_with_layer.yaml
@@ -37,3 +37,7 @@ Outputs:
   MyLambdaLayerArn:
     Value: 
       Ref: MyLambdaLayer
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_mq.yaml
+++ b/integration/resources/templates/combination/function_with_mq.yaml
@@ -173,3 +173,7 @@ Resources:
       SecretString:
         Fn::Sub: '{"username":"${MQBrokerUser}","password":"${MQBrokerPassword}"}'
       Description: SecretsManager Secret for broker user and password
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
+++ b/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
@@ -132,3 +132,8 @@ Resources:
       SecretString:
         Fn::Sub: '{"username":"${MQBrokerUser}","password":"${MQBrokerPassword}"}'
       Description: SecretsManager Secret for broker user and password
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_msk.yaml
+++ b/integration/resources/templates/combination/function_with_msk.yaml
@@ -72,3 +72,8 @@ Resources:
             Topics:
               - "MyDummyTestTopic"
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_msk_using_managed_policy.yaml
+++ b/integration/resources/templates/combination/function_with_msk_using_managed_policy.yaml
@@ -39,3 +39,8 @@ Resources:
             Topics:
               - "MyDummyTestTopic"
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_policy_templates.yaml
+++ b/integration/resources/templates/combination/function_with_policy_templates.yaml
@@ -39,3 +39,8 @@ Resources:
 
   MyQueue:
     Type: AWS::SQS::Queue
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_resource_refs.yaml
+++ b/integration/resources/templates/combination/function_with_resource_refs.yaml
@@ -42,3 +42,8 @@ Outputs:
   VersionNumber:
     Value:
       Fn::GetAtt: ["MyLambdaFunction.Version", "Version"]
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_s3.yaml
+++ b/integration/resources/templates/combination/function_with_s3.yaml
@@ -16,3 +16,8 @@ Resources:
             Events: s3:ObjectCreated:*
   MyBucket:
     Type: AWS::S3::Bucket
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_s3_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_s3_intrinsics.yaml
@@ -34,3 +34,8 @@ Resources:
 
   MyBucket:
     Type: AWS::S3::Bucket
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_schedule.yaml
+++ b/integration/resources/templates/combination/function_with_schedule.yaml
@@ -20,3 +20,8 @@ Resources:
                 Ref: ScheduleName
               Description: test schedule
               Enabled: True
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_schedule_dlq_and_retry_policy.yaml
+++ b/integration/resources/templates/combination/function_with_schedule_dlq_and_retry_policy.yaml
@@ -36,3 +36,7 @@ Outputs:
       Fn::GetAtt:
         - "MyDeadLetterQueue"
         - "Arn"
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_schedule_dlq_generated.yaml
+++ b/integration/resources/templates/combination/function_with_schedule_dlq_generated.yaml
@@ -38,3 +38,7 @@ Outputs:
     Description: "Url of the dead-letter queue created for the Schedule rule target"
     Value:
       Ref: MyLambdaFunctionRepeatQueue
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_self_managed_kafka.yaml
+++ b/integration/resources/templates/combination/function_with_self_managed_kafka.yaml
@@ -27,3 +27,8 @@ Resources:
       SecretString:
         Fn::Sub: '{"username":"testBrokerUser","password":"testBrokerPassword"}'
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_self_managed_kafka_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_self_managed_kafka_intrinsics.yaml
@@ -35,3 +35,8 @@ Resources:
       SecretString:
         Fn::Sub: '{"username":"testBrokerUserWithInstrinsic","password":"testBrokerPasswordWithInstrinsic"}'
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_signing_profile.yaml
+++ b/integration/resources/templates/combination/function_with_signing_profile.yaml
@@ -27,3 +27,8 @@ Resources:
      Type: AWS::Signer::SigningProfile
      Properties:
        PlatformId: AWSLambda-SHA384-ECDSA
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_sns.yaml
+++ b/integration/resources/templates/combination/function_with_sns.yaml
@@ -26,3 +26,8 @@ Resources:
   MySnsTopic:
     Type: AWS::SNS::Topic
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_sns_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_sns_intrinsics.yaml
@@ -36,3 +36,8 @@ Resources:
 
   MySnsTopic:
     Type: AWS::SNS::Topic
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_sqs.yaml
+++ b/integration/resources/templates/combination/function_with_sqs.yaml
@@ -15,3 +15,7 @@ Resources:
 
   MySqsQueue:
     Type: AWS::SQS::Queue
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/function_with_userpool_event.yaml
+++ b/integration/resources/templates/combination/function_with_userpool_event.yaml
@@ -53,3 +53,7 @@ Outputs:
       Description: "Cognito User Pool Id"
       Value:
         Ref: MyCognitoUserPool
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/http_api_with_auth.yaml
+++ b/integration/resources/templates/combination/http_api_with_auth.yaml
@@ -79,3 +79,7 @@ Resources:
                 - MyApi
             IdentitySource: "$request.querystring.param"
         DefaultAuthorizer: MyOAuth2Auth
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/http_api_with_auth_updated.yaml
+++ b/integration/resources/templates/combination/http_api_with_auth_updated.yaml
@@ -51,3 +51,7 @@ Resources:
             EnableSimpleResponses: false
             AuthorizerPayloadFormatVersion: 1.0
         DefaultAuthorizer: MyLambdaAuthUpdated
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/http_api_with_cors.yaml
+++ b/integration/resources/templates/combination/http_api_with_cors.yaml
@@ -43,3 +43,8 @@ Outputs:
     Description: Api id of ServerlessHttpApi
     Value:
       Ref: ServerlessHttpApi      
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/http_api_with_custom_domains_regional.yaml
+++ b/integration/resources/templates/combination/http_api_with_custom_domains_regional.yaml
@@ -58,3 +58,8 @@ Resources:
     Type: AWS::Serverless::HttpApi
     Properties:
       StageName: Prod
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/http_api_with_custom_domains_regional_ownership_verification.yaml
+++ b/integration/resources/templates/combination/http_api_with_custom_domains_regional_ownership_verification.yaml
@@ -62,3 +62,8 @@ Resources:
     Type: AWS::Serverless::HttpApi
     Properties:
       StageName: Prod
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_false.yaml
+++ b/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_false.yaml
@@ -36,3 +36,7 @@ Outputs:
   ApiId:
     Value:
       Ref: MyApi  
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_true.yaml
+++ b/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_true.yaml
@@ -37,3 +37,7 @@ Outputs:
   ApiId:
     Value:
       Ref: MyApi  
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/implicit_api_with_settings.yaml
+++ b/integration/resources/templates/combination/implicit_api_with_settings.yaml
@@ -27,3 +27,8 @@ Resources:
           Properties:
             Path: /pathget
             Method: get
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
+++ b/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
@@ -33,3 +33,8 @@ Resources:
         Key:
           Ref: SwaggerKey
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/intrinsics_serverless_api.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_api.yaml
@@ -116,3 +116,8 @@ Resources:
         Var2:
           "Fn::Join": ["", ["1", "2"]]
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/intrinsics_serverless_function.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_function.yaml
@@ -116,3 +116,8 @@ Resources:
         "Fn::Join": ["", ["nodejs", "12.x"]]
 
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/state_machine_with_api.yaml
+++ b/integration/resources/templates/combination/state_machine_with_api.yaml
@@ -72,3 +72,8 @@ Outputs:
     Description: "ARN of the role created for the explicit Api method"
     Value:
       Fn::GetAtt: MyStateMachineGetApiRole.Arn
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/state_machine_with_cwe.yaml
+++ b/integration/resources/templates/combination/state_machine_with_cwe.yaml
@@ -43,3 +43,7 @@ Outputs:
     Description: "Name of the role created for the CWE rule"
     Value:
       Ref: MyStateMachineCWEventRole
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/state_machine_with_cwe_dlq_generated.yaml
+++ b/integration/resources/templates/combination/state_machine_with_cwe_dlq_generated.yaml
@@ -57,3 +57,7 @@ Outputs:
     Description: "Url of the dead-letter queue created for the CWE rule target"
     Value:
       Ref: MyStateMachineCWEventQueue
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/state_machine_with_cwe_with_dlq_and_retry_policy.yaml
+++ b/integration/resources/templates/combination/state_machine_with_cwe_with_dlq_and_retry_policy.yaml
@@ -59,3 +59,7 @@ Outputs:
       Fn::GetAtt:
         - "MyDeadLetterQueue"
         - "Arn"
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/state_machine_with_policy_templates.yaml
+++ b/integration/resources/templates/combination/state_machine_with_policy_templates.yaml
@@ -34,3 +34,7 @@ Outputs:
     Description: "ARN of the role created for the State Machine"
     Value:
       Ref: MyStateMachineRole
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/state_machine_with_schedule.yaml
+++ b/integration/resources/templates/combination/state_machine_with_schedule.yaml
@@ -43,3 +43,7 @@ Outputs:
     Description: "ARN of the role created for the Schedule rule"
     Value:
       Ref: MyStateMachineCWScheduleRole
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/state_machine_with_schedule_dlq_and_retry_policy.yaml
+++ b/integration/resources/templates/combination/state_machine_with_schedule_dlq_and_retry_policy.yaml
@@ -59,3 +59,7 @@ Outputs:
       Fn::GetAtt:
         - "MyDeadLetterQueue"
         - "Arn"
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/combination/state_machine_with_schedule_dlq_generated.yaml
+++ b/integration/resources/templates/combination/state_machine_with_schedule_dlq_generated.yaml
@@ -56,3 +56,7 @@ Outputs:
     Description: "Url of the dead-letter queue created for the Schedule rule target"
     Value:
       Ref: MyDlq
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_api.yaml
+++ b/integration/resources/templates/single/basic_api.yaml
@@ -4,3 +4,8 @@ Resources:
     Properties:
       StageName: MyNewStageName
       DefinitionUri: ${definitionuri}
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_api_inline_openapi.yaml
+++ b/integration/resources/templates/single/basic_api_inline_openapi.yaml
@@ -25,3 +25,8 @@ Resources:
                 passthroughBehavior: "when_no_match"
                 requestParameters:
                   integration.request.path.proxy: "method.request.path.proxy"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_api_inline_swagger.yaml
+++ b/integration/resources/templates/single/basic_api_inline_swagger.yaml
@@ -25,3 +25,8 @@ Resources:
                 passthroughBehavior: "when_no_match"
                 requestParameters:
                   integration.request.path.proxy: "method.request.path.proxy"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_api_with_mode.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode.yaml
@@ -32,3 +32,8 @@ Resources:
 Outputs:
   ApiEndpoint:
     Value: !Sub "https://${MyApi}.execute-api.${AWS::Region}.amazonaws.com/MyNewStageName"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_api_with_mode_update.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode_update.yaml
@@ -22,3 +22,8 @@ Resources:
             Method: put
             RestApiId: !Ref MyApi
 
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_api_with_tags.yaml
+++ b/integration/resources/templates/single/basic_api_with_tags.yaml
@@ -7,3 +7,8 @@ Resources:
       Tags:
        TagKey1: TagValue1
        TagKey2: ""
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_application_s3_location.yaml
+++ b/integration/resources/templates/single/basic_application_s3_location.yaml
@@ -3,3 +3,8 @@ Resources:
     Type: AWS::Serverless::Application
     Properties:
       Location: ${templateurl}
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_application_sar_location.yaml
+++ b/integration/resources/templates/single/basic_application_sar_location.yaml
@@ -11,3 +11,8 @@ Resources:
         SemanticVersion: 1.0.3
       Parameters:
         IdentityNameParameter: test
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_application_sar_location_with_intrinsics.yaml
+++ b/integration/resources/templates/single/basic_application_sar_location_with_intrinsics.yaml
@@ -54,3 +54,7 @@ Resources:
 
   MySns:
     Type: AWS::SNS::Topic
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function.yaml
+++ b/integration/resources/templates/single/basic_function.yaml
@@ -13,3 +13,8 @@ Resources:
                 Variables:
                     Name: Value
                     Name2: Value2
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_event_destinations.yaml
+++ b/integration/resources/templates/single/basic_function_event_destinations.yaml
@@ -93,3 +93,8 @@ Resources:
     DestinationSQS:
         Condition: QueueCreationDisabled
         Type: AWS::SQS::Queue
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_no_envvar.yaml
+++ b/integration/resources/templates/single/basic_function_no_envvar.yaml
@@ -9,3 +9,8 @@ Resources:
             Policies:
                 - AWSLambdaRole
                 - AmazonS3ReadOnlyAccess
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_openapi.yaml
+++ b/integration/resources/templates/single/basic_function_openapi.yaml
@@ -16,3 +16,8 @@ Resources:
                 Variables:
                     Name: Value
                     Name2: Value2
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_arm_architecture.yaml
+++ b/integration/resources/templates/single/basic_function_with_arm_architecture.yaml
@@ -8,3 +8,7 @@ Resources:
             MemorySize: 128
             Architectures: ["arm64"]
             
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_function_url_config.yaml
+++ b/integration/resources/templates/single/basic_function_with_function_url_config.yaml
@@ -19,3 +19,8 @@ Resources:
                     ExposeHeaders: 
                         - "x-amzn-header"
                     MaxAge: 10
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_function_url_with_autopuplishalias.yaml
+++ b/integration/resources/templates/single/basic_function_with_function_url_with_autopuplishalias.yaml
@@ -20,3 +20,8 @@ Resources:
                     ExposeHeaders: 
                         - "x-amzn-header"
                     MaxAge: 10
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_kmskeyarn.yaml
+++ b/integration/resources/templates/single/basic_function_with_kmskeyarn.yaml
@@ -30,3 +30,7 @@ Resources:
                Action:
                  - "kms:*"
                Resource: "*"
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_sns_dlq.yaml
+++ b/integration/resources/templates/single/basic_function_with_sns_dlq.yaml
@@ -12,3 +12,8 @@ Resources:
 
   MyTopic:
     Type: AWS::SNS::Topic
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_sqs_dlq.yaml
+++ b/integration/resources/templates/single/basic_function_with_sqs_dlq.yaml
@@ -13,3 +13,8 @@ Resources:
 
   MyQueue:
     Type: AWS::SQS::Queue
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_tags.yaml
+++ b/integration/resources/templates/single/basic_function_with_tags.yaml
@@ -12,3 +12,8 @@ Resources:
             Tags:
                 TagKey1: TagValue1
                 TagKey2: ""
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_tracing.yaml
+++ b/integration/resources/templates/single/basic_function_with_tracing.yaml
@@ -34,3 +34,8 @@ Resources:
                 - AmazonS3ReadOnlyAccess
             Tracing:
               Ref: TracingParamPassThrough
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_function_with_x86_architecture.yaml
+++ b/integration/resources/templates/single/basic_function_with_x86_architecture.yaml
@@ -9,3 +9,8 @@ Resources:
             Architectures:
                 - x86_64
             
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_http_api.yaml
+++ b/integration/resources/templates/single/basic_http_api.yaml
@@ -9,3 +9,7 @@ Resources:
             Ref: AWS::StackName
         openapi: 3.0.1
         paths: {}
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_layer.yaml
+++ b/integration/resources/templates/single/basic_layer.yaml
@@ -4,3 +4,8 @@ Resources:
         Properties:
             ContentUri: ${contenturi}
             RetentionPolicy: Delete
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_layer_with_compatible_architecture.yaml
+++ b/integration/resources/templates/single/basic_layer_with_compatible_architecture.yaml
@@ -26,3 +26,8 @@ Outputs:
         Value:
             Ref: LayerName
             
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_layer_with_parameters.yaml
+++ b/integration/resources/templates/single/basic_layer_with_parameters.yaml
@@ -44,3 +44,7 @@ Outputs:
     LayerName:
         Value:
             Ref: LayerName
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_state_machine_inline_definition.yaml
+++ b/integration/resources/templates/single/basic_state_machine_inline_definition.yaml
@@ -21,3 +21,8 @@ Resources:
           - Effect: Deny
             Action: "*"
             Resource: "*"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_state_machine_with_tags.yaml
+++ b/integration/resources/templates/single/basic_state_machine_with_tags.yaml
@@ -31,3 +31,8 @@ Outputs:
     Description: ARN of the state machine
     Value:
       Ref: MyStateMachine
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_table_no_param.yaml
+++ b/integration/resources/templates/single/basic_table_no_param.yaml
@@ -2,3 +2,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::SimpleTable
     # SimpleTable does NOT require any parameters
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/basic_table_with_param.yaml
+++ b/integration/resources/templates/single/basic_table_with_param.yaml
@@ -10,3 +10,8 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: 2
         WriteCapacityUnits: 2
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/function_alias_with_http_api_events.yaml
+++ b/integration/resources/templates/single/function_alias_with_http_api_events.yaml
@@ -21,3 +21,8 @@ Resources:
               Ref: MyHttpApi
             Path: /bar
             Method: POST
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/function_with_deployment_preference_alarms_intrinsic_if.yaml
+++ b/integration/resources/templates/single/function_with_deployment_preference_alarms_intrinsic_if.yaml
@@ -21,3 +21,8 @@ Resources:
               - Alarm3
             - - Alarm1
               - Alarm5
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/function_with_ephemeral_storage.yaml
+++ b/integration/resources/templates/single/function_with_ephemeral_storage.yaml
@@ -15,3 +15,7 @@ Resources:
                 Variables:
                     Name: Value
                     Name2: Value2
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/function_with_http_api_events.yaml
+++ b/integration/resources/templates/single/function_with_http_api_events.yaml
@@ -20,3 +20,8 @@ Resources:
               Ref: MyHttpApi
             Path: /bar
             Method: POST
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/function_with_http_api_events_and_auth.yaml
+++ b/integration/resources/templates/single/function_with_http_api_events_and_auth.yaml
@@ -94,3 +94,8 @@ Resources:
     Properties:
       Auth:
         EnableIamAuthorizer: true
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/resources/templates/single/state_machine_with_api.yaml
+++ b/integration/resources/templates/single/state_machine_with_api.yaml
@@ -37,3 +37,8 @@ Resources:
 Outputs:
   ApiEndpoint:
     Value: !Sub "https://${MyApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/echo"
+
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -66,3 +66,7 @@ Outputs:
     Description: "Pre-created S3 Bucket that can be used inside other tests"
     Value: 
       Ref: PreCreatedS3Bucket
+
+Metadata:
+  SamTransformTest: true
+

--- a/integration/setup/example-sar-app.yaml
+++ b/integration/setup/example-sar-app.yaml
@@ -19,3 +19,7 @@ Resources:
       Environment:
         Variables:
           IdentityNameParameter: !Ref IdentityNameParameter
+
+Metadata:
+  SamTransformTest: true
+


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Add test metadata to integ test files.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
