### PR TITLE
fix: Raise correct exception when bucket tags are not list

### DIFF
--- a/tests/translator/input/error_s3_bucket_invalid_properties.yaml
+++ b/tests/translator/input/error_s3_bucket_invalid_properties.yaml
@@ -1,3 +1,10 @@
+Conditions:
+  Condition:
+    Fn::Equals:
+    - 1
+    - 1
+
+
 Resources:
   Function:
     Type: AWS::Serverless::Function
@@ -15,3 +22,28 @@ Resources:
   Bucket:
     Type: AWS::S3::Bucket
     Properties: This should be a dict
+
+
+  Function2:
+    Condition: Condition
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/thumbnails.zip
+      Handler: index.generate_thumbails
+      Runtime: nodejs12.x
+      Events:
+        ImageBucket:
+          Type: S3
+          Properties:
+            Bucket: !Ref Bucket2
+            Events: s3:ObjectCreated:*
+      Tags:
+        Key: Value
+
+  Bucket2:
+    Condition: Condition
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        # This validation is triggered when the function has tags and condition
+        This: should be a list

--- a/tests/translator/output/error_s3_bucket_invalid_properties.json
+++ b/tests/translator/output/error_s3_bucket_invalid_properties.json
@@ -1,3 +1,3 @@
 {
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Bucket] is invalid. Properties should be a map."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [Bucket] is invalid. Properties should be a map. Resource with id [Bucket2] is invalid. Property 'Tags' should be a list."
 }


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
