### PR TITLE
ci: Fix interface scan omits types (e.g., ConnectorResourceReference)

### DIFF
--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -51,6 +51,8 @@ class InterfaceScanner:
         There is no method to verify if a module attribute is a constant,
         After some experiment, here we assume if an attribute is a value
         (without `__module__`) and not a module itself is a constant.
+
+        Note: Class (and other types) should be treated as a variable too
         """
         for constant_name, _ in inspect.getmembers(
             importlib.import_module(module_name),
@@ -59,6 +61,13 @@ class InterfaceScanner:
             if constant_name.startswith("_"):
                 continue
             full_path = f"{module_name}.{constant_name}"
+            self.variables.add(full_path)
+
+        for class_name, _class in inspect.getmembers(importlib.import_module(module_name), inspect.isclass):
+            # Skip imported and ones starting with "_"
+            if _class.__module__ != module_name or class_name.startswith("_"):
+                continue
+            full_path = f"{module_name}.{class_name}"
             self.variables.add(full_path)
 
     def _scan_classes_in_module(self, module_name: str) -> None:


### PR DESCRIPTION
### Issue #, if available

### Description of changes

`ConnectorResourceReference` was not detected in https://github.com/aws/serverless-application-model/pull/2878/

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
