### PR TITLE
fix: Raise correct exception when FunctionUrlConfig.Cors is not dict

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1067,6 +1067,12 @@ class SamFunction(SamResourceMacro):
         if not cors or is_intrinsic(cors):
             return
 
+        if not isinstance(cors, dict):
+            raise InvalidResourceException(
+                lambda_function.logical_id,
+                "Invalid type for 'Cors'. It must be a dictionary.",
+            )
+
         for prop_name, prop_value in cors.items():
             if prop_name not in cors_property_data_type:
                 raise InvalidResourceException(

--- a/tests/translator/input/error_function_with_function_url_config_with_invalid_cors_parameter.yaml
+++ b/tests/translator/input/error_function_with_function_url_config_with_invalid_cors_parameter.yaml
@@ -15,3 +15,22 @@ Resources:
         Cors:
           AllowOrigin:
           - https://example.com
+
+  MyFunction2:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Description: Created by SAM
+      Handler: index.handler
+      MemorySize: 1024
+      Runtime: nodejs12.x
+      Timeout: 3
+      FunctionUrlConfig:
+        AuthType: NONE
+        Cors:
+        - This
+        - should
+        - not
+        - be
+        - a
+        - list

--- a/tests/translator/output/error_function_with_function_url_config_with_invalid_cors_parameter.json
+++ b/tests/translator/output/error_function_with_function_url_config_with_invalid_cors_parameter.json
@@ -1,3 +1,3 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. AllowOrigin is not a valid property for configuring Cors."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [MyFunction] is invalid. AllowOrigin is not a valid property for configuring Cors. Resource with id [MyFunction2] is invalid. Invalid type for 'Cors'. It must be a dictionary."
 }


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
