### PR TITLE
chore: Add back argument "name" to BasePlugin for compatibility

### DIFF
--- a/samtranslator/plugins/__init__.py
+++ b/samtranslator/plugins/__init__.py
@@ -2,6 +2,7 @@ import logging
 from abc import ABC
 
 from enum import Enum
+from typing import Optional
 
 LOG = logging.getLogger(__name__)
 
@@ -21,13 +22,27 @@ class BasePlugin(ABC):
     Base class for a NoOp plugin that implements all available hooks
     """
 
+    _custom_name: Optional[str]
+
+    def __init__(self, name: Optional[str] = None) -> None:
+        """
+        Initialize the plugin with optional given name.
+
+        The optional name argument is for compatibility purpose.
+        In SAM-T codebase all plugins use the default name (class name).
+        :param name: Custom name of this plugin.
+        """
+        self._custom_name = name
+
     @classmethod
-    def _name(cls) -> str:
+    def _class_name(cls) -> str:
         return cls.__name__
 
     @property
     def name(self) -> str:
-        return self._name()
+        if self._custom_name:
+            return self._custom_name
+        return self._class_name()
 
     def on_before_transform_resource(self, logical_id, resource_type, resource_properties):  # type: ignore[no-untyped-def]
         """

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -296,6 +296,11 @@ class TestBasePlugin(TestCase):
         plugin = Yoyoyo()
         self.assertEqual("Yoyoyo", plugin.name)
 
+    def test_initialization_should_set_custom_name(self):
+
+        plugin = Yoyoyo("custom-name")
+        self.assertEqual("custom-name", plugin.name)
+
     def test_on_methods_must_not_do_anything(self):
         data_mock = Mock()
 


### PR DESCRIPTION
### Issue #, if available

In https://github.com/aws/serverless-application-model/commit/ff75c8afd0579f124c06e48f187cadf02e3e1682#diff-a5c7f4a8324ba62f991e6b2846fd0ac4e85894b65143a3e61430fc7080a3567eR23-L30 we removed the required `name` argument of `BasePlugin` constructor. It might break whoever is consuming SAM-T library. This PR brings it back as an optional argument.

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
