### PR TITLE
chore: Add PassThroughProperty and use it in :HttpApi Name

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.model.exceptions import InvalidResourceException
-from samtranslator.model.types import Validator
+from samtranslator.model.types import Validator, any_type
 from samtranslator.plugins import LifeCycleEvents
 from samtranslator.model.tags.resource_tagging import get_tag_list
 
@@ -43,6 +43,17 @@ class Property(PropertyType):
 
     def __init__(self, required: bool, validate: Validator) -> None:
         super().__init__(required, validate, False)
+
+
+class PassThroughProperty(PropertyType):
+    """
+    Pass-through property.
+
+    SAM Translator should not try to read the value other than passing it to underlaying CFN resources.
+    """
+
+    def __init__(self, required: bool) -> None:
+        super().__init__(required, any_type(), False)
 
 
 class Resource(object):

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -31,7 +31,7 @@ from .tags.resource_tagging import get_tag_list
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import (
     ResourceResolver,
-    Property,
+    PassThroughProperty,
     PropertyType,
     SamResourceMacro,
     Resource,
@@ -1283,7 +1283,7 @@ class SamHttpApi(SamResourceMacro):
         # In the future, we might rename and expose this property to customers so they can have SAM manage Explicit APIs
         # Swagger.
         "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),
-        "Name": Property(False, any_type()),
+        "Name": PassThroughProperty(False),
         "StageName": PropertyType(False, one_of(is_str(), is_type(dict))),
         "Tags": PropertyType(False, is_type(dict)),
         "DefinitionBody": PropertyType(False, is_type(dict)),


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
