### PR TITLE
fix: Raise correct exception when "ResponseParameters" is not dict

### DIFF
--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -164,8 +164,12 @@ class ApiGatewayResponse(object):
         prefixed_parameters = Py27Dict()
 
         parameter_prefix_pairs = [("Headers", "header."), ("Paths", "path."), ("QueryStrings", "querystring.")]
-        for parameter, prefix in parameter_prefix_pairs:
-            for key, value in response_parameters.get(parameter, {}).items():
+        for parameter_property_name, prefix in parameter_prefix_pairs:
+            parameter_property_value = response_parameters.get(parameter_property_name, {})
+            sam_expect(
+                parameter_property_value, self.api_logical_id, f"ResponseParameters.{parameter_property_name}"
+            ).to_be_a_map()
+            for key, value in parameter_property_value.items():
                 param_key = GATEWAY_RESPONSE_PREFIX + prefix + key
                 if isinstance(key, Py27UniStr):
                     # if key is from template, we need to convert param_key to Py27UniStr

--- a/tests/translator/input/error_api_gateway_responses_responseparameter_invalid_type.yaml
+++ b/tests/translator/input/error_api_gateway_responses_responseparameter_invalid_type.yaml
@@ -1,0 +1,24 @@
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs12.x
+      Events:
+        GetHtml:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+            RestApiId: !Ref ExplicitApi
+
+  ExplicitApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      GatewayResponses:
+        UNAUTHORIZED:
+          StatusCode: 401
+          ResponseParameters:
+          - ResponseParameters should not be a list

--- a/tests/translator/output/error_api_gateway_responses_responseparameter_invalid_type.json
+++ b/tests/translator/output/error_api_gateway_responses_responseparameter_invalid_type.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [ExplicitApi] is invalid. Property 'GatewayResponses.UNAUTHORIZED.ResponseParameters' should be a map."
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
