### PR TITLE
chore: Add connect timeout to serverlessrepo clients

### DIFF
--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -9,6 +9,7 @@ from samtranslator.feature_toggle.dialup import (
     SimpleAccountPercentileDialup,
 )
 from samtranslator.metrics.method_decorator import cw_timer
+from samtranslator.utils.constants import BOTO3_CONNECT_TIMEOUT
 
 LOG = logging.getLogger(__name__)
 
@@ -133,7 +134,9 @@ class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
             # Lambda function has 120 seconds limit
             # (5 + 5) * 2, 20 seconds maximum timeout duration
             # In case of high latency from AppConfig, we can always fall back to use an empty config and continue transform
-            client_config = Config(connect_timeout=5, read_timeout=5, retries={"total_max_attempts": 2})
+            client_config = Config(
+                connect_timeout=BOTO3_CONNECT_TIMEOUT, read_timeout=5, retries={"total_max_attempts": 2}
+            )
             self.app_config_client = (
                 boto3.client("appconfig", config=client_config) if not app_config_client else app_config_client
             )

--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -1,5 +1,6 @@
 import boto3
 import json
+from botocore.config import Config
 from botocore.exceptions import ClientError, EndpointConnectionError
 import logging
 from time import sleep
@@ -14,6 +15,7 @@ from samtranslator.public.sdk.template import SamTemplate
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.intrinsics.actions import FindInMapAction
 from samtranslator.region_configuration import RegionConfiguration
+from samtranslator.utils.constants import BOTO3_CONNECT_TIMEOUT
 from samtranslator.validator.value_validator import sam_expect
 
 LOG = logging.getLogger(__name__)
@@ -119,7 +121,9 @@ class ServerlessAppPlugin(BasePlugin):
                         )
                     # Lazy initialization of the client- create it when it is needed
                     if not self._sar_client:
-                        self._sar_client = boto3.client("serverlessrepo")
+                        # a SAR call could take a while to finish, leaving the read_timeout default (60s).
+                        client_config = Config(connect_timeout=BOTO3_CONNECT_TIMEOUT)
+                        self._sar_client = boto3.client("serverlessrepo", config=client_config)
                     self._make_service_call_with_retry(service_call, app_id, semver, key, logical_id)  # type: ignore[no-untyped-call]
                 except InvalidResourceException as e:
                     # Catch all InvalidResourceExceptions, raise those in the before_resource_transform target.

--- a/samtranslator/utils/constants.py
+++ b/samtranslator/utils/constants.py
@@ -1,0 +1,3 @@
+"""A module containing constants."""
+
+BOTO3_CONNECT_TIMEOUT = 5


### PR DESCRIPTION
### Issue #, if available

Add connect_timeout=5 (consistent with what we have been using with AppConfig) to SAR. read_timeout remains default, which is 60s as it can take a while to complete request.

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
