### PR TITLE
chore: Rewrite the AppConfig part to make it efficient

### DIFF
--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -1,12 +1,17 @@
 import json
+import time
 from abc import ABC, abstractmethod
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, Type, cast
 
 import boto3
 import logging
 
+from botocore.client import BaseClient
 from botocore.config import Config
+from botocore.exceptions import ClientError
+
 from samtranslator.feature_toggle.dialup import (
+    BaseDialup,
     DisabledDialup,
     ToggleDialup,
     SimpleAccountPercentileDialup,
@@ -17,24 +22,33 @@ from samtranslator.utils.constants import BOTO3_CONNECT_TIMEOUT
 LOG = logging.getLogger(__name__)
 
 
+FIVE_MINS_IN_SECS = 300
+
+
 class FeatureToggle:
     """
     FeatureToggle is the class which will provide methods to query and decide if a feature is enabled based on where
     SAM is executing or not.
     """
 
-    DIALUP_RESOLVER = {
+    DIALUP_RESOLVER: Dict[str, Type[BaseDialup]] = {
         "toggle": ToggleDialup,
         "account-percentile": SimpleAccountPercentileDialup,
     }
 
-    def __init__(self, config_provider, stage, account_id, region):  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        config_provider: "FeatureToggleConfigProvider",
+        stage: Optional[str],
+        account_id: Optional[str],
+        region: Optional[str],
+    ) -> None:
         self.feature_config = config_provider.config
         self.stage = stage
         self.account_id = account_id
         self.region = region
 
-    def _get_dialup(self, region_config, feature_name):  # type: ignore[no-untyped-def]
+    def _get_dialup(self, region_config: Dict[str, Any], feature_name: str) -> BaseDialup:
         """
         get the right dialup instance
         if no dialup type is provided or the specified dialup is not supported,
@@ -82,7 +96,7 @@ class FeatureToggle:
         else:
             region_config = stage_config[region] if region in stage_config else stage_config.get("default", {})
 
-        dialup = self._get_dialup(region_config, feature_name=feature_name)  # type: ignore[no-untyped-call]
+        dialup = self._get_dialup(region_config, feature_name=feature_name)
         LOG.info("Using Dialip {}".format(dialup))
         is_enabled: bool = dialup.is_enabled()
 
@@ -130,34 +144,89 @@ class FeatureToggleLocalConfigProvider(FeatureToggleConfigProvider):
 class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
     """Feature toggle config provider which loads config from AppConfig."""
 
+    configuration_token: str
+    feature_toggle_config: Dict[str, Any]
+    next_poll_due_time: int
+
+    successfully_loaded: bool
+
     @cw_timer(prefix="External", name="AppConfig")  # type: ignore[misc]
-    def __init__(self, application_id, environment_id, configuration_profile_id, app_config_client=None):  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        application_id: str,
+        environment_id: str,
+        configuration_profile_id: str,
+        app_config_data_client: Optional[BaseClient] = None,
+        required_min_poll_interval_in_secs: int = FIVE_MINS_IN_SECS,
+    ) -> None:
         FeatureToggleConfigProvider.__init__(self)
         try:
             LOG.info("Loading feature toggle config from AppConfig...")
             # Lambda function has 120 seconds limit
             # (5 + 5) * 2, 20 seconds maximum timeout duration
-            # In case of high latency from AppConfig, we can always fall back to use an empty config and continue transform
+            # In case of high latency from AppConfig,
+            # we can always fall back to use an empty config and continue transform
             client_config = Config(
                 connect_timeout=BOTO3_CONNECT_TIMEOUT, read_timeout=5, retries={"total_max_attempts": 2}
             )
-            self.app_config_client = (
-                boto3.client("appconfig", config=client_config) if not app_config_client else app_config_client
+            self.feature_toggle_config = {}
+
+            self.application_id = application_id
+            self.environment_id = environment_id
+            self.configuration_profile_id = configuration_profile_id
+            self.required_min_poll_interval_in_secs = required_min_poll_interval_in_secs
+
+            self.app_config_data_client = (
+                boto3.client("appconfigdata", config=client_config)
+                if not app_config_data_client
+                else app_config_data_client
             )
-            response = self.app_config_client.get_configuration(
-                Application=application_id,
-                Environment=environment_id,
-                Configuration=configuration_profile_id,
-                ClientId="FeatureToggleAppConfigConfigProvider",
-            )
-            binary_config_string = response["Content"].read()
-            self.feature_toggle_config = cast(Dict[str, Any], json.loads(binary_config_string.decode("utf-8")))
-            LOG.info("Finished loading feature toggle config from AppConfig.")
+
+            self._reset_configuration_session()
+            self._refresh_configuration()
+            self.successfully_loaded = True
         except Exception as ex:
             LOG.error("Failed to load config from AppConfig: {}. Using empty config.".format(ex))
             # There is chance that AppConfig is not available in a particular region.
-            self.feature_toggle_config = {}
+            self.successfully_loaded = False
+
+    def _reset_configuration_session(self) -> None:
+        """
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/appconfigdata.html#AppConfigData.Client.start_configuration_session
+        """
+        response = self.app_config_data_client.start_configuration_session(
+            ApplicationIdentifier=self.application_id,
+            EnvironmentIdentifier=self.environment_id,
+            ConfigurationProfileIdentifier=self.configuration_profile_id,
+            # We don't change feature flags very often, default 60s is too frequent
+            RequiredMinimumPollIntervalInSeconds=self.required_min_poll_interval_in_secs,
+        )
+
+        self.configuration_token = cast(str, response["InitialConfigurationToken"])
+        self.next_poll_due_time = 0  # set to VERY past so it needs to poll immediately
+
+    def _refresh_configuration(self) -> None:
+        try:
+            response = self.app_config_data_client.get_latest_configuration(ConfigurationToken=self.configuration_token)
+        except ClientError:
+            LOG.exception("Fail to call get_latest_configuration, reset session and retry.")
+            self._reset_configuration_session()
+            response = self.app_config_data_client.get_latest_configuration(ConfigurationToken=self.configuration_token)
+
+        self.configuration_token = response["NextPollConfigurationToken"]
+        self.next_poll_due_time = cast(int, response["NextPollIntervalInSeconds"]) + int(time.time())
+        binary_config_string = response["Configuration"].read()
+        if not binary_config_string:
+            # This may be empty if the client already has the latest version of configuration.
+            LOG.info("The local feature toggle config is up-to-date.")
+            return
+
+        # We store feature toggles in the format of JSON:
+        self.feature_toggle_config = cast(Dict[str, Any], json.loads(binary_config_string.decode("utf-8")))
+        LOG.info("Finished loading feature toggle config from AppConfig.")
 
     @property
     def config(self) -> Dict[str, Any]:
+        if self.successfully_loaded and int(time.time()) >= self.next_poll_due_time:
+            self._refresh_configuration()
         return self.feature_toggle_config

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -111,7 +111,7 @@ class Translator:
         self.feature_toggle = (
             feature_toggle
             if feature_toggle
-            else FeatureToggle(FeatureToggleDefaultConfigProvider(), stage=None, account_id=None, region=None)  # type: ignore[no-untyped-call, no-untyped-call]
+            else FeatureToggle(FeatureToggleDefaultConfigProvider(), stage=None, account_id=None, region=None)
         )
         self.function_names: Dict[Any, Any] = {}
         self.redeploy_restapi_parameters = {}


### PR DESCRIPTION
### Issue #, if available

> This API action has been deprecated. Calls to receive configuration data should use the [StartConfigurationSession](https://docs.aws.amazon.com/appconfig/2019-10-09/APIReference/API_appconfigdata_StartConfigurationSession.html) and [GetLatestConfiguration](https://docs.aws.amazon.com/appconfig/2019-10-09/APIReference/API_appconfigdata_GetLatestConfiguration.html) APIs instead.
    GetConfiguration is a priced call. For more information, see [Pricing](https://aws.amazon.com/systems-manager/pricing/).
    AppConfig uses the value of the ClientConfigurationVersion parameter to identify the configuration version on your clients. If you don’t send ClientConfigurationVersion with each call to GetConfiguration , your clients receive the current configuration. You are charged each time your clients receive a configuration. **To avoid excess charges, we recommend you use the [StartConfigurationSession](https://docs.aws.amazon.com/appconfig/2019-10-09/APIReference/StartConfigurationSession.html) and [GetLatestConfiguration](https://docs.aws.amazon.com/appconfig/2019-10-09/APIReference/GetLatestConfiguration.html) APIs, which track the client configuration version on your behalf.** If you choose to continue using GetConfiguration , we recommend that you include the ClientConfigurationVersion value with every call to GetConfiguration . The value to use for ClientConfigurationVersion comes from the ConfigurationVersion attribute returned by GetConfiguration when there is new or updated data, and should be saved for subsequent calls to GetConfiguration .
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/appconfig.html#AppConfig.Client.get_configuration

### Description of changes

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
