### PR TITLE
Replace Fn::GetAtt Key.APIKeyId with Ref: Key

### DIFF
--- a/integration/resources/templates/combination/api_with_authorizer_apikey.yaml
+++ b/integration/resources/templates/combination/api_with_authorizer_apikey.yaml
@@ -104,7 +104,7 @@ Outputs:
   ApiKeyId:
     Description: API Key ID
     Value:
-      Fn::GetAtt: MyFirstApiKey.APIKeyId
+      Ref: MyFirstApiKey
   ApiUrl:
     Description: API endpoint URL for Prod environment
     Value:


### PR DESCRIPTION
In some AWS regions, Fn::GetAtt Key.APIKeyId does not work, but Ref: Key also returns the API Key ID and seems to work even in these regions.

### Issue #, if available

### Description of changes

### Description of how you validated changes
Manually deployed minimally modified [test template](https://github.com/aws/serverless-application-model/blob/develop/integration/resources/templates/combination/api_with_authorizer_apikey.yaml) in ap-southeast-4 both with and without this change; with change the stack deploys successfully and without, we see:
```
Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Template error: resource MyFirstApiKey does not support attribute type APIKeyId in Fn::GetAtt
```

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
