### PR TITLE
fix: Raise correct exception when Api.Domain is not a map

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -1,6 +1,6 @@
 import logging
 from collections import namedtuple
-from typing import List, Optional, Set, Dict
+from typing import Any, List, Optional, Set, Dict
 
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.intrinsics import ref, fnGetAtt, make_or_condition
@@ -20,6 +20,7 @@ from samtranslator.model.route53 import Route53RecordSetGroup
 from samtranslator.model.exceptions import InvalidResourceException, InvalidTemplateException
 from samtranslator.model.s3_utils.uri_parser import parse_s3_uri
 from samtranslator.region_configuration import RegionConfiguration
+from samtranslator.schema.schema import PassThrough
 from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.model.intrinsics import is_intrinsic, fnSub
 from samtranslator.model.lambda_ import LambdaPermission
@@ -427,17 +428,18 @@ class ApiGenerator(object):
         if self.domain is None:
             return None, None, None
 
-        if self.domain.get("DomainName") is None or self.domain.get("CertificateArn") is None:
-            raise InvalidResourceException(
-                self.logical_id, "Custom Domains only works if both DomainName and CertificateArn are provided."
-            )
+        sam_expect(self.domain, self.logical_id, "Domain").to_be_a_map()
+        domain_name: PassThrough = sam_expect(
+            self.domain.get("DomainName"), self.logical_id, "Domain.DomainName"
+        ).to_not_be_none()
+        certificate_arn: PassThrough = sam_expect(
+            self.domain.get("CertificateArn"), self.logical_id, "Domain.CertificateArn"
+        ).to_not_be_none()
 
-        self.domain["ApiDomainName"] = "{}{}".format(
-            "ApiGatewayDomainName", LogicalIdGenerator("", self.domain.get("DomainName")).gen()
-        )
+        self.domain["ApiDomainName"] = "{}{}".format("ApiGatewayDomainName", LogicalIdGenerator("", domain_name).gen())
 
         domain = ApiGatewayDomainName(self.domain.get("ApiDomainName"), attributes=self.passthrough_resource_attributes)
-        domain.DomainName = self.domain.get("DomainName")
+        domain.DomainName = domain_name
         endpoint = self.domain.get("EndpointConfiguration")
 
         if endpoint is None:
@@ -451,9 +453,9 @@ class ApiGenerator(object):
             )
 
         if endpoint == "REGIONAL":
-            domain.RegionalCertificateArn = self.domain.get("CertificateArn")
+            domain.RegionalCertificateArn = certificate_arn
         else:
-            domain.CertificateArn = self.domain.get("CertificateArn")
+            domain.CertificateArn = certificate_arn
 
         domain.EndpointConfiguration = {"Types": [endpoint]}
 

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -1,6 +1,6 @@
 import logging
 from collections import namedtuple
-from typing import Any, List, Optional, Set, Dict
+from typing import List, Optional, Set, Dict
 
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model.intrinsics import ref, fnGetAtt, make_or_condition

--- a/samtranslator/schema/schema.py
+++ b/samtranslator/schema/schema.py
@@ -11,7 +11,7 @@ from pydantic import Extra, Field, constr
 Unknown = Optional[Any]
 
 # Value passed directly to CloudFormation; not used by SAM
-PassThrough = Any
+PassThrough = Any  # TODO: Make it behave like typescript's unknown
 
 # Intrinsic resolvable by the SAM transform
 SamIntrinsic = Dict[str, Any]

--- a/samtranslator/schema/schema.py
+++ b/samtranslator/schema/schema.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing_extensions import Literal
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel as LenientBaseModel
-from pydantic import Extra, Field, constr
+import pydantic
+from pydantic import Extra
+
 
 # TODO: Get rid of this in favor of proper types
 Unknown = Optional[Any]
@@ -16,9 +16,16 @@ PassThrough = Any  # TODO: Make it behave like typescript's unknown
 # Intrinsic resolvable by the SAM transform
 SamIntrinsic = Dict[str, Any]
 
-# By default strict
-# https://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally
-class BaseModel(LenientBaseModel):
+_LenientBaseModel = pydantic.BaseModel
+constr = pydantic.constr
+
+
+class BaseModel(_LenientBaseModel):
+    """
+    By default strict
+    https://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally
+    """
+
     class Config:
         extra = Extra.forbid
 
@@ -238,7 +245,7 @@ class AwsServerlessApplication(BaseModel):
 
 
 # Match anything not containing Serverless
-class AnyNonServerlessResource(LenientBaseModel):
+class AnyNonServerlessResource(_LenientBaseModel):
     Type: constr(regex=r"^((?!::Serverless::).)*$")  # type: ignore
 
 
@@ -310,7 +317,7 @@ class Globals(BaseModel):
     SimpleTable: Optional[GlobalsSimpleTable]
 
 
-class Model(LenientBaseModel):
+class Model(_LenientBaseModel):
     Globals: Optional[Globals]
     Resources: Dict[
         str,

--- a/tests/translator/input/error_api_with_custom_domains_invalid.yaml
+++ b/tests/translator/input/error_api_with_custom_domains_invalid.yaml
@@ -39,6 +39,12 @@ Resources:
             RestApiId: !Ref MyApi
             Method: Post
             Path: /fetch
+        Fetch2:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApiMissingCertificateArn
+            Method: Post
+            Path: /fetch
         ImplicitGet:
           Type: Api
           Properties:
@@ -55,3 +61,19 @@ Resources:
         CertificateArn: my-api-cert-arn
         EndpointConfiguration: Invalid
         BasePath: [/get, /fetch]
+
+  MyApiMissingCertificateArn:
+    Type: AWS::Serverless::Api
+    Properties:
+      OpenApiVersion: 3.0.1
+      StageName: Prod
+      Domain:
+        DomainName: api-example.com
+        CertificateArn:
+
+  MyApiInvalidDomainType:
+    Type: AWS::Serverless::Api
+    Properties:
+      OpenApiVersion: 3.0.1
+      StageName: Prod
+      Domain: !Ref MyDomainName  # this should be a map after solution

--- a/tests/translator/output/error_api_with_custom_domains_invalid.json
+++ b/tests/translator/output/error_api_with_custom_domains_invalid.json
@@ -1,8 +1,3 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [MyApi] is invalid. EndpointConfiguration for Custom Domains must be one of ['EDGE', 'REGIONAL', 'PRIVATE']. Resource with id [ServerlessRestApi] is invalid. Custom Domains only works if both DomainName and CertificateArn are provided.",
-  "errors": [
-    {
-      "errorMessage": "Resource with id [MyApi] is invalid. EndpointConfiguration for Custom Domains must be one of ['EDGE', 'REGIONAL', 'PRIVATE']. Resource with id [ServerlessRestApi] is invalid. Custom Domains only works if both DomainName and CertificateArn are provided."
-    }
-  ]
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 4. Resource with id [MyApi] is invalid. EndpointConfiguration for Custom Domains must be one of ['EDGE', 'REGIONAL', 'PRIVATE']. Resource with id [MyApiInvalidDomainType] is invalid. Property 'Domain' should be a map. Resource with id [MyApiMissingCertificateArn] is invalid. Property 'Domain.CertificateArn' is required. Resource with id [ServerlessRestApi] is invalid. Property 'Domain.DomainName' is required."
 }


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
