### PR TITLE
Fix warning when using default stage name and FailOnWarnings is on

### DIFF
--- a/integration/combination/test_http_api_with_fail_on_warnings.py
+++ b/integration/combination/test_http_api_with_fail_on_warnings.py
@@ -11,7 +11,7 @@ class TestHttpApiWithFailOnWarnings(BaseTest):
     @parameterized.expand(
         [
             ("combination/http_api_with_fail_on_warnings_and_default_stage_name", True),
-            ("combination/http_api_with_fail_on_warnings_and_default_stage_name", False)
+            ("combination/http_api_with_fail_on_warnings_and_default_stage_name", False),
         ]
     )
     def test_http_api_with_fail_on_warnings(self, file_name, disable_value):

--- a/integration/combination/test_http_api_with_fail_on_warnings.py
+++ b/integration/combination/test_http_api_with_fail_on_warnings.py
@@ -1,0 +1,33 @@
+from unittest.case import skipIf
+from parameterized import parameterized
+
+from integration.helpers.base_test import BaseTest
+from integration.helpers.resource import current_region_does_not_support
+from integration.config.service_names import HTTP_API
+
+
+@skipIf(current_region_does_not_support([HTTP_API]), "HttpApi is not supported in this testing region")
+class TestHttpApiWithFailOnWarnings(BaseTest):
+    @parameterized.expand(
+        [
+            ("combination/http_api_with_fail_on_warnings_and_default_stage_name", True),
+            ("combination/http_api_with_fail_on_warnings_and_default_stage_name", False)
+        ]
+    )
+    def test_http_api_with_fail_on_warnings(self, file_name, disable_value):
+        parameters = [
+            {
+                "ParameterKey": "FailOnWarningsValue",
+                "ParameterValue": "true" if disable_value else "false",
+                "UsePreviousValue": False,
+                "ResolvedValue": "string",
+            }
+        ]
+
+        self.create_and_verify_stack(file_name, parameters)
+
+        http_api_id = self.get_physical_id_by_type("AWS::ApiGatewayV2::Api")
+        apigw_v2_client = self.client_provider.api_v2_client
+
+        api_result = apigw_v2_client.get_api(ApiId=http_api_id)
+        self.assertEqual(api_result["ResponseMetadata"]["HTTPStatusCode"], 200)

--- a/integration/resources/expected/combination/http_api_with_fail_on_warnings_and_default_stage_name.json
+++ b/integration/resources/expected/combination/http_api_with_fail_on_warnings_and_default_stage_name.json
@@ -1,0 +1,22 @@
+[
+  {
+    "LogicalResourceId": "AppFunctionAppHandlerPermission",
+    "ResourceType": "AWS::Lambda::Permission"
+  },
+  {
+    "LogicalResourceId": "AppApi",
+    "ResourceType": "AWS::ApiGatewayV2::Api"
+  },
+  {
+    "LogicalResourceId": "AppApiApiGatewayDefaultStage",
+    "ResourceType": "AWS::ApiGatewayV2::Stage"
+  },
+  {
+    "LogicalResourceId": "AppFunction",
+    "ResourceType": "AWS::Lambda::Function"
+  },
+  {
+    "LogicalResourceId": "AppFunctionRole",
+    "ResourceType": "AWS::IAM::Role"
+  }
+]

--- a/integration/resources/templates/combination/http_api_with_fail_on_warnings_and_default_stage_name.yaml
+++ b/integration/resources/templates/combination/http_api_with_fail_on_warnings_and_default_stage_name.yaml
@@ -18,7 +18,7 @@ Resources:
           print("Hello, world!")
       Runtime: python3.8
       Architectures:
-        - x86_64
+      - x86_64
       Events:
         AppHandler:
           Type: HttpApi

--- a/integration/resources/templates/combination/http_api_with_fail_on_warnings_and_default_stage_name.yaml
+++ b/integration/resources/templates/combination/http_api_with_fail_on_warnings_and_default_stage_name.yaml
@@ -1,0 +1,29 @@
+Parameters:
+  FailOnWarningsValue:
+    Type: String
+    AllowedValues: [true, false]
+
+Resources:
+  AppApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      FailOnWarnings: !Ref FailOnWarningsValue
+      StageName: $default
+  AppFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      InlineCode: |
+        def handler(event, context):
+          print("Hello, world!")
+      Runtime: python3.8
+      Architectures:
+        - x86_64
+      Events:
+        AppHandler:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref AppApi
+
+Metadata:
+  SamTransformTest: true

--- a/integration/resources/templates/combination/intrinsics_serverless_function.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_function.yaml
@@ -44,7 +44,7 @@ Resources:
         Fn::Sub: ['${filename}.handler', filename: index]
 
       Runtime:
-        Fn::Join: ['', [nodejs, 12.x]]
+        Fn::Join: ['', [nodejs, 16.x]]
 
       Role:
         Fn::GetAtt: [MyNewRole, Arn]

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -120,6 +120,7 @@ class HttpApiGenerator(object):
 
         self._add_title()
         self._add_description()
+        self._update_paths()
 
         if self.definition_uri:
             http_api.BodyS3Location = self._construct_body_s3_dict(self.definition_uri)
@@ -223,6 +224,19 @@ class HttpApiGenerator(object):
 
         # Assign the OpenApi back to template
         self.definition_body = editor.openapi
