### PR TITLE
fix: Raise correct exception FindInMap used on parameters not a 2-level-map

### DIFF
--- a/tests/intrinsics/test_actions.py
+++ b/tests/intrinsics/test_actions.py
@@ -15,19 +15,6 @@ class TestAction(TestCase):
         with self.assertRaises(TypeError):
             MyAction()
 
-    def test_subclass_must_implement_resolve_method(self):
-        class MyAction(Action):
-            intrinsic_name = "foo"
-
-        with self.assertRaises(NotImplementedError):
-            MyAction().resolve_parameter_refs({}, {})
-
-        with self.assertRaises(NotImplementedError):
-            MyAction().resolve_resource_refs({}, {})
-
-        with self.assertRaises(NotImplementedError):
-            MyAction().resolve_resource_id_refs({}, {})
-
     def test_can_handle_input(self):
         class MyAction(Action):
             intrinsic_name = "foo"

--- a/tests/translator/input/error_invalid_mapping_by_findinmap.yaml
+++ b/tests/translator/input/error_invalid_mapping_by_findinmap.yaml
@@ -1,0 +1,31 @@
+Parameters:
+  ApplicationIdParam:
+    Type: String
+    Default: arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world
+  VersionParam:
+    Type: String
+    Default: 1.0.0
+
+Mappings:
+  InvaliMapping:
+    ap-southeast-1:
+    - Version: this should not be a list
+    cn-north-1:
+    - Version: this should not be a list
+    us-gov-west-1:
+    - Version: this should not be a list
+
+Resources:
+
+  ApplicationFindInInvalidMap:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: !FindInMap
+        - InvaliMapping
+        - !Ref 'AWS::Region'
+        - Version
+        SemanticVersion: !FindInMap
+        - InvaliMapping
+        - !Ref 'AWS::Region'
+        - Version

--- a/tests/translator/output/error_invalid_mapping_by_findinmap.json
+++ b/tests/translator/output/error_invalid_mapping_by_findinmap.json
@@ -1,0 +1,3 @@
+{
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Structure of the SAM template is invalid. Cannot use Fn::FindInMap on Mapping 'InvaliMapping' which is not a a two-level map."
+}


### PR DESCRIPTION
**I want to use `dict_deep_get()` but it doesn't have the same behavior here.**

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
