### PR TITLE
Update caller credential partition

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -6,6 +6,7 @@ from samtranslator.model.apigateway import ApiGatewayAuthorizer
 from samtranslator.model.intrinsics import ref, make_conditional, fnSub
 from samtranslator.model.exceptions import InvalidDocumentException, InvalidTemplateException
 from samtranslator.open_api.base_editor import BaseEditor
+from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.utils.py27hash_fix import Py27Dict, Py27UniStr
 
 
@@ -223,7 +224,7 @@ class SwaggerEditor(BaseEditor):
 
     @staticmethod
     def _get_invoke_role(invoke_role):  # type: ignore[no-untyped-def]
-        CALLER_CREDENTIALS_ARN = "arn:aws:iam::*:user/*"
+        CALLER_CREDENTIALS_ARN = f"arn:{ArnGenerator.get_partition_name()}:iam::*:user/*"
         return invoke_role if invoke_role and invoke_role != "CALLER_CREDENTIALS" else CALLER_CREDENTIALS_ARN
 
     def iter_on_all_methods_for_path(self, path_name, skip_methods_without_apigw_integration=True):  # type: ignore[no-untyped-def]

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -224,7 +224,7 @@ class SwaggerEditor(BaseEditor):
 
     @staticmethod
     def _get_invoke_role(invoke_role):  # type: ignore[no-untyped-def]
-        CALLER_CREDENTIALS_ARN = f"arn:{ArnGenerator.get_partition_name()}:iam::*:user/*"
+        CALLER_CREDENTIALS_ARN = f"arn:{ArnGenerator.get_partition_name()}:iam::*:user/*"  # type: ignore[no-untyped-call]
         return invoke_role if invoke_role and invoke_role != "CALLER_CREDENTIALS" else CALLER_CREDENTIALS_ARN
 
     def iter_on_all_methods_for_path(self, path_name, skip_methods_without_apigw_integration=True):  # type: ignore[no-untyped-def]

