### PR TITLE
chore: Update node.js version in test

### DIFF
--- a/integration/resources/templates/combination/intrinsics_serverless_function.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_function.yaml
@@ -44,7 +44,7 @@ Resources:
         Fn::Sub: ['${filename}.handler', filename: index]
 
       Runtime:
-        Fn::Join: ['', [nodejs, 12.x]]
+        Fn::Join: ['', [nodejs, 16.x]]
 
       Role:
         Fn::GetAtt: [MyNewRole, Arn]


### PR DESCRIPTION
Node 12.x is not supported in some regions; AWS recommends 16.x so updating to use that.

### Issue #, if available

### Description of changes
Updates node.js version used in intrinsics integration test

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