+
+    def _update_paths(self):
+        if not self.fail_on_warnings:
+            return
+
+        # Using default stage name generate warning during deployment
+        #   Warnings found during import: Parse issue: attribute paths. 
+        #   Resource $default should start with / (Service: AmazonApiGatewayV2; Status Code: 400; 
+        # Deployment fails when FailOnWarnings is true
+        paths: Optional[Dict[str, Any]] = self.definition_body.get("paths")
+        if DefaultStageName in paths:
+            paths[f"/{DefaultStageName}"] = paths.pop(DefaultStageName)
+
 
     def _construct_api_domain(
         self, http_api: ApiGatewayV2HttpApi, route53_record_set_groups: Dict[str, Route53RecordSetGroup]

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -120,7 +120,7 @@ class HttpApiGenerator(object):
 
         self._add_title()
         self._add_description()
-        self._update_paths()
+        self._update_default_path()
 
         if self.definition_uri:
             http_api.BodyS3Location = self._construct_body_s3_dict(self.definition_uri)
@@ -225,14 +225,14 @@ class HttpApiGenerator(object):
         # Assign the OpenApi back to template
         self.definition_body = editor.openapi
 
-    def _update_paths(self) -> None:
+    def _update_default_path(self) -> None:
         if not self.fail_on_warnings or not self.definition_body:
             return
 
         # Using default stage name generate warning during deployment
         #   Warnings found during import: Parse issue: attribute paths.
         #   Resource $default should start with / (Service: AmazonApiGatewayV2; Status Code: 400;
-        # Deployment fails when FailOnWarnings is true
+        # Deployment fails when FailOnWarnings is true: https://github.com/aws/serverless-application-model/issues/2297
         paths: Dict[str, Any] = self.definition_body.get("paths", {})
         if DefaultStageName in paths:
             paths[f"/{DefaultStageName}"] = paths.pop(DefaultStageName)

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -226,6 +226,7 @@ class HttpApiGenerator(object):
         self.definition_body = editor.openapi
 
     def _update_default_path(self) -> None:
+        # Only do the following if FailOnWarnings is enabled for backward compatibility.
         if not self.fail_on_warnings or not self.definition_body:
             return
 

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -225,18 +225,17 @@ class HttpApiGenerator(object):
         # Assign the OpenApi back to template
         self.definition_body = editor.openapi
 
-    def _update_paths(self):
-        if not self.fail_on_warnings:
+    def _update_paths(self) -> None:
+        if not self.fail_on_warnings or not self.definition_body:
             return
 
         # Using default stage name generate warning during deployment
-        #   Warnings found during import: Parse issue: attribute paths. 
-        #   Resource $default should start with / (Service: AmazonApiGatewayV2; Status Code: 400; 
+        #   Warnings found during import: Parse issue: attribute paths.
+        #   Resource $default should start with / (Service: AmazonApiGatewayV2; Status Code: 400;
         # Deployment fails when FailOnWarnings is true
-        paths: Optional[Dict[str, Any]] = self.definition_body.get("paths")
+        paths: Dict[str, Any] = self.definition_body.get("paths", {})
         if DefaultStageName in paths:
             paths[f"/{DefaultStageName}"] = paths.pop(DefaultStageName)
-
 
     def _construct_api_domain(
         self, http_api: ApiGatewayV2HttpApi, route53_record_set_groups: Dict[str, Route53RecordSetGroup]

--- a/tests/translator/output/aws-cn/explicit_http_api.json
+++ b/tests/translator/output/aws-cn/explicit_http_api.json
@@ -123,7 +123,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},

--- a/tests/translator/output/aws-cn/http_api_explicit_stage.json
+++ b/tests/translator/output/aws-cn/http_api_explicit_stage.json
@@ -95,7 +95,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},

--- a/tests/translator/output/aws-cn/http_api_with_default_stage_name_and_fail_on_warnings.json
+++ b/tests/translator/output/aws-cn/http_api_with_default_stage_name_and_fail_on_warnings.json
@@ -11,7 +11,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},

--- a/tests/translator/output/aws-us-gov/explicit_http_api.json
+++ b/tests/translator/output/aws-us-gov/explicit_http_api.json
@@ -123,7 +123,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},

--- a/tests/translator/output/aws-us-gov/http_api_explicit_stage.json
+++ b/tests/translator/output/aws-us-gov/http_api_explicit_stage.json
@@ -95,7 +95,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},

--- a/tests/translator/output/aws-us-gov/http_api_with_default_stage_name_and_fail_on_warnings.json
+++ b/tests/translator/output/aws-us-gov/http_api_with_default_stage_name_and_fail_on_warnings.json
@@ -11,7 +11,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},

--- a/tests/translator/output/explicit_http_api.json
+++ b/tests/translator/output/explicit_http_api.json
@@ -123,7 +123,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},

--- a/tests/translator/output/http_api_explicit_stage.json
+++ b/tests/translator/output/http_api_explicit_stage.json
@@ -95,7 +95,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},

--- a/tests/translator/output/http_api_with_default_stage_name_and_fail_on_warnings.json
+++ b/tests/translator/output/http_api_with_default_stage_name_and_fail_on_warnings.json
@@ -11,7 +11,7 @@
           },
           "openapi": "3.0.1",
           "paths": {
-            "$default": {
+            "/$default": {
               "x-amazon-apigateway-any-method": {
                 "isDefaultRoute": true,
                 "responses": {},


### PR DESCRIPTION
### Issue #, if available
https://github.com/aws/serverless-application-model/issues/2297

### Description of changes
Before the change, when we turn on `FailOnWarnings` flag and use a default stage name, the deployment will fail because it will generate a warning saying 
```
Warnings found during import: Parse issue: attribute paths. 

Resource $default should start with / 
```

### Description of how you validated changes
Added integ test and ran all unit tests.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
