### PR TITLE
Add support for AT_TIMESTAMP and StartingPositionTimestamp

### DIFF
--- a/integration/combination/test_function_with_kinesis.py
+++ b/integration/combination/test_function_with_kinesis.py
@@ -1,5 +1,5 @@
 from unittest.case import skipIf
-
+from parameterized import parameterized
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
 from integration.config.service_names import KINESIS
@@ -15,18 +15,26 @@ class TestFunctionWithKinesis(BaseTest):
         kinesis_stream = kinesis_client.describe_stream(StreamName=kinesis_id)["StreamDescription"]
 
         lambda_client = self.client_provider.lambda_client
-        function_name = self.get_physical_id_by_type("AWS::Lambda::Function")
-        lambda_function_arn = lambda_client.get_function_configuration(FunctionName=function_name)["FunctionArn"]
+        for function_name, event_source_mapping_arn in [
+            (
+                self.get_physical_id_by_logical_id("MyLambdaFunction"),
+                self.get_physical_id_by_logical_id("MyLambdaFunctionKinesisStream"),
+            ),
+            (
+                self.get_physical_id_by_logical_id("MyLambdaFunction2"),
+                self.get_physical_id_by_logical_id("MyLambdaFunction2KinesisStream"),
+            ),
+        ]:
+            lambda_function_arn = lambda_client.get_function_configuration(FunctionName=function_name)["FunctionArn"]
 
-        event_source_mapping_arn = self.get_physical_id_by_type("AWS::Lambda::EventSourceMapping")
-        event_source_mapping_result = lambda_client.get_event_source_mapping(UUID=event_source_mapping_arn)
-        event_source_mapping_batch_size = event_source_mapping_result["BatchSize"]
-        event_source_mapping_function_arn = event_source_mapping_result["FunctionArn"]
-        event_source_mapping_kinesis_stream_arn = event_source_mapping_result["EventSourceArn"]
+            event_source_mapping_result = lambda_client.get_event_source_mapping(UUID=event_source_mapping_arn)
+            event_source_mapping_batch_size = event_source_mapping_result["BatchSize"]
+            event_source_mapping_function_arn = event_source_mapping_result["FunctionArn"]
+            event_source_mapping_kinesis_stream_arn = event_source_mapping_result["EventSourceArn"]
 
-        self.assertEqual(event_source_mapping_batch_size, 100)
-        self.assertEqual(event_source_mapping_function_arn, lambda_function_arn)
-        self.assertEqual(event_source_mapping_kinesis_stream_arn, kinesis_stream["StreamARN"])
+            self.assertEqual(event_source_mapping_batch_size, 100)
+            self.assertEqual(event_source_mapping_function_arn, lambda_function_arn)
+            self.assertEqual(event_source_mapping_kinesis_stream_arn, kinesis_stream["StreamARN"])
 
 
 @skipIf(current_region_does_not_support([KINESIS]), "Kinesis is not supported in this testing region")

