### PR TITLE
chore: Refactor OpenApiEditor and SwaggerEditor to reduce duplicate code

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -322,7 +322,7 @@ class ApiGenerator(object):
             raise InvalidResourceException(
                 self.logical_id, "DisableExecuteApiEndpoint works only within 'DefinitionBody' property."
             )
-        editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        editor = SwaggerEditor(self.definition_body)
         editor.add_disable_execute_api_endpoint_extension(self.disable_execute_api_endpoint)  # type: ignore[no-untyped-call]
         self.definition_body = editor.swagger
 
@@ -644,7 +644,7 @@ class ApiGenerator(object):
         else:
             raise InvalidResourceException(self.logical_id, INVALID_ERROR)
 
-        if not SwaggerEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+        if not SwaggerEditor.is_valid(self.definition_body):
             raise InvalidResourceException(
                 self.logical_id,
                 "Unable to add Cors configuration because "
@@ -659,7 +659,7 @@ class ApiGenerator(object):
                 "'AllowOrigin' is \"'*'\" or not set",
             )
 
-        editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        editor = SwaggerEditor(self.definition_body)
         for path in editor.iter_on_path():
             try:
                 editor.add_cors(  # type: ignore[no-untyped-call]
@@ -688,7 +688,7 @@ class ApiGenerator(object):
         if self.binary_media and not self.definition_body:
             return
 
-        editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        editor = SwaggerEditor(self.definition_body)
         editor.add_binary_media_types(self.binary_media)  # type: ignore[no-untyped-call]
 
         # Assign the Swagger back to template
@@ -711,13 +711,13 @@ class ApiGenerator(object):
         if not all(key in AuthProperties._fields for key in self.auth.keys()):
             raise InvalidResourceException(self.logical_id, "Invalid value for 'Auth' property")
 
-        if not SwaggerEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+        if not SwaggerEditor.is_valid(self.definition_body):
             raise InvalidResourceException(
                 self.logical_id,
                 "Unable to add Auth configuration because "
                 "'DefinitionBody' does not contain a valid Swagger definition.",
             )
-        swagger_editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        swagger_editor = SwaggerEditor(self.definition_body)
         auth_properties = AuthProperties(**self.auth)
         authorizers = self._get_authorizers(auth_properties.Authorizers, auth_properties.DefaultAuthorizer)  # type: ignore[no-untyped-call]
 
@@ -731,8 +731,8 @@ class ApiGenerator(object):
             )
 
         if auth_properties.ApiKeyRequired:
-            swagger_editor.add_apikey_security_definition()  # type: ignore[no-untyped-call]
-            self._set_default_apikey_required(swagger_editor)  # type: ignore[no-untyped-call]
+            swagger_editor.add_apikey_security_definition()
+            self._set_default_apikey_required(swagger_editor)
 
         if auth_properties.ResourcePolicy:
             SwaggerEditor.validate_is_dict(
@@ -946,14 +946,14 @@ class ApiGenerator(object):
                         ),
                     )
 
-        if not SwaggerEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+        if not SwaggerEditor.is_valid(self.definition_body):
             raise InvalidResourceException(
                 self.logical_id,
                 "Unable to add Auth configuration because "
                 "'DefinitionBody' does not contain a valid Swagger definition.",
             )
 
-        swagger_editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        swagger_editor = SwaggerEditor(self.definition_body)
 
         # The dicts below will eventually become part of swagger/openapi definition, thus requires using Py27Dict()
         gateway_responses = Py27Dict()
@@ -992,7 +992,7 @@ class ApiGenerator(object):
                 self.logical_id, "Models works only with inline Swagger specified in 'DefinitionBody' property."
             )
 
