### PR TITLE
Add a cache on top of python27 hashing

### DIFF
--- a/samtranslator/third_party/py27hash/hash.py
+++ b/samtranslator/third_party/py27hash/hash.py
@@ -7,19 +7,7 @@ This is designed for compatibility not performance.
 
 import ctypes
 import math
-
-# See https://github.com/python/mypy/issues/5107
-from typing import TYPE_CHECKING, TypeVar, Callable, Any
-
-if TYPE_CHECKING:
-    F = TypeVar("F", bound=Callable[[Any], Any])
-
-    def lru_cache(maxsize: int = 128, typed: bool = False) -> Callable[[F], F]:
-        pass
-
-
-else:
-    from functools import lru_cache
+from functools import lru_cache
 
 
 def hash27(value):  # type: ignore[no-untyped-def]
@@ -33,7 +21,7 @@ def hash27(value):  # type: ignore[no-untyped-def]
         Python 2.7 hash
     """
 
-    return Hash.hash(value)  # type: ignore[no-untyped-call]
+    return Hash.hash(value)
 
 
 class Hash(object):
@@ -88,7 +76,7 @@ class Hash(object):
         for y in value:
             length -= 1
 
-            y = Hash.hash(y)  # type: ignore[no-untyped-call]
+            y = Hash.hash(y)
             x = (x ^ y) * mult
             mult += 82520 + length + length
 

--- a/samtranslator/third_party/py27hash/hash.py
+++ b/samtranslator/third_party/py27hash/hash.py
@@ -42,14 +42,14 @@ class Hash(object):
             Python 2.7 hash
         """
 
+        if isinstance(value, ("".__class__, bytes)) or type(value).__name__ == "buffer":
+            return Hash.shash(value)  # type: ignore[no-untyped-call]
         if isinstance(value, tuple):
             return Hash.thash(value)  # type: ignore[no-untyped-call]
         if isinstance(value, float):
             return Hash.fhash(value)  # type: ignore[no-untyped-call]
         if isinstance(value, int):
             return hash(value)
-        if isinstance(value, ("".__class__, bytes)) or type(value).__name__ == "buffer":
-            return Hash.shash(value)  # type: ignore[no-untyped-call]
 
         raise TypeError("unhashable type: '%s'" % (type(value).__name__))
 

--- a/samtranslator/third_party/py27hash/hash.py
+++ b/samtranslator/third_party/py27hash/hash.py
@@ -2,10 +2,13 @@
 Compatibility methods to support Python 2.7 style hashing in Python 3.X+
 
 This is designed for compatibility not performance.
+
 """
 
 import ctypes
 import math
+
+from functools import lru_cache
 
 
 def hash27(value):  # type: ignore[no-untyped-def]
@@ -28,6 +31,7 @@ class Hash(object):
     """
 
     @staticmethod
+    @lru_cache(maxsize=2048)
     def hash(value):  # type: ignore[no-untyped-def]
         """
         Returns a Python 2.7 hash for a value.

--- a/samtranslator/third_party/py27hash/hash.py
+++ b/samtranslator/third_party/py27hash/hash.py
@@ -8,7 +8,18 @@ This is designed for compatibility not performance.
 import ctypes
 import math
 
-from functools import lru_cache
+# See https://github.com/python/mypy/issues/5107
+from typing import TYPE_CHECKING, TypeVar, Callable, Any
+
+if TYPE_CHECKING:
+    F = TypeVar("F", bound=Callable[[Any], Any])
+
+    def lru_cache(maxsize: int = 128, typed: bool = False) -> Callable[[F], F]:
+        pass
+
+
+else:
+    from functools import lru_cache
 
 
 def hash27(value):  # type: ignore[no-untyped-def]

--- a/samtranslator/utils/py27hash_fix.py
+++ b/samtranslator/utils/py27hash_fix.py
@@ -141,7 +141,7 @@ class Py27UniStr(unicode_string_type):
     def _get_py27_hash(self):  # type: ignore[no-untyped-def]
         h = getattr(self, "_py27_hash", None)
         if h is None:
-            self._py27_hash = h = ctypes.c_size_t(Hash.hash(self)).value  # type: ignore[no-untyped-call]
+            self._py27_hash = h = ctypes.c_size_t(Hash.hash(self)).value
         return h
 
 
@@ -198,7 +198,7 @@ class Py27Keys(object):
         if isinstance(k, Py27UniStr):
             h = k._get_py27_hash()  # type: ignore[no-untyped-call]
         else:
-            h = ctypes.c_size_t(Hash.hash(k)).value  # type: ignore[no-untyped-call]
+            h = ctypes.c_size_t(Hash.hash(k)).value
 
         i = h & self.mask
 


### PR DESCRIPTION
Profiling indicated that we spend a lot of time in our custom deepcopy, mostly due to maintaining compatibility with python2.7 hashes and their ordering of keys. If we change the ordering of keys, we will change logical IDs of some generated resources, breaking backwards compatibility.

We found that during the hashing code, we made some 13MM calls to Hash.hash, but with caching this is reduced to 1040 calls for a large test template.

On my laptop, this reduces wall clock time from ~15s to ~13s, or ~34s to ~27s with cProfiler.

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
