### PR TITLE
fix: Raise correct exception when some properties are not dict when used dict methods

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -1073,25 +1073,27 @@ class ApiGenerator(object):
                                     "dictionary according to Swagger spec.".format(path),
                                 )
                                 response_200 = field_val.get("200")
-                                if response_200:
-                                    SwaggerEditor.validate_is_dict(
-                                        response_200,
-                                        "Value of responses.200 in options method for path {} must be a "
-                                        "dictionary according to Swagger spec.".format(path),
-                                    )
-                                    response_200_headers = response_200.get("headers")
-                                    if response_200_headers:
-                                        SwaggerEditor.validate_is_dict(
-                                            response_200_headers,
-                                            "Value of response's headers in options method for path {} must be a "
-                                            "dictionary according to Swagger spec.".format(path),
-                                        )
-                                        for header, header_val in response_200_headers.items():
-                                            new_header_val_with_schema = Py27Dict()
-                                            new_header_val_with_schema["schema"] = header_val
-                                            definition_body["paths"][path]["options"][field]["200"]["headers"][
-                                                header
-                                            ] = new_header_val_with_schema
+                                if not response_200:
+                                    continue
+                                SwaggerEditor.validate_is_dict(
+                                    response_200,
+                                    "Value of responses.200 in options method for path {} must be a "
+                                    "dictionary according to Swagger spec.".format(path),
+                                )
+                                response_200_headers = response_200.get("headers")
+                                if not response_200_headers:
+                                    continue
+                                SwaggerEditor.validate_is_dict(
+                                    response_200_headers,
+                                    "Value of response's headers in options method for path {} must be a "
+                                    "dictionary according to Swagger spec.".format(path),
+                                )
+                                for header, header_val in response_200_headers.items():
+                                    new_header_val_with_schema = Py27Dict()
+                                    new_header_val_with_schema["schema"] = header_val
+                                    definition_body["paths"][path]["options"][field]["200"]["headers"][
+                                        header
+                                    ] = new_header_val_with_schema
 
         return definition_body
 

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -964,8 +964,6 @@ class ApiGenerator(object):
                 sam_expect(
                     response_parameters, self.logical_id, f"GatewayResponses.{response_type}.ResponseParameters"
                 ).to_be_a_map()
-            if response_templates:
-                sam_expect(response_templates, self.logical_id, f"GatewayResponses.{response_type}.ResponseTemplates")
             gateway_responses[response_type] = ApiGatewayResponse(
                 api_logical_id=self.logical_id,
                 response_parameters=response_parameters,
@@ -1037,13 +1035,12 @@ class ApiGenerator(object):
                 del definition_body["securityDefinitions"]
             if definition_body.get("definitions"):
                 components = definition_body.get("components", Py27Dict())
-                # the follow lines to check if components is None
+                # the following line to check if components is None
                 # is copied from the previous if...
                 # In the previous line, the default value `Py27Dict()` will be only returned only if `components`
                 # property is not in definition_body dict, but if it exist, and its value is None, so None will be
                 # returned and not the default value. That is why the below line is required.
                 components = components if components else Py27Dict()
-                components["securitySchemes"] = definition_body["securityDefinitions"]
                 components["schemas"] = definition_body["definitions"]
                 definition_body["components"] = components
                 del definition_body["definitions"]

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -656,7 +656,13 @@ class HttpApiGenerator(object):
                 self.logical_id,
                 "Description works only with inline OpenApi specified in the 'DefinitionBody' property.",
             )
-        if self.definition_body.get("info", {}).get("description"):
+        info = self.definition_body.get("info", {})
+        if not isinstance(info, dict):
+            raise InvalidResourceException(
+                self.logical_id,
+                "'info' in OpenApi definition body must be a map.",
+            )
+        if info.get("description"):
             raise InvalidResourceException(
                 self.logical_id,
                 "Unable to set Description because it is already defined within inline OpenAPI specified in the "
@@ -677,7 +683,14 @@ class HttpApiGenerator(object):
                 "Name works only with inline OpenApi specified in the 'DefinitionBody' property.",
             )
 
-        if self.definition_body.get("info", {}).get("title") != OpenApiEditor._DEFAULT_OPENAPI_TITLE:
+        info = self.definition_body.get("info", {})
+        if not isinstance(info, dict):
+            raise InvalidResourceException(
+                self.logical_id,
+                "'info' in OpenApi definition body must be a map.",
+            )
+
+        if info.get("title") != OpenApiEditor._DEFAULT_OPENAPI_TITLE:
             raise InvalidResourceException(
                 self.logical_id,
                 "Unable to set Name because it is already defined within inline OpenAPI specified in the "

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -127,6 +127,7 @@ class ApiGatewayResponse(object):
         status_code: Optional[str] = None,
     ) -> None:
         if response_parameters:
+            # response_parameters has been validated in ApiGenerator._add_gateway_responses()
             for response_parameter_key in response_parameters.keys():
                 if response_parameter_key not in ApiGatewayResponse.ResponseParameterProperties:
                     raise InvalidResourceException(

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -6,6 +6,7 @@ from samtranslator.model import PropertyType, Resource
 from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.model.types import is_type, one_of, is_str, list_of
 from samtranslator.model.intrinsics import ref, fnSub
+from samtranslator.schema.common import PassThrough
 from samtranslator.translator import logical_id_generator
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.utils.py27hash_fix import Py27Dict, Py27UniStr
@@ -123,7 +124,7 @@ class ApiGatewayResponse(object):
         self,
         api_logical_id: str,
         response_parameters: Optional[Dict[str, Any]] = None,
-        response_templates: Optional[Dict[str, Any]] = None,
+        response_templates: Optional[PassThrough] = None,
         status_code: Optional[str] = None,
     ) -> None:
         if response_parameters:

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -67,7 +67,7 @@ class SwaggerEditor(object):
         # so we don't need to validate wherever we use them.
         for path in self.iter_on_path():
             for path_item in self.get_conditional_contents(self.paths.get(path)):  # type: ignore[no-untyped-call]
-                SwaggerEditor.validate_path_item_is_dict(path_item, path)  # type: ignore[no-untyped-call]
+                SwaggerEditor.validate_path_item_is_dict(path_item, path)
 
     def get_conditional_contents(self, item):  # type: ignore[no-untyped-def]
         """
@@ -1368,7 +1368,7 @@ class SwaggerEditor(object):
             raise InvalidDocumentException([InvalidTemplateException(exception_message)])
 
     @staticmethod
-    def validate_path_item_is_dict(path_item, path):  # type: ignore[no-untyped-def]
+    def validate_path_item_is_dict(path_item: Any, path: str) -> None:
         """
         Throws exception if path_item is not a dict
 


### PR DESCRIPTION

### Issue #, if available

another round of scan of dict type validation

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
