### PR TITLE
fix: Raise correct exception when Fn::If value is not a list

### DIFF
--- a/samtranslator/open_api/base_editor.py
+++ b/samtranslator/open_api/base_editor.py
@@ -36,7 +36,12 @@ class BaseEditor(object):
         """
         contents = [item]
         if isinstance(item, dict) and BaseEditor._CONDITIONAL_IF in item:
-            contents = item[BaseEditor._CONDITIONAL_IF][1:]
+            if_parameters = item[BaseEditor._CONDITIONAL_IF]
+            if not isinstance(if_parameters, list):
+                raise InvalidDocumentException(
+                    [InvalidTemplateException(f"Value of {BaseEditor._CONDITIONAL_IF} must be a list.")]
+                )
+            contents = if_parameters[1:]
             contents = [content for content in contents if not is_intrinsic_no_value(content)]
         return contents
 

--- a/tests/translator/input/error_api_with_invalid_if_condition_swagger.yaml
+++ b/tests/translator/input/error_api_with_invalid_if_condition_swagger.yaml
@@ -1,0 +1,22 @@
+Resources:
+  MyAuthFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: index.handler
+      Runtime: nodejs12.x
+
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: dev
+      Auth:
+        ApiKeyRequired: true
+      DefinitionBody:
+        swagger: '2.0'
+        info:
+          title: !Sub ${AWS::StackName}-Api
+        paths:
+          /post:
+            Fn::If:
+              This: should not be a dict

--- a/tests/translator/output/error_api_with_invalid_if_condition_swagger.json
+++ b/tests/translator/output/error_api_with_invalid_if_condition_swagger.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Value of Fn::If must be a list."
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
