### PR TITLE
fix: Raise correct exception when swagger: securityDefinitions is not dict

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -623,6 +623,9 @@ class SwaggerEditor(object):
         api_key_security_definition["api_key"]["in"] = "header"
 
         self.security_definitions = self.security_definitions or Py27Dict()
+        if not isinstance(self.security_definitions, dict):
+            # https://swagger.io/docs/specification/2-0/authentication/
+            raise InvalidTemplateException("securityDefinitions must be a dictionary.")
 
         # Only add the security definition if it doesn't exist.  This helps ensure
         # that we minimize changes to the swagger in the case of user defined swagger

--- a/tests/translator/input/error_swagger_security_definitions_not_dict.yaml
+++ b/tests/translator/input/error_swagger_security_definitions_not_dict.yaml
@@ -1,0 +1,46 @@
+Resources:
+  GetHtmlFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.handler
+      Runtime: nodejs12.x
+  ExplicitApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      Auth:
+        ApiKeyRequired: true
+      DefinitionBody:
+        info:
+          version: '1.0'
+          title:
+            Ref: AWS::StackName
+        securityDefinitions: # 1 Add security definition
+        - CognitoAuthorizer:  # this should not be a list
+            type: apiKey
+            name: Authorization
+            in: header
+            x-amazon-apigateway-authtype: cognito_user_pools
+            x-amazon-apigateway-authorizer:
+              providerARNs:
+              - 
+                  # userPool ARN
+              type: cognito_user_pools
+        paths:
+          /{proxy+}:
+            x-amazon-apigateway-any-method:
+              x-amazon-apigateway-integration:
+                httpMethod: POST
+                type: aws_proxy
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations
+              responses: {}
+        components:
+          schemas:
+            Error:
+              type: Object
+              properties:
+                message:
+                  type: string
+        openapi: 3.0.0

--- a/tests/translator/output/error_swagger_security_definitions_not_dict.json
+++ b/tests/translator/output/error_swagger_security_definitions_not_dict.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. securityDefinitions must be a dictionary."
+}


### PR DESCRIPTION
… a dict

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
