### PR TITLE
chore: Enable linting for tests and integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ init:
 	pip install -e '.[dev]'
 
 test:
-	AWS_DEFAULT_REGION=us-east-1 pytest --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/*
+	AWS_DEFAULT_REGION=us-east-1 pytest --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/
 
 test-fast:
-	pytest -x --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/*
+	pytest -x --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/
 
 test-cov-report:
-	pytest --cov samtranslator --cov-report term-missing --cov-report html --cov-fail-under 95 tests/*
+	pytest --cov samtranslator --cov-report term-missing --cov-report html --cov-fail-under 95 tests/
 
 integ-test:
 	pytest --no-cov integration/*

--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,14 @@ black-check:
 	bin/yaml-format.py --check integration --add-test-metadata
 
 lint:
-	ruff samtranslator bin schema_source
+	ruff samtranslator bin schema_source integration tests
 	# mypy performs type check
 	mypy --strict samtranslator bin schema_source
 	# cfn-lint to make sure generated CloudFormation makes sense
 	bin/run_cfn_lint.sh
 
 lint-fix:
-	ruff --fix samtranslator bin schema_source
+	ruff --fix samtranslator bin schema_source integration tests
 
 prepare-companion-stack:
 	pytest -v --no-cov integration/setup -m setup

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ integ-test:
 	pytest --no-cov integration/*
 
 black:
-	black setup.py samtranslator/* tests/* integration/* bin/*.py schema_source
+	black setup.py samtranslator tests integration bin schema_source
 	bin/json-format.py --write tests integration samtranslator/policy_templates_data
 	bin/yaml-format.py --write tests
 	bin/yaml-format.py --write integration --add-test-metadata
@@ -29,7 +29,7 @@ black-check:
 	python -m schema_source.schema --sam-schema .tmp/sam.schema.json --cfn-schema schema_source/cloudformation.schema.json --unified-schema .tmp/schema.json
 	diff -u schema_source/sam.schema.json .tmp/sam.schema.json
 	diff -u samtranslator/schema/schema.json .tmp/schema.json
-	black --check setup.py samtranslator/* tests/* integration/* bin/*.py schema_source
+	black --check setup.py samtranslator tests integration bin schema_source
 	bin/json-format.py --check tests integration samtranslator/policy_templates_data
 	bin/yaml-format.py --check tests
 	bin/yaml-format.py --check integration --add-test-metadata

--- a/integration/combination/test_api_settings.py
+++ b/integration/combination/test_api_settings.py
@@ -1,8 +1,8 @@
 import hashlib
 from unittest.case import skipIf
 
-from integration.helpers.resource import current_region_does_not_support
 from integration.config.service_names import REST_API
+from integration.helpers.resource import current_region_does_not_support
 
 try:
     from pathlib import Path

--- a/integration/combination/test_api_with_authorizer_apikey.py
+++ b/integration/combination/test_api_with_authorizer_apikey.py
@@ -1,12 +1,10 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import API_KEY, REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.deployer.utils.retry import retry
 from integration.helpers.exception import StatusCodeError
-
-
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API, API_KEY
 
 
 @skipIf(current_region_does_not_support([REST_API, API_KEY]), "RestApi/ApiKey is not supported in this testing region")

--- a/integration/combination/test_api_with_authorizers.py
+++ b/integration/combination/test_api_with_authorizers.py
@@ -1,10 +1,10 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import API_KEY, COGNITO, REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.deployer.utils.retry import retry
 from integration.helpers.exception import StatusCodeError
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import API_KEY, COGNITO, REST_API
 
 
 @skipIf(

--- a/integration/combination/test_api_with_cors.py
+++ b/integration/combination/test_api_with_cors.py
@@ -1,12 +1,10 @@
-from integration.helpers.base_test import BaseTest
-import requests
 from unittest.case import skipIf
 
+from parameterized import parameterized
+
+from integration.config.service_names import REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API
-from integration.helpers.deployer.utils.retry import retry
-from parameterized import parameterized
 
 ALL_METHODS = "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT"
 

--- a/integration/combination/test_api_with_disable_execute_api_endpoint.py
+++ b/integration/combination/test_api_with_disable_execute_api_endpoint.py
@@ -1,11 +1,10 @@
 from unittest.case import skipIf
+
 from parameterized import parameterized
 
-from integration.helpers.base_test import BaseTest
-
-
-from integration.helpers.resource import current_region_does_not_support
 from integration.config.service_names import REST_API
+from integration.helpers.base_test import BaseTest
+from integration.helpers.resource import current_region_does_not_support
 
 
 @skipIf(current_region_does_not_support([REST_API]), "RestApi is not supported in this testing region")
@@ -41,7 +40,7 @@ class TestApiWithDisableExecuteApiEndpoint(BaseTest):
             ("combination/api_with_disable_execute_api_endpoint_openapi_3", False),
         ]
     )
-    def test_end_point_configuration(self, file_name, disable_value):
+    def test_end_point_configuration_openapi(self, file_name, disable_value):
         parameters = [
             {
                 "ParameterKey": "DisableExecuteApiEndpointValue",

--- a/integration/combination/test_api_with_fail_on_warnings.py
+++ b/integration/combination/test_api_with_fail_on_warnings.py
@@ -1,9 +1,10 @@
 from unittest.case import skipIf
+
 from parameterized import parameterized
 
+from integration.config.service_names import REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API
 
 
 @skipIf(current_region_does_not_support([REST_API]), "RestApi is not supported in this testing region")

--- a/integration/combination/test_api_with_gateway_responses.py
+++ b/integration/combination/test_api_with_gateway_responses.py
@@ -1,11 +1,11 @@
 import logging
 from unittest.case import skipIf
 
-from tenacity import stop_after_attempt, retry_if_exception_type, after_log, wait_exponential, retry, wait_random
+from tenacity import after_log, retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_random
 
+from integration.config.service_names import GATEWAY_RESPONSES, REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import GATEWAY_RESPONSES, REST_API
 
 LOG = logging.getLogger(__name__)
 

--- a/integration/combination/test_api_with_resource_policies.py
+++ b/integration/combination/test_api_with_resource_policies.py
@@ -1,9 +1,9 @@
 import json
 from unittest.case import skipIf
 
+from integration.config.service_names import REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API
 
 
 @skipIf(current_region_does_not_support([REST_API]), "Rest API is not supported in this testing region")

--- a/integration/combination/test_api_with_usage_plan.py
+++ b/integration/combination/test_api_with_usage_plan.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import REST_API, USAGE_PLANS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import USAGE_PLANS, REST_API
 
 
 @skipIf(current_region_does_not_support([USAGE_PLANS, REST_API]), "UsagePlans is not supported in this testing region")

--- a/integration/combination/test_connectors.py
+++ b/integration/combination/test_connectors.py
@@ -1,7 +1,9 @@
 from time import sleep
 from unittest import SkipTest
+
 from parameterized import parameterized
-from tenacity import retry, stop_after_attempt, retry_if_exception
+from tenacity import retry, retry_if_exception, stop_after_attempt
+
 from integration.conftest import clean_bucket
 from integration.helpers.base_test import S3_BUCKET_PREFIX, BaseTest
 from integration.helpers.resource import generate_suffix
@@ -93,7 +95,6 @@ class TestConnectors(BaseTest):
 
         state_machine_arn = self.get_physical_id_by_logical_id("TriggerStateMachine")
         sfn_client = self.client_provider.sfn_client
-        s3_client = self.client_provider.s3_client
 
         response = sfn_client.start_sync_execution(
             stateMachineArn=state_machine_arn,
@@ -149,7 +150,6 @@ class TestConnectors(BaseTest):
 
         lambda_function_name = self.get_physical_id_by_logical_id("TriggerFunction")
         lambda_client = self.client_provider.lambda_client
-        s3_client = self.client_provider.s3_client
 
         request_params = {
             "FunctionName": lambda_function_name,

--- a/integration/combination/test_function_with_alias.py
+++ b/integration/combination/test_function_with_alias.py
@@ -2,10 +2,11 @@ import json
 from unittest.case import skipIf
 
 from botocore.exceptions import ClientError
-from integration.helpers.base_test import BaseTest, LOG
+
+from integration.config.service_names import REST_API
+from integration.helpers.base_test import LOG, BaseTest
 from integration.helpers.common_api import get_function_versions
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API
 
 
 class TestFunctionWithAlias(BaseTest):
@@ -73,7 +74,6 @@ class TestFunctionWithAlias(BaseTest):
 
     def test_alias_deletion_must_retain_version(self):
         self.create_and_verify_stack("combination/function_with_alias")
-        alias_name = "Live"
         function_name = self.get_physical_id_by_type("AWS::Lambda::Function")
         version_ids = self.get_function_version_by_name(function_name)
         self.assertEqual(["1"], version_ids)

--- a/integration/combination/test_function_with_all_event_types.py
+++ b/integration/combination/test_function_with_all_event_types.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import IOT, SCHEDULE_EVENT
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support, generate_suffix
-from integration.config.service_names import IOT, SCHEDULE_EVENT
 
 
 @skipIf(

--- a/integration/combination/test_function_with_api.py
+++ b/integration/combination/test_function_with_api.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API
 
 
 @skipIf(current_region_does_not_support([REST_API]), "Rest API is not supported in this testing region")

--- a/integration/combination/test_function_with_application.py
+++ b/integration/combination/test_function_with_application.py
@@ -2,11 +2,11 @@ from unittest.case import skipIf
 
 from botocore.exceptions import ClientError
 
+from integration.config.service_names import SERVERLESS_REPO
 from integration.helpers.base_test import BaseTest
 from integration.helpers.deployer.exceptions.exceptions import ThrottlingError
 from integration.helpers.deployer.utils.retry import retry_with_exponential_backoff_and_jitter
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import SERVERLESS_REPO
 
 
 class TestFunctionWithApplication(BaseTest):

--- a/integration/combination/test_function_with_cwe_dlq_and_retry_policy.py
+++ b/integration/combination/test_function_with_cwe_dlq_and_retry_policy.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CWE_CWS_DLQ
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import CWE_CWS_DLQ
 
 
 @skipIf(current_region_does_not_support([CWE_CWS_DLQ]), "CweCwsDlq is not supported in this testing region")

--- a/integration/combination/test_function_with_cwe_dlq_generated.py
+++ b/integration/combination/test_function_with_cwe_dlq_generated.py
@@ -1,10 +1,9 @@
-import json
 from unittest.case import skipIf
 
+from integration.config.service_names import CWE_CWS_DLQ
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_queue_policy
-from integration.helpers.resource import first_item_in_dict, current_region_does_not_support
-from integration.config.service_names import CWE_CWS_DLQ
+from integration.helpers.resource import current_region_does_not_support, first_item_in_dict
 
 
 @skipIf(current_region_does_not_support([CWE_CWS_DLQ]), "CweCwsDlq is not supported in this testing region")

--- a/integration/combination/test_function_with_deployment_preference.py
+++ b/integration/combination/test_function_with_deployment_preference.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CODE_DEPLOY
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support, generate_suffix
-from integration.config.service_names import CODE_DEPLOY
 
 CODEDEPLOY_APPLICATION_LOGICAL_ID = "ServerlessDeploymentApplication"
 LAMBDA_FUNCTION_NAME = "MyLambdaFunction"

--- a/integration/combination/test_function_with_dynamoDB.py
+++ b/integration/combination/test_function_with_dynamoDB.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import DYNAMO_DB
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import DYNAMO_DB
 
 
 @skipIf(current_region_does_not_support([DYNAMO_DB]), "DynamoDB is not supported in this testing region")

--- a/integration/combination/test_function_with_file_system_config.py
+++ b/integration/combination/test_function_with_file_system_config.py
@@ -1,4 +1,5 @@
 from unittest.case import skipIf
+
 import pytest
 
 from integration.config.service_names import EFS

--- a/integration/combination/test_function_with_http_api.py
+++ b/integration/combination/test_function_with_http_api.py
@@ -3,9 +3,9 @@ from unittest.case import skipIf
 
 import pytest
 
+from integration.config.service_names import HTTP_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import HTTP_API
 
 LOG = logging.getLogger(__name__)
 

--- a/integration/combination/test_function_with_implicit_api_and_conditions.py
+++ b/integration/combination/test_function_with_implicit_api_and_conditions.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API
 
 
 @skipIf(current_region_does_not_support([REST_API]), "Rest API is not supported in this testing region")

--- a/integration/combination/test_function_with_implicit_http_api.py
+++ b/integration/combination/test_function_with_implicit_http_api.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import HTTP_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import HTTP_API
 
 
 @skipIf(current_region_does_not_support([HTTP_API]), "HttpApi is not supported in this testing region")

--- a/integration/combination/test_function_with_kinesis.py
+++ b/integration/combination/test_function_with_kinesis.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
-from parameterized import parameterized
+
+from integration.config.service_names import KINESIS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import KINESIS
 
 
 @skipIf(current_region_does_not_support([KINESIS]), "Kinesis is not supported in this testing region")

--- a/integration/combination/test_function_with_layers.py
+++ b/integration/combination/test_function_with_layers.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import LAYERS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import LAYERS
 
 
 @skipIf(current_region_does_not_support([LAYERS]), "Layers is not supported in this testing region")

--- a/integration/combination/test_function_with_mq.py
+++ b/integration/combination/test_function_with_mq.py
@@ -3,9 +3,9 @@ from unittest.case import skipIf
 import pytest
 from parameterized import parameterized
 
+from integration.config.service_names import MQ
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support, generate_suffix
-from integration.config.service_names import MQ
 
 
 @skipIf(current_region_does_not_support([MQ]), "MQ is not supported in this testing region")

--- a/integration/combination/test_function_with_msk.py
+++ b/integration/combination/test_function_with_msk.py
@@ -2,9 +2,9 @@ from unittest.case import skipIf
 
 import pytest
 
+from integration.config.service_names import MSK
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support, generate_suffix
-from integration.config.service_names import MSK
 
 
 @skipIf(current_region_does_not_support([MSK]), "MSK is not supported in this testing region")

--- a/integration/combination/test_function_with_s3_bucket.py
+++ b/integration/combination/test_function_with_s3_bucket.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import S3_EVENTS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import S3_EVENTS
 
 
 @skipIf(current_region_does_not_support([S3_EVENTS]), "S3 Events feature is not supported in this testing region")

--- a/integration/combination/test_function_with_schedule.py
+++ b/integration/combination/test_function_with_schedule.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import SCHEDULE_EVENT
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support, generate_suffix
-from integration.config.service_names import SCHEDULE_EVENT
 
 
 @skipIf(current_region_does_not_support([SCHEDULE_EVENT]), "ScheduleEvent is not supported in this testing region")

--- a/integration/combination/test_function_with_schedule_dlq_and_retry_policy.py
+++ b/integration/combination/test_function_with_schedule_dlq_and_retry_policy.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CWE_CWS_DLQ
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import CWE_CWS_DLQ
 
 
 @skipIf(current_region_does_not_support([CWE_CWS_DLQ]), "CweCwsDlq is not supported in this testing region")

--- a/integration/combination/test_function_with_schedule_dlq_generated.py
+++ b/integration/combination/test_function_with_schedule_dlq_generated.py
@@ -1,9 +1,9 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CWE_CWS_DLQ
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_queue_policy
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import CWE_CWS_DLQ
 
 
 @skipIf(current_region_does_not_support([CWE_CWS_DLQ]), "CweCwsDlq is not supported in this testing region")

--- a/integration/combination/test_function_with_self_managed_kafka.py
+++ b/integration/combination/test_function_with_self_managed_kafka.py
@@ -1,11 +1,11 @@
 from unittest.case import skipIf
-import pytest
 
-from integration.helpers.base_test import BaseTest
-from integration.helpers.resource import current_region_not_included
+import pytest
+from parameterized import parameterized
 
 from integration.config.service_names import SELF_MANAGED_KAFKA
-from parameterized import parameterized
+from integration.helpers.base_test import BaseTest
+from integration.helpers.resource import current_region_not_included
 
 
 @skipIf(

--- a/integration/combination/test_function_with_signing_profile.py
+++ b/integration/combination/test_function_with_signing_profile.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CODE_SIGN
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import CODE_SIGN
 
 
 class TestFunctionWithSigningProfile(BaseTest):

--- a/integration/combination/test_function_with_sns.py
+++ b/integration/combination/test_function_with_sns.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import SNS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import SNS
 
 
 @skipIf(current_region_does_not_support([SNS]), "SNS is not supported in this testing region")

--- a/integration/combination/test_function_with_sqs.py
+++ b/integration/combination/test_function_with_sqs.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import SQS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import SQS
 
 
 @skipIf(current_region_does_not_support([SQS]), "SQS is not supported in this testing region")

--- a/integration/combination/test_function_with_user_pool_event.py
+++ b/integration/combination/test_function_with_user_pool_event.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import COGNITO
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import COGNITO
 
 
 @skipIf(current_region_does_not_support([COGNITO]), "Cognito is not supported in this testing region")

--- a/integration/combination/test_http_api_with_auth.py
+++ b/integration/combination/test_http_api_with_auth.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import HTTP_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import HTTP_API
 
 
 @skipIf(current_region_does_not_support([HTTP_API]), "HttpApi is not supported in this testing region")

--- a/integration/combination/test_http_api_with_cors.py
+++ b/integration/combination/test_http_api_with_cors.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import HTTP_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import HTTP_API
 
 
 @skipIf(current_region_does_not_support([HTTP_API]), "HttpApi is not supported in this testing region")

--- a/integration/combination/test_http_api_with_disable_execute_api_endpoint.py
+++ b/integration/combination/test_http_api_with_disable_execute_api_endpoint.py
@@ -2,9 +2,9 @@ from unittest.case import skipIf
 
 from parameterized import parameterized
 
+from integration.config.service_names import CUSTOM_DOMAIN
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_not_included
-from integration.config.service_names import CUSTOM_DOMAIN
 
 
 @skipIf(current_region_not_included([CUSTOM_DOMAIN]), "CustomDomain is not supported in this testing region")

--- a/integration/combination/test_http_api_with_fail_on_warnings.py
+++ b/integration/combination/test_http_api_with_fail_on_warnings.py
@@ -1,9 +1,10 @@
 from unittest.case import skipIf
+
 from parameterized import parameterized
 
+from integration.config.service_names import HTTP_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import HTTP_API
 
 
 @skipIf(current_region_does_not_support([HTTP_API]), "HttpApi is not supported in this testing region")

--- a/integration/combination/test_intrinsic_function_support.py
+++ b/integration/combination/test_intrinsic_function_support.py
@@ -1,9 +1,10 @@
 from unittest.case import skipIf
+
 import pytest
 
+from integration.config.service_names import REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API
 
 
 @skipIf(current_region_does_not_support([REST_API]), "Rest API is not supported in this testing region")

--- a/integration/combination/test_resource_references.py
+++ b/integration/combination/test_resource_references.py
@@ -1,9 +1,9 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_function_versions
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import REST_API
 
 
 # Tests resource references support of SAM Function resource

--- a/integration/combination/test_state_machine_with_api.py
+++ b/integration/combination/test_state_machine_with_api.py
@@ -1,10 +1,9 @@
 from unittest.case import skipIf
+
+from integration.config.service_names import STATE_MACHINE_WITH_APIS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_policy_statements
-
-
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import STATE_MACHINE_WITH_APIS
 
 
 @skipIf(

--- a/integration/combination/test_state_machine_with_cwe.py
+++ b/integration/combination/test_state_machine_with_cwe.py
@@ -1,9 +1,9 @@
 from unittest.case import skipIf
+
+from integration.config.service_names import STATE_MACHINE_CWE_CWS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_policy_statements
-
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import STATE_MACHINE_CWE_CWS
 
 
 @skipIf(

--- a/integration/combination/test_state_machine_with_cwe_dlq_and_retry_policy.py
+++ b/integration/combination/test_state_machine_with_cwe_dlq_and_retry_policy.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CWE_CWS_DLQ, STATE_MACHINE_CWE_CWS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import CWE_CWS_DLQ, STATE_MACHINE_CWE_CWS
 
 
 @skipIf(

--- a/integration/combination/test_state_machine_with_cwe_dlq_generated.py
+++ b/integration/combination/test_state_machine_with_cwe_dlq_generated.py
@@ -1,9 +1,9 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CWE_CWS_DLQ, STATE_MACHINE_CWE_CWS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_policy_statements, get_queue_policy
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import CWE_CWS_DLQ, STATE_MACHINE_CWE_CWS
 
 
 @skipIf(

--- a/integration/combination/test_state_machine_with_policy_templates.py
+++ b/integration/combination/test_state_machine_with_policy_templates.py
@@ -1,9 +1,9 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import SQS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_policy_statements
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import SQS
 
 
 @skipIf(current_region_does_not_support([SQS]), "SQS is not supported in this testing region")

--- a/integration/combination/test_state_machine_with_schedule.py
+++ b/integration/combination/test_state_machine_with_schedule.py
@@ -1,11 +1,11 @@
 from unittest.case import skipIf
+
 from parameterized import parameterized
+
+from integration.config.service_names import STATE_MACHINE_CWE_CWS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_policy_statements
-
-
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import STATE_MACHINE_CWE_CWS
 
 
 @skipIf(

--- a/integration/combination/test_state_machine_with_schedule_dlq_and_retry_policy.py
+++ b/integration/combination/test_state_machine_with_schedule_dlq_and_retry_policy.py
@@ -1,9 +1,9 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CWE_CWS_DLQ
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_policy_statements
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import CWE_CWS_DLQ
 
 
 @skipIf(current_region_does_not_support([CWE_CWS_DLQ]), "CweCwsDlq is not supported in this testing region")

--- a/integration/combination/test_state_machine_with_schedule_dlq_generated.py
+++ b/integration/combination/test_state_machine_with_schedule_dlq_generated.py
@@ -1,9 +1,9 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import CWE_CWS_DLQ
 from integration.helpers.base_test import BaseTest
 from integration.helpers.common_api import get_queue_policy
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import CWE_CWS_DLQ
 
 
 @skipIf(current_region_does_not_support([CWE_CWS_DLQ]), "CweCwsDlq is not supported in this testing region")

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,21 +1,22 @@
+import logging
 import time
+
 import boto3
 import botocore
 import pytest
 from botocore.exceptions import ClientError
-import logging
 
 from integration.helpers.base_test import S3_BUCKET_PREFIX
 from integration.helpers.client_provider import ClientProvider
 from integration.helpers.deployer.exceptions.exceptions import S3DoesNotExistException, ThrottlingError
 from integration.helpers.deployer.utils.retry import retry_with_exponential_backoff_and_jitter
-from integration.helpers.stack import Stack
-from integration.helpers.yaml_utils import load_yaml
 from integration.helpers.resource import (
+    current_region_does_not_support,
     read_test_config_file,
     write_test_config_file_to_json,
-    current_region_does_not_support,
 )
+from integration.helpers.stack import Stack
+from integration.helpers.yaml_utils import load_yaml
 
 try:
     from pathlib import Path
@@ -110,7 +111,7 @@ def get_serverless_application_repository_app():
     """Create or re-use a simple SAR app"""
     if current_region_does_not_support(["ServerlessRepo"]):
         LOG.info("Creating SAR application is skipped since SAR tests are not supported in this region.")
-        return
+        return None
 
     sar_client = ClientProvider().sar_client
     sar_apps = sar_client.list_applications().get("Applications", [])

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -1,11 +1,21 @@
 import json
 import logging
 import os
-import requests
 import shutil
 
 import botocore
 import pytest
+import requests
+from samtranslator.yaml_helper import yaml_parse
+from tenacity import (
+    after_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_fixed,
+    wait_random,
+)
 
 from integration.config.logger_configurations import LoggingConfiguration
 from integration.helpers.client_provider import ClientProvider
@@ -17,22 +27,11 @@ from integration.helpers.resource import (
     current_region_does_not_support,
     detect_services,
     generate_suffix,
+    read_test_config_file,
     verify_stack_resources,
 )
 from integration.helpers.s3_uploader import S3Uploader
 from integration.helpers.yaml_utils import dump_yaml, load_yaml
-from integration.helpers.resource import read_test_config_file
-from samtranslator.yaml_helper import yaml_parse
-
-from tenacity import (
-    retry,
-    stop_after_attempt,
-    wait_exponential,
-    wait_fixed,
-    retry_if_exception_type,
-    after_log,
-    wait_random,
-)
 
 try:
     from pathlib import Path
@@ -41,9 +40,9 @@ except ImportError:
 from unittest.case import TestCase
 
 import boto3
+
 from integration.helpers.deployer.deployer import Deployer
 from integration.helpers.template import transform_template
-
 
 LOG = logging.getLogger(__name__)
 

--- a/integration/helpers/client_provider.py
+++ b/integration/helpers/client_provider.py
@@ -1,6 +1,7 @@
+from threading import Lock
+
 import boto3
 from botocore.config import Config
-from threading import Lock
 
 
 class ClientProvider:

--- a/integration/helpers/common_api.py
+++ b/integration/helpers/common_api.py
@@ -2,11 +2,11 @@ import json
 import logging
 
 from tenacity import (
+    after_log,
     retry,
+    retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
-    retry_if_exception_type,
-    after_log,
     wait_random,
 )
 

--- a/integration/helpers/deployer/deployer.py
+++ b/integration/helpers/deployer/deployer.py
@@ -25,27 +25,26 @@ This was ported over from the sam-cli repo
 #  - Moved UserException to exceptions.py
 #  - Moved DeployColor to colors.py
 #  - Removed unnecessary functions from artifact_exporter
-import sys
-from collections import OrderedDict
 import logging
+import sys
 import time
+from collections import OrderedDict
 from datetime import datetime
-
-from integration.helpers.resource import generate_suffix
 
 import botocore
 
-from integration.helpers.deployer.utils.colors import DeployColor
 from integration.helpers.deployer.exceptions import exceptions as deploy_exceptions
+from integration.helpers.deployer.utils.artifact_exporter import mktempfile
+from integration.helpers.deployer.utils.colors import DeployColor
 from integration.helpers.deployer.utils.retry import retry_with_exponential_backoff_and_jitter
 from integration.helpers.deployer.utils.table_print import (
+    MIN_OFFSET,
+    newline_per_item,
     pprint_column_names,
     pprint_columns,
-    newline_per_item,
-    MIN_OFFSET,
 )
-from integration.helpers.deployer.utils.artifact_exporter import mktempfile, parse_s3_url
 from integration.helpers.deployer.utils.time_util import utc_to_timestamp
+from integration.helpers.resource import generate_suffix
 
 LOG = logging.getLogger(__name__)
 
@@ -373,7 +372,7 @@ class Deployer:
             self.wait_for_changeset(result["Id"], stack_name)
             self.describe_changeset(result["Id"], stack_name)
             return result
-        except deploy_exceptions.ChangeEmptyError as ex:
+        except deploy_exceptions.ChangeEmptyError:
             return {}
         except botocore.exceptions.ClientError as ex:
             raise deploy_exceptions.DeployFailedError(stack_name=stack_name, msg=str(ex))

--- a/integration/helpers/deployer/utils/artifact_exporter.py
+++ b/integration/helpers/deployer/utils/artifact_exporter.py
@@ -19,14 +19,9 @@ This was ported over from the sam-cli repo
 
 import os
 import tempfile
-import contextlib
-from contextlib import contextmanager
-
-try:
-    from urllib.parse import urlparse, parse_qs
-except ImportError:  # py2
-    from urlparse import urlparse, parse_qs
 import uuid
+from contextlib import contextmanager
+from urllib.parse import parse_qs, urlparse
 
 
 def parse_s3_url(url, bucket_name_property="Bucket", object_key_property="Key", version_property=None):

--- a/integration/helpers/deployer/utils/retry.py
+++ b/integration/helpers/deployer/utils/retry.py
@@ -4,7 +4,6 @@ Retry decorator to retry decorated function based on Exception with exponential 
 import math
 import random
 import time
-
 from functools import wraps
 
 

--- a/integration/helpers/deployer/utils/table_print.py
+++ b/integration/helpers/deployer/utils/table_print.py
@@ -3,10 +3,9 @@ Utilities for table pretty printing
 This was ported over from the sam-cli repo
 """
 import shutil
-from itertools import count, zip_longest
-
 import textwrap
 from functools import wraps
+from itertools import count, zip_longest
 
 from integration.helpers.deployer.utils.colors import cprint
 

--- a/integration/helpers/deployer/utils/time_util.py
+++ b/integration/helpers/deployer/utils/time_util.py
@@ -4,8 +4,8 @@ This was ported over from the sam-cli repo
 """
 
 import datetime
-import dateparser
 
+import dateparser
 from dateutil.tz import tzutc
 
 

--- a/integration/helpers/exception.py
+++ b/integration/helpers/exception.py
@@ -3,4 +3,3 @@ from py.error import Error
 
 class StatusCodeError(Error):
     """raise when the return status code is not match the expected one"""
-

--- a/integration/helpers/exception.py
+++ b/integration/helpers/exception.py
@@ -4,4 +4,3 @@ from py.error import Error
 class StatusCodeError(Error):
     """raise when the return status code is not match the expected one"""
 
-    pass

--- a/integration/helpers/resource.py
+++ b/integration/helpers/resource.py
@@ -1,17 +1,17 @@
 import json
-import re
 import random
+import re
 import string  # pylint: disable=deprecated-module
-from typing import Any, Callable, Dict, List, Set
+from typing import Any, Callable, Dict, Set
 
 from integration.config.service_names import (
     DYNAMO_DB,
     HTTP_API,
+    LOCATION,
     REST_API,
     S3_EVENTS,
-    SQS,
-    LOCATION,
     SCHEDULE_EVENT,
+    SQS,
     STATE_MACHINE_INLINE_DEFINITION,
 )
 from integration.helpers.yaml_utils import load_yaml
@@ -22,8 +22,7 @@ except ImportError:
     from pathlib2 import Path
 
 import boto3
-from botocore.exceptions import ClientError, NoRegionError
-
+from botocore.exceptions import NoRegionError
 from samtranslator.translator.logical_id_generator import LogicalIdGenerator
 
 # Length of the random suffix added at the end of the resources we create

--- a/integration/helpers/s3_uploader.py
+++ b/integration/helpers/s3_uploader.py
@@ -1,10 +1,10 @@
 """
 Client for uploading files to s3
 """
+import logging
 from typing import Any
 
 from botocore.exceptions import ClientError
-import logging
 
 LOG = logging.getLogger(__name__)
 

--- a/integration/helpers/template.py
+++ b/integration/helpers/template.py
@@ -3,7 +3,6 @@ import logging
 from functools import reduce
 
 import boto3
-
 from samtranslator.model.exceptions import InvalidDocumentException
 from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
 from samtranslator.translator.transform import transform

--- a/integration/helpers/yaml_utils.py
+++ b/integration/helpers/yaml_utils.py
@@ -1,5 +1,4 @@
 import yaml
-
 from samtranslator.yaml_helper import yaml_parse
 
 

--- a/integration/metrics/test_metrics_integration.py
+++ b/integration/metrics/test_metrics_integration.py
@@ -1,11 +1,12 @@
-import boto3
 import time
 import uuid
 from datetime import datetime, timedelta
 from unittest import TestCase
+
+import boto3
 from samtranslator.metrics.metrics import (
-    Metrics,
     CWMetricsPublisher,
+    Metrics,
 )
 
 

--- a/integration/ruff.toml
+++ b/integration/ruff.toml
@@ -1,0 +1,23 @@
+# black formatter takes care of the line length
+line-length = 999
+
+# The code quality of tests can be a bit lower compared to samtranslator
+select = [
+    "E",  # Pyflakes
+    "F",  # Pyflakes
+    "PL", # pylint
+    "I", # isort
+    "ICN", # flake8-import-conventions
+    "PIE", # flake8-pie
+    "Q", # flake8-quotes
+    "TID", # flake8-tidy-imports
+    "RUF", # Ruff-specific rules
+]
+
+[per-file-ignores]
+
+# The code quality of tests can be a bit lower:
+"**/*.py" = [
+    "S101", # Use of `assert` detected
+    "PLR", # pylint-refactor
+]

