### PR TITLE
ci: Add public_interface command

### DIFF
--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -72,14 +72,17 @@ def _save(signature: Dict[str, inspect.Signature], variables: Set[str], output_f
     with open(output_file, "w") as f:
         result: Dict[str, Any] = {"routines": {}, "variables": sorted(variables)}
         for key, value in signature.items():
-            result["routines"][key] = [
-                {
-                    "name": parameter.name,
-                    "kind": parameter.kind.name,
-                    "default": parameter.default if parameter.default != inspect.Parameter.empty else None,
-                }
-                for parameter in value.parameters.values()
-            ]
+            for parameter in value.parameters.values():
+                result["routines"][key] = [
+                    {
+                        "name": parameter.name,
+                        "kind": parameter.kind.name,
+                        "default": parameter.default,
+                    }
+                    if parameter.default != inspect.Parameter.empty
+                    else {"name": parameter.name, "kind": parameter.kind.name}
+                    for parameter in value.parameters.values()
+                ]
         json.dump(result, f, indent=2, sort_keys=True)
 
 

--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -88,6 +88,7 @@ def main() -> None:
 
     subparsers = parser.add_subparsers(dest="command")
     extract = subparsers.add_parser("extract", help="Extract public interfaces into a JSON file")
+    extract.add_argument("--module", help="The module to extract public interfaces", type=str, default="samtranslator")
     extract.add_argument(
         "output_file",
         help="The path to output JSON file",
@@ -97,7 +98,7 @@ def main() -> None:
 
     if args.command == "extract":
         scanner = InterfaceScanner()
-        scanner.scan_interfaces_recursively("samtranslator")
+        scanner.scan_interfaces_recursively(args.module)
         _save(scanner.signatures, scanner.constants, args.output_file)
     # TODO: handle compare
     else:

--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Set, Union
 class InterfaceScanner:
     def __init__(self) -> None:
         self.signatures: Dict[str, Union[inspect.Signature]] = {}
-        self.constants: Set[str] = set()
+        self.variables: Set[str] = set()
 
     def scan_interfaces_recursively(self, module_name: str) -> None:
         self._scan_interfaces_in_module(module_name)
@@ -24,7 +24,7 @@ class InterfaceScanner:
     def _scan_interfaces_in_module(self, module_name: str) -> None:
         self._scan_functions_in_module(module_name)
         self._scan_classes_in_module(module_name)
-        self._scan_constants_in_module(module_name)
+        self._scan_variables_in_module(module_name)
 
     def _scan_functions_in_module(self, module_name: str) -> None:
         for function_name, function in inspect.getmembers(
@@ -36,7 +36,7 @@ class InterfaceScanner:
             full_path = f"{module_name}.{function_name}"
             self.signatures[full_path] = inspect.signature(function)
 
-    def _scan_constants_in_module(self, module_name: str) -> None:
+    def _scan_variables_in_module(self, module_name: str) -> None:
         """
         There is no method to verify if a module attribute is a constant,
         After some experiment, here we assume if an attribute is a value
@@ -49,7 +49,7 @@ class InterfaceScanner:
             if constant_name.startswith("_"):
                 continue
             full_path = f"{module_name}.{constant_name}"
-            self.constants.add(full_path)
+            self.variables.add(full_path)
 
     def _scan_classes_in_module(self, module_name: str) -> None:
         for class_name, _class in inspect.getmembers(importlib.import_module(module_name), inspect.isclass):
@@ -68,9 +68,9 @@ class InterfaceScanner:
             self.signatures[full_path] = inspect.signature(method)
 
 
-def _save(signature: Dict[str, inspect.Signature], constants: Set[str], output_file: Path) -> None:
+def _save(signature: Dict[str, inspect.Signature], variables: Set[str], output_file: Path) -> None:
     with open(output_file, "w") as f:
-        result: Dict[str, Any] = {"routines": {}, "constants": sorted(constants)}
+        result: Dict[str, Any] = {"routines": {}, "variables": sorted(variables)}
         for key, value in signature.items():
             result["routines"][key] = [
                 {
@@ -99,7 +99,7 @@ def main() -> None:
     if args.command == "extract":
         scanner = InterfaceScanner()
         scanner.scan_interfaces_recursively(args.module)
-        _save(scanner.signatures, scanner.constants, args.output_file)
+        _save(scanner.signatures, scanner.variables, args.output_file)
     # TODO: handle compare
     else:
         parser.print_help()

--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
-"""Extract/compare public interfaces."""
+"""
+Extract/compare public interfaces.
+
+aws-sam-translator library hasn't documented public interfaces,
+so we assume anything public by convention unless it is prefixed with "_".
+(see https://peps.python.org/pep-0008/#descriptive-naming-styles)
+This CLI tool helps automate the detection of compatibility-breaking changes.
+"""
 import argparse
 import importlib
 import inspect

--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""Extract/compare public interfaces."""
+import argparse
+import importlib
+import inspect
+import json
+import os.path
+import pkgutil
+from pathlib import Path
+from typing import Any, Dict, Set, Union
+
+
+class InterfaceScanner:
+    def __init__(self) -> None:
+        self.signatures: Dict[str, Union[inspect.Signature]] = {}
+        self.constants: Set[str] = set()
+
+    def scan_interfaces_recursively(self, module_name: str) -> None:
+        self._scan_interfaces_in_module(module_name)
+        for submodule in pkgutil.iter_modules([module_name.replace(".", os.path.sep)]):
+            submodule_name = module_name + "." + submodule.name
+            self.scan_interfaces_recursively(submodule_name)
+
+    def _scan_interfaces_in_module(self, module_name: str) -> None:
+        self._scan_functions_in_module(module_name)
+        self._scan_classes_in_module(module_name)
+        self._scan_constants_in_module(module_name)
+
+    def _scan_functions_in_module(self, module_name: str) -> None:
+        for function_name, function in inspect.getmembers(
+            importlib.import_module(module_name), lambda obj: inspect.ismethod(obj) or inspect.isfunction(obj)
+        ):
+            # Skip imported functions and ones starting with "_"
+            if function.__module__ != module_name or function_name.startswith("_"):
+                continue
+            full_path = f"{module_name}.{function_name}"
+            self.signatures[full_path] = inspect.signature(function)
+
+    def _scan_constants_in_module(self, module_name: str) -> None:
+        """
+        There is no method to verify if a module attribute is a constant,
+        After some experiment, here we assume if an attribute is a value
+        (without `__module__`) and not a module itself is a constant.
+        """
+        for constant_name, _ in inspect.getmembers(
+            importlib.import_module(module_name),
+            lambda obj: not hasattr(obj, "__module__") and not inspect.ismodule(obj),
+        ):
+            if constant_name.startswith("_"):
+                continue
+            full_path = f"{module_name}.{constant_name}"
+            self.constants.add(full_path)
+
+    def _scan_classes_in_module(self, module_name: str) -> None:
+        for class_name, _class in inspect.getmembers(importlib.import_module(module_name), inspect.isclass):
+            # Skip imported and ones starting with "_"
+            if _class.__module__ != module_name or class_name.startswith("_"):
+                continue
+            self._scan_methods_in_class(class_name, _class)
+
+    def _scan_methods_in_class(self, class_name: str, _class: Any) -> None:
+        for method_name, method in inspect.getmembers(
+            _class, lambda obj: inspect.ismethod(obj) or inspect.isfunction(obj)
+        ):
+            if method_name.startswith("_"):
+                continue
+            full_path = f"{_class.__module__}.{class_name}.{method_name}"
+            self.signatures[full_path] = inspect.signature(method)
+
+
+def _save(signature: Dict[str, inspect.Signature], constants: Set[str], output_file: Path) -> None:
+    with open(output_file, "w") as f:
+        result: Dict[str, Any] = {"routines": {}, "constants": sorted(constants)}
+        for key, value in signature.items():
+            result["routines"][key] = [
+                {
+                    "name": parameter.name,
+                    "kind": parameter.kind.name,
+                    "default": parameter.default if parameter.default != inspect.Parameter.empty else None,
+                }
+                for parameter in value.parameters.values()
+            ]
+        json.dump(result, f, indent=2, sort_keys=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    subparsers = parser.add_subparsers(dest="command")
+    extract = subparsers.add_parser("extract", help="Extract public interfaces into a JSON file")
+    extract.add_argument(
+        "output_file",
+        help="The path to output JSON file",
+        type=Path,
+    )
+    args = parser.parse_args()
+
+    if args.command == "extract":
+        scanner = InterfaceScanner()
+        scanner.scan_interfaces_recursively("samtranslator")
+        _save(scanner.signatures, scanner.constants, args.output_file)
+    # TODO: handle compare
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Issue #, if available

### Description of changes

This command allows extraction of all public interfaces into a file. This allows us to compare two files to determine if there is a compatibility-breaking changes.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

```
bin/public_interface.py extract out.json
```

Snippet of generated JSON file:
```
{
  "constants": [
    "samtranslator.feature_toggle.feature_toggle.BOTO3_CONNECT_TIMEOUT",
    "samtranslator.intrinsics.resolver.DEFAULT_SUPPORTED_INTRINSICS",
    "samtranslator.model.api.api_generator.GatewayResponseProperties",
    "samtranslator.model.api.http_api_generator.DefaultStageName",
    "samtranslator.model.api.http_api_generator.HttpApiTagName",
    "samtranslator.model.apigatewayv2.APIGATEWAY_AUTHORIZER_KEY",
    "samtranslator.model.architecture.ARM64",
    "samtranslator.model.architecture.X86_64",
    "samtranslator.model.connector_profiles.profile.PROFILE",
    "samtranslator.model.connector_profiles.profile.f",
    "samtranslator.model.eventsources.FUNCTION_EVETSOURCE_METRIC_PREFIX",
    "samtranslator.model.eventsources.cloudwatchlogs.FUNCTION_EVETSOURCE_METRIC_PREFIX",
    "samtranslator.model.eventsources.pull.FUNCTION_EVETSOURCE_METRIC_PREFIX",
    "samtranslator.model.eventsources.push.CONDITION",
    "samtranslator.model.eventsources.push.FUNCTION_EVETSOURCE_METRIC_PREFIX",
    "samtranslator.model.eventsources.push.REQUEST_PARAMETER_PROPERTIES",
    "samtranslator.model.eventsources.scheduler.FUNCTION_EVETSOURCE_METRIC_PREFIX",
    "samtranslator.model.intrinsics.MIN_NUM_CONDITIONS_TO_COMBINE",
    "samtranslator.model.packagetype.IMAGE",
    "samtranslator.model.packagetype.ZIP",
    "samtranslator.model.preferences.deployment_preference_collection.CODEDEPLOY_APPLICATION_LOGICAL_ID",
    "samtranslator.model.preferences.deployment_preference_collection.CODEDEPLOY_PREDEFINED_CONFIGURATIONS_LIST",
    "samtranslator.model.preferences.deployment_preference_collection.CODE_DEPLOY_CONDITION_NAME",
    "samtranslator.model.preferences.deployment_preference_collection.CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID",
    "samtranslator.model.sam_resources.ARM64",
    "samtranslator.model.sam_resources.IMAGE",
    "samtranslator.model.sam_resources.X86_64",
    "samtranslator.model.sam_resources.ZIP",
    "samtranslator.model.stepfunctions.events.CONDITION",
    "samtranslator.model.stepfunctions.events.SFN_EVETSOURCE_METRIC_PREFIX",
    "samtranslator.plugins.api.implicit_api_plugin.MIN_NUM_CONDITIONS_TO_COMBINE",
    "samtranslator.plugins.application.serverless_app_plugin.BOTO3_CONNECT_TIMEOUT",
    "samtranslator.plugins.application.serverless_app_plugin.PLUGIN_METRICS_PREFIX",
    "samtranslator.policy_template_processor.template.POLICY_PARAMETER_DISAMBIGUATE_PREFIX",
    "samtranslator.policy_templates_data.POLICY_TEMPLATES_FILE",
    "samtranslator.policy_templates_data.SCHEMA_FILE",
    "samtranslator.translator.translator.TYPE_CHECKING",
    "samtranslator.translator.verify_logical_id.do_not_verify",
    "samtranslator.utils.constants.BOTO3_CONNECT_TIMEOUT",
    "samtranslator.utils.py27hash_fix.MINSIZE",
    "samtranslator.utils.py27hash_fix.PERTURB_SHIFT",
    "samtranslator.validator.sam_schema.SCHEMA_DIR",
    "samtranslator.validator.sam_schema.SCHEMA_FILE",
    "samtranslator.validator.sam_schema.SCHEMA_NEW_FILE",
    "samtranslator.validator.validator.INTRINSIC_ATTR"
  ],
  "routines": {
    "samtranslator.feature_toggle.dialup.BaseDialup.is_enabled": [
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "self"
      }
    ],
    "samtranslator.feature_toggle.dialup.DisabledDialup.is_enabled": [
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "self"
      }
    ],
    "samtranslator.feature_toggle.dialup.SimpleAccountPercentileDialup.is_enabled": [
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "self"
      }
    ],
    "samtranslator.feature_toggle.dialup.ToggleDialup.is_enabled": [
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "self"
      }
    ],
    "samtranslator.feature_toggle.feature_toggle.FeatureToggle.is_enabled": [
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "self"
      },
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "feature_name"
      }
    ],
    "samtranslator.intrinsics.actions.Action.can_handle": [
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "self"
      },
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "input_dict"
      }
    ],
    "samtranslator.intrinsics.actions.Action.resolve_parameter_refs": [
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "self"
      },
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "input_dict"
      },
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "parameters"
      }
    ],
    "samtranslator.intrinsics.actions.Action.resolve_resource_id_refs": [
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "self"
      },
      {
        "default": null,
        "kind": "POSITIONAL_OR_KEYWORD",
        "name": "input_dict"
      },
      {
```

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
