### PR TITLE
fix: Handle when httpapi Auth could be null

### DIFF
--- a/tests/translator/input/error_http_api_with_invalid_auth_while_method_auth_is_none.yaml
+++ b/tests/translator/input/error_http_api_with_invalid_auth_while_method_auth_is_none.yaml
@@ -1,0 +1,23 @@
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.7
+      InlineCode: |
+        def handler(event, context):
+            return {'body': 'Hello World!', 'statusCode': 200}
+      Events:
+        GetApi:
+          Type: HttpApi
+          Properties:
+            Auth:
+              Authorizer: NONE
+            ApiId:
+              Ref: MyApi
+            Method: GET
+            Path: /get
+  MyApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Auth:

--- a/tests/translator/output/error_http_api_with_invalid_auth_while_method_auth_is_none.json
+++ b/tests/translator/output/error_http_api_with_invalid_auth_while_method_auth_is_none.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApi] is invalid. Property 'Auth' should be a map."
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
