### PR TITLE
Use consistent method of determining AWS Partition from a region

### DIFF
--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -95,7 +95,6 @@ class BaseTest(TestCase):
         cls.code_dir = Path(cls.resources_dir, "code")
         cls.session = boto3.session.Session()
         cls.my_region = cls.session.region_name
-        cls.partition = cls.session.get_partition_for_region(cls.my_region)
         cls.client_provider = ClientProvider()
         cls.file_to_s3_uri_map = read_test_config_file("file_to_s3_map_modified.json")
         cls.code_key_to_file = read_test_config_file("code_key_to_file_map.json")

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -52,6 +52,6 @@ class RegionConfiguration:
                     raise NoRegionFound("AWS Region cannot be found")
 
         # check if the service is available in region
-        partition = session.get_partition_for_region(region)
+        partition = ArnGenerator.get_partition_name(region)
         available_regions = session.get_available_regions(service, partition_name=partition)
         return region in available_regions


### PR DESCRIPTION
### Issue #, if available
N/A
### Description of changes
Changes how we fetch AWS parittion name from region to be consistent across code base.

### Description of how you validated changes
Integration tests, unit tests

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