--- a/integration/setup/test_setup_teardown.py
+++ b/integration/setup/test_setup_teardown.py
@@ -1,4 +1,5 @@
 import pytest
+
 from integration.helpers.resource import read_test_config_file
 
 
@@ -14,7 +15,4 @@ def test_teardown(delete_companion_stack_once):
 
 def s3_upload_successful():
     modified_map = read_test_config_file("file_to_s3_map_modified.json")
-    for _, file_info in modified_map.items():
-        if not file_info["uri"]:
-            return False
-    return True
+    return all(file_info["uri"] for _, file_info in modified_map.items())

--- a/integration/single/test_basic_api.py
+++ b/integration/single/test_basic_api.py
@@ -2,14 +2,12 @@ import json
 import logging
 from unittest.case import skipIf
 
-import requests
-from tenacity import stop_after_attempt, wait_exponential, retry_if_exception_type, after_log, wait_random
+from tenacity import after_log, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_random
 
+from integration.config.service_names import MODE, REST_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.exception import StatusCodeError
-
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import MODE, REST_API
 
 LOG = logging.getLogger(__name__)
 

--- a/integration/single/test_basic_function.py
+++ b/integration/single/test_basic_function.py
@@ -2,20 +2,20 @@ import logging
 from unittest.case import skipIf
 
 import pytest
