### PR TITLE
chore: Fix make integ-test as integration contains non-py files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-cov-report:
 	pytest --cov samtranslator --cov-report term-missing --cov-report html --cov-fail-under 95 tests/
 
 integ-test:
-	pytest --no-cov integration/*
+	pytest --no-cov integration/
 
 black:
 	black setup.py samtranslator tests integration bin schema_source


### PR DESCRIPTION
### Issue #, if available


### Description of changes

```
pytest --no-cov integration/*                                                                                                                          ✘ 2 
=============================================================================================== test session starts ===============================================================================================
platform darwin -- Python 3.7.2, pytest-6.2.5, py-1.9.0, pluggy-0.13.1
rootdir: /Users/xinhol/Projects/serverless-application-model, configfile: pytest.ini
plugins: xdist-2.5.0, rerunfailures-9.1.1, env-0.6.2, cov-2.10.1, forked-1.3.0
collected 0 items                                                                                                                                                                                                 

============================================================================================== no tests ran in 0.15s ==============================================================================================
ERROR: not found: /Users/xinhol/Projects/serverless-application-model/integration/ruff.toml
(no name '/Users/xinhol/Projects/serverless-application-model/integration/ruff.toml' in any of [])
```

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
