### PR TITLE
chore: add HttpApi schema

### DIFF
--- a/samtranslator/schema/schema.json
+++ b/samtranslator/schema/schema.json
@@ -2608,6 +2608,286 @@
       ],
       "additionalProperties": false
     },
+    "HttpApiAuthOAuth2Authorizer": {
+      "title": "HttpApiAuthOAuth2Authorizer",
+      "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
+      "type": "object",
+      "properties": {
+        "AuthorizationScopes": {
+          "title": "Authorizationscopes",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "IdentitySource": {
+          "title": "Identitysource",
+          "type": "string"
+        },
+        "JwtConfiguration": {
+          "title": "Jwtconfiguration"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HttpApiAuthLambdaAuthorizerIdentity": {
+      "title": "HttpApiAuthLambdaAuthorizerIdentity",
+      "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
+      "type": "object",
+      "properties": {
+        "Context": {
+          "title": "Context",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Headers": {
+          "title": "Headers",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "QueryStrings": {
+          "title": "Querystrings",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ReauthorizeEvery": {
+          "title": "Reauthorizeevery",
+          "type": "integer"
+        },
+        "StageVariables": {
+          "title": "Stagevariables",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "HttpApiAuthLambdaAuthorizer": {
+      "title": "HttpApiAuthLambdaAuthorizer",
+      "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
+      "type": "object",
+      "properties": {
+        "AuthorizerPayloadFormatVersion": {
+          "title": "Authorizerpayloadformatversion",
+          "anyOf": [
+            {
+              "enum": [
+                "1.0",
+                "2.0"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "EnableSimpleResponses": {
+          "title": "Enablesimpleresponses",
+          "type": "boolean"
+        },
+        "FunctionArn": {
+          "title": "Functionarn",
+          "type": "object"
+        },
+        "FunctionInvokeRole": {
+          "title": "Functioninvokerole",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "Identity": {
+          "$ref": "#/definitions/HttpApiAuthLambdaAuthorizerIdentity"
+        }
+      },
+      "required": [
+        "AuthorizerPayloadFormatVersion",
+        "FunctionArn"
+      ],
+      "additionalProperties": false
+    },
+    "HttpApiAuth": {
+      "title": "HttpApiAuth",
+      "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
+      "type": "object",
+      "properties": {
+        "Authorizers": {
+          "title": "Authorizers",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/HttpApiAuthOAuth2Authorizer"
+              },
+              {
+                "$ref": "#/definitions/HttpApiAuthLambdaAuthorizer"
+              }
+            ]
+          }
+        },
+        "DefaultAuthorizer": {
+          "title": "Defaultauthorizer",
+          "type": "string"
+        },
+        "EnableIamAuthorizer": {
+          "title": "Enableiamauthorizer",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HttpApiCorsConfiguration": {
+      "title": "HttpApiCorsConfiguration",
+      "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
+      "type": "object",
+      "properties": {
+        "AllowCredentials": {
+          "title": "Allowcredentials",
+          "type": "boolean"
+        },
+        "AllowHeaders": {
+          "title": "Allowheaders",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AllowMethods": {
+          "title": "Allowmethods",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AllowOrigins": {
+          "title": "Alloworigins",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ExposeHeaders": {
+          "title": "Exposeheaders",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "MaxAge": {
+          "title": "Maxage",
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HttpApiDefinitionUri": {
+      "title": "HttpApiDefinitionUri",
+      "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
+      "type": "object",
+      "properties": {
+        "Bucket": {
+          "title": "Bucket",
+          "type": "string"
+        },
+        "Key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "Version": {
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Bucket",
+        "Key"
+      ],
+      "additionalProperties": false
+    },
+    "HttpApiDomainRoute53": {
+      "title": "HttpApiDomainRoute53",
+      "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
+      "type": "object",
+      "properties": {
+        "DistributionDomainName": {
+          "title": "Distributiondomainname"
+        },
+        "EvaluateTargetHealth": {
+          "title": "Evaluatetargethealth"
+        },
+        "HostedZoneId": {
+          "title": "Hostedzoneid"
+        },
+        "HostedZoneName": {
+          "title": "Hostedzonename"
+        },
+        "IpV6": {
+          "title": "Ipv6",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HttpApiDomain": {
+      "title": "HttpApiDomain",
+      "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
+      "type": "object",
+      "properties": {
+        "BasePath": {
+          "title": "Basepath",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "CertificateArn": {
+          "title": "Certificatearn"
+        },
+        "DomainName": {
+          "title": "Domainname"
+        },
+        "EndpointConfiguration": {
+          "title": "Endpointconfiguration",
+          "anyOf": [
+            {
+              "enum": [
+                "REGIONAL"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "MutualTlsAuthentication": {
+          "title": "Mutualtlsauthentication"
+        },
+        "OwnershipVerificationCertificateArn": {
+          "title": "Ownershipverificationcertificatearn"
+        },
+        "Route53": {
+          "$ref": "#/definitions/HttpApiDomainRoute53"
+        },
+        "SecurityPolicy": {
+          "title": "Securitypolicy"
+        }
+      },
+      "additionalProperties": false
+    },
     "HttpApiProperties": {
       "title": "HttpApiProperties",
       "description": "By default strict\nhttps://pydantic-docs.helpmanual.io/usage/model_config/#change-behaviour-globally",
@@ -2617,28 +2897,46 @@
           "title": "Accesslogsettings"
         },
         "Auth": {
-          "title": "Auth"
+          "$ref": "#/definitions/HttpApiAuth"
         },
         "CorsConfiguration": {
-          "title": "Corsconfiguration"
+          "title": "Corsconfiguration",
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/HttpApiCorsConfiguration"
+            }
+          ]
         },
         "DefaultRouteSettings": {
           "title": "Defaultroutesettings"
         },
         "DefinitionBody": {
-          "title": "Definitionbody"
+          "title": "Definitionbody",
+          "type": "object"
         },
         "DefinitionUri": {
-          "title": "Definitionuri"
+          "title": "Definitionuri",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/HttpApiDefinitionUri"
+            }
+          ]
         },
         "Description": {
-          "title": "Description"
+          "title": "Description",
+          "type": "string"
         },
         "DisableExecuteApiEndpoint": {
           "title": "Disableexecuteapiendpoint"
         },
         "Domain": {
-          "title": "Domain"
+          "$ref": "#/definitions/HttpApiDomain"
         },
         "FailOnWarnings": {
           "title": "Failonwarnings"
@@ -2653,7 +2951,8 @@
           "title": "Stagevariables"
         },
         "Tags": {
-          "title": "Tags"
+          "title": "Tags",
+          "type": "object"
         },
         "Name": {
           "title": "Name"

--- a/samtranslator/schema/schema.py
+++ b/samtranslator/schema/schema.py
@@ -652,29 +652,102 @@ class AwsServerlessApi(BaseModel):
     Metadata: Unknown
 
 
+class HttpApiAuthOAuth2Authorizer(BaseModel):
+    AuthorizationScopes: Optional[List[str]]
+    IdentitySource: Optional[str]
+    JwtConfiguration: Optional[PassThrough]
+
+
+class HttpApiAuthLambdaAuthorizerIdentity(BaseModel):
+    Context: Optional[List[str]]
+    Headers: Optional[List[str]]
+    QueryStrings: Optional[List[str]]
+    ReauthorizeEvery: Optional[int]
+    StageVariables: Optional[List[str]]
+
+
+class HttpApiAuthLambdaAuthorizer(BaseModel):
+    # TODO: Many tests use floats for the version string; docs only mention string
+    AuthorizerPayloadFormatVersion: Union[Literal["1.0", "2.0"], float]
+    EnableSimpleResponses: Optional[bool]
+    FunctionArn: SamIntrinsic
+    FunctionInvokeRole: Optional[Union[str, SamIntrinsic]]
+    Identity: Optional[HttpApiAuthLambdaAuthorizerIdentity]
+
+
+class HttpApiAuth(BaseModel):
+    # TODO: Docs doesn't say it's a map
+    Authorizers: Optional[
+        Dict[
+            str,
+            Union[
+                HttpApiAuthOAuth2Authorizer,
+                HttpApiAuthLambdaAuthorizer,
+            ],
+        ]
+    ]
+    DefaultAuthorizer: Optional[str]
+    EnableIamAuthorizer: Optional[bool]
+
+
+class HttpApiCorsConfiguration(BaseModel):
+    AllowCredentials: Optional[bool]
+    AllowHeaders: Optional[List[str]]
+    AllowMethods: Optional[List[str]]
+    AllowOrigins: Optional[List[str]]
+    ExposeHeaders: Optional[List[str]]
+    MaxAge: Optional[int]
+
+
+class HttpApiDefinitionUri(BaseModel):
+    Bucket: str
+    Key: str
+    Version: Optional[str]
+
+
+class HttpApiDomainRoute53(BaseModel):
+    DistributionDomainName: Optional[PassThrough]
+    EvaluateTargetHealth: Optional[PassThrough]
+    HostedZoneId: Optional[PassThrough]
+    HostedZoneName: Optional[PassThrough]
+    IpV6: Optional[bool]
+
+
+class HttpApiDomain(BaseModel):
+    BasePath: Optional[List[str]]
+    CertificateArn: PassThrough
+    DomainName: PassThrough
+    EndpointConfiguration: Optional[Union[Literal["REGIONAL"], SamIntrinsic]]
+    MutualTlsAuthentication: Optional[PassThrough]
+    OwnershipVerificationCertificateArn: Optional[PassThrough]
+    Route53: Optional[HttpApiDomainRoute53]
+    SecurityPolicy: Optional[PassThrough]
+
+
 class HttpApiProperties(BaseModel):
-    AccessLogSettings: Unknown
-    Auth: Unknown
-    CorsConfiguration: Unknown
-    DefaultRouteSettings: Unknown
-    DefinitionBody: Unknown
-    DefinitionUri: Unknown
-    Description: Unknown
-    DisableExecuteApiEndpoint: Unknown
-    Domain: Unknown
-    FailOnWarnings: Unknown
-    RouteSettings: Unknown
-    StageName: Unknown
-    StageVariables: Unknown
-    Tags: Unknown
-    Name: Unknown
+    AccessLogSettings: Optional[PassThrough]
+    Auth: Optional[HttpApiAuth]
+    # TODO: Also string like in the docs?
+    CorsConfiguration: Optional[Union[SamIntrinsic, HttpApiCorsConfiguration]]
+    DefaultRouteSettings: Optional[PassThrough]
+    DefinitionBody: Optional[Dict[str, Any]]
+    DefinitionUri: Optional[Union[str, HttpApiDefinitionUri]]
+    Description: Optional[str]
+    DisableExecuteApiEndpoint: Optional[PassThrough]
+    Domain: Optional[HttpApiDomain]
+    FailOnWarnings: Optional[PassThrough]
+    RouteSettings: Optional[PassThrough]
+    StageName: Optional[PassThrough]
+    StageVariables: Optional[PassThrough]
+    Tags: Optional[Dict[str, Any]]
+    Name: Optional[PassThrough]  # TODO: Add to docs
 
 
 class AwsServerlessHttpApi(BaseModel):
     Type: Literal["AWS::Serverless::HttpApi"]
     Properties: Optional[HttpApiProperties]
-    Metadata: Unknown
-    Condition: Unknown
+    Metadata: Optional[PassThrough]
+    Condition: Optional[PassThrough]
 
 
 class ApplicationLocation(BaseModel):


### PR DESCRIPTION
### Issue #, if available

#1133 

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
