### PR TITLE
chore: retry 2 times with 30s wait if the stack deletion fails

### DIFF
--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -125,7 +125,7 @@ class BaseTest(TestCase):
         if self.stack_name:
             client = self.client_provider.cfn_client
             client.delete_stack(StackName=self.stack_name)
-            waiter = client.get_waiter('stack_delete_complete')
+            waiter = client.get_waiter("stack_delete_complete")
             waiter.wait(StackName=self.stack_name)
         if self.output_file_path and os.path.exists(self.output_file_path):
             os.remove(self.output_file_path)

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -28,6 +28,7 @@ from tenacity import (
     retry,
     stop_after_attempt,
     wait_exponential,
+    wait_fixed,
     retry_if_exception_type,
     after_log,
     wait_random,
@@ -115,9 +116,17 @@ class BaseTest(TestCase):
         self.output_file_path = None
         self.sub_input_file_path = None
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(30),
+        retry=retry_if_exception_type(Exception),
+    )
     def tearDown(self):
         if self.stack_name:
-            self.client_provider.cfn_client.delete_stack(StackName=self.stack_name)
+            client = self.client_provider.cfn_client
+            client.delete_stack(StackName=self.stack_name)
+            waiter = client.get_waiter('stack_delete_complete')
+            waiter.wait(StackName=self.stack_name)
         if self.output_file_path and os.path.exists(self.output_file_path):
             os.remove(self.output_file_path)
         if self.sub_input_file_path and os.path.exists(self.sub_input_file_path):


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [unit tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Do these changes include any template validations?
    - [ ] Did the newly validated properties support intrinsics prior to adding the validations? (If unsure, please review [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) before proceeding).
        - [ ] Does the pull request ensure that intrinsics remain functional with the new validations?

### Examples?

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