--- a/tests/translator/output/aws-cn/api_request_model_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_request_model_openapi_3.json
@@ -72,7 +72,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -100,7 +100,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -122,9 +122,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "HtmlApiDeploymentf84be626f3": {
+    "HtmlApiDeployment8a330bd7a7": {
       "Properties": {
-        "Description": "RestApi deployment id: f84be626f359fc9697fd8e228c5ffe53e252f82c",
+        "Description": "RestApi deployment id: 8a330bd7a7ab7fd27c5b7aa46af537d348a4b0d9",
         "RestApiId": {
           "Ref": "HtmlApi"
         }
@@ -134,7 +134,7 @@
     "HtmlApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentf84be626f3"
+          "Ref": "HtmlApiDeployment8a330bd7a7"
         },
         "RestApiId": {
           "Ref": "HtmlApi"

--- a/tests/translator/output/aws-cn/api_swagger_integration_with_ref_intrinsic_api_id.json
+++ b/tests/translator/output/aws-cn/api_swagger_integration_with_ref_intrinsic_api_id.json
@@ -19,7 +19,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -72,9 +72,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "HtmlApiDeploymentda1577e1dd": {
+    "HtmlApiDeployment874ee11bea": {
       "Properties": {
-        "Description": "RestApi deployment id: da1577e1ddadc82fbcc104e2477852594eeb133c",
+        "Description": "RestApi deployment id: 874ee11bea39ab234d0bfbcc481f76e58c4d2195",
         "RestApiId": {
           "Ref": "HtmlApi"
         },
@@ -85,7 +85,7 @@
     "HtmlApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentda1577e1dd"
+          "Ref": "HtmlApiDeployment874ee11bea"
         },
         "RestApiId": {
           "Ref": "HtmlApi"

--- a/tests/translator/output/aws-cn/api_swagger_integration_with_string_api_id.json
+++ b/tests/translator/output/aws-cn/api_swagger_integration_with_string_api_id.json
@@ -19,7 +19,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -72,9 +72,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "HtmlApiDeploymentda1577e1dd": {
+    "HtmlApiDeployment874ee11bea": {
       "Properties": {
-        "Description": "RestApi deployment id: da1577e1ddadc82fbcc104e2477852594eeb133c",
+        "Description": "RestApi deployment id: 874ee11bea39ab234d0bfbcc481f76e58c4d2195",
         "RestApiId": {
           "Ref": "HtmlApi"
         },
@@ -85,7 +85,7 @@
     "HtmlApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentda1577e1dd"
+          "Ref": "HtmlApiDeployment874ee11bea"
         },
         "RestApiId": {
           "Ref": "HtmlApi"

--- a/tests/translator/output/aws-cn/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/aws-cn/api_with_aws_iam_auth_overrides.json
@@ -37,7 +37,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -166,9 +166,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithAwsIamAuthDeployment4253f994cd": {
+    "MyApiWithAwsIamAuthDeploymentda2f42798a": {
       "Properties": {
-        "Description": "RestApi deployment id: 4253f994cdaf14767907decd5cb875cbafc08704",
+        "Description": "RestApi deployment id: da2f42798a8e92b56e915bab3a7e653e6f7f120d",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
@@ -195,7 +195,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -241,9 +241,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment07ee28f86e": {
+    "MyApiWithAwsIamAuthNoCallerCredentialsDeploymente482264f6c": {
       "Properties": {
-        "Description": "RestApi deployment id: 07ee28f86edc705d064d88266db4dea8f5c305b1",
+        "Description": "RestApi deployment id: e482264f6c49baa1099a7f5463cf057222ee9b3c",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
         },
@@ -254,7 +254,7 @@
     "MyApiWithAwsIamAuthNoCallerCredentialsProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment07ee28f86e"
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeploymente482264f6c"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
@@ -266,7 +266,7 @@
     "MyApiWithAwsIamAuthProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeployment4253f994cd"
+          "Ref": "MyApiWithAwsIamAuthDeploymentda2f42798a"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"

--- a/tests/translator/output/aws-cn/api_with_default_aws_iam_auth.json
+++ b/tests/translator/output/aws-cn/api_with_default_aws_iam_auth.json
@@ -19,7 +19,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -141,7 +141,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -172,9 +172,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentd0103947f7": {
+    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeployment0a94105dab": {
       "Properties": {
-        "Description": "RestApi deployment id: d0103947f7e2e1d52ca7afac92f5afc8339a051b",
+        "Description": "RestApi deployment id: 0a94105dab568f7a8bff9a1eda496ca87694cb3f",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
         },
@@ -185,7 +185,7 @@
     "MyApiWithAwsIamAuthAndDefaultInvokeRoleProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentd0103947f7"
+          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeployment0a94105dab"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
@@ -194,9 +194,9 @@
       },
       "Type": "AWS::ApiGateway::Stage"
     },
-    "MyApiWithAwsIamAuthDeploymentc8adfb74cf": {
+    "MyApiWithAwsIamAuthDeployment7ad0de4d9a": {
       "Properties": {
-        "Description": "RestApi deployment id: c8adfb74cfae8b8052802a21a258ecbd5178d144",
+        "Description": "RestApi deployment id: 7ad0de4d9ab0659e436bf913df69d19f6b6b6e34",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
@@ -207,7 +207,7 @@
     "MyApiWithAwsIamAuthProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentc8adfb74cf"
+          "Ref": "MyApiWithAwsIamAuthDeployment7ad0de4d9a"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"

--- a/tests/translator/output/aws-cn/api_with_default_aws_iam_auth_and_no_auth_route.json
+++ b/tests/translator/output/aws-cn/api_with_default_aws_iam_auth_and_no_auth_route.json
@@ -34,7 +34,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -52,7 +52,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -100,9 +100,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithAwsIamAuthDeploymentfbe9aee08e": {
+    "MyApiWithAwsIamAuthDeploymenta388b99c2b": {
       "Properties": {
-        "Description": "RestApi deployment id: fbe9aee08eb164bd4de9a7a7c91782c10b86d7df",
+        "Description": "RestApi deployment id: a388b99c2b4ca0be2559b61649bdffa5c5fcddcc",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
@@ -113,7 +113,7 @@
     "MyApiWithAwsIamAuthProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentfbe9aee08e"
+          "Ref": "MyApiWithAwsIamAuthDeploymenta388b99c2b"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"

--- a/tests/translator/output/aws-cn/api_with_method_aws_iam_auth.json
+++ b/tests/translator/output/aws-cn/api_with_method_aws_iam_auth.json
@@ -19,7 +19,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -53,7 +53,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -71,7 +71,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -89,7 +89,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-cn:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -140,9 +140,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithoutAuthDeployment3de35e9b3b": {
+    "MyApiWithoutAuthDeployment5cac94edbc": {
       "Properties": {
-        "Description": "RestApi deployment id: 3de35e9b3bf45c40811c36bd46b8e8513409c050",
+        "Description": "RestApi deployment id: 5cac94edbcf51122b60f1a122d953131665eccc8",
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
         },
@@ -153,7 +153,7 @@
     "MyApiWithoutAuthProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment3de35e9b3b"
+          "Ref": "MyApiWithoutAuthDeployment5cac94edbc"
         },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"

--- a/tests/translator/output/aws-us-gov/api_request_model_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_request_model_openapi_3.json
@@ -72,7 +72,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -100,7 +100,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -122,9 +122,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "HtmlApiDeployment2274fb58ae": {
+    "HtmlApiDeploymentd5a98edb8f": {
       "Properties": {
-        "Description": "RestApi deployment id: 2274fb58ae60fc2a69a3feb3b433d9bcf6947be5",
+        "Description": "RestApi deployment id: d5a98edb8f10f3d3a1c0b7693dd9c6afa4f2206b",
         "RestApiId": {
           "Ref": "HtmlApi"
         }
@@ -134,7 +134,7 @@
     "HtmlApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment2274fb58ae"
+          "Ref": "HtmlApiDeploymentd5a98edb8f"
         },
         "RestApiId": {
           "Ref": "HtmlApi"

--- a/tests/translator/output/aws-us-gov/api_swagger_integration_with_ref_intrinsic_api_id.json
+++ b/tests/translator/output/aws-us-gov/api_swagger_integration_with_ref_intrinsic_api_id.json
@@ -19,7 +19,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -72,9 +72,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "HtmlApiDeployment0ab6cda881": {
+    "HtmlApiDeployment8e22eea330": {
       "Properties": {
-        "Description": "RestApi deployment id: 0ab6cda8810d586361f754db101bd7e456f7f561",
+        "Description": "RestApi deployment id: 8e22eea330e7ebbbb6cb117f9552f98df24ecfb2",
         "RestApiId": {
           "Ref": "HtmlApi"
         },
@@ -85,7 +85,7 @@
     "HtmlApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment0ab6cda881"
+          "Ref": "HtmlApiDeployment8e22eea330"
         },
         "RestApiId": {
           "Ref": "HtmlApi"

--- a/tests/translator/output/aws-us-gov/api_swagger_integration_with_string_api_id.json
+++ b/tests/translator/output/aws-us-gov/api_swagger_integration_with_string_api_id.json
@@ -19,7 +19,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -72,9 +72,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "HtmlApiDeployment0ab6cda881": {
+    "HtmlApiDeployment8e22eea330": {
       "Properties": {
-        "Description": "RestApi deployment id: 0ab6cda8810d586361f754db101bd7e456f7f561",
+        "Description": "RestApi deployment id: 8e22eea330e7ebbbb6cb117f9552f98df24ecfb2",
         "RestApiId": {
           "Ref": "HtmlApi"
         },
@@ -85,7 +85,7 @@
     "HtmlApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment0ab6cda881"
+          "Ref": "HtmlApiDeployment8e22eea330"
         },
         "RestApiId": {
           "Ref": "HtmlApi"

--- a/tests/translator/output/aws-us-gov/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/aws-us-gov/api_with_aws_iam_auth_overrides.json
@@ -37,7 +37,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -166,9 +166,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithAwsIamAuthDeploymentc7d4214444": {
+    "MyApiWithAwsIamAuthDeployment85ae497f4c": {
       "Properties": {
-        "Description": "RestApi deployment id: c7d4214444b325ee43f7a16744a5a74d01b268b2",
+        "Description": "RestApi deployment id: 85ae497f4c051c484311099f96599995f856b22f",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
@@ -195,7 +195,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -241,9 +241,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment673da6c5e9": {
+    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment9e2d1735be": {
       "Properties": {
-        "Description": "RestApi deployment id: 673da6c5e9481163e7b1cbf6d5604eb84cf64fd0",
+        "Description": "RestApi deployment id: 9e2d1735be958ebf91b1983bd9de7fc7a19bffc6",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
         },
@@ -254,7 +254,7 @@
     "MyApiWithAwsIamAuthNoCallerCredentialsProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment673da6c5e9"
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment9e2d1735be"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
@@ -266,7 +266,7 @@
     "MyApiWithAwsIamAuthProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentc7d4214444"
+          "Ref": "MyApiWithAwsIamAuthDeployment85ae497f4c"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"

--- a/tests/translator/output/aws-us-gov/api_with_default_aws_iam_auth.json
+++ b/tests/translator/output/aws-us-gov/api_with_default_aws_iam_auth.json
@@ -19,7 +19,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -141,7 +141,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -172,9 +172,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentce2dead7de": {
+    "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeployment0db5d3724d": {
       "Properties": {
-        "Description": "RestApi deployment id: ce2dead7ded0bb502db5bd0c105948c27bc96729",
+        "Description": "RestApi deployment id: 0db5d3724d1d43ad53aabfbc5feb5203d9250e1e",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
         },
@@ -185,7 +185,7 @@
     "MyApiWithAwsIamAuthAndDefaultInvokeRoleProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeploymentce2dead7de"
+          "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRoleDeployment0db5d3724d"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuthAndDefaultInvokeRole"
@@ -194,9 +194,9 @@
       },
       "Type": "AWS::ApiGateway::Stage"
     },
-    "MyApiWithAwsIamAuthDeploymentf9a4964a7d": {
+    "MyApiWithAwsIamAuthDeploymentff4d7da889": {
       "Properties": {
-        "Description": "RestApi deployment id: f9a4964a7df5021874e5a094662f1a2443982e0a",
+        "Description": "RestApi deployment id: ff4d7da889cc91390c6618d14459f4ea400e1197",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
@@ -207,7 +207,7 @@
     "MyApiWithAwsIamAuthProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentf9a4964a7d"
+          "Ref": "MyApiWithAwsIamAuthDeploymentff4d7da889"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"

--- a/tests/translator/output/aws-us-gov/api_with_default_aws_iam_auth_and_no_auth_route.json
+++ b/tests/translator/output/aws-us-gov/api_with_default_aws_iam_auth_and_no_auth_route.json
@@ -34,7 +34,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -52,7 +52,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -100,9 +100,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithAwsIamAuthDeploymentf50d541bef": {
+    "MyApiWithAwsIamAuthDeploymentdfc1685ec6": {
       "Properties": {
-        "Description": "RestApi deployment id: f50d541bef5f3b607af4650464da9c65103e8dc3",
+        "Description": "RestApi deployment id: dfc1685ec60c93f4367c419d58c209a36de689ad",
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
         },
@@ -113,7 +113,7 @@
     "MyApiWithAwsIamAuthProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentf50d541bef"
+          "Ref": "MyApiWithAwsIamAuthDeploymentdfc1685ec6"
         },
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"

--- a/tests/translator/output/aws-us-gov/api_with_method_aws_iam_auth.json
+++ b/tests/translator/output/aws-us-gov/api_with_method_aws_iam_auth.json
@@ -19,7 +19,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -53,7 +53,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -71,7 +71,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -89,7 +89,7 @@
                   }
                 ],
                 "x-amazon-apigateway-integration": {
-                  "credentials": "arn:aws:iam::*:user/*",
+                  "credentials": "arn:aws-us-gov:iam::*:user/*",
                   "httpMethod": "POST",
                   "type": "aws_proxy",
                   "uri": {
@@ -140,9 +140,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiWithoutAuthDeployment54f5d55d46": {
+    "MyApiWithoutAuthDeployment6f92b4154d": {
       "Properties": {
-        "Description": "RestApi deployment id: 54f5d55d468ea3230714ba75e1dbe2dda41795f3",
+        "Description": "RestApi deployment id: 6f92b4154dc9069ca251091e47fa6bce142d75be",
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
         },
@@ -153,7 +153,7 @@
     "MyApiWithoutAuthProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment54f5d55d46"
+          "Ref": "MyApiWithoutAuthDeployment6f92b4154d"
         },
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"


### PR DESCRIPTION
### Issue #, if available
https://github.com/aws/serverless-application-model/issues/1667

### Description of changes
Caller credentials defaults to use hardcoded partition. It doesn't work in US Gov or CN regions.

### Description of how you validated changes
All unit tests file updated and ran successfully.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