-        if not SwaggerEditor.is_valid(self.definition_body):  # type: ignore[no-untyped-call]
+        if not SwaggerEditor.is_valid(self.definition_body):
             raise InvalidResourceException(
                 self.logical_id,
                 "Unable to add Models definitions because "
@@ -1002,7 +1002,7 @@ class ApiGenerator(object):
         if not all(isinstance(model, dict) for model in self.models.values()):
             raise InvalidResourceException(self.logical_id, "Invalid value for 'Models' property")
 
-        swagger_editor = SwaggerEditor(self.definition_body)  # type: ignore[no-untyped-call]
+        swagger_editor = SwaggerEditor(self.definition_body)
         swagger_editor.add_models(self.models)  # type: ignore[no-untyped-call]
 
         # Assign the Swagger back to template
@@ -1023,7 +1023,7 @@ class ApiGenerator(object):
             self.open_api_version = definition_body.get("openapi")
 
         if self.open_api_version and SwaggerEditor.safe_compare_regex_with_string(
-            SwaggerEditor.get_openapi_version_3_regex(), self.open_api_version
+            SwaggerEditor._OPENAPI_VERSION_3_REGEX, self.open_api_version
         ):
             if definition_body.get("securityDefinitions"):
                 components = definition_body.get("components", Py27Dict())
@@ -1208,7 +1208,7 @@ class ApiGenerator(object):
                 add_default_auth_to_preflight=add_default_auth_to_preflight,
             )
 
-    def _set_default_apikey_required(self, swagger_editor):  # type: ignore[no-untyped-def]
+    def _set_default_apikey_required(self, swagger_editor: SwaggerEditor) -> None:
         for path in swagger_editor.iter_on_path():
             swagger_editor.set_path_default_apikey_required(path)
 

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -726,9 +726,9 @@ class Api(PushEventSource):
         partition = ArnGenerator.get_partition_name()  # type: ignore[no-untyped-call]
         uri = _build_apigw_integration_uri(function, partition)  # type: ignore[no-untyped-call]
 
-        editor = SwaggerEditor(swagger_body)  # type: ignore[no-untyped-call]
+        editor = SwaggerEditor(swagger_body)
 
