### PR TITLE
fix: Raise correct exception when swagger: responses.headers is not a dict

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -737,7 +737,7 @@ class ApiGenerator(object):
             self._set_default_apikey_required(swagger_editor)  # type: ignore[no-untyped-call]
 
         if auth_properties.ResourcePolicy:
-            SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
+            SwaggerEditor.validate_is_dict(
                 auth_properties.ResourcePolicy, "ResourcePolicy must be a map (ResourcePolicyStatement)."
             )
             for path in swagger_editor.iter_on_path():  # type: ignore[no-untyped-call]
@@ -1048,13 +1048,18 @@ class ApiGenerator(object):
                                 del definition_body["paths"][path]["options"][field]
                             # add schema for the headers in options section for openapi3
                             if field in ["responses"]:
-                                SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
+                                SwaggerEditor.validate_is_dict(
                                     field_val,
                                     "Value of responses in options method for path {} must be a "
                                     "dictionary according to Swagger spec.".format(path),
                                 )
                                 if field_val.get("200") and field_val.get("200").get("headers"):
                                     headers = field_val["200"]["headers"]
+                                    SwaggerEditor.validate_is_dict(
+                                        headers,
+                                        "Value of response's headers in options method for path {} must be a "
+                                        "dictionary according to Swagger spec.".format(path),
+                                    )
                                     for header, header_val in headers.items():
                                         new_header_val_with_schema = Py27Dict()
                                         new_header_val_with_schema["schema"] = header_val

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -372,7 +372,7 @@ class SwaggerEditor(object):
                     continue
 
                 for method_definition in self.get_conditional_contents(method):  # type: ignore[no-untyped-call]
-                    SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
+                    SwaggerEditor.validate_is_dict(
                         method_definition,
                         'Value of "{}" ({}) for path {} is not a valid dictionary.'.format(
                             method_name, method_definition, path_name
@@ -661,7 +661,7 @@ class SwaggerEditor(object):
             # (e.g. sigv4 (AWS_IAM), api_key (API Key/Usage Plans), NONE (marker for ignoring default))
             # We want to ensure only a single Authorizer security entry exists while keeping everything else
             for security in existing_security:
-                SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
+                SwaggerEditor.validate_is_dict(
                     security,
                     "{} in Security for path {} method {} is not a valid dictionary.".format(
                         security, path, method_name
@@ -732,7 +732,7 @@ class SwaggerEditor(object):
             # (e.g. sigv4 (AWS_IAM), authorizers, NONE (marker for ignoring default authorizer))
             # We want to ensure only a single ApiKey security entry exists while keeping everything else
             for security in existing_security:
-                SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
+                SwaggerEditor.validate_is_dict(
                     security,
                     "{} in Security for path {} method {} is not a valid dictionary.".format(
                         security, path, method_name
@@ -977,7 +977,7 @@ class SwaggerEditor(object):
         """
         if resource_policy is None:
             return
-        SwaggerEditor.validate_is_dict(resource_policy, "Resource Policy is not a valid dictionary.")  # type: ignore[no-untyped-call]
+        SwaggerEditor.validate_is_dict(resource_policy, "Resource Policy is not a valid dictionary.")
 
         aws_account_whitelist = resource_policy.get("AwsAccountWhitelist")
         aws_account_blacklist = resource_policy.get("AwsAccountBlacklist")
@@ -1326,7 +1326,7 @@ class SwaggerEditor(object):
         return SwaggerEditor.safe_compare_regex_with_string(SwaggerEditor.get_openapi_version_3_regex(), api_version)
 
     @staticmethod
-    def validate_is_dict(obj, exception_message):  # type: ignore[no-untyped-def]
+    def validate_is_dict(obj: Any, exception_message: str) -> None:
         """
         Throws exception if obj is not a dict
 
@@ -1346,7 +1346,7 @@ class SwaggerEditor(object):
         :param path: path name
         """
 
-        SwaggerEditor.validate_is_dict(  # type: ignore[no-untyped-call]
+        SwaggerEditor.validate_is_dict(
             path_item, "Value of '{}' path must be a dictionary according to Swagger spec.".format(path)
         )
 

--- a/tests/translator/input/error_api_invalid_openapi_path_with_invalid_responses.yaml
+++ b/tests/translator/input/error_api_invalid_openapi_path_with_invalid_responses.yaml
@@ -1,0 +1,17 @@
+Resources:
+  ApiWithInvalidPath:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      Cors: "'*'"
+      OpenApiVersion: 3.0.1
+      DefinitionBody:
+        openapi: 3.0.1
+        info:
+          title: test invalid paths Api
+        paths:
+          /foo:
+            options:
+              responses:
+                '200':
+                  headers: this should be a dict

--- a/tests/translator/output/error_api_invalid_openapi_path_with_invalid_responses.json
+++ b/tests/translator/output/error_api_invalid_openapi_path_with_invalid_responses.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Value of response's headers in options method for path /foo must be a dictionary according to Swagger spec."
+}


### PR DESCRIPTION
… dict

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
