### PR TITLE
chore: remove docopt

### DIFF
--- a/bin/sam-translate.py
+++ b/bin/sam-translate.py
@@ -3,34 +3,17 @@
 """Convert SAM templates to CloudFormation templates.
 
 Known limitations: cannot transform CodeUri pointing at local directory.
-
-Usage:
-  sam-translate.py --template-file=sam-template.yaml [--verbose] [--output-template=<o>]
-  sam-translate.py package --template-file=sam-template.yaml --s3-bucket=my-bucket [--verbose] [--output-template=<o>]
-  sam-translate.py deploy --template-file=sam-template.yaml --s3-bucket=my-bucket --capabilities=CAPABILITY_NAMED_IAM --stack-name=my-stack [--verbose] [--output-template=<o>]
-
-Options:
-  --template-file=<i>       Location of SAM template to transform [default: template.yaml].
-  --output-template=<o>     Location to store resulting CloudFormation template [default: transformed-template.json].
-  --s3-bucket=<s>           S3 bucket to use for SAM artifacts when using the `package` command
-  --capabilities=<c>        Capabilities
-  --stack-name=<n>          Unique name for your CloudFormation Stack
-  --verbose                 Enables verbose logging
-
 """
+import argparse
 import json
 import logging
-import os
 import platform
 import subprocess
 import sys
 from functools import reduce
+from pathlib import Path
 
 import boto3
-from docopt import docopt  # type: ignore[import]
-
-my_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, my_path + "/..")
 
 from samtranslator.model.exceptions import InvalidDocumentException
 from samtranslator.public.translator import ManagedPolicyLoader
@@ -38,11 +21,42 @@ from samtranslator.translator.transform import transform
 from samtranslator.yaml_helper import yaml_parse
 
 LOG = logging.getLogger(__name__)
-cli_options = docopt(__doc__)
 iam_client = boto3.client("iam")
-cwd = os.getcwd()
 
-if cli_options.get("--verbose"):
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("command", nargs="?")
+parser.add_argument(
+    "--template-file",
+    help="Location of SAM template to transform [default: template.yaml].",
+    type=Path,
+    default=Path("template.yaml"),
+)
+parser.add_argument(
+    "--output-template",
+    help="Location to store resulting CloudFormation template [default: transformed-template.json].",
+    type=Path,
+    default=Path("transformed-template.yaml"),
+)
+parser.add_argument(
+    "--s3-bucket",
+    help="S3 bucket to use for SAM artifacts when using the `package` command",
+)
+parser.add_argument(
+    "--capabilities",
+    help="Capabilities",
+)
+parser.add_argument(
+    "--stack-name",
+    help="Unique name for your CloudFormation Stack",
+)
+parser.add_argument(
+    "--verbose",
+    help="Enables verbose logging",
+    action="store_true",
+)
+cli_options = parser.parse_args()
+
+if cli_options.verbose:
     logging.basicConfig(level=logging.DEBUG)
 else:
     logging.basicConfig()
@@ -64,19 +78,10 @@ def execute_command(command, args):  # type: ignore[no-untyped-def]
         sys.exit(e.returncode)
 
 
-def get_input_output_file_paths():  # type: ignore[no-untyped-def]
-    input_file_option = cli_options.get("--template-file")
-    output_file_option = cli_options.get("--output-template")
-    input_file_path = os.path.join(cwd, input_file_option)
-    output_file_path = os.path.join(cwd, output_file_option)
-
-    return input_file_path, output_file_path
-
-
 def package(input_file_path, output_file_path):  # type: ignore[no-untyped-def]
     template_file = input_file_path
     package_output_template_file = input_file_path + "._sam_packaged_.yaml"