+from parameterized import parameterized
 
 from integration.config.service_names import (
+    ARM,
+    CODE_DEPLOY,
+    EPHEMERAL_STORAGE,
     EVENT_INVOKE_CONFIG,
+    HTTP_API,
     KMS,
     LAMBDA_URL,
     XRAY,
-    ARM,
-    CODE_DEPLOY,
-    HTTP_API,
-    EPHEMERAL_STORAGE,
 )
-from integration.helpers.resource import current_region_does_not_support
-from parameterized import parameterized
 from integration.helpers.base_test import BaseTest
+from integration.helpers.resource import current_region_does_not_support
 
 LOG = logging.getLogger(__name__)
 

--- a/integration/single/test_basic_layer_version.py
+++ b/integration/single/test_basic_layer_version.py
@@ -1,6 +1,6 @@
 from unittest.case import skipIf
 
-from integration.config.service_names import LAYERS, ARM
+from integration.config.service_names import ARM, LAYERS
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
 

--- a/integration/single/test_basic_state_machine.py
+++ b/integration/single/test_basic_state_machine.py
@@ -1,8 +1,8 @@
 from unittest.case import skipIf
 
+from integration.config.service_names import STATE_MACHINE_INLINE_DEFINITION, XRAY
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import XRAY, STATE_MACHINE_INLINE_DEFINITION
 
 
 class TestBasicLayerVersion(BaseTest):

