### PR TITLE
chore: Optimize the use of deepcopy in Translator._get_function_names()

### DIFF
--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -74,15 +74,16 @@ class Translator:
                 if item.get("Type") == "Api" and item_properties.get("RestApiId"):
                     rest_api = item_properties.get("RestApiId")
                     api_name = Api.get_rest_api_id_string(rest_api)
-                    if isinstance(api_name, str):
-                        resource_dict_copy = copy.deepcopy(resource_dict)
-                        function_name = intrinsics_resolver.resolve_parameter_refs(
-                            resource_dict_copy.get("Properties", {}).get("FunctionName")
-                        )
-                        if function_name:
-                            self.function_names[api_name] = str(self.function_names.get(api_name, "")) + str(
-                                function_name
-                            )
+                    if not isinstance(api_name, str):
+                        continue
+                    raw_function_name = resource_dict.get("Properties", {}).get("FunctionName")
+                    resolved_function_name = intrinsics_resolver.resolve_parameter_refs(
+                        copy.deepcopy(raw_function_name)
+                    )
+                    if not resolved_function_name:
+                        continue
+                    self.function_names.setdefault(api_name, "")
+                    self.function_names[api_name] += str(resolved_function_name)
         return self.function_names
 
     def translate(


### PR DESCRIPTION
### Issue #, if available

Spot an unecessary deepcopy on the entire SAM Function resource dict despite only the property "FunctionName" can be potentially mutated by `resolve_parameter_refs`.

### Description of changes

Only to deepcopy the part we don't want to mutate.

### Description of how you validated changes

Tested on a template with a single function with 411 `Api` event sources. Transform time is reduced from 45s to 36s (**20.7%** improvement)
```
before: 39.48s user 0.49s system 87% cpu 45.437 total
after: 30.83s user 0.53s system 86% cpu 36.140 total
```

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