-        if editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined, no-untyped-call]
+        if editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined]
             # Cannot add the Lambda Integration, if it is already present
             raise InvalidEventException(
                 self.relative_id,
@@ -1232,7 +1232,7 @@ class HttpApi(PushEventSource):
 
         editor = OpenApiEditor(open_api_body)
 
-        if manage_swagger and editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined, no-untyped-call]
+        if manage_swagger and editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined]
             # Cannot add the Lambda Integration, if it is already present
             raise InvalidEventException(
                 self.relative_id,

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -350,9 +350,9 @@ class Api(EventSource):
 
         integration_uri = fnSub("arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution")
 
-        editor = SwaggerEditor(swagger_body)  # type: ignore[no-untyped-call]
+        editor = SwaggerEditor(swagger_body)
 
-        if editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined, no-untyped-call]
+        if editor.has_integration(self.Path, self.Method):  # type: ignore[attr-defined]
             # Cannot add the integration, if it is already present
             raise InvalidEventException(
                 self.relative_id,

--- a/samtranslator/open_api/base_editor.py
+++ b/samtranslator/open_api/base_editor.py
@@ -1,0 +1,229 @@
+"""Base class for OpenApiEditor and SwaggerEditor."""
+import re
+from typing import Any, Dict, Iterator, List, Optional, Union
+
+from samtranslator.model.apigateway import ApiGatewayAuthorizer
+from samtranslator.model.apigatewayv2 import ApiGatewayV2Authorizer
+from samtranslator.model.exceptions import InvalidDocumentException, InvalidTemplateException
+from samtranslator.model.intrinsics import is_intrinsic_no_value, make_conditional
+from samtranslator.utils.py27hash_fix import Py27Dict
+
+
+class BaseEditor(object):
+    # constants:
+    _X_APIGW_INTEGRATION = "x-amazon-apigateway-integration"
+    _CONDITIONAL_IF = "Fn::If"
+    _X_ANY_METHOD = "x-amazon-apigateway-any-method"
+    # https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
+    _ALL_HTTP_METHODS = ["OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"]
+    _SERVERS = "servers"
+    _OPENAPI_VERSION_3_REGEX = r"\A3(\.\d)(\.\d)?$"
+
+    # attributes:
+    _doc: Dict[str, Any]
+    paths: Dict[str, Any]
+
+    @staticmethod
+    def get_conditional_contents(item: Any) -> List[Any]:
+        """
+        Returns the contents of the given item.
+        If a conditional block has been used inside the item, returns a list of the content
+        inside the conditional (both the then and the else cases). Skips {'Ref': 'AWS::NoValue'} content.
+        If there's no conditional block, then returns an list with the single item in it.
+
+        :param dict item: item from which the contents will be extracted
+        :return: list of item content
+        """
+        contents = [item]
+        if isinstance(item, dict) and BaseEditor._CONDITIONAL_IF in item:
+            contents = item[BaseEditor._CONDITIONAL_IF][1:]
+            contents = [content for content in contents if not is_intrinsic_no_value(content)]
+        return contents
+
+    @staticmethod
+    def method_definition_has_integration(method_definition: Dict[str, Any]) -> bool:
+        """
+        Checks a method definition to make sure it has an apigw integration
+
+        :param dict method_definition: method definition dictionary
+        :return: True if an integration exists
+        """
+
+        return bool(method_definition.get(BaseEditor._X_APIGW_INTEGRATION))
+
+    def method_has_integration(self, method: Dict[str, Any]) -> bool:
+        """
+        Returns true if the given method contains a valid method definition.
+        This uses the get_conditional_contents function to handle conditionals.
+
+        :param dict method: method dictionary
+        :return: true if method has one or multiple integrations
+        """
+        for method_definition in self.get_conditional_contents(method):
+            if self.method_definition_has_integration(method_definition):
+                return True
+        return False
+
+    def make_path_conditional(self, path: str, condition: str) -> None:
+        """
+        Wrap entire API path definition in a CloudFormation if condition.
+        :param path: path name
+        :param condition: condition name
+        """
+        self.paths[path] = make_conditional(condition, self.paths[path])
+
+    def iter_on_path(self) -> Iterator[str]:
+        """
+        Yields all the paths available in the Swagger. As a caller, if you add new paths to Swagger while iterating,
+        they will not show up in this iterator
+
+        :yields string: Path name
+        """
+
+        for path, _ in self.paths.items():
+            yield path
+
+    @staticmethod
+    def _normalize_method_name(method: Any) -> Any:
+        """
+        Returns a lower case, normalized version of HTTP Method. It also know how to handle API Gateway specific methods
+        like "ANY"
+
+        NOTE: Always normalize before using the `method` value passed in as input
+
+        :param string method: Name of the HTTP Method
+        :return string: Normalized method name
+        """
+        if not method or not isinstance(method, str):
+            return method
+
+        method = method.lower()
+        if method == "any":
+            return BaseEditor._X_ANY_METHOD
+        return method
+
+    def has_path(self, path: str, method: Optional[str] = None) -> bool:
+        """
+        Returns True if this Swagger has the given path and optional method
+        For paths with conditionals, only returns true if both items (true case, and false case) have the method.
+
+        :param string path: Path name
+        :param string method: HTTP method
+        :return: True, if this path/method is present in the document
+        """
+        if path not in self.paths:
+            return False
+
+        method = self._normalize_method_name(method)
+        if method:
+            for path_item in self.get_conditional_contents(self.paths.get(path)):
+                if not path_item or method not in path_item:
+                    return False
+        return True
+
+    def has_integration(self, path: str, method: str) -> bool:
+        """
+        Checks if an API Gateway integration is already present at the given path/method.
+        For paths with conditionals, it only returns True if both items (true case, false case) have the integration
+
+        :param string path: Path name
+        :param string method: HTTP method
+        :return: True, if an API Gateway integration is already present
+        """
+        method = self._normalize_method_name(method)
+
+        if not self.has_path(path, method):
+            return False
+
+        for path_item in self.get_conditional_contents(self.paths.get(path)):
+            method_definition = path_item.get(method)
+            if not (isinstance(method_definition, dict) and self.method_has_integration(method_definition)):
+                return False
+        # Integration present and non-empty
+        return True
+
+    def add_path(self, path: str, method: Optional[str] = None) -> None:
+        """
+        Adds the path/method combination to the Swagger, if not already present
+
+        :param string path: Path name
+        :param string method: HTTP method
+        :raises InvalidDocumentException: If the value of `path` in Swagger is not a dictionary
+        """
+        method = self._normalize_method_name(method)
+
+        path_dict = self.paths.setdefault(path, Py27Dict())
+
+        if not isinstance(path_dict, dict):
+            # Either customers has provided us an invalid Swagger, or this class has messed it somehow
+            raise InvalidDocumentException(
+                [InvalidTemplateException(f"Value of '{path}' path must be a dictionary according to Swagger spec.")]
+            )
+
+        for path_item in self.get_conditional_contents(path_dict):
+            path_item.setdefault(method, Py27Dict())
+
+    @staticmethod
+    def _get_authorization_scopes(
+        authorizers: Union[Dict[str, ApiGatewayAuthorizer], Dict[str, ApiGatewayV2Authorizer]], default_authorizer: str
+    ) -> Any:
+        """
+        Returns auth scopes for an authorizer if present
+        :param authorizers: authorizer definitions
+        :param default_authorizer: name of the default authorizer
+        """
+        authorizer = authorizers.get(default_authorizer)
+        if authorizer and authorizer.authorization_scopes is not None:
+            return authorizer.authorization_scopes
+        return []
+
+    def iter_on_method_definitions_for_path_at_method(
+        self, path_name: str, method_name: str, skip_methods_without_apigw_integration: bool = True
+    ) -> Iterator[Dict[str, Any]]:
+        """
+        Yields all the method definitions for the path+method combinations if path and/or method have IF conditionals.
+        If there are no conditionals, will just yield the single method definition at the given path and method name.
+
+        :param path_name: path name
+        :param method_name: method name
+        :param skip_methods_without_apigw_integration: if True, skips method definitions without apigw integration
+        :yields dict: method definition
+        """
+        normalized_method_name = self._normalize_method_name(method_name)
+
+        for path_item in self.get_conditional_contents(self.paths.get(path_name)):
+            for method_definition in self.get_conditional_contents(path_item.get(normalized_method_name)):
+                if skip_methods_without_apigw_integration and not self.method_definition_has_integration(
+                    method_definition
+                ):
+                    continue
+                yield method_definition
+
+    @staticmethod
+    def validate_is_dict(obj: Any, exception_message: str) -> None:
+        """
+        Throws exception if obj is not a dict
+
+        :param obj: object being validated
+        :param exception_message: message to include in exception if obj is not a dict
+        """
+
+        if not isinstance(obj, dict):
+            raise InvalidDocumentException([InvalidTemplateException(exception_message)])
+
+    @staticmethod
+    def validate_path_item_is_dict(path_item: Any, path: str) -> None:
+        """
+        Throws exception if path_item is not a dict
+
+        :param path_item: path_item (value at the path) being validated
+        :param path: path name
+        """
+
+        BaseEditor.validate_is_dict(
+            path_item, "Value of '{}' path must be a dictionary according to Swagger spec.".format(path)
+        )
+
+    @staticmethod
+    def safe_compare_regex_with_string(regex: str, data: Any) -> bool:
+        return re.match(regex, str(data)) is not None

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -163,7 +163,7 @@ class Globals(object):
                     (cls._OPENAPIVERSION in properties)
                     and (cls._MANAGE_SWAGGER in properties)
                     and SwaggerEditor.safe_compare_regex_with_string(
-                        SwaggerEditor.get_openapi_version_3_regex(), properties[cls._OPENAPIVERSION]
+                        SwaggerEditor._OPENAPI_VERSION_3_REGEX, properties[cls._OPENAPIVERSION]
                     )
                 ):
                     if not isinstance(properties[cls._OPENAPIVERSION], str):


### PR DESCRIPTION
### Issue #, if available

These two classes share so many same code, making it tedious to sync the code fixes.

### Description of changes

Move the same methods into their super class. There are 2 methods that are not shared `validate_path_item_is_dict` and `validate_is_dict` but I think it will be useful in `OpenApiEditor` as well as it is generic.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