--- a/integration/single/test_function_with_http_api_and_auth.py
+++ b/integration/single/test_function_with_http_api_and_auth.py
@@ -1,11 +1,11 @@
+import time
 from unittest.case import skipIf
 
 import pytest
-import time
 
+from integration.config.service_names import HTTP_API
 from integration.helpers.base_test import BaseTest
 from integration.helpers.resource import current_region_does_not_support
-from integration.config.service_names import HTTP_API
 
 
 @skipIf(current_region_does_not_support([HTTP_API]), "HttpApi is not supported in this testing region")

--- a/tests/feature_toggle/test_dialup.py
+++ b/tests/feature_toggle/test_dialup.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-from parameterized import parameterized, param
-from samtranslator.feature_toggle.dialup import *
+from parameterized import param, parameterized
+from samtranslator.feature_toggle.dialup import DisabledDialup, SimpleAccountPercentileDialup, ToggleDialup
 
 
 class TestDisabledDialup(TestCase):

--- a/tests/feature_toggle/test_feature_toggle.py
+++ b/tests/feature_toggle/test_feature_toggle.py
@@ -1,14 +1,15 @@
-from unittest.mock import patch, Mock
-from parameterized import parameterized, param
+import os
+import sys
 from unittest import TestCase
-import os, sys
+from unittest.mock import Mock, patch
 
+from parameterized import param, parameterized
+from samtranslator.feature_toggle.dialup import DisabledDialup, SimpleAccountPercentileDialup, ToggleDialup
 from samtranslator.feature_toggle.feature_toggle import (
     FeatureToggle,
-    FeatureToggleLocalConfigProvider,
     FeatureToggleAppConfigConfigProvider,
+    FeatureToggleLocalConfigProvider,
 )
-from samtranslator.feature_toggle.dialup import ToggleDialup, SimpleAccountPercentileDialup, DisabledDialup
 
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, my_path + "/..")

--- a/tests/intrinsics/test_actions.py
+++ b/tests/intrinsics/test_actions.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
-from unittest.mock import patch, Mock
-from samtranslator.intrinsics.actions import Action, RefAction, SubAction, GetAttAction, FindInMapAction
+from unittest.mock import Mock, patch
+
+from samtranslator.intrinsics.actions import Action, FindInMapAction, GetAttAction, RefAction, SubAction
 from samtranslator.intrinsics.resource_refs import SupportedResourceReferences
-from samtranslator.model.exceptions import InvalidTemplateException, InvalidDocumentException
+from samtranslator.model.exceptions import InvalidDocumentException
 
 
 class TestAction(TestCase):

--- a/tests/intrinsics/test_resolver.py
+++ b/tests/intrinsics/test_resolver.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
-from samtranslator.intrinsics.resolver import IntrinsicsResolver
+
 from samtranslator.intrinsics.actions import Action
+from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.model.exceptions import InvalidDocumentException
 
 

--- a/tests/intrinsics/test_resource_refs.py
+++ b/tests/intrinsics/test_resource_refs.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from samtranslator.intrinsics.resource_refs import SupportedResourceReferences
 
 

--- a/tests/metrics/test_method_decorator.py
+++ b/tests/metrics/test_method_decorator.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import ANY, Mock, patch
 
 from samtranslator.metrics.method_decorator import (
     MetricsMethodWrapperSingleton,

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -1,14 +1,15 @@
-from parameterized import parameterized, param
 from datetime import datetime
 from unittest import TestCase
-from unittest.mock import MagicMock, call, ANY
+from unittest.mock import ANY, MagicMock, call
+
+from parameterized import param, parameterized
 from samtranslator.metrics.metrics import (
-    Metrics,
-    MetricsPublisher,
     CWMetricsPublisher,
     DummyMetricsPublisher,
-    Unit,
     MetricDatum,
+    Metrics,
+    MetricsPublisher,
+    Unit,
 )
 
 

--- a/tests/model/api/test_api_generator.py
+++ b/tests/model/api/test_api_generator.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from parameterized import parameterized
-
 from samtranslator.model import InvalidResourceException
 from samtranslator.model.api.api_generator import ApiGenerator
 

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -1,8 +1,6 @@
 from unittest import TestCase
-from unittest.mock import patch
-import pytest
-from functools import reduce
 
+import pytest
 from samtranslator.model import InvalidResourceException
 from samtranslator.model.api.http_api_generator import HttpApiGenerator
 from samtranslator.open_api.open_api import OpenApiEditor
@@ -356,7 +354,7 @@ class TestCustomDomains(TestCase):
             e.value.message, "Resource with id [HttpApiId] is invalid. " + "Invalid Basepath name provided."
         )
 