--- a/integration/resources/expected/combination/function_with_kinesis.json
+++ b/integration/resources/expected/combination/function_with_kinesis.json
@@ -8,8 +8,20 @@
     "ResourceType": "AWS::IAM::Role"
   },
   {
+    "LogicalResourceId": "MyLambdaFunction2",
+    "ResourceType": "AWS::Lambda::Function"
+  },
+  {
+    "LogicalResourceId": "MyLambdaFunction2Role",
+    "ResourceType": "AWS::IAM::Role"
+  },
+  {
     "LogicalResourceId": "MyStream",
     "ResourceType": "AWS::Kinesis::Stream"
+  },
+  {
+    "LogicalResourceId": "MyLambdaFunction2KinesisStream",
+    "ResourceType": "AWS::Lambda::EventSourceMapping"
   },
   {
     "LogicalResourceId": "MyLambdaFunctionKinesisStream",

--- a/integration/resources/templates/combination/function_with_kinesis.yaml
+++ b/integration/resources/templates/combination/function_with_kinesis.yaml
@@ -21,6 +21,29 @@ Resources:
             FunctionResponseTypes:
             - ReportBatchItemFailures
 
+  MyLambdaFunction2:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs14.x
+      CodeUri: ${codeuri}
+      MemorySize: 128
+
+      Events:
+        KinesisStream:
+          Type: Kinesis
+          Properties:
+            Stream:
+              # Connect with the stream we have created in this template
+              Fn::GetAtt: [MyStream, Arn]
+
+            BatchSize: 100
+            StartingPosition: AT_TIMESTAMP
+            StartingPositionTimestamp: 1671489395
+            TumblingWindowInSeconds: 120
+            FunctionResponseTypes:
+            - ReportBatchItemFailures
+
   MyStream:
     Type: AWS::Kinesis::Stream
     Properties:

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -124,9 +124,6 @@ class PullEventSource(ResourceMacro):
         if self.Stream and not self.StartingPosition:
             raise InvalidEventException(self.relative_id, "StartingPosition is required for Kinesis, DynamoDB and MSK.")
 
-        if self.StartingPositionTimestamp:
-            self.StartingPositionTimestamp = float(self.StartingPositionTimestamp)
-
         lambda_eventsourcemapping.FunctionName = function_name_or_arn
         lambda_eventsourcemapping.EventSourceArn = self.Stream or self.Queue or self.Broker
         lambda_eventsourcemapping.StartingPosition = self.StartingPosition

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict, List, Optional
 
 from samtranslator.metrics.method_decorator import cw_timer
-from samtranslator.model import ResourceMacro, PropertyType
+from samtranslator.model import ResourceMacro, PropertyType, PassThroughProperty
 from samtranslator.model.eventsources import FUNCTION_EVETSOURCE_METRIC_PREFIX
 from samtranslator.model.types import IS_DICT, is_type, IS_STR
+from samtranslator.schema.common import PassThrough
 from samtranslator.model.intrinsics import is_intrinsic
 
 from samtranslator.model.lambda_ import LambdaEventSourceMapping
@@ -37,7 +38,8 @@ class PullEventSource(ResourceMacro):
         "Stream": PropertyType(False, IS_STR),
         "Queue": PropertyType(False, IS_STR),
         "BatchSize": PropertyType(False, is_type(int)),
-        "StartingPosition": PropertyType(False, IS_STR),
+        "StartingPosition": PassThroughProperty(False),
+        "StartingPositionTimestamp": PassThroughProperty(False),
         "Enabled": PropertyType(False, is_type(bool)),
         "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),
         "MaximumRetryAttempts": PropertyType(False, is_type(int)),
@@ -60,7 +62,8 @@ class PullEventSource(ResourceMacro):
     Stream: Optional[Intrinsicable[str]]
     Queue: Optional[Intrinsicable[str]]
     BatchSize: Optional[Intrinsicable[int]]
-    StartingPosition: Optional[Intrinsicable[str]]
+    StartingPosition: Optional[PassThrough]
+    StartingPositionTimestamp: Optional[PassThrough]
     Enabled: Optional[bool]
     MaximumBatchingWindowInSeconds: Optional[Intrinsicable[int]]
     MaximumRetryAttempts: Optional[Intrinsicable[int]]
@@ -121,9 +124,13 @@ class PullEventSource(ResourceMacro):
         if self.Stream and not self.StartingPosition:
             raise InvalidEventException(self.relative_id, "StartingPosition is required for Kinesis, DynamoDB and MSK.")
 
+        if self.StartingPositionTimestamp:
+            self.StartingPositionTimestamp = float(self.StartingPositionTimestamp)
+
         lambda_eventsourcemapping.FunctionName = function_name_or_arn
         lambda_eventsourcemapping.EventSourceArn = self.Stream or self.Queue or self.Broker
         lambda_eventsourcemapping.StartingPosition = self.StartingPosition
+        lambda_eventsourcemapping.StartingPositionTimestamp = self.StartingPositionTimestamp
         lambda_eventsourcemapping.BatchSize = self.BatchSize
         lambda_eventsourcemapping.Enabled = self.Enabled
         lambda_eventsourcemapping.MaximumBatchingWindowInSeconds = self.MaximumBatchingWindowInSeconds

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -101,6 +101,7 @@ class LambdaEventSourceMapping(Resource):
         "DestinationConfig": PropertyType(False, IS_DICT),
         "ParallelizationFactor": PropertyType(False, is_type(int)),
         "StartingPosition": PropertyType(False, IS_STR),
+        "StartingPositionTimestamp": PropertyType(False, is_type(float)),
         "Topics": PropertyType(False, is_type(list)),
         "Queues": PropertyType(False, is_type(list)),
         "SourceAccessConfigurations": PropertyType(False, is_type(list)),

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -1,5 +1,5 @@
 from typing import Optional, Dict, Any, List, Union
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import PropertyType, Resource, PassThroughProperty
 from samtranslator.model.types import IS_DICT, is_type, one_of, IS_STR, list_of, any_type
 from samtranslator.model.intrinsics import fnGetAtt, ref
 from samtranslator.utils.types import Intrinsicable
@@ -101,7 +101,7 @@ class LambdaEventSourceMapping(Resource):
         "DestinationConfig": PropertyType(False, IS_DICT),
         "ParallelizationFactor": PropertyType(False, is_type(int)),
         "StartingPosition": PropertyType(False, IS_STR),
-        "StartingPositionTimestamp": PropertyType(False, is_type(float)),
+        "StartingPositionTimestamp": PassThroughProperty(False),
         "Topics": PropertyType(False, is_type(list)),
         "Queues": PropertyType(False, is_type(list)),
         "SourceAccessConfigurations": PropertyType(False, is_type(list)),

--- a/samtranslator/schema/aws_serverless_function.py
+++ b/samtranslator/schema/aws_serverless_function.py
@@ -157,6 +157,7 @@ class KinesisEventProperties(BaseModel):
     MaximumRetryAttempts: Optional[PassThrough] = kinesiseventproperties("MaximumRetryAttempts")
     ParallelizationFactor: Optional[PassThrough] = kinesiseventproperties("ParallelizationFactor")
     StartingPosition: PassThrough = kinesiseventproperties("StartingPosition")
+    StartingPositionTimestamp: PassThrough  # TODO: add documentation
     Stream: PassThrough = kinesiseventproperties("Stream")
     TumblingWindowInSeconds: Optional[PassThrough] = kinesiseventproperties("TumblingWindowInSeconds")
 
@@ -178,6 +179,7 @@ class DynamoDBEventProperties(BaseModel):
     MaximumRetryAttempts: Optional[PassThrough] = dynamodbeventproperties("MaximumRetryAttempts")
     ParallelizationFactor: Optional[PassThrough] = dynamodbeventproperties("ParallelizationFactor")
     StartingPosition: PassThrough = dynamodbeventproperties("StartingPosition")
+    StartingPositionTimestamp: PassThrough  # TODO: add documentation
     Stream: PassThrough = dynamodbeventproperties("Stream")
     TumblingWindowInSeconds: Optional[PassThrough] = dynamodbeventproperties("TumblingWindowInSeconds")
 
@@ -353,6 +355,7 @@ class MSKEventProperties(BaseModel):
     FilterCriteria: Optional[PassThrough] = mskeventproperties("FilterCriteria")
     MaximumBatchingWindowInSeconds: Optional[PassThrough] = mskeventproperties("MaximumBatchingWindowInSeconds")
     StartingPosition: PassThrough = mskeventproperties("StartingPosition")
+    StartingPositionTimestamp: PassThrough  # TODO: add documentation
     Stream: PassThrough = mskeventproperties("Stream")
     Topics: PassThrough = mskeventproperties("Topics")
 

--- a/samtranslator/schema/schema.json
+++ b/samtranslator/schema/schema.json
@@ -2118,6 +2118,9 @@
           "description": "The position in a stream from which to start reading\\.  \n*Valid values*: `TRIM_HORIZON` or `LATEST`  \n*Type*: String  \n*Required*: Yes  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`StartingPosition`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingposition) property of an `AWS::Lambda::EventSourceMapping` resource\\.",
           "markdownDescription": "The position in a stream from which to start reading\\.  \n*Valid values*: `TRIM_HORIZON` or `LATEST`  \n*Type*: String  \n*Required*: Yes  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`StartingPosition`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingposition) property of an `AWS::Lambda::EventSourceMapping` resource\\."
         },
