### PR TITLE
S3ObjectTagging: allow Object Tagging actions in policy template for S3 Read/Write/Crud

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -348,7 +348,8 @@
               "s3:ListBucket",
               "s3:GetBucketLocation",
               "s3:GetObjectVersion",
-              "s3:GetLifecycleConfiguration"
+              "s3:GetLifecycleConfiguration",
+              "s3:GetObjectTagging"
             ],
             "Resource": [
               {
@@ -390,7 +391,8 @@
             "Action": [
               "s3:PutObject",
               "s3:PutObjectAcl",
-              "s3:PutLifecycleConfiguration"
+              "s3:PutLifecycleConfiguration",
+              "s3:PutObjectTagging"
             ],
             "Resource": [
               {

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -440,7 +440,10 @@
               "s3:PutObjectAcl",
               "s3:GetLifecycleConfiguration",
               "s3:PutLifecycleConfiguration",
-              "s3:DeleteObject"
+              "s3:DeleteObject",
+              "s3:PutObjectTagging",
+              "s3:GetObjectTagging",
+              "s3:DeleteObjectTagging"
             ],
             "Resource": [
               {


### PR DESCRIPTION
### Issue #, if available

None I can find

### Description of changes

Using boto3 to write S3 Object Tags using the put_object(Tagging='string') is not currently supported with the S3WritePolicy which does not allow the S3 Object Tagging actions. Users currently will have to write a managed policy to be able to use the S3 Object Tagging API.

I have added the three actions Put/Get/Delete to the respective policies:

S3CrudPolicy: PutObjectTagging, GetObjectTagging and DeleteObjectTagging
S3WritePolicy: PutObjectTagging
S3ReadPolicy: GetObjectTagging

The S3FullAccessPolicy already has all these actions allowed. 


### Description of how you validated changes

policy_templates.json is still valid JSON `cat samtranslator/policy_templates_data/policy_templates.json | jq .`
verified S3 Object Tagging actions from 
https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html
https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html
https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html


### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