-    def test_basepaths(self):
+    def test_basepaths_complex(self):
         self.kwargs["domain"] = {
             "DomainName": "example.com",
             "CertificateArn": "some-url",

--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -371,7 +371,7 @@ class TestCustomDomains(TestCase):
         self.assertIsNotNone(route, None)
         self.assertEqual(route.HostedZoneName, None)
         self.assertEqual(route.HostedZoneId, "xyz")
-        self.assertEqual(len(route.RecordSets), 2)
+        self.assertEqual(len(route.RecordSets), 4)
         self.assertEqual(
             list(map(lambda base: base.ApiMappingKey, basepath)),
             ["one-1", "two_2", "three", "", "api", "api/v1", "api/v1", "api/v1"],

--- a/tests/model/connector_profiles/test_profile.py
+++ b/tests/model/connector_profiles/test_profile.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
 from parameterized import parameterized
-
 from samtranslator.model.connector_profiles.profile import (
     get_profile,
     profile_replace,

--- a/tests/model/eventsources/test_api_event_source.py
+++ b/tests/model/eventsources/test_api_event_source.py
@@ -1,5 +1,5 @@
-from unittest.mock import Mock, patch
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
 from samtranslator.model.eventsources.push import Api
 from samtranslator.model.lambda_ import LambdaFunction, LambdaPermission

--- a/tests/model/eventsources/test_cloudwatch_event_source.py
+++ b/tests/model/eventsources/test_cloudwatch_event_source.py
@@ -1,4 +1,3 @@
-from unittest.mock import Mock, patch
 from unittest import TestCase
 
 from samtranslator.model.eventsources.push import CloudWatchEvent

--- a/tests/model/eventsources/test_cloudwatchlogs_event_source.py
+++ b/tests/model/eventsources/test_cloudwatchlogs_event_source.py
@@ -1,5 +1,6 @@
-from unittest.mock import Mock, patch
 from unittest import TestCase
+from unittest.mock import Mock, patch
+
 from samtranslator.model.eventsources.cloudwatchlogs import CloudWatchLogs
 
 

--- a/tests/model/eventsources/test_eventbridge_rule_source.py
+++ b/tests/model/eventsources/test_eventbridge_rule_source.py
@@ -1,10 +1,9 @@
-from unittest.mock import Mock, patch
 from unittest import TestCase
-from parameterized import parameterized
 
+from parameterized import parameterized
 from samtranslator.model.eventsources.push import EventBridgeRule
-from samtranslator.model.lambda_ import LambdaFunction
 from samtranslator.model.exceptions import InvalidEventException
+from samtranslator.model.lambda_ import LambdaFunction
 
 
 class EventBridgeRuleSourceTests(TestCase):

--- a/tests/model/eventsources/test_mq_event_source.py
+++ b/tests/model/eventsources/test_mq_event_source.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
+
+from parameterized import parameterized
 from samtranslator.model.eventsources.pull import MQ
 from samtranslator.model.exceptions import InvalidEventException
-from parameterized import parameterized
 
 
 class MQEventSource(TestCase):

--- a/tests/model/eventsources/test_msk_event_source.py
+++ b/tests/model/eventsources/test_msk_event_source.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from samtranslator.model.eventsources.pull import MSK
 
 

--- a/tests/model/eventsources/test_schedule_event_source.py
+++ b/tests/model/eventsources/test_schedule_event_source.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
 
-from samtranslator.model.eventsources.push import Schedule
-from samtranslator.model.lambda_ import LambdaFunction
-from samtranslator.model.exceptions import InvalidEventException
 from parameterized import parameterized
+from samtranslator.model.eventsources.push import Schedule
+from samtranslator.model.exceptions import InvalidEventException
+from samtranslator.model.lambda_ import LambdaFunction
 
 
 class ScheduleEventSource(TestCase):

--- a/tests/model/eventsources/test_schedulev2_event_source.py
+++ b/tests/model/eventsources/test_schedulev2_event_source.py
@@ -2,11 +2,10 @@ from typing import cast
 from unittest import TestCase
 from unittest.mock import Mock
 
-from samtranslator.model.eventsources.scheduler import SchedulerEventSource
-from samtranslator.model.lambda_ import LambdaFunction
-from samtranslator.model.exceptions import InvalidEventException
 from parameterized import parameterized
-
+from samtranslator.model.eventsources.scheduler import SchedulerEventSource
+from samtranslator.model.exceptions import InvalidEventException
+from samtranslator.model.lambda_ import LambdaFunction
 from samtranslator.model.scheduler import SchedulerSchedule
 
 

--- a/tests/model/eventsources/test_self_managed_kafka_event_source.py
+++ b/tests/model/eventsources/test_self_managed_kafka_event_source.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
+
+from parameterized import parameterized
 from samtranslator.model.eventsources.pull import SelfManagedKafka
 from samtranslator.model.exceptions import InvalidEventException
-from parameterized import parameterized
 
 
 class SelfManagedKafkaEventSource(TestCase):

--- a/tests/model/eventsources/test_sns_event_source.py
+++ b/tests/model/eventsources/test_sns_event_source.py
@@ -1,5 +1,6 @@
-from unittest.mock import Mock
 from unittest import TestCase
+from unittest.mock import Mock
+
 from samtranslator.model.eventsources.push import SNS
 
 

--- a/tests/model/stepfunctions/test_api_event.py
+++ b/tests/model/stepfunctions/test_api_event.py
@@ -1,8 +1,8 @@
-from unittest.mock import Mock
 from unittest import TestCase
+from unittest.mock import Mock
 
+from samtranslator.model.exceptions import InvalidEventException
 from samtranslator.model.stepfunctions.events import Api
-from samtranslator.model.exceptions import InvalidResourceException, InvalidEventException
 
 
 class ApiEventSource(TestCase):
@@ -76,8 +76,8 @@ class ApiEventSource(TestCase):
     def test_resources_to_link_with_undefined_explicit_api(self):
         resources = {}
         self.api_event_source.RestApiId = {"Ref": "MyExplicitApi"}
-        with self.assertRaises(InvalidEventException) as error:
-            resources_to_link = self.api_event_source.resources_to_link(resources)
+        with self.assertRaises(InvalidEventException):
+            self.api_event_source.resources_to_link(resources)
 
     def test_resources_to_link_without_explicit_api(self):
         resources = {}

--- a/tests/model/stepfunctions/test_cloudwatchevents_event.py
+++ b/tests/model/stepfunctions/test_cloudwatchevents_event.py
@@ -1,7 +1,8 @@
-from unittest.mock import Mock
 from unittest import TestCase
-from samtranslator.model.stepfunctions.events import CloudWatchEvent
+from unittest.mock import Mock
+
 from samtranslator.model.exceptions import InvalidEventException
+from samtranslator.model.stepfunctions.events import CloudWatchEvent
 
 
 class CloudWatchEventsEventSource(TestCase):

--- a/tests/model/stepfunctions/test_eventbridge_rule_source.py
+++ b/tests/model/stepfunctions/test_eventbridge_rule_source.py
@@ -1,5 +1,5 @@
-from unittest.mock import Mock
 from unittest import TestCase
+from unittest.mock import Mock
 
 from samtranslator.model.exceptions import InvalidEventException
 from samtranslator.model.stepfunctions.events import EventBridgeRule

--- a/tests/model/stepfunctions/test_schedule_event.py
+++ b/tests/model/stepfunctions/test_schedule_event.py
@@ -1,8 +1,9 @@
-from unittest.mock import Mock
 from unittest import TestCase
-from samtranslator.model.stepfunctions.events import Schedule
-from samtranslator.model.exceptions import InvalidEventException
+from unittest.mock import Mock
+
 from parameterized import parameterized
+from samtranslator.model.exceptions import InvalidEventException
+from samtranslator.model.stepfunctions.events import Schedule
 
 
 class ScheduleEventSource(TestCase):

--- a/tests/model/stepfunctions/test_state_machine_generator.py
+++ b/tests/model/stepfunctions/test_state_machine_generator.py
@@ -1,8 +1,7 @@
-from unittest.mock import Mock
 from unittest import TestCase
+from unittest.mock import Mock
 
-from samtranslator.model import ResourceTypeResolver
-from samtranslator.model.exceptions import InvalidResourceException, InvalidEventException
+from samtranslator.model.exceptions import InvalidEventException, InvalidResourceException
 from samtranslator.model.stepfunctions import StateMachineGenerator
 from samtranslator.model.stepfunctions.events import CloudWatchEvent
 
@@ -144,5 +143,5 @@ class StepFunctionsStateMachine(TestCase):
             }
         }
         self.kwargs["event_resources"] = {"KinesesEvent": {}}
-        with self.assertRaises(InvalidEventException) as error:
+        with self.assertRaises(InvalidEventException):
             StateMachineGenerator(**self.kwargs).to_cloudformation()

--- a/tests/model/test_api.py
+++ b/tests/model/test_api.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
-import pytest
 
+import pytest
 from samtranslator.model import InvalidResourceException
 from samtranslator.model.apigateway import ApiGatewayAuthorizer
 from samtranslator.utils.py27hash_fix import Py27Dict

--- a/tests/model/test_api_v2.py
+++ b/tests/model/test_api_v2.py
@@ -1,7 +1,6 @@
-from unittest import TestCase
-from unittest import mock
-import pytest
+from unittest import TestCase, mock
 
+import pytest
 from samtranslator.model import InvalidResourceException
 from samtranslator.model.apigatewayv2 import ApiGatewayV2Authorizer
 

--- a/tests/model/test_exceptions.py
+++ b/tests/model/test_exceptions.py
@@ -2,10 +2,10 @@ from unittest import TestCase
 
 from samtranslator.model.exceptions import (
     DuplicateLogicalIdException,
-    InvalidResourceException,
     InvalidDocumentException,
-    InvalidTemplateException,
     InvalidEventException,
+    InvalidResourceException,
+    InvalidTemplateException,
 )
 
 

--- a/tests/model/test_resource_policies.py
+++ b/tests/model/test_resource_policies.py
@@ -1,9 +1,9 @@
-from unittest.mock import Mock, patch
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
-from samtranslator.model.resource_policies import ResourcePolicies, PolicyTypes, PolicyEntry
 from samtranslator.model.exceptions import InvalidTemplateException
 from samtranslator.model.intrinsics import is_intrinsic_if, is_intrinsic_no_value
+from samtranslator.model.resource_policies import PolicyEntry, PolicyTypes, ResourcePolicies
 
 
 class TestResourcePolicies(TestCase):

--- a/tests/model/test_sam_resources.py
+++ b/tests/model/test_sam_resources.py
@@ -1,21 +1,20 @@
 from unittest import TestCase
 from unittest.mock import patch
-import pytest
 
+import pytest
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
-from samtranslator.model import ResourceResolver, InvalidResourceException
+from samtranslator.model import InvalidResourceException, ResourceResolver
+from samtranslator.model.apigateway import ApiGatewayDeployment, ApiGatewayRestApi, ApiGatewayStage
 from samtranslator.model.apigatewayv2 import ApiGatewayV2HttpApi
-from samtranslator.model.lambda_ import LambdaFunction, LambdaLayerVersion, LambdaVersion, LambdaUrl, LambdaPermission
-from samtranslator.model.apigateway import ApiGatewayDeployment, ApiGatewayRestApi
-from samtranslator.model.apigateway import ApiGatewayStage
 from samtranslator.model.iam import IAMRole
+from samtranslator.model.lambda_ import LambdaFunction, LambdaLayerVersion, LambdaPermission, LambdaUrl, LambdaVersion
 from samtranslator.model.packagetype import IMAGE, ZIP
 from samtranslator.model.sam_resources import (
+    SamApi,
     SamConnector,
     SamFunction,
-    SamLayerVersion,
-    SamApi,
     SamHttpApi,
+    SamLayerVersion,
 )
 
 
@@ -244,7 +243,6 @@ class TestVersionDescription(TestCase):
     @patch("boto3.session.Session.region_name", "ap-southeast-1")
     def test_with_autopublish_bad_hash(self):
         function = SamFunction("foo")
-        test_description = "foobar"
 
         function.Runtime = "foo"
         function.Handler = "bar"
@@ -258,7 +256,6 @@ class TestVersionDescription(TestCase):
     @patch("boto3.session.Session.region_name", "ap-southeast-1")
     def test_with_autopublish_good_hash(self):
         function = SamFunction("foo")
-        test_description = "foobar"
 
         function.Runtime = "foo"
         function.Handler = "bar"
@@ -454,7 +451,7 @@ class TestLayers(TestCase):
         layer = SamLayerVersion("foo")
         layer.ContentUri = "s3://foobar/foo.zip"
         cfnResources = layer.to_cloudformation(**self.kwargs)
-        generatedLayerList = [x for x in cfnResources if isinstance(x, LambdaLayerVersion)]
+        [x for x in cfnResources if isinstance(x, LambdaLayerVersion)]
         self.assertEqual(cfnResources.__len__(), 1)
         self.assertTrue(isinstance(cfnResources[0], LambdaLayerVersion))
         self.assertEqual(cfnResources[0].Content, {"S3Key": "foo.zip", "S3Bucket": "foobar"})
@@ -621,7 +618,7 @@ class TestFunctionUrlConfig(TestCase):
         function.FunctionUrlConfig = {"AuthType": None}
 
         with pytest.raises(InvalidResourceException) as e:
-            cfnResources = function.to_cloudformation(**self.kwargs)
+            function.to_cloudformation(**self.kwargs)
         self.assertEqual(
             str(e.value.message),
             "Resource with id [foo] is invalid. AuthType is required to configure function property "

--- a/tests/openapi/test_openapi.py
+++ b/tests/openapi/test_openapi.py
@@ -1,10 +1,9 @@
 import copy
-
 from unittest import TestCase
-from parameterized import parameterized, param
 
-from samtranslator.open_api.open_api import OpenApiEditor
+from parameterized import param, parameterized
 from samtranslator.model.exceptions import InvalidDocumentException
+from samtranslator.open_api.open_api import OpenApiEditor
 from samtranslator.utils.py27hash_fix import Py27Dict
 
 _X_INTEGRATION = "x-amazon-apigateway-integration"

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
-from unittest.mock import patch, Mock, call
+from unittest.mock import Mock, call, patch
 
+from samtranslator.model.exceptions import InvalidDocumentException
 from samtranslator.parser.parser import Parser
 from samtranslator.plugins import LifeCycleEvents
-from samtranslator.model.exceptions import InvalidDocumentException, InvalidTemplateException, InvalidResourceException
 
 
 class TestParser(TestCase):

--- a/tests/plugins/api/test_default_definition_body_plugin.py
+++ b/tests/plugins/api/test_default_definition_body_plugin.py
@@ -1,5 +1,5 @@
-from unittest.mock import Mock, patch
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
 from samtranslator.plugins.api.default_definition_body_plugin import DefaultDefinitionBodyPlugin
 from samtranslator.public.plugins import BasePlugin

--- a/tests/plugins/api/test_implicit_api_plugin.py
+++ b/tests/plugins/api/test_implicit_api_plugin.py
@@ -1,10 +1,10 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock, call, patch
 
-from samtranslator.public.sdk.resource import SamResource, SamResourceType
-from samtranslator.public.exceptions import InvalidEventException, InvalidResourceException, InvalidDocumentException
-from samtranslator.plugins.api.implicit_rest_api_plugin import ImplicitRestApiPlugin, ImplicitApiResource
+from samtranslator.plugins.api.implicit_rest_api_plugin import ImplicitApiResource, ImplicitRestApiPlugin
+from samtranslator.public.exceptions import InvalidDocumentException, InvalidEventException, InvalidResourceException
 from samtranslator.public.plugins import BasePlugin
+from samtranslator.public.sdk.resource import SamResource, SamResourceType
 
 IMPLICIT_API_LOGICAL_ID = "ServerlessRestApi"
 
@@ -14,13 +14,11 @@ class TestImplicitRestApiPluginEndtoEnd(TestCase):
         """
         Test the basic case of one function with a few API events
         """
-        pass
 
     def test_must_work_with_multiple_functions(self):
         """
         Test a more advanced case of multiple functions with API events
         """
-        pass
 
     def test_must_work_with_api_events_with_intrinsic_function(self):
         pass
@@ -29,19 +27,16 @@ class TestImplicitRestApiPluginEndtoEnd(TestCase):
         """
         Functions without API events must not be processed
         """
-        pass
 
     def test_must_ignore_api_events_with_restapiid(self):
         """
         API event sources that are already connected to a AWS::Serverless::Api resource must be skipped
         """
-        pass
 
     def test_must_ignore_template_without_function(self):
         """
         Template without function resource must be unmodified
         """
-        pass
 
 
 class TestImplicitRestApiPlugin_init(TestCase):
@@ -378,7 +373,7 @@ class TestImplicitRestApiPlugin_process_api_events(TestCase):
         function = SamResource({"Type": SamResourceType.Function.value, "Properties": {"Events": function_events_mock}})
         function_events_mock.update = Mock()
 
-        with self.assertRaises(InvalidEventException) as context:
+        with self.assertRaises(InvalidEventException):
             self.plugin._process_api_events(function, api_events, template)
 
     def test_must_verify_method_is_string(self):
@@ -389,7 +384,7 @@ class TestImplicitRestApiPlugin_process_api_events(TestCase):
         function = SamResource({"Type": SamResourceType.Function.value, "Properties": {"Events": function_events_mock}})
         function_events_mock.update = Mock()
 
-        with self.assertRaises(InvalidEventException) as context:
+        with self.assertRaises(InvalidEventException):
             self.plugin._process_api_events(function, api_events, template)
 
     def test_must_verify_rest_api_id_is_string(self):
@@ -409,7 +404,7 @@ class TestImplicitRestApiPlugin_process_api_events(TestCase):
         function = SamResource({"Type": SamResourceType.Function.value, "Properties": {"Events": function_events_mock}})
         function_events_mock.update = Mock()
 
-        with self.assertRaises(InvalidEventException) as context:
+        with self.assertRaises(InvalidEventException):
             self.plugin._process_api_events(function, api_events, template)
 
     def test_must_verify_path_is_string(self):
@@ -420,7 +415,7 @@ class TestImplicitRestApiPlugin_process_api_events(TestCase):
         function = SamResource({"Type": SamResourceType.Function.value, "Properties": {"Events": function_events_mock}})
         function_events_mock.update = Mock()
 
-        with self.assertRaises(InvalidEventException) as context:
+        with self.assertRaises(InvalidEventException):
             self.plugin._process_api_events(function, api_events, template)
 
     def test_must_skip_events_without_properties(self):

--- a/tests/plugins/application/test_serverless_app_plugin.py
+++ b/tests/plugins/application/test_serverless_app_plugin.py
@@ -1,14 +1,11 @@
-import boto3
-import itertools
-from botocore.exceptions import ClientError
-
-from unittest.mock import Mock, patch
 from unittest import TestCase
-from parameterized import parameterized, param
+from unittest.mock import Mock, patch
 
+import boto3
+from botocore.exceptions import ClientError
+from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.plugins.application.serverless_app_plugin import ServerlessAppPlugin
 from samtranslator.plugins.exceptions import InvalidPluginException
-from samtranslator.model.exceptions import InvalidResourceException
 
 # TODO: run tests when AWS CLI is not configured (so they can run in brazil)
 
@@ -20,18 +17,17 @@ STATUS_EXPIRED = "EXPIRED"
 
 
 def mock_create_cloud_formation_template(ApplicationId=None, SemanticVersion=None):
-    message = {
+    return {
         "ApplicationId": ApplicationId,
         "SemanticVersion": SemanticVersion,
         "Status": STATUS_ACTIVE,
         "TemplateId": MOCK_TEMPLATE_ID,
         "TemplateUrl": MOCK_TEMPLATE_URL,
     }
-    return message
 
 
 def mock_get_application(ApplicationId=None, SemanticVersion=None):
-    message = {
+    return {
         "ApplicationId": ApplicationId,
         "Author": "AWS",
         "Description": "Application description",
@@ -39,18 +35,16 @@ def mock_get_application(ApplicationId=None, SemanticVersion=None):
         "ParameterDefinitions": [{"Name": "Parameter1", "ReferencedByResources": ["resource1"], "Type": "String"}],
         "SemanticVersion": SemanticVersion,
     }
-    return message
 
 
 def mock_get_cloud_formation_template(ApplicationId=None, TemplateId=None):
-    message = {
+    return {
         "ApplicationId": ApplicationId,
         "SemanticVersion": "1.0.0",
         "Status": STATUS_ACTIVE,
         "TemplateId": TemplateId,
         "TemplateUrl": MOCK_TEMPLATE_URL,
     }
-    return message
 
 
 def mock_get_region(self, service_name, region_name):
@@ -90,7 +84,7 @@ class TestServerlessAppPlugin_init(TestCase):
     @patch("botocore.client.ClientEndpointBridge._check_default_region", mock_get_region)
     def test_plugin_invalid_configuration_raises_exception(self):
         with self.assertRaises(InvalidPluginException):
-            plugin = ServerlessAppPlugin(wait_for_template_active_status=True, validate_only=True)
+            ServerlessAppPlugin(wait_for_template_active_status=True, validate_only=True)
 
     @patch("botocore.client.ClientEndpointBridge._check_default_region", mock_get_region)
     def test_plugin_accepts_parameters(self):

--- a/tests/plugins/globals/test_globals.py
+++ b/tests/plugins/globals/test_globals.py
@@ -1,8 +1,7 @@
-from parameterized import parameterized
-
 from unittest import TestCase
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
+from parameterized import parameterized
 from samtranslator.plugins.globals.globals import GlobalProperties, Globals, InvalidGlobalsSectionException
 
 

--- a/tests/plugins/globals/test_globals_plugin.py
+++ b/tests/plugins/globals/test_globals_plugin.py
@@ -1,10 +1,10 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+from samtranslator.plugins.globals.globals import InvalidGlobalsSectionException
+from samtranslator.plugins.globals.globals_plugin import GlobalsPlugin
 from samtranslator.public.exceptions import InvalidDocumentException
 from samtranslator.public.plugins import BasePlugin
-from samtranslator.plugins.globals.globals_plugin import GlobalsPlugin
-from samtranslator.plugins.globals.globals import InvalidGlobalsSectionException
 
 
 class TestGlobalsPlugin(TestCase):

--- a/tests/plugins/policies/test_policy_templates_plugin.py
+++ b/tests/plugins/policies/test_policy_templates_plugin.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest.mock import MagicMock, Mock, call, patch
 
-from samtranslator.plugins import BasePlugin
-from samtranslator.model.resource_policies import PolicyTypes, PolicyEntry
 from samtranslator.model.exceptions import InvalidResourceException
+from samtranslator.model.resource_policies import PolicyEntry, PolicyTypes
+from samtranslator.plugins import BasePlugin
 from samtranslator.plugins.policies.policy_templates_plugin import PolicyTemplatesForResourcePlugin
 from samtranslator.policy_template_processor.exceptions import InsufficientParameterValues, InvalidParameterValues
 

--- a/tests/policy_template_processor/test_processor.py
+++ b/tests/policy_template_processor/test_processor.py
@@ -1,13 +1,12 @@
+import json
 from unittest import TestCase
-from unittest.mock import mock_open, Mock, patch
+from unittest.mock import Mock, mock_open, patch
 
 import jsonschema
-import json
-
 from jsonschema.exceptions import ValidationError
+from samtranslator.policy_template_processor.exceptions import TemplateNotFoundException
 from samtranslator.policy_template_processor.processor import PolicyTemplatesProcessor
 from samtranslator.policy_template_processor.template import Template
-from samtranslator.policy_template_processor.exceptions import TemplateNotFoundException
 
 
 class TestPolicyTemplateProcessor(TestCase):

--- a/tests/policy_template_processor/test_schema.py
+++ b/tests/policy_template_processor/test_schema.py
@@ -1,7 +1,7 @@
-from samtranslator.policy_template_processor.processor import PolicyTemplatesProcessor
+from unittest import TestCase
 
 from parameterized import parameterized
-from unittest import TestCase
+from samtranslator.policy_template_processor.processor import PolicyTemplatesProcessor
 
 
 class TestTemplates(object):

--- a/tests/policy_template_processor/test_template.py
+++ b/tests/policy_template_processor/test_template.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import ANY, Mock, patch
 
+from samtranslator.policy_template_processor.exceptions import InsufficientParameterValues, InvalidParameterValues
 from samtranslator.policy_template_processor.template import Template
-from samtranslator.policy_template_processor.exceptions import InvalidParameterValues, InsufficientParameterValues
 
 
 class TestTemplateObject(TestCase):

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -1,0 +1,23 @@
+# black formatter takes care of the line length
+line-length = 999
+
+# The code quality of tests can be a bit lower compared to samtranslator
+select = [
+    "E",  # Pyflakes
+    "F",  # Pyflakes
+    "PL", # pylint
+    "I", # isort
+    "ICN", # flake8-import-conventions
+    "PIE", # flake8-pie
+    "Q", # flake8-quotes
+    "TID", # flake8-tidy-imports
+    "RUF", # Ruff-specific rules
+]
+
+[per-file-ignores]
+
+# The code quality of tests can be a bit lower:
+"**/*.py" = [
+    "S101", # Use of `assert` detected
+    "PLR", # pylint-refactor
+]

--- a/tests/schema/test_validate_schema.py
+++ b/tests/schema/test_validate_schema.py
@@ -1,15 +1,14 @@
 import copy
-import json
-import pytest
 import itertools
-
+import json
 from pathlib import Path
 from unittest import TestCase
+
+import pytest
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from jsonschema.validators import Draft4Validator
 from parameterized import parameterized
-
 from samtranslator.yaml_helper import yaml_parse
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
@@ -62,10 +61,7 @@ SKIPPED_TESTS = [
 
 
 def should_skip_test(s: str) -> bool:
-    for test in SKIPPED_TESTS:
-        if test in s:
-            return True
-    return False
+    return any(test in s for test in SKIPPED_TESTS)
 
 
 def get_all_test_templates():

--- a/tests/sdk/test_parameter.py
+++ b/tests/sdk/test_parameter.py
@@ -1,9 +1,8 @@
-from parameterized import parameterized, param
-
 from unittest import TestCase
-from samtranslator.sdk.parameter import SamParameterValues
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
+from parameterized import param, parameterized
+from samtranslator.sdk.parameter import SamParameterValues
 from samtranslator.translator.arn_generator import NoRegionFound
 
 

--- a/tests/sdk/test_template.py
+++ b/tests/sdk/test_template.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-from samtranslator.sdk.template import SamTemplate
 from samtranslator.sdk.resource import SamResource
+from samtranslator.sdk.template import SamTemplate
 
 
 class TestSamTemplate(TestCase):

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -1,12 +1,12 @@
 import copy
-
 from unittest import TestCase
 from unittest.mock import Mock
-from parameterized import parameterized, param
 
-from samtranslator.swagger.swagger import SwaggerEditor
+from parameterized import param, parameterized
 from samtranslator.model.exceptions import InvalidDocumentException, InvalidTemplateException
+from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.utils.py27hash_fix import Py27Dict
+
 from tests.translator.test_translator import deep_sort_lists
 
 _X_INTEGRATION = "x-amazon-apigateway-integration"
@@ -1474,7 +1474,7 @@ class TestSwaggerEditor_add_resource_policy(TestCase):
 
 class TestSwaggerEditor_add_authorization_scopes(TestCase):
     def setUp(self):
-        self.api = api = {
+        self.api = {
             "Auth": {
                 "Authorizers": {"MyOtherCognitoAuth": {}, "MyCognitoAuth": {}},
                 "DefaultAuthorizer": "MyCognitoAuth",

--- a/tests/test_intrinsics.py
+++ b/tests/test_intrinsics.py
@@ -1,13 +1,13 @@
-from parameterized import parameterized
 from unittest import TestCase
 
+from parameterized import parameterized
 from samtranslator.model.intrinsics import (
-    is_intrinsic,
-    make_shorthand,
-    is_intrinsic_if,
-    validate_intrinsic_if_items,
-    is_intrinsic_no_value,
     get_logical_id_from_intrinsic,
+    is_intrinsic,
+    is_intrinsic_if,
+    is_intrinsic_no_value,
+    make_shorthand,
+    validate_intrinsic_if_items,
 )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,12 +1,11 @@
 from typing import Any, List
+from unittest import TestCase
+from unittest.mock import Mock
 
 import pytest
-
-from unittest import TestCase
-from unittest.mock import Mock, call, ANY
-from samtranslator.model.exceptions import InvalidResourceException
-from samtranslator.model import PropertyType, Resource, SamResourceMacro, ResourceTypeResolver
 from samtranslator.intrinsics.resource_refs import SupportedResourceReferences
+from samtranslator.model import PropertyType, Resource, ResourceTypeResolver, SamResourceMacro
+from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.plugins import LifeCycleEvents
 
 
@@ -131,7 +130,7 @@ class TestResourceAttributes(TestCase):
         self.assertEqual(r.to_dict(), dict_with_attributes2)
 
     def test_invalid_attr(self):
-        with pytest.raises(KeyError) as ex:
+        with pytest.raises(KeyError):
             # Unsupported attributes cannot be added to the resource
             self.MyResource("id", attributes={"foo": "bar"})
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,9 +1,9 @@
 from enum import Enum
+from unittest import TestCase
+from unittest.mock import Mock, call
+
 from samtranslator.plugins import BasePlugin, LifeCycleEvents
 from samtranslator.plugins.sam_plugins import SamPlugins
-
-from unittest import TestCase
-from unittest.mock import Mock, patch, call
 
 
 class TestSamPluginsRegistration(TestCase):
@@ -214,7 +214,7 @@ class TestSamPluginsAct(TestCase):
     def test_act_must_fail_on_non_existent_hook_method(self):
         # Create a plugin but setup hook method with wrong name
         plugin1 = _make_mock_plugin("plugin1")
-        setattr(plugin1, "on_unknown_event", Mock())
+        plugin1.on_unknown_event = Mock()
         self.sam_plugins.register(plugin1)
 
         with self.assertRaises(NameError):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,5 @@
 import pytest
-
-from samtranslator.model.types import is_type, list_of, dict_of, one_of
+from samtranslator.model.types import dict_of, is_type, list_of, one_of
 
 
 class DummyType(object):

--- a/tests/translator/model/preferences/test_deployment_preference_collection.py
+++ b/tests/translator/model/preferences/test_deployment_preference_collection.py
@@ -1,14 +1,15 @@
-from unittest.mock import patch
 from unittest import TestCase
+from unittest.mock import patch
 
-from samtranslator.model.codedeploy import CodeDeployApplication
-from samtranslator.model.codedeploy import CodeDeployDeploymentGroup
+from samtranslator.model.codedeploy import CodeDeployApplication, CodeDeployDeploymentGroup
 from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.model.iam import IAMRole
 from samtranslator.model.preferences.deployment_preference import DeploymentPreference
-from samtranslator.model.preferences.deployment_preference_collection import CODEDEPLOY_APPLICATION_LOGICAL_ID
-from samtranslator.model.preferences.deployment_preference_collection import CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID
-from samtranslator.model.preferences.deployment_preference_collection import DeploymentPreferenceCollection
+from samtranslator.model.preferences.deployment_preference_collection import (
+    CODE_DEPLOY_SERVICE_ROLE_LOGICAL_ID,
+    CODEDEPLOY_APPLICATION_LOGICAL_ID,
+    DeploymentPreferenceCollection,
+)
 
 
 class TestDeploymentPreferenceCollection(TestCase):
@@ -410,11 +411,10 @@ class TestDeploymentPreferenceCollection(TestCase):
         return deployment_preference_yaml_dict
 
     def global_deployment_preference(self):
-        expected_deployment_preference = DeploymentPreference(
+        return DeploymentPreference(
             self.deployment_type_global,
             self.pre_traffic_hook_global,
             self.post_traffic_host_global,
             self.alarms_global,
             True,
         )
-        return expected_deployment_preference

--- a/tests/translator/test_api_resource.py
+++ b/tests/translator/test_api_resource.py
@@ -1,12 +1,12 @@
 import json
-import os
-
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
-from tests.translator.helpers import get_template_parameter_values
-from samtranslator.translator.transform import transform
+
 from samtranslator.model.apigateway import ApiGatewayDeployment
+from samtranslator.translator.transform import transform
+
 from tests.plugins.application.test_serverless_app_plugin import mock_get_region
+from tests.translator.helpers import get_template_parameter_values
 
 mock_policy_loader = MagicMock()
 mock_policy_loader.load.return_value = {

--- a/tests/translator/test_arn_generator.py
+++ b/tests/translator/test_arn_generator.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
-from parameterized import parameterized
 from unittest.mock import Mock, patch
 
+from parameterized import parameterized
 from samtranslator.translator.arn_generator import ArnGenerator, NoRegionFound
 
 

--- a/tests/translator/test_function_resources.py
+++ b/tests/translator/test_function_resources.py
@@ -1,13 +1,12 @@
 from unittest import TestCase
-from unittest.mock import patch, Mock
-from parameterized import parameterized
+from unittest.mock import Mock, patch
 
-import os
-from samtranslator.model.sam_resources import SamFunction
-from samtranslator.model.lambda_ import LambdaAlias, LambdaVersion, LambdaFunction
+from parameterized import parameterized
 from samtranslator.model.exceptions import InvalidResourceException
-from samtranslator.model.update_policy import UpdatePolicy
+from samtranslator.model.lambda_ import LambdaAlias, LambdaFunction, LambdaVersion
 from samtranslator.model.preferences.deployment_preference import DeploymentPreference
+from samtranslator.model.sam_resources import SamFunction
+from samtranslator.model.update_policy import UpdatePolicy
 
 
 class TestVersionsAndAliases(TestCase):

--- a/tests/translator/test_logical_id_generator.py
+++ b/tests/translator/test_logical_id_generator.py
@@ -1,8 +1,8 @@
 import hashlib
 import json
-
 from unittest import TestCase
 from unittest.mock import patch
+
 from samtranslator.translator.logical_id_generator import LogicalIdGenerator
 
 

--- a/tests/translator/test_managed_policies_translator.py
+++ b/tests/translator/test_managed_policies_translator.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+
 from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
 
 

--- a/tests/translator/test_resource_level_attributes.py
+++ b/tests/translator/test_resource_level_attributes.py
@@ -3,8 +3,7 @@ from unittest.mock import patch
 
 from parameterized import parameterized
 
-from tests.plugins.application.test_serverless_app_plugin import mock_get_region
-from tests.translator.test_translator import mock_sar_service_call, AbstractTestTranslator
+from tests.translator.test_translator import AbstractTestTranslator, mock_sar_service_call
 
 
 class TestResourceLevelAttributes(AbstractTestTranslator):

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -1,28 +1,25 @@
-import json
-import itertools
-import os.path
 import hashlib
-import sys
+import itertools
+import json
+import os.path
 import re
-from functools import reduce, cmp_to_key
-
-from samtranslator.translator.translator import Translator, prepare_plugins, make_policy_template_for_function_plugin
-from samtranslator.parser.parser import Parser
-from samtranslator.model.exceptions import InvalidDocumentException, InvalidResourceException
-from samtranslator.model import Resource
-from samtranslator.model.sam_resources import SamSimpleTable
-from samtranslator.public.plugins import BasePlugin
-
-from tests.translator.helpers import get_template_parameter_values
-from tests.plugins.application.test_serverless_app_plugin import mock_get_region
-from samtranslator.yaml_helper import yaml_parse
-from parameterized import parameterized, param
+from functools import cmp_to_key, reduce
+from unittest import TestCase
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-import yaml
-from unittest import TestCase
+from parameterized import parameterized
+from samtranslator.model import Resource
+from samtranslator.model.exceptions import InvalidDocumentException, InvalidResourceException
+from samtranslator.model.sam_resources import SamSimpleTable
+from samtranslator.parser.parser import Parser
+from samtranslator.public.plugins import BasePlugin
 from samtranslator.translator.transform import transform
-from unittest.mock import Mock, MagicMock, patch
+from samtranslator.translator.translator import Translator, make_policy_template_for_function_plugin, prepare_plugins
+from samtranslator.yaml_helper import yaml_parse
+
+from tests.plugins.application.test_serverless_app_plugin import mock_get_region
+from tests.translator.helpers import get_template_parameter_values
 
 BASE_PATH = os.path.dirname(__file__)
 INPUT_FOLDER = BASE_PATH + "/input"
@@ -34,9 +31,7 @@ DO_NOT_SORT = ["Layers"]
 BASE_PATH = os.path.dirname(__file__)
 INPUT_FOLDER = os.path.join(BASE_PATH, "input")
 SUCCESS_FILES_NAMES_FOR_TESTING = [
-    os.path.splitext(f)[0]
-    for f in os.listdir(INPUT_FOLDER)
-    if not (f.startswith("error_") or f.startswith("translate_"))
+    os.path.splitext(f)[0] for f in os.listdir(INPUT_FOLDER) if not (f.startswith("error_", "translate_"))
 ]
 ERROR_FILES_NAMES_FOR_TESTING = [os.path.splitext(f)[0] for f in os.listdir(INPUT_FOLDER) if f.startswith("error_")]
 OUTPUT_FOLDER = os.path.join(BASE_PATH, "output")
@@ -109,9 +104,7 @@ def mock_sar_service_call(self, service_call_function, logical_id, *args):
     elif application_id == "invalid-semver":
         raise InvalidResourceException(logical_id, "Cannot access application: {}.".format(application_id))
     elif application_id == 1:
-        raise InvalidResourceException(
-            logical_id, "Type of property 'ApplicationId' is invalid.".format(application_id)
-        )
+        raise InvalidResourceException(logical_id, "Type of property 'ApplicationId' is invalid.")
     elif application_id == "preparing" and self._wait_for_template_active_status < 2:
         self._wait_for_template_active_status += 1
         self.SLEEP_TIME_SECONDS = 0
@@ -192,7 +185,7 @@ class AbstractTestTranslator(TestCase):
 
         # Find all RestApis in the template
         for logical_id, resource_dict in output_resources.items():
-            if "AWS::ApiGateway::RestApi" == resource_dict.get("Type"):
+            if resource_dict.get("Type") == "AWS::ApiGateway::RestApi":
                 resource_properties = resource_dict.get("Properties", {})
                 if "Body" in resource_properties:
                     self._generate_new_deployment_hash(
@@ -206,7 +199,7 @@ class AbstractTestTranslator(TestCase):
 
         # Collect all APIGW Deployments LogicalIds and generate the new ones
         for logical_id, resource_dict in output_resources.items():
-            if "AWS::ApiGateway::Deployment" == resource_dict.get("Type"):
+            if resource_dict.get("Type") == "AWS::ApiGateway::Deployment":
                 resource_properties = resource_dict.get("Properties", {})
 
                 rest_id = resource_properties.get("RestApiId").get("Ref")
@@ -224,7 +217,7 @@ class AbstractTestTranslator(TestCase):
 
         # Update References to APIGW Deployments
         for logical_id, resource_dict in output_resources.items():
-            if "AWS::ApiGateway::Stage" == resource_dict.get("Type"):
+            if resource_dict.get("Type") == "AWS::ApiGateway::Stage":
                 resource_properties = resource_dict.get("Properties", {})
 
                 rest_id = resource_properties.get("RestApiId", {}).get("Ref", "")
@@ -243,7 +236,7 @@ class AbstractTestTranslator(TestCase):
             del output_resources[logical_id_to_remove]
 
         # Update any Output References in the template
-        for output_key, output_value in resources.get("Outputs", {}).items():
+        for _output_key, output_value in resources.get("Outputs", {}).items():
             if output_value.get("Value").get("Ref") in deployment_logical_id_dict:
                 output_value["Value"]["Ref"] = deployment_logical_id_dict[output_value.get("Value").get("Ref")]
 
@@ -876,6 +869,7 @@ def get_resource_by_type(template, type):
         value = resources[key]
         if "Type" in value and value.get("Type") == type:
             return key, value
+    return None
 
 
 def get_exception_error_message(e):

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -31,7 +31,7 @@ DO_NOT_SORT = ["Layers"]
 BASE_PATH = os.path.dirname(__file__)
 INPUT_FOLDER = os.path.join(BASE_PATH, "input")
 SUCCESS_FILES_NAMES_FOR_TESTING = [
-    os.path.splitext(f)[0] for f in os.listdir(INPUT_FOLDER) if not (f.startswith("error_", "translate_"))
+    os.path.splitext(f)[0] for f in os.listdir(INPUT_FOLDER) if not (f.startswith(("error_", "translate_")))
 ]
 ERROR_FILES_NAMES_FOR_TESTING = [os.path.splitext(f)[0] for f in os.listdir(INPUT_FOLDER) if f.startswith("error_")]
 OUTPUT_FOLDER = os.path.join(BASE_PATH, "output")

--- a/tests/unit/model/api/TestSharedApiUsagePlan.py
+++ b/tests/unit/model/api/TestSharedApiUsagePlan.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
-from parameterized import parameterized, param
-
+from parameterized import parameterized
 from samtranslator.model.api.api_generator import SharedApiUsagePlan
 from samtranslator.model.exceptions import InvalidTemplateException
 

--- a/tests/unit/model/preferences/test_deployment_preference_collection.py
+++ b/tests/unit/model/preferences/test_deployment_preference_collection.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
-
 from unittest.mock import patch
-from parameterized import parameterized
 
+from parameterized import parameterized
 from samtranslator.model.preferences.deployment_preference_collection import DeploymentPreferenceCollection
 
 

--- a/tests/unit/test_region_configuration.py
+++ b/tests/unit/test_region_configuration.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
-
 from unittest.mock import patch
-from parameterized import parameterized
 
+from parameterized import parameterized
 from samtranslator.region_configuration import RegionConfiguration
 
 

--- a/tests/unit/translator/test_arn_generator.py
+++ b/tests/unit/translator/test_arn_generator.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
-
 from unittest.mock import Mock, patch
-from parameterized import parameterized
 
+from parameterized import parameterized
 from samtranslator.translator.arn_generator import ArnGenerator
 
 

--- a/tests/utils/test_dynamic_references.py
+++ b/tests/utils/test_dynamic_references.py
@@ -1,6 +1,6 @@
-from parameterized import parameterized
 from unittest import TestCase
 
+from parameterized import parameterized
 from samtranslator.utils.cfn_dynamic_references import is_dynamic_reference
 
 

--- a/tests/utils/test_py27hash_fix.py
+++ b/tests/utils/test_py27hash_fix.py
@@ -1,17 +1,16 @@
 import copy
-
 from unittest import TestCase
 from unittest.mock import patch
+
+from samtranslator.model.exceptions import InvalidDocumentException
 from samtranslator.utils.py27hash_fix import (
     Py27Dict,
     Py27Keys,
-    Py27UniStr,
     Py27LongInt,
+    Py27UniStr,
     _convert_to_py27_type,
     to_py27_compatible_template,
-    _template_has_api_resource,
 )
-from samtranslator.model.exceptions import InvalidDocumentException
 
 
 class TestPy27UniStr(TestCase):
@@ -377,7 +376,7 @@ class TestPy27Dict(TestCase):
 
         for expected_copied_order in expected_copied_orders:
             py27_dict = copy.deepcopy(py27_dict)
-            key_idx_order = [expected_order.index(i) for i in py27_dict.keys()]
+            key_idx_order = [expected_order.index(i) for i in py27_dict]
             self.assertEqual(key_idx_order, expected_copied_order)
 
     def test_dict_with_any_hashable_keys(self):

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -1,9 +1,9 @@
 import os.path
 from unittest import TestCase
-import pytest
+
 from parameterized import parameterized
+from samtranslator.validator.validator import SamTemplateValidator
 from samtranslator.yaml_helper import yaml_parse
-from samtranslator.validator.validator import SamTemplateValidator, sam_schema
 
 BASE_PATH = os.path.dirname(__file__)
 TRANSLATOR_INPUT_FOLDER = os.path.join(BASE_PATH, os.pardir, "translator", "input")

--- a/tests/validator/test_validator_api.py
+++ b/tests/validator/test_validator_api.py
@@ -1,10 +1,8 @@
-import jsonschema
 import os.path
+
+import jsonschema
 from parameterized import parameterized
-import pytest
-from unittest import TestCase
-from samtranslator.yaml_helper import yaml_parse
-from samtranslator.validator.validator import SamTemplateValidator
+
 from tests.validator.test_validator import TestValidatorBase
 
 BASE_PATH = os.path.dirname(__file__)

--- a/tests/validator/test_validator_root.py
+++ b/tests/validator/test_validator_root.py
@@ -1,9 +1,7 @@
 import os.path
+
 from parameterized import parameterized
-import pytest
-from unittest import TestCase
-from samtranslator.yaml_helper import yaml_parse
-from samtranslator.validator.validator import SamTemplateValidator
+
 from tests.validator.test_validator import TestValidatorBase
 
 BASE_PATH = os.path.dirname(__file__)


### PR DESCRIPTION
### Issue #, if available

### Description of changes

From the previous PR, I noticed the code quality of integ test is not great. We don't need great quality but good quality should be expected. This PR enables a reasonable small number of rules on tests and integration folders.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
