### PR TITLE
fix: recognize license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Before:

<img width="174" alt="Screenshot 2023-02-09 at 09 12 51" src="https://user-images.githubusercontent.com/1280602/217887772-cc581663-3b9e-40d3-9bee-33519df489e8.png">

After (see https://github.com/hoffa/serverless-application-model):

<img width="180" alt="Screenshot 2023-02-09 at 09 13 42" src="https://user-images.githubusercontent.com/1280602/217888002-63aa61b1-ca98-449a-b1a4-c6edbb0b135d.png">

### Description of how you validated changes

The `{}` come from the original commit, where the date/name placeholders were delimited with them:

https://github.com/aws/serverless-application-model/blob/38b4a782bd42e2a51f202a50bb6abea2e317d6a8/LICENSE#L189

However the original Apache-2.0 license (at the time of checking) uses square brackets: https://www.apache.org/licenses/LICENSE-2.0.txt

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
