### PR TITLE
chore: Cache get_partition_name to reduce transform latency

### DIFF
--- a/samtranslator/translator/arn_generator.py
+++ b/samtranslator/translator/arn_generator.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import boto3
 
 from typing import Optional
@@ -36,6 +38,10 @@ class ArnGenerator(object):
         return "arn:{}:iam::aws:policy/{}".format(ArnGenerator.get_partition_name(), policy_name)
 
     @classmethod
+    # Once the translator is initialized, the region doesn't change.
+    # After examining all the usage of get_partition_name(), the input region is either None or the current region.
+    # TODO: Make this function run during initialization.
+    @lru_cache(maxsize=2)
     def get_partition_name(cls, region: Optional[str] = None) -> str:
         """
         Gets the name of the partition given the region name. If region name is not provided, this method will

--- a/tests/translator/test_arn_generator.py
+++ b/tests/translator/test_arn_generator.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from parameterized import parameterized
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from samtranslator.translator.arn_generator import ArnGenerator, NoRegionFound
 
@@ -17,7 +17,7 @@ class TestArnGenerator(TestCase):
 
         self.assertEqual(actual, expected)
 
-    @patch("boto3.session.Session.region_name", None)
+    @patch("samtranslator.translator.arn_generator._get_region_from_session", Mock(return_value=None))
     def test_get_partition_name_raise_NoRegionFound(self):
         with self.assertRaises(NoRegionFound):
             ArnGenerator.get_partition_name(None)

--- a/tests/translator/test_resource_level_attributes.py
+++ b/tests/translator/test_resource_level_attributes.py
@@ -64,10 +64,13 @@ class TestResourceLevelAttributes(AbstractTestTranslator):
         "samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call",
         mock_sar_service_call,
     )
-    @patch("botocore.client.ClientEndpointBridge._check_default_region", mock_get_region)
-    def test_transform_with_additional_resource_level_attributes(self, testcase, partition_with_region):
+    @patch("samtranslator.translator.arn_generator._get_region_from_session")
+    def test_transform_with_additional_resource_level_attributes(
+        self, testcase, partition_with_region, mock_get_region_from_session
+    ):
         partition = partition_with_region[0]
         region = partition_with_region[1]
+        mock_get_region_from_session.return_value = region
 
         # add resource level attributes to input resources
         manifest = self._read_input(testcase)

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -268,10 +268,11 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
         "samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call",
         mock_sar_service_call,
     )
-    @patch("botocore.client.ClientEndpointBridge._check_default_region", mock_get_region)
-    def test_transform_success(self, testcase, partition_with_region):
+    @patch("samtranslator.translator.arn_generator._get_region_from_session")
+    def test_transform_success(self, testcase, partition_with_region, mock_get_region_from_session):
         partition = partition_with_region[0]
         region = partition_with_region[1]
+        mock_get_region_from_session.return_value = region
 
         manifest = self._read_input(testcase)
         expected = self._read_expected_output(testcase, partition)
@@ -338,10 +339,11 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
         "samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call",
         mock_sar_service_call,
     )
-    @patch("botocore.client.ClientEndpointBridge._check_default_region", mock_get_region)
-    def test_transform_success_openapi3(self, testcase, partition_with_region):
+    @patch("samtranslator.translator.arn_generator._get_region_from_session")
+    def test_transform_success_openapi3(self, testcase, partition_with_region, mock_get_region_from_session):
         partition = partition_with_region[0]
         region = partition_with_region[1]
+        mock_get_region_from_session.return_value = region
 
         manifest = yaml_parse(open(os.path.join(INPUT_FOLDER, testcase + ".yaml"), "r"))
         # To uncover unicode-related bugs, convert dict to JSON string and parse JSON back to dict
@@ -393,10 +395,11 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
         "samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call",
         mock_sar_service_call,
     )
-    @patch("botocore.client.ClientEndpointBridge._check_default_region", mock_get_region)
-    def test_transform_success_resource_policy(self, testcase, partition_with_region):
+    @patch("samtranslator.translator.arn_generator._get_region_from_session")
+    def test_transform_success_resource_policy(self, testcase, partition_with_region, mock_get_region_from_session):
         partition = partition_with_region[0]
         region = partition_with_region[1]
+        mock_get_region_from_session.return_value = region
 
         manifest = yaml_parse(open(os.path.join(INPUT_FOLDER, testcase + ".yaml"), "r"))
         # To uncover unicode-related bugs, convert dict to JSON string and parse JSON back to dict
@@ -441,8 +444,8 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
         "samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call",
         mock_sar_service_call,
     )
-    @patch("botocore.client.ClientEndpointBridge._check_default_region", mock_get_region)
-    def test_transform_success_no_side_effect(self, testcase, partition_with_region):
+    @patch("samtranslator.translator.arn_generator._get_region_from_session")
+    def test_transform_success_no_side_effect(self, testcase, partition_with_region, mock_get_region_from_session):
         """
         Tests that the transform does not leak/leave data in shared caches/lists between executions
         Performs the transform of the templates in a row without reinitialization
@@ -457,6 +460,7 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
         """
         partition = partition_with_region[0]
         region = partition_with_region[1]
+        mock_get_region_from_session.return_value = region
 
         for template in testcase[1]:
             print(template, partition, region)

--- a/tests/unit/translator/test_arn_generator.py
+++ b/tests/unit/translator/test_arn_generator.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from parameterized import parameterized
 
 from samtranslator.translator.arn_generator import ArnGenerator
@@ -31,5 +31,5 @@ class TestArnGenerator(TestCase):
         ]
     )
     def test_get_partition_name_when_region_not_provided(self, region, expected_partition):
-        with patch("boto3.session.Session.region_name", region):
+        with patch("samtranslator.translator.arn_generator._get_region_from_session", Mock(return_value=region)):
             self.assertEqual(expected_partition, ArnGenerator.get_partition_name())


### PR DESCRIPTION
### Issue #, if available

Tested on a template with 411 Api event sources. By looking at the profile result, `get_partition_name()` is called 824 times, making up 10.76s (out of 47s, ~23%).

```
824	0.004326	5.25e-06	10.76	0.01306	arn_generator.py:38(get_partition_name)
```

After this change, it only called **twice** and only took 0.01s.

```
2 | 1.1e-05 | 5.5e-06 | 0.01354 | 0.006768 | arn_generator.py:40(get_partition_name)
```

this brought down the time from 47s to 40s (the duration fluctuates so it doesn't have exact 10.76s difference).

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
