### PR TITLE
chore: tighter schema type for RestApiId

### DIFF
--- a/samtranslator/schema/aws_serverless_function.py
+++ b/samtranslator/schema/aws_serverless_function.py
@@ -4,7 +4,7 @@ from typing import Optional, Dict, Union, List
 
 from typing_extensions import Literal
 
-from samtranslator.schema.common import PassThrough, BaseModel, SamIntrinsicable, get_prop, DictStrAny
+from samtranslator.schema.common import PassThrough, BaseModel, SamIntrinsicable, get_prop, DictStrAny, Ref
 
 
 alexaskilleventproperties = get_prop("sam-property-function-alexaskill")
@@ -226,7 +226,7 @@ class ApiEventProperties(BaseModel):
     Path: str = apieventproperties("Path")
     RequestModel: Optional[RequestModel] = apieventproperties("RequestModel")
     RequestParameters: Optional[Union[str, RequestParameters]] = apieventproperties("RequestParameters")
-    RestApiId: Optional[SamIntrinsicable[str]] = apieventproperties("RestApiId")
+    RestApiId: Optional[Union[str, Ref]] = apieventproperties("RestApiId")
 
 
 class ApiEvent(BaseModel):

--- a/samtranslator/schema/common.py
+++ b/samtranslator/schema/common.py
@@ -42,3 +42,8 @@ def _get_prop(stem: str, name: str) -> Any:
 class BaseModel(LenientBaseModel):
     class Config:
         extra = Extra.forbid
+
+
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html
+class Ref(BaseModel):
+    Ref: str

--- a/samtranslator/schema/schema.json
+++ b/samtranslator/schema/schema.json
@@ -2614,6 +2614,20 @@
       },
       "additionalProperties": false
     },
+    "Ref": {
+      "title": "Ref",
+      "type": "object",
+      "properties": {
+        "Ref": {
+          "title": "Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Ref"
+      ],
+      "additionalProperties": false
+    },
     "samtranslator__schema__aws_serverless_function__ApiEventProperties": {
       "title": "ApiEventProperties",
       "type": "object",
@@ -2669,10 +2683,10 @@
           "markdownDescription": "Identifier of a RestApi resource, which must contain an operation with the given path and method\\. Typically, this is set to reference an [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource defined in this template\\.  \nIf you don't define this property, AWS SAM creates a default [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource using a generated `OpenApi` document\\. That resource contains a union of all paths and methods defined by `Api` events in the same template that do not specify a `RestApiId`\\.  \nThis cannot reference an [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource defined in another template\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
           "anyOf": [
             {
-              "type": "object"
+              "type": "string"
             },
             {
-              "type": "string"
+              "$ref": "#/definitions/Ref"
             }
           ]
         }


### PR DESCRIPTION
### Issue #, if available

### Description of changes

See:

https://github.com/aws/serverless-application-model/blob/5e3741c05f0635135469b15db5a2feabdd263440/samtranslator/model/eventsources/push.py#L948-L957

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
