### PR TITLE
chore: Add decorator @deprecated and add it to is_str()

### DIFF
--- a/samtranslator/internal/__init__.py
+++ b/samtranslator/internal/__init__.py
@@ -1,0 +1,6 @@
+"""
+The module for samtranslator internal implementations.
+
+External packages should not import anything from it
+as all interfaces are subject to change without warning.
+"""

--- a/samtranslator/internal/deprecation_control.py
+++ b/samtranslator/internal/deprecation_control.py
@@ -17,7 +17,7 @@ RT = TypeVar("RT")  # return type
 
 
 def _make_message(message: str, replacement: Optional[str]) -> str:
-    return f"{message}, please use {replacement}" if replacement else f"{message} and there is no replacement."
+    return f"{message}, please use {replacement}" if replacement else message
 
 
 def deprecated(replacement: Optional[str]) -> Callable[[Callable[..., RT]], Callable[..., RT]]:

--- a/samtranslator/internal/deprecation_control.py
+++ b/samtranslator/internal/deprecation_control.py
@@ -33,7 +33,9 @@ def deprecated(replacement: Optional[str]) -> Callable[[Callable[..., RT]], Call
     def decorator(func: Callable[..., RT]) -> Callable[..., RT]:
         @wraps(func)
         def wrapper(*args, **kwargs) -> RT:  # type: ignore
-            warning_message = _make_message(f"{func.__name__} is deprecated", replacement)
+            warning_message = _make_message(
+                f"{func.__name__} is deprecated and will be removed in a future release", replacement
+            )
             # Setting stacklevel=2 to let Python print the line that calls
             # this wrapper, not the line below.
             warnings.warn(warning_message, DeprecationWarning, stacklevel=2)

--- a/samtranslator/internal/deprecation_control.py
+++ b/samtranslator/internal/deprecation_control.py
@@ -1,0 +1,65 @@
+"""
+Utils for deprecating our code using warning.warn().
+The warning message is written to stderr when shown.
+
+For the difference between DeprecationWarning
+and PendingDeprecationWarning, refer to
+https://peps.python.org/pep-0565/#additional-use-case-for-futurewarning
+
+If external packages import deprecated/pending-deprecation
+interfaces, it is their responsibility to detect and remove them.
+"""
+import warnings
+from functools import wraps
+from typing import Callable, Optional, TypeVar
+
+RT = TypeVar("RT")  # return type
+
+
+def _make_message(message: str, replacement: Optional[str]) -> str:
+    if replacement:
+        return f"{message}, please consider to use {replacement}"
+    return f"{message} and there is no replacement."
+
+
+def deprecated(replacement: Optional[str]) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+    """
+    Mark a function/method as deprecated.
+
+    The warning is shown by default when triggered directly
+    by code in __main__.
+    """
+
+    def decorator(func: Callable[..., RT]) -> Callable[..., RT]:
+        @wraps(func)
+        def wrapper(*args, **kwargs) -> RT:  # type: ignore
+            warning_message = _make_message(f"{func.__name__} is deprecated", replacement)
+            # Setting stacklevel=2 to let Python print the line that calls
+            # this wrapper, not the line below.
+            warnings.warn(warning_message, DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def pending_deprecation(replacement: Optional[str]) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+    """
+    Mark a function/method as pending deprecation.
+
+    The warning is not shown by default in runtime.
+    """
+
+    def decorator(func: Callable[..., RT]) -> Callable[..., RT]:
+        @wraps(func)
+        def wrapper(*args, **kwargs) -> RT:  # type: ignore
+            warning_message = _make_message(f"{func.__name__} will be deprecated", replacement)
+            # Setting stacklevel=2 to let Python print the line that calls
+            # this wrapper, not the line below.
+            warnings.warn(warning_message, PendingDeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/samtranslator/internal/deprecation_control.py
+++ b/samtranslator/internal/deprecation_control.py
@@ -6,8 +6,8 @@ For the difference between DeprecationWarning
 and other deprecation warning classes, refer to
 https://peps.python.org/pep-0565/#additional-use-case-for-futurewarning
 
-If external packages import deprecated/pending-deprecation
-interfaces, it is their responsibility to detect and remove them.
+If external packages import deprecated interfaces,
+it is their responsibility to detect and remove them.
 """
 import warnings
 from functools import wraps

--- a/samtranslator/internal/deprecation_control.py
+++ b/samtranslator/internal/deprecation_control.py
@@ -17,9 +17,7 @@ RT = TypeVar("RT")  # return type
 
 
 def _make_message(message: str, replacement: Optional[str]) -> str:
-    if replacement:
-        return f"{message}, please consider to use {replacement}"
-    return f"{message} and there is no replacement."
+    return f"{message}, please use {replacement}" if replacement else f"{message} and there is no replacement."
 
 
 def deprecated(replacement: Optional[str]) -> Callable[[Callable[..., RT]], Callable[..., RT]]:

--- a/samtranslator/internal/deprecation_control.py
+++ b/samtranslator/internal/deprecation_control.py
@@ -3,7 +3,7 @@ Utils for deprecating our code using warning.warn().
 The warning message is written to stderr when shown.
 
 For the difference between DeprecationWarning
-and PendingDeprecationWarning, refer to
+and other deprecation warning classes, refer to
 https://peps.python.org/pep-0565/#additional-use-case-for-futurewarning
 
 If external packages import deprecated/pending-deprecation
@@ -39,27 +39,6 @@ def deprecated(replacement: Optional[str]) -> Callable[[Callable[..., RT]], Call
             # Setting stacklevel=2 to let Python print the line that calls
             # this wrapper, not the line below.
             warnings.warn(warning_message, DeprecationWarning, stacklevel=2)
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
-def pending_deprecation(replacement: Optional[str]) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
-    """
-    Mark a function/method as pending deprecation.
-
-    The warning is not shown by default in runtime.
-    """
-
-    def decorator(func: Callable[..., RT]) -> Callable[..., RT]:
-        @wraps(func)
-        def wrapper(*args, **kwargs) -> RT:  # type: ignore
-            warning_message = _make_message(f"{func.__name__} will be deprecated", replacement)
-            # Setting stacklevel=2 to let Python print the line that calls
-            # this wrapper, not the line below.
-            warnings.warn(warning_message, PendingDeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         return wrapper

--- a/samtranslator/model/types.py
+++ b/samtranslator/model/types.py
@@ -11,6 +11,7 @@ either a string or a list of strings, but do not validate whether the string(s) 
 from typing import Any, Callable, Type, Union
 
 import samtranslator.model.exceptions
+from samtranslator.internal.deprecation_control import deprecated
 
 # Validator always looks like def ...(value: Any, should_raise: bool = True) -> bool,
 # However, Python type hint doesn't support functions with optional keyword argument
@@ -137,6 +138,7 @@ def any_type() -> Validator:
     return validate
 
 
+@deprecated(replacement="IS_STR")
 def is_str() -> Validator:
     """
     For compatibility reason, we need this `is_str()` as it

--- a/tests/internal/test_deprecation_control.py
+++ b/tests/internal/test_deprecation_control.py
@@ -13,11 +13,6 @@ def deprecated_function(x, y):
     return x + y
 
 
-@pending_deprecation(replacement="replacement_function")
-def pending_deprecation_function(x, y):
-    return x + y
-
-
 class TestDeprecationControl(TestCase):
     def test_deprecated_decorator(self):
         with warnings.catch_warnings(record=True) as w:
@@ -27,15 +22,5 @@ class TestDeprecationControl(TestCase):
             self.assertIn(
                 "deprecated_function is deprecated and will be removed in a future release, "
                 "please consider to use replacement_function",
-                str(w[-1].message),
-            )
-
-    def test_pending_deprecation_decorator(self):
-        with warnings.catch_warnings(record=True) as w:
-            pending_deprecation_function(1, 1)
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, PendingDeprecationWarning))
-            self.assertIn(
-                "pending_deprecation_function will be deprecated, please consider to use replacement_function",
                 str(w[-1].message),
             )

--- a/tests/internal/test_deprecation_control.py
+++ b/tests/internal/test_deprecation_control.py
@@ -1,0 +1,39 @@
+import warnings
+from unittest import TestCase
+
+from samtranslator.internal.deprecation_control import deprecated, pending_deprecation
+
+
+def replacement_function(x, y):
+    return x + y
+
+
+@deprecated(replacement="replacement_function")
+def deprecated_function(x, y):
+    return x + y
+
+
+@pending_deprecation(replacement="replacement_function")
+def pending_deprecation_function(x, y):
+    return x + y
+
+
+class TestDeprecationControl(TestCase):
+    def test_deprecated_decorator(self):
+        with warnings.catch_warnings(record=True) as w:
+            deprecated_function(1, 1)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn(
+                "deprecated_function is deprecated, please consider to use replacement_function", str(w[-1].message)
+            )
+
+    def test_pending_deprecation_decorator(self):
+        with warnings.catch_warnings(record=True) as w:
+            pending_deprecation_function(1, 1)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, PendingDeprecationWarning))
+            self.assertIn(
+                "pending_deprecation_function will be deprecated, please consider to use replacement_function",
+                str(w[-1].message),
+            )

