### PR TITLE
Adding metadata property for unsupported connector profile

### DIFF
--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -20,6 +20,7 @@ ConnectorResourceReference = namedtuple(
     ],
 )
 
+UNSUPPORTED_CONNECTOR_PROFILE_TYPE = "UNSUPPORTED_CONNECTOR_PROFILE_TYPE"
 
 class ConnectorResourceError(Exception):
     """

--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -22,6 +22,7 @@ ConnectorResourceReference = namedtuple(
 
 UNSUPPORTED_CONNECTOR_PROFILE_TYPE = "UNSUPPORTED_CONNECTOR_PROFILE_TYPE"
 
+
 class ConnectorResourceError(Exception):
     """
     Indicates a template error making a resource unusable for connectors.

--- a/samtranslator/model/exceptions.py
+++ b/samtranslator/model/exceptions.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from enum import Enum
-from typing import List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 
 class ExpectedType(Enum):
@@ -16,12 +17,16 @@ class ExceptionWithMessage(ABC, Exception):
     def message(self) -> str:
         """Return the exception message."""
 
+    @property
+    def metadata(self) -> Optional[Dict[str, Any]]:
+        """Return the exception metadata."""
 
 class InvalidDocumentException(ExceptionWithMessage):
     """Exception raised when the given document is invalid and cannot be transformed.
 
     Attributes:
         message -- explanation of the error
+        metadata -- a dictionary of metadata (key, value pair)
         causes -- list of errors which caused this document to be invalid
     """
 
@@ -36,6 +41,17 @@ class InvalidDocumentException(ExceptionWithMessage):
         return "Invalid Serverless Application Specification document. Number of errors found: {}.".format(
             len(self.causes)
         )
+
+    @property
+    def metadata(self) -> Dict[str, List[Any]]:
+        # Merge metadata in each exception to one single metadata dictionary
+        metadata_dict = defaultdict(list)
+        for cause in self.causes:
+            if not cause.metadata:
+                continue
+            for k, v in cause.metadata.items():
+                metadata_dict[k].append(v)
+        return metadata_dict
 
     @property
     def causes(self) -> Sequence[ExceptionWithMessage]:
@@ -86,9 +102,10 @@ class InvalidResourceException(ExceptionWithMessage):
         message -- explanation of the error
     """
 
-    def __init__(self, logical_id: Union[str, List[str]], message: str) -> None:
+    def __init__(self, logical_id: Union[str, List[str]], message: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         self._logical_id = logical_id
         self._message = message
+        self._metadata = metadata
 
     def __lt__(self, other):  # type: ignore[no-untyped-def]
         return self._logical_id < other._logical_id
@@ -96,6 +113,10 @@ class InvalidResourceException(ExceptionWithMessage):
     @property
     def message(self) -> str:
         return "Resource with id [{}] is invalid. {}".format(self._logical_id, self._message)
+
+    @property
+    def metadata(self) -> Optional[Dict[str, Any]]:
+        return self._metadata
 
 
 class InvalidResourcePropertyTypeException(InvalidResourceException):

--- a/samtranslator/model/exceptions.py
+++ b/samtranslator/model/exceptions.py
@@ -21,6 +21,7 @@ class ExceptionWithMessage(ABC, Exception):
     def metadata(self) -> Optional[Dict[str, Any]]:
         """Return the exception metadata."""
 
+
 class InvalidDocumentException(ExceptionWithMessage):
     """Exception raised when the given document is invalid and cannot be transformed.
 
@@ -102,7 +103,9 @@ class InvalidResourceException(ExceptionWithMessage):
         message -- explanation of the error
     """
 
-    def __init__(self, logical_id: Union[str, List[str]], message: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self, logical_id: Union[str, List[str]], message: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
         self._logical_id = logical_id
         self._message = message
         self._metadata = metadata

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -32,6 +32,7 @@ from samtranslator.model.apigatewayv2 import ApiGatewayV2DomainName, ApiGatewayV
 from samtranslator.model.architecture import ARM64, X86_64
 from samtranslator.model.cloudformation import NestedStack
 from samtranslator.model.connector.connector import (
+    UNSUPPORTED_CONNECTOR_PROFILE_TYPE,
     ConnectorResourceError,
     ConnectorResourceReference,
     add_depends_on,
@@ -1861,6 +1862,7 @@ class SamConnector(SamResourceMacro):
             raise InvalidResourceException(
                 self.logical_id,
                 f"Unable to create connector from {source.resource_type} to {destination.resource_type}; it's not supported or the template is invalid.",
+                {UNSUPPORTED_CONNECTOR_PROFILE_TYPE: f"{source.resource_type} to {destination.resource_type}"}
             )
 
         # removing duplicate permissions

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1862,7 +1862,7 @@ class SamConnector(SamResourceMacro):
             raise InvalidResourceException(
                 self.logical_id,
                 f"Unable to create connector from {source.resource_type} to {destination.resource_type}; it's not supported or the template is invalid.",
-                {UNSUPPORTED_CONNECTOR_PROFILE_TYPE: f"{source.resource_type} to {destination.resource_type}"}
+                {UNSUPPORTED_CONNECTOR_PROFILE_TYPE: f"{source.resource_type} to {destination.resource_type}"},
             )
 
         # removing duplicate permissions


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Adding metadata property for `InvalidDocumentException`. Allow publishing metrics related to unsupported connector resource. 

### Description of how you validated changes
Verified in pipeline and the changes work. `make test` passes.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
