### PR TITLE
ci: Upgrade ruff to 0.0.239

### DIFF
--- a/bin/json-format.py
+++ b/bin/json-format.py
@@ -9,7 +9,7 @@ sys.path.insert(0, my_path + "/..")
 import json
 from typing import Type
 
-from bin._file_formatter import FileFormatter  # noqa: module-import-not-at-top-of-file
+from bin._file_formatter import FileFormatter
 
 
 class JSONFormatter(FileFormatter):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@ pytest-xdist~=2.5
 pytest-env~=0.6.2
 pytest-rerunfailures~=9.1.1
 pyyaml~=5.4
-ruff==0.0.237  # loose the requirement once it is more stable
+ruff==0.0.239  # loose the requirement once it is more stable
 
 # Test requirements
 pytest~=6.2.5

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,3 +25,25 @@ target-version = "py37"
 [per-file-ignores]
 # python scripts in bin/ needs some python path configurations before import
 "bin/*.py" = ["E402"]  # E402: module-import-not-at-top-of-file
+
+# Quick exclusion of too-many-args in legacy files,
+# due to there are too many violations in them.
+"samtranslator/metrics/metrics.py" = ["PLR0913"]
+"samtranslator/model/api/api_generator.py" = ["PLR0913"]
+"samtranslator/model/api/http_api_generator.py" = ["PLR0913"]
+"samtranslator/model/apigateway.py" = ["PLR0913"]
+"samtranslator/model/apigatewayv2.py" = ["PLR0913"]
+"samtranslator/model/eventsources/push.py" = ["PLR0913"]
+"samtranslator/model/eventsources/scheduler.py" = ["PLR0913"]
+"samtranslator/model/role_utils/role_constructor.py" = ["PLR0913"]
+"samtranslator/model/sam_resources.py" = ["PLR0913"]
+"samtranslator/model/stepfunctions/events.py" = ["PLR0913"]
+"samtranslator/model/stepfunctions/generators.py" = ["PLR0913"]
+"samtranslator/open_api/open_api.py" = ["PLR0913"]
+"samtranslator/plugins/api/implicit_api_plugin.py" = ["PLR0913"]
+"samtranslator/plugins/api/implicit_http_api_plugin.py" = ["PLR0913"]
+"samtranslator/plugins/api/implicit_rest_api_plugin.py" = ["PLR0913"]
+"samtranslator/plugins/application/serverless_app_plugin.py" = ["PLR0913"]
+"samtranslator/swagger/swagger.py" = ["PLR0913"]
+"samtranslator/translator/translator.py" = ["PLR0913"]
+"samtranslator/validator/value_validator.py" = ["PLR0913"]


### PR DESCRIPTION
### Issue #, if available

### Description of changes

I believe the rule "too-many-args" is still valuable but adding `noqa` to them all is tedious. Excluding at the file level is easier to do

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