+        "StartingPositionTimestamp": {
+          "title": "Startingpositiontimestamp"
+        },
         "Stream": {
           "title": "Stream",
           "description": "The Amazon Resource Name \\(ARN\\) of the data stream or a stream consumer\\.  \n*Type*: String  \n*Required*: Yes  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EventSourceArn`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-eventsourcearn) property of an `AWS::Lambda::EventSourceMapping` resource\\.",
@@ -2219,6 +2222,9 @@
           "title": "StartingPosition",
           "description": "The position in a stream from which to start reading\\.  \n*Valid values*: `TRIM_HORIZON` or `LATEST`  \n*Type*: String  \n*Required*: Yes  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`StartingPosition`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingposition) property of an `AWS::Lambda::EventSourceMapping` resource\\.",
           "markdownDescription": "The position in a stream from which to start reading\\.  \n*Valid values*: `TRIM_HORIZON` or `LATEST`  \n*Type*: String  \n*Required*: Yes  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`StartingPosition`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingposition) property of an `AWS::Lambda::EventSourceMapping` resource\\."
+        },
+        "StartingPositionTimestamp": {
+          "title": "Startingpositiontimestamp"
         },
         "Stream": {
           "title": "Stream",
@@ -3453,6 +3459,9 @@
           "title": "StartingPosition",
           "description": "The position in a stream from which to start reading\\.  \n*Valid values*: `TRIM_HORIZON` or `LATEST`  \n*Type*: String  \n*Required*: Yes  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`StartingPosition`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingposition) property of an `AWS::Lambda::EventSourceMapping` resource\\.",
           "markdownDescription": "The position in a stream from which to start reading\\.  \n*Valid values*: `TRIM_HORIZON` or `LATEST`  \n*Type*: String  \n*Required*: Yes  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`StartingPosition`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingposition) property of an `AWS::Lambda::EventSourceMapping` resource\\."
+        },
+        "StartingPositionTimestamp": {
+          "title": "Startingpositiontimestamp"
         },
         "Stream": {
           "title": "Stream",

--- a/tests/translator/input/function_with_kinesis_with_start_time_timestamp.yaml
+++ b/tests/translator/input/function_with_kinesis_with_start_time_timestamp.yaml
@@ -1,0 +1,43 @@
+Resources:
+  KinesisTriggerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Timeout: 5
+      Runtime: nodejs12.x
+      MemorySize: 128
+      Tracing: Active
+      AutoPublishAlias: live
+      InlineCode: |
+        exports.handler = async (event, context, callback) => {
+          return {
+            statusCode: 200,
+            body: 'Success'
+          }
+        }
+      Handler: trigger.handler
+      Description: >
+        This function triggered when a file is uploaded in a stream (Kinesis)
+      Events:
+        Stream:
+          Type: Kinesis
+          Properties:
+            Stream: !GetAtt KinesisStream.Arn
+            BatchSize: 500
+            StartingPosition: AT_TIMESTAMP
+            StartingPositionTimestamp: 1671489395
+            ParallelizationFactor: 1
+            MaximumRetryAttempts: 1000
+            BisectBatchOnFunctionError: true
+      Policies:
+      - KinesisStreamReadPolicy:
+          StreamName: !Ref KinesisStream
+
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: KinesisStream
+      RetentionPeriodHours: 24
+      ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: alias/aws/kinesis

--- a/tests/translator/output/aws-cn/function_with_kinesis_with_start_time_timestamp.json
+++ b/tests/translator/output/aws-cn/function_with_kinesis_with_start_time_timestamp.json
@@ -1,0 +1,158 @@
+{
+  "Resources": {
+    "KinesisStream": {
+      "Properties": {
+        "Name": "KinesisStream",
+        "RetentionPeriodHours": 24,
+        "ShardCount": 1,
+        "StreamEncryption": {
+          "EncryptionType": "KMS",
+          "KeyId": "alias/aws/kinesis"
+        }
+      },
+      "Type": "AWS::Kinesis::Stream"
+    },
+    "KinesisTriggerFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Description": "This function triggered when a file is uploaded in a stream (Kinesis)\n",
+        "Handler": "trigger.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "KinesisTriggerFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "Active"
+        }
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "KinesisTriggerFunctionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunction"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "KinesisTriggerFunctionVersion36dc1e06a1",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "KinesisTriggerFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess",
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "kinesis:ListStreams",
+                    "kinesis:DescribeLimits"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/*"
+                  }
+                },
+                {
+                  "Action": [
+                    "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
+                    "kinesis:GetRecords",
+                    "kinesis:GetShardIterator"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
+                      {
+                        "streamName": {
+                          "Ref": "KinesisStream"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "KinesisTriggerFunctionRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "KinesisTriggerFunctionStream": {
+      "Properties": {
+        "BatchSize": 500,
+        "BisectBatchOnFunctionError": true,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunctionAliaslive"
+        },
+        "MaximumRetryAttempts": 1000,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "AT_TIMESTAMP",
+        "StartingPositionTimestamp": 1671489395.0
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "KinesisTriggerFunctionVersion36dc1e06a1": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunction"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/function_with_kinesis_with_start_time_timestamp.json
+++ b/tests/translator/output/aws-cn/function_with_kinesis_with_start_time_timestamp.json
@@ -141,7 +141,7 @@
         "MaximumRetryAttempts": 1000,
         "ParallelizationFactor": 1,
         "StartingPosition": "AT_TIMESTAMP",
-        "StartingPositionTimestamp": 1671489395.0
+        "StartingPositionTimestamp": 1671489395
       },
       "Type": "AWS::Lambda::EventSourceMapping"
     },

--- a/tests/translator/output/aws-us-gov/function_with_kinesis_with_start_time_timestamp.json
+++ b/tests/translator/output/aws-us-gov/function_with_kinesis_with_start_time_timestamp.json
@@ -1,0 +1,158 @@
+{
+  "Resources": {
+    "KinesisStream": {
+      "Properties": {
+        "Name": "KinesisStream",
+        "RetentionPeriodHours": 24,
+        "ShardCount": 1,
+        "StreamEncryption": {
+          "EncryptionType": "KMS",
+          "KeyId": "alias/aws/kinesis"
+        }
+      },
+      "Type": "AWS::Kinesis::Stream"
+    },
+    "KinesisTriggerFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Description": "This function triggered when a file is uploaded in a stream (Kinesis)\n",
+        "Handler": "trigger.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "KinesisTriggerFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "Active"
+        }
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "KinesisTriggerFunctionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunction"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "KinesisTriggerFunctionVersion36dc1e06a1",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "KinesisTriggerFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "kinesis:ListStreams",
+                    "kinesis:DescribeLimits"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/*"
+                  }
+                },
+                {
+                  "Action": [
+                    "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
+                    "kinesis:GetRecords",
+                    "kinesis:GetShardIterator"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
+                      {
+                        "streamName": {
+                          "Ref": "KinesisStream"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "KinesisTriggerFunctionRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "KinesisTriggerFunctionStream": {
+      "Properties": {
+        "BatchSize": 500,
+        "BisectBatchOnFunctionError": true,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunctionAliaslive"
+        },
+        "MaximumRetryAttempts": 1000,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "AT_TIMESTAMP",
+        "StartingPositionTimestamp": 1671489395.0
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "KinesisTriggerFunctionVersion36dc1e06a1": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunction"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/function_with_kinesis_with_start_time_timestamp.json
+++ b/tests/translator/output/aws-us-gov/function_with_kinesis_with_start_time_timestamp.json
@@ -141,7 +141,7 @@
         "MaximumRetryAttempts": 1000,
         "ParallelizationFactor": 1,
         "StartingPosition": "AT_TIMESTAMP",
-        "StartingPositionTimestamp": 1671489395.0
+        "StartingPositionTimestamp": 1671489395
       },
       "Type": "AWS::Lambda::EventSourceMapping"
     },

--- a/tests/translator/output/function_with_kinesis_with_start_time_timestamp.json
+++ b/tests/translator/output/function_with_kinesis_with_start_time_timestamp.json
@@ -1,0 +1,158 @@
+{
+  "Resources": {
+    "KinesisStream": {
+      "Properties": {
+        "Name": "KinesisStream",
+        "RetentionPeriodHours": 24,
+        "ShardCount": 1,
+        "StreamEncryption": {
+          "EncryptionType": "KMS",
+          "KeyId": "alias/aws/kinesis"
+        }
+      },
+      "Type": "AWS::Kinesis::Stream"
+    },
+    "KinesisTriggerFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Description": "This function triggered when a file is uploaded in a stream (Kinesis)\n",
+        "Handler": "trigger.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "KinesisTriggerFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "Timeout": 5,
+        "TracingConfig": {
+          "Mode": "Active"
+        }
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "KinesisTriggerFunctionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunction"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "KinesisTriggerFunctionVersion36dc1e06a1",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "KinesisTriggerFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "kinesis:ListStreams",
+                    "kinesis:DescribeLimits"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/*"
+                  }
+                },
+                {
+                  "Action": [
+                    "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
+                    "kinesis:GetRecords",
+                    "kinesis:GetShardIterator"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
+                      {
+                        "streamName": {
+                          "Ref": "KinesisStream"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "KinesisTriggerFunctionRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "KinesisTriggerFunctionStream": {
+      "Properties": {
+        "BatchSize": 500,
+        "BisectBatchOnFunctionError": true,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "KinesisStream",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunctionAliaslive"
+        },
+        "MaximumRetryAttempts": 1000,
+        "ParallelizationFactor": 1,
+        "StartingPosition": "AT_TIMESTAMP",
+        "StartingPositionTimestamp": 1671489395.0
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "KinesisTriggerFunctionVersion36dc1e06a1": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "KinesisTriggerFunction"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    }
+  }
+}

--- a/tests/translator/output/function_with_kinesis_with_start_time_timestamp.json
+++ b/tests/translator/output/function_with_kinesis_with_start_time_timestamp.json
@@ -141,7 +141,7 @@
         "MaximumRetryAttempts": 1000,
         "ParallelizationFactor": 1,
         "StartingPosition": "AT_TIMESTAMP",
-        "StartingPositionTimestamp": 1671489395.0
+        "StartingPositionTimestamp": 1671489395
       },
       "Type": "AWS::Lambda::EventSourceMapping"
     },


### PR DESCRIPTION
### Issue #, if available
https://github.com/aws/serverless-application-model/issues/2754

### Description of changes
Verified that CFN now supports `AT_TIMESTAMP` as one of the possible value for [StartingPosition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingposition)
If we support `AT_TIMESTAMP`, we also need to support [StartingPositionTimestamp](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-startingpositiontimestamp)

### Description of how you validated changes
Added transform and integration tests

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
