### PR TITLE
fix: Raise correct exception when Identity.Headers is not of valid type

### DIFF
--- a/tests/translator/input/error_api_authorizer_property_indentity_with_invalid_type.yaml
+++ b/tests/translator/input/error_api_authorizer_property_indentity_with_invalid_type.yaml
@@ -58,3 +58,29 @@ Resources:
             FunctionArn: Function.Arn
             FunctionPayloadType: REQUEST
             Identity: This should not be a string
+
+  MyRestApiInvalidHeadersType:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Stage name
+      Auth:
+        Authorizers:
+          LambdaRequestIdentityNotObject:
+            FunctionArn: Function.Arn
+            FunctionPayloadType: REQUEST
+            Identity:
+              Headers: this should be a list
+
+  MyRestApiInvalidHeadersItemType:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Stage name
+      Auth:
+        Authorizers:
+          LambdaRequestIdentityNotObject:
+            FunctionArn: Function.Arn
+            FunctionPayloadType: REQUEST
+            Identity:
+              Headers:
+              - This is of correct type
+              - Key: This array item should not be a dict

--- a/tests/translator/output/error_api_authorizer_property_indentity_with_invalid_type.json
+++ b/tests/translator/output/error_api_authorizer_property_indentity_with_invalid_type.json
@@ -1,3 +1,3 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [MyApi] is invalid. Property 'Authorizer.MyLambdaAuthUpdated.Identity' should be a map. Resource with id [MyRestApi] is invalid. Property 'Authorizer.LambdaRequestIdentityNotObject.Identity' should be a map."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 4. Resource with id [MyApi] is invalid. Property 'Authorizer.MyLambdaAuthUpdated.Identity' should be a map. Resource with id [MyRestApi] is invalid. Property 'Authorizer.LambdaRequestIdentityNotObject.Identity' should be a map. Resource with id [MyRestApiInvalidHeadersItemType] is invalid. Property 'Auth.Authorizers.LambdaRequestIdentityNotObject.Identity.Headers[1]' should be a string. Resource with id [MyRestApiInvalidHeadersType] is invalid. Property 'Auth.Authorizers.LambdaRequestIdentityNotObject.Identity.Headers' should be a list."
 }


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
