### PR TITLE
fix: Raise correct exception when DestinationConfig or DestinationConfig.x is not dict

### DIFF
--- a/tests/translator/input/error_function_with_event_dest_type.yaml
+++ b/tests/translator/input/error_function_with_event_dest_type.yaml
@@ -2,16 +2,6 @@ Parameters:
   SNSArn:
     Type: String
     Default: my-sns-arn
-Globals:
-  Function:
-    AutoPublishAlias: live
-    EventInvokeConfig:
-      MaximumEventAgeInSeconds: 70
-      MaximumRetryAttempts: 1
-      DestinationConfig:
-        OnFailure:
-          Type: blah
-          Destination: !Ref SNSArn
 
 Resources:
   MyTestFunction:
@@ -36,3 +26,36 @@ Resources:
       Handler: index.handler
       Runtime: nodejs12.x
       MemorySize: 1024
+      AutoPublishAlias: live
+      EventInvokeConfig:
+        MaximumEventAgeInSeconds: 70
+        MaximumRetryAttempts: 1
+        DestinationConfig:
+          OnFailure:
+            Type: blah
+            Destination: !Ref SNSArn
+
+  MyTestFunctionInvalidDestinationConfigType:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: hello
+      Handler: index.handler
+      Runtime: nodejs12.x
+      EventInvokeConfig:
+        MaximumEventAgeInSeconds: 70
+        MaximumRetryAttempts: 1
+        DestinationConfig:
+        - this should not be a list
+
+  MyTestFunctionInvalidDestinationConfigOnSuccessType:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: hello
+      Handler: index.handler
+      Runtime: nodejs12.x
+      EventInvokeConfig:
+        MaximumEventAgeInSeconds: 70
+        MaximumRetryAttempts: 1
+        DestinationConfig:
+          OnSuccess:
+          - this should not be a list

--- a/tests/translator/output/error_function_with_event_dest_type.json
+++ b/tests/translator/output/error_function_with_event_dest_type.json
@@ -1,8 +1,3 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyTestFunction] is invalid. 'Type: blah' must be one of ['SQS', 'SNS', 'EventBridge', 'Lambda']",
-  "errors": [
-    {
-      "errorMessage": "Resource with id [MyTestFunction] is invalid. 'Type: blah' must be one of ['SQS', 'SNS', 'EventBridge', 'Lambda']"
-    }
-  ]
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 3. Resource with id [MyTestFunction] is invalid. 'Type: blah' must be one of ['SQS', 'SNS', 'EventBridge', 'Lambda'] Resource with id [MyTestFunctionInvalidDestinationConfigOnSuccessType] is invalid. Property 'EventInvokeConfig.DestinationConfig.OnSuccess' should be a map. Resource with id [MyTestFunctionInvalidDestinationConfigType] is invalid. Property 'EventInvokeConfig.DestinationConfig' should be a map."
 }


### PR DESCRIPTION
…fig.x is not dict

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
