### PR TITLE
fix: allow `Api` model without `properties`

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -860,9 +860,6 @@ class SwaggerEditor(BaseEditor):
             if not model_type:
                 raise InvalidDocumentException([InvalidTemplateException("'Models' schema is missing 'type'.")])
 
-            if not model_properties:
-                raise InvalidDocumentException([InvalidTemplateException("'Models' schema is missing 'properties'.")])
-
             self.definitions[model_name.lower()] = schema
 
     def add_resource_policy(self, resource_policy, path, stage):  # type: ignore[no-untyped-def]

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -855,7 +855,6 @@ class SwaggerEditor(BaseEditor):
         for model_name, schema in models.items():
 
             model_type = schema.get("type")
-            model_properties = schema.get("properties")
 
             if not model_type:
                 raise InvalidDocumentException([InvalidTemplateException("'Models' schema is missing 'type'.")])

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -692,12 +692,6 @@ class TestSwaggerEditor_add_models(TestCase):
         with self.assertRaises(InvalidDocumentException):
             self.editor.add_models(models)
 
-    def test_must_fail_without_properties_in_model(self):
-        models = {"User": {"type": "object"}}
-
-        with self.assertRaises(InvalidDocumentException):
-            self.editor.add_models(models)
-
 
 class TestSwaggerEditor_add_request_model_to_method(TestCase):
     def setUp(self):

--- a/tests/translator/input/api_model_without_properties.yaml
+++ b/tests/translator/input/api_model_without_properties.yaml
@@ -1,0 +1,11 @@
+Resources:
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      Models:
+        MyModel:
+          items:
+            type: integer
+          type: array
+          title: MyModel

--- a/tests/translator/output/api_model_without_properties.json
+++ b/tests/translator/output/api_model_without_properties.json
@@ -1,0 +1,50 @@
+{
+  "Resources": {
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "definitions": {
+            "mymodel": {
+              "items": {
+                "type": "integer"
+              },
+              "title": "MyModel",
+              "type": "array"
+            }
+          },
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {},
+          "swagger": "2.0"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeployment49616beda5": {
+      "Properties": {
+        "Description": "RestApi deployment id: 49616beda518d56ac1dbce9c34f09ccca4862616",
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment49616beda5"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_model_without_properties.json
+++ b/tests/translator/output/aws-cn/api_model_without_properties.json
@@ -1,0 +1,58 @@
+{
+  "Resources": {
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "definitions": {
+            "mymodel": {
+              "items": {
+                "type": "integer"
+              },
+              "title": "MyModel",
+              "type": "array"
+            }
+          },
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeployment49616beda5": {
+      "Properties": {
+        "Description": "RestApi deployment id: 49616beda518d56ac1dbce9c34f09ccca4862616",
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment49616beda5"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_model_without_properties.json
+++ b/tests/translator/output/aws-us-gov/api_model_without_properties.json
@@ -1,0 +1,58 @@
+{
+  "Resources": {
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "definitions": {
+            "mymodel": {
+              "items": {
+                "type": "integer"
+              },
+              "title": "MyModel",
+              "type": "array"
+            }
+          },
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {},
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeployment49616beda5": {
+      "Properties": {
+        "Description": "RestApi deployment id: 49616beda518d56ac1dbce9c34f09ccca4862616",
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment49616beda5"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

#1559 

### Description of changes

JSON schema doesn't require `properties` at the top-level, see e.g. https://json-schema.org/understanding-json-schema/reference/array.html#items.

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