-    s3_bucket = cli_options.get("--s3-bucket")
+    s3_bucket = cli_options.s3_bucket
     args = [
         "--template-file",
         template_file,
@@ -111,8 +116,8 @@ def transform_template(input_file_path, output_file_path):  # type: ignore[no-un
 
 
 def deploy(template_file):  # type: ignore[no-untyped-def]
-    capabilities = cli_options.get("--capabilities")
-    stack_name = cli_options.get("--stack-name")
+    capabilities = cli_options.capabilities
+    stack_name = cli_options.stack_name
     args = ["--template-file", template_file, "--capabilities", capabilities, "--stack-name", stack_name]
 
     execute_command("deploy", args)  # type: ignore[no-untyped-call]
@@ -121,12 +126,13 @@ def deploy(template_file):  # type: ignore[no-untyped-def]
 
 
 if __name__ == "__main__":
-    input_file_path, output_file_path = get_input_output_file_paths()  # type: ignore[no-untyped-call]
+    input_file_path = str(cli_options.template_file)
+    output_file_path = str(cli_options.output_template)
 
-    if cli_options.get("package"):
+    if cli_options.command == "package":
         package_output_template_file = package(input_file_path, output_file_path)  # type: ignore[no-untyped-call]
         transform_template(package_output_template_file, output_file_path)  # type: ignore[no-untyped-call]
-    elif cli_options.get("deploy"):
+    elif cli_options.command == "deploy":
         package_output_template_file = package(input_file_path, output_file_path)  # type: ignore[no-untyped-call]
         transform_template(package_output_template_file, output_file_path)  # type: ignore[no-untyped-call]
         deploy(output_file_path)  # type: ignore[no-untyped-call]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,9 +19,6 @@ tenacity~=7.0.0
 # Requirements for examples
 requests~=2.25.0
 
-# CLI requirements
-docopt~=0.6.2
-
 # formatter
 black==20.8b1
 ruamel.yaml==0.17.21  # It can parse yaml while perserving comments


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Useless dependency, and warnings at installation.

### Description of how you validated changes

```
% python bin/sam-translate.py --template-file tests/translator/input/connector_esm_dependson.yaml
Wrote transformed CloudFormation template to: transformed-template.yaml
```

```
% python bin/add_transform_test.py --template-file foo.yaml
Transform Test input file generated /Users/rehnc/Desktop/schemastuff/serverless-application-model/bin/../tests/translator/input/foo.yaml
Wrote transformed CloudFormation template to: /var/folders/8p/907sv7jd1673mkdw5b609_992s40z7/T/tmpboomgz8l
Transform Test output files generated /Users/rehnc/Desktop/schemastuff/serverless-application-model/bin/../tests/translator/output/aws-cn/foo.json
Transform Test output files generated /Users/rehnc/Desktop/schemastuff/serverless-application-model/bin/../tests/translator/output/aws-us-gov/foo.json
Generating transform test input and output files complete. 

Please check the generated output is as expected. This tool does not guarantee correct output.
```

```
% python bin/add_transform_test.py -h
usage: add_transform_test.py [-h] [--template-file TEMPLATE_FILE] [--disable-api-configuration] [--disable-update-partition]

Automatically create transform tests input and output files given an input template.

options:
  -h, --help            show this help message and exit
  --template-file TEMPLATE_FILE
                        Location of SAM template to transform [default: template.yaml].
  --disable-api-configuration
                        Disable adding REGIONAL configuration to AWS::ApiGateway::RestApi
  --disable-update-partition
                        Disable updating the partition of arn to aws-cn/aws-us-gov
```

```
% python bin/sam-translate.py -h
usage: sam-translate.py [-h] [--template-file TEMPLATE_FILE] [--output-template OUTPUT_TEMPLATE] [--s3-bucket S3_BUCKET] [--capabilities CAPABILITIES] [--stack-name STACK_NAME] [--verbose] [command]

Convert SAM templates to CloudFormation templates. Known limitations: cannot transform CodeUri pointing at local directory.

positional arguments:
  command

options:
  -h, --help            show this help message and exit
  --template-file TEMPLATE_FILE
                        Location of SAM template to transform [default: template.yaml].
  --output-template OUTPUT_TEMPLATE
                        Location to store resulting CloudFormation template [default: transformed-template.json].
  --s3-bucket S3_BUCKET
                        S3 bucket to use for SAM artifacts when using the `package` command
  --capabilities CAPABILITIES
                        Capabilities
  --stack-name STACK_NAME
                        Unique name for your CloudFormation Stack
  --verbose             Enables verbose logging
```

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