--- a/tests/internal/test_deprecation_control.py
+++ b/tests/internal/test_deprecation_control.py
@@ -25,7 +25,9 @@ class TestDeprecationControl(TestCase):
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertIn(
-                "deprecated_function is deprecated, please consider to use replacement_function", str(w[-1].message)
+                "deprecated_function is deprecated and will be removed in a future release, "
+                "please consider to use replacement_function",
+                str(w[-1].message),
             )
 
     def test_pending_deprecation_decorator(self):

--- a/tests/internal/test_deprecation_control.py
+++ b/tests/internal/test_deprecation_control.py
@@ -1,7 +1,7 @@
 import warnings
 from unittest import TestCase
 
-from samtranslator.internal.deprecation_control import deprecated, pending_deprecation
+from samtranslator.internal.deprecation_control import deprecated
 
 
 def replacement_function(x, y):
@@ -21,6 +21,6 @@ class TestDeprecationControl(TestCase):
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertIn(
                 "deprecated_function is deprecated and will be removed in a future release, "
-                "please consider to use replacement_function",
+                "please use replacement_function",
                 str(w[-1].message),
             )


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

Create a file "bin/test_deprecation.py" with the content:
```py
from samtranslator.model.types import is_str

if __name__ == "__main__":
    is_str()("hi")

```

Then:

```sh
(samtranslator37) ~/P/serverless-application-model ❯❯❯ python bin/test_deprecation.py
bin/test_deprecation.py:4: DeprecationWarning: is_str is deprecated, please consider to use IS_STR
  is_str()("hi")
```

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
