### PR TITLE
fix: Raise correct exception when event OnFailure is not of valid type

### DIFF
--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -11,6 +11,7 @@ from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.model.exceptions import InvalidEventException
 from samtranslator.model.iam import IAMRolePolicies
 from samtranslator.utils.types import Intrinsicable
+from samtranslator.validator.value_validator import sam_expect
 
 
 class PullEventSource(ResourceMacro):
@@ -155,9 +156,12 @@ class PullEventSource(ResourceMacro):
 
         destination_config_policy = None
         if self.DestinationConfig:
-            on_failure = self.DestinationConfig.get("OnFailure")
-            if on_failure is None:
-                raise InvalidEventException(self.logical_id, "'OnFailure' is a required field for 'DestinationConfig'")
+            on_failure: Dict[str, Any] = sam_expect(
+                self.DestinationConfig.get("OnFailure"),
+                self.logical_id,
+                "DestinationConfig.OnFailure",
+                is_sam_event=True,
+            ).to_be_a_map()
 
             # `Type` property is for sam to attach the right policies
             destination_type = on_failure.get("Type")

--- a/samtranslator/validator/value_validator.py
+++ b/samtranslator/validator/value_validator.py
@@ -32,7 +32,7 @@ class _ResourcePropertyValueValidator(Generic[T]):
         else:
             self.resource_logical_id = resource_id
 
-    def to_be_a(self, expected_type: ExpectedType, message: Optional[str] = "") -> Optional[T]:
+    def to_be_a(self, expected_type: ExpectedType, message: Optional[str] = "") -> T:
         """
         Validate the type of the value and return the value if valid.
 
@@ -69,16 +69,16 @@ class _ResourcePropertyValueValidator(Generic[T]):
     #
     # alias methods:
     #
-    def to_be_a_map(self, message: Optional[str] = "") -> Optional[T]:
+    def to_be_a_map(self, message: Optional[str] = "") -> T:
         return self.to_be_a(ExpectedType.MAP, message)
 
-    def to_be_a_list(self, message: Optional[str] = "") -> Optional[T]:
+    def to_be_a_list(self, message: Optional[str] = "") -> T:
         return self.to_be_a(ExpectedType.LIST, message)
 
-    def to_be_a_string(self, message: Optional[str] = "") -> Optional[T]:
+    def to_be_a_string(self, message: Optional[str] = "") -> T:
         return self.to_be_a(ExpectedType.STRING, message)
 
-    def to_be_an_integer(self, message: Optional[str] = "") -> Optional[T]:
+    def to_be_an_integer(self, message: Optional[str] = "") -> T:
         return self.to_be_a(ExpectedType.INTEGER, message)
 
 

--- a/tests/translator/input/error_function_with_invalid_event_destination_config.yaml
+++ b/tests/translator/input/error_function_with_invalid_event_destination_config.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: parameter for batching window in seconds
 
 Resources:
-  MyFunction:
+  MyFunctionWithMissingOnFailure:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
@@ -35,6 +35,35 @@ Resources:
               InvalidConfig:
                 Type: SNS
                 Destination: !Ref MySnsTopic
+
+  MyFunctionWithInvalidOnFailureType:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      InlineCode: |
+        exports.handler = async (event) => {
+            return {
+            statusCode: 200,
+            body: JSON.stringify(event),
+            headers: {}
+            }
+        }
+      Runtime: nodejs12.x
+      Policies:
+      - SQSSendMessagePolicy:
+          QueueName: !GetAtt MySqsQueue.QueueName
+      Events:
+        StreamEvent:
+          Type: Kinesis
+          Properties:
+            Stream: !GetAtt KinesisStream.Arn
+            MaximumBatchingWindowInSeconds: !Ref MyBatchingWindowParam
+            StartingPosition: LATEST
+            DestinationConfig:
+              InvalidConfig:
+                Type: SNS
+                Destination: !Ref MySnsTopic
+              OnFailure: this should be a dict
 
   KinesisStream:
     Type: AWS::Kinesis::Stream

--- a/tests/translator/output/aws-cn/error_function_with_missing_on_failure_in_stream_event_destination_config.json
+++ b/tests/translator/output/aws-cn/error_function_with_missing_on_failure_in_stream_event_destination_config.json
@@ -1,8 +1,0 @@
-{
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'",
-  "errors": [
-    {
-      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
-    }
-  ]
-}

--- a/tests/translator/output/aws-us-gov/error_function_with_missing_on_failure_in_stream_event_destination_config.json
+++ b/tests/translator/output/aws-us-gov/error_function_with_missing_on_failure_in_stream_event_destination_config.json
@@ -1,8 +1,0 @@
-{
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'",
-  "errors": [
-    {
-      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
-    }
-  ]
-}

--- a/tests/translator/output/error_function_with_invalid_event_destination_config.json
+++ b/tests/translator/output/error_function_with_invalid_event_destination_config.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [MyFunctionWithInvalidOnFailureType] is invalid. Event with id [MyFunctionWithInvalidOnFailureTypeStreamEvent] is invalid. Property 'DestinationConfig.OnFailure' should be a map. Resource with id [MyFunctionWithMissingOnFailure] is invalid. Event with id [MyFunctionWithMissingOnFailureStreamEvent] is invalid. Property 'DestinationConfig.OnFailure' should be a map."
+}

--- a/tests/translator/output/error_function_with_missing_on_failure_in_stream_event_destination_config.json
+++ b/tests/translator/output/error_function_with_missing_on_failure_in_stream_event_destination_config.json
@@ -1,8 +1,0 @@
-{
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'",
-  "errors": [
-    {
-      "errorMessage": "Resource with id [MyFunction] is invalid. Event with id [MyFunctionStreamEvent] is invalid. 'OnFailure' is a required field for 'DestinationConfig'"
-    }
-  ]
-}


### PR DESCRIPTION
### Issue #, if available

Remove unused error files in aws-cn and aws-us-gov

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [x] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
