### PR TITLE
fix: Raise correct exception when S3 event referring to a bucket whose properties is not dict

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -417,10 +417,9 @@ class S3(PushEventSource):
                 lambda_event = make_conditional(function.resource_attributes[CONDITION], lambda_event)
             event_mappings.append(lambda_event)
 
-        properties = bucket.get("Properties", None)
-        if properties is None:
-            properties = {}
-            bucket["Properties"] = properties
+        properties = bucket.get("Properties", {})
+        sam_expect(properties, bucket_id, "").to_be_a_map("Properties should be a map.")
+        bucket["Properties"] = properties
 
         notification_config = properties.get("NotificationConfiguration", None)
         if notification_config is None:

--- a/tests/translator/input/error_s3_bucket_invalid_properties.yaml
+++ b/tests/translator/input/error_s3_bucket_invalid_properties.yaml
@@ -1,0 +1,17 @@
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/thumbnails.zip
+      Handler: index.generate_thumbails
+      Runtime: nodejs12.x
+      Events:
+        ImageBucket:
+          Type: S3
+          Properties:
+            Bucket: !Ref Bucket
+            Events: s3:ObjectCreated:*
+
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties: This should be a dict

--- a/tests/translator/output/error_s3_bucket_invalid_properties.json
+++ b/tests/translator/output/error_s3_bucket_invalid_properties.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Bucket] is invalid. Properties should be a map."
+}


### PR DESCRIPTION
…e properties is not dict

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
