### PR TITLE
chore: Remove outdated CompatibleRuntimes in basic_layer.yaml (from sam-cli#4672)

### DIFF
--- a/tests/translator/input/basic_layer.yaml
+++ b/tests/translator/input/basic_layer.yaml
@@ -31,8 +31,7 @@ Resources:
       ContentUri: s3://sam-demo-bucket/layer.zip
       Description: Starter Lambda Layer
       CompatibleRuntimes:
-      - python3.6
-      - python2.7
+      - python3.9
       LicenseInfo: License information
       RetentionPolicy: Retain
 

--- a/tests/translator/output/aws-cn/basic_layer.json
+++ b/tests/translator/output/aws-cn/basic_layer.json
@@ -14,12 +14,11 @@
     }
   },
   "Resources": {
-    "CompleteLayer5d71a60e81": {
+    "CompleteLayer429cb63b84": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "CompatibleRuntimes": [
-          "python3.6",
-          "python2.7"
+          "python3.9"
         ],
         "Content": {
           "S3Bucket": "sam-demo-bucket",

--- a/tests/translator/output/aws-us-gov/basic_layer.json
+++ b/tests/translator/output/aws-us-gov/basic_layer.json
@@ -14,12 +14,11 @@
     }
   },
   "Resources": {
-    "CompleteLayer5d71a60e81": {
+    "CompleteLayer429cb63b84": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "CompatibleRuntimes": [
-          "python3.6",
-          "python2.7"
+          "python3.9"
         ],
         "Content": {
           "S3Bucket": "sam-demo-bucket",

--- a/tests/translator/output/basic_layer.json
+++ b/tests/translator/output/basic_layer.json
@@ -14,12 +14,11 @@
     }
   },
   "Resources": {
-    "CompleteLayer5d71a60e81": {
+    "CompleteLayer429cb63b84": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "CompatibleRuntimes": [
-          "python3.6",
-          "python2.7"
+          "python3.9"
         ],
         "Content": {
           "S3Bucket": "sam-demo-bucket",


### PR DESCRIPTION


### Issue #, if available

### Description of changes

Bring the change from https://github.com/aws/aws-sam-cli/pull/4672 to SAM-T

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
