### PR TITLE
ci: (experimental) Add ruff before pylint to lint the codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ black-check:
 	bin/yaml-format.py --check integration --add-test-metadata
 
 lint:
+	# experimental: use ruff to perform checks before pylint to see
+	# if it can check issues before pylint
+	ruff samtranslator bin schema_source
 	# mypy performs type check
 	mypy --strict samtranslator bin schema_source
 	# Linter performs static analysis to catch latent bugs

--- a/bin/json-format.py
+++ b/bin/json-format.py
@@ -9,7 +9,7 @@ sys.path.insert(0, my_path + "/..")
 import json
 from typing import Type
 
-from bin._file_formatter import FileFormatter
+from bin._file_formatter import FileFormatter  # noqa: module-import-not-at-top-of-file
 
 
 class JSONFormatter(FileFormatter):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,6 +7,7 @@ pytest-env~=0.6.2
 pytest-rerunfailures~=9.1.1
 pylint~=2.15.0
 pyyaml~=5.4
+ruff==0.0.237  # loose the requirement once it is more stable
 
 # Test requirements
 pytest~=6.2.5

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+# black formatter takes care of the line length
+line-length = 999
+
+[per-file-ignores]
+# python scripts in bin/ needs some python path configurations before import
+"bin/*.py" = ["E402"]  # E402: module-import-not-at-top-of-file

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -592,3 +592,20 @@ class ResourceResolver:
             raise TypeError("Invalid logical ID '{}'. Expected a string.".format(_input))
 
         return self.resources.get(_input, None)
+
+
+__all__: List[str] = [
+    "IS_DICT",
+    "IS_STR",
+    "Validator",
+    "any_type",
+    "is_type",
+    "PropertyType",
+    "Property",
+    "PassThroughProperty",
+    "Resource",
+    "ResourceMacro",
+    "SamResourceMacro",
+    "ResourceTypeResolver",
+    "ResourceResolver",
+]

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -477,7 +477,7 @@ class ApiGenerator:
             if not set(mutual_tls_auth.keys()).issubset({"TruststoreUri", "TruststoreVersion"}):
                 invalid_keys = []
                 for key in mutual_tls_auth.keys():
-                    if not key in {"TruststoreUri", "TruststoreVersion"}:
+                    if key not in {"TruststoreUri", "TruststoreVersion"}:
                         invalid_keys.append(key)
                 invalid_keys.sort()
                 raise InvalidResourceException(

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -205,7 +205,7 @@ class PullEventSource(ResourceMacro, metaclass=ABCMeta):
                     role.Policies = []
                 for policy in policy_statements:
                     if policy not in role.Policies:
-                        if not policy.get("PolicyDocument") in [d["PolicyDocument"] for d in role.Policies]:
+                        if policy.get("PolicyDocument") not in [d["PolicyDocument"] for d in role.Policies]:
                             role.Policies.append(policy)
         # add SQS or SNS policy only if role is present in kwargs
         if role is not None and destination_config_policy is not None and destination_config_policy:
@@ -214,7 +214,7 @@ class PullEventSource(ResourceMacro, metaclass=ABCMeta):
                 role.Policies.append(destination_config_policy)
             if role.Policies and destination_config_policy not in role.Policies:
                 # do not add the  policy if the same policy document is already present
-                if not destination_config_policy.get("PolicyDocument") in [d["PolicyDocument"] for d in role.Policies]:
+                if destination_config_policy.get("PolicyDocument") not in [d["PolicyDocument"] for d in role.Policies]:
                     role.Policies.append(destination_config_policy)
 
     def _validate_filter_criteria(self) -> None:

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -698,7 +698,7 @@ class SamFunction(SamResourceMacro):
         sam_expect(dlq_type, self.logical_id, "DeadLetterQueue.Type").to_be_a_string()
 
         # Validate required Types
-        if not dlq_type in self.dead_letter_queue_policy_actions:
+        if dlq_type not in self.dead_letter_queue_policy_actions:
             raise InvalidResourceException(
                 self.logical_id, "'DeadLetterQueue' requires Type of {}".format(valid_dlq_types)
             )
@@ -1693,7 +1693,7 @@ class SamLayerVersion(SamResourceMacro):
             return
         for arq in architectures:
             # We validate the values only if we they're not intrinsics
-            if not is_intrinsic(arq) and not arq in [ARM64, X86_64]:
+            if not is_intrinsic(arq) and arq not in [ARM64, X86_64]:
                 raise InvalidResourceException(
                     lambda_layer.logical_id,
                     "CompatibleArchitectures needs to be a list of '{}' or '{}'".format(X86_64, ARM64),

--- a/schema_source/any_cfn_resource.py
+++ b/schema_source/any_cfn_resource.py
@@ -6,4 +6,4 @@ constr = pydantic.constr
 
 # Anything goes if has string Type but is not AWS::Serverless::*
 class Resource(LenientBaseModel):
-    Type: constr(regex=r"^(?!AWS::Serverless::).+$")  # type: ignore
+    Type: constr(regex=r"^(?!AWS::Serverless::).+$")  # type: ignore  # noqa: forward-annotation-syntax-error


### PR DESCRIPTION
### Issue #, if available

ruff (https://github.com/charliermarsh/ruff) is extremely fast and covers a lot of lint rules from different linters.
Our pylint check is very slow.

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
