### PR TITLE
chore: add schema types for Connector and SimpleTable

### DIFF
--- a/samtranslator/schema/schema.json
+++ b/samtranslator/schema/schema.json
@@ -266,7 +266,8 @@
           "title": "Rolename"
         },
         "Type": {
-          "title": "Type"
+          "title": "Type",
+          "type": "string"
         }
       },
       "additionalProperties": false
@@ -468,12 +469,25 @@
       ],
       "additionalProperties": false
     },
+    "SimpleTablePrimaryKey": {
+      "title": "SimpleTablePrimaryKey",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "title": "Name"
+        },
+        "Type": {
+          "title": "Type"
+        }
+      },
+      "additionalProperties": false
+    },
     "SimpleTableProperties": {
       "title": "SimpleTableProperties",
       "type": "object",
       "properties": {
         "PrimaryKey": {
-          "title": "Primarykey"
+          "$ref": "#/definitions/SimpleTablePrimaryKey"
         },
         "ProvisionedThroughput": {
           "title": "Provisionedthroughput"
@@ -485,7 +499,8 @@
           "title": "Tablename"
         },
         "Tags": {
-          "title": "Tags"
+          "title": "Tags",
+          "type": "object"
         }
       },
       "additionalProperties": false

--- a/samtranslator/schema/schema.py
+++ b/samtranslator/schema/schema.py
@@ -10,6 +10,8 @@ from pydantic import Extra, Field, constr
 # TODO: Get rid of this in favor of proper types
 Unknown = Optional[Any]
 
+# Value passed directly to CloudFormation; not used by SAM
+PassThrough = Any
 
 # By default strict
 # https://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally
@@ -20,13 +22,13 @@ class BaseModel(LenientBaseModel):
 
 class ResourceReference(BaseModel):
     Id: Optional[str]
-    Arn: Unknown
-    Name: Unknown
-    Qualifier: Unknown
-    QueueUrl: Unknown
-    ResourceId: Unknown
-    RoleName: Unknown
-    Type: Unknown
+    Arn: Optional[PassThrough]
+    Name: Optional[PassThrough]
+    Qualifier: Optional[PassThrough]
+    QueueUrl: Optional[PassThrough]
+    ResourceId: Optional[PassThrough]
+    RoleName: Optional[PassThrough]
+    Type: Optional[str]
 
 
 class ConnectorProperties(BaseModel):
@@ -88,12 +90,17 @@ class AwsServerlessFunction(BaseModel):
     Metadata: Unknown
 
 
+class SimpleTablePrimaryKey(BaseModel):
+    Name: PassThrough
+    Type: PassThrough
+
+
 class SimpleTableProperties(BaseModel):
-    PrimaryKey: Unknown
-    ProvisionedThroughput: Unknown
-    SSESpecification: Unknown
-    TableName: Unknown
-    Tags: Unknown
+    PrimaryKey: Optional[SimpleTablePrimaryKey]
+    ProvisionedThroughput: Optional[PassThrough]
+    SSESpecification: Optional[PassThrough]
+    TableName: Optional[PassThrough]
+    Tags: Optional[Dict[str, Any]]
 
 
 class AwsServerlessSimpleTable(BaseModel):


### PR DESCRIPTION
### Issue #, if available

#1133 

### Description of changes

```
make schema
```

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
