### PR TITLE
fix: Fix TestCustomDomains unit tests have side effect on others

### DIFF
--- a/tests/model/api/test_http_api_generator.py
+++ b/tests/model/api/test_http_api_generator.py
@@ -216,7 +216,9 @@ class TestCustomDomains(TestCase):
         "passthrough_resource_attributes": None,
         "domain": None,
     }
-    route53_record_set_groups = {}
+
+    def setUp(self) -> None:
+        self.route53_record_set_groups = {}
 
     def test_no_domain(self):
         self.kwargs["domain"] = None
@@ -371,7 +373,7 @@ class TestCustomDomains(TestCase):
         self.assertIsNotNone(route, None)
         self.assertEqual(route.HostedZoneName, None)
         self.assertEqual(route.HostedZoneId, "xyz")
-        self.assertEqual(len(route.RecordSets), 4)
+        self.assertEqual(len(route.RecordSets), 2)
         self.assertEqual(
             list(map(lambda base: base.ApiMappingKey, basepath)),
             ["one-1", "two_2", "three", "", "api", "api/v1", "api/v1", "api/v1"],


### PR DESCRIPTION
### Issue #, if available

### Description of changes

`self.route53_record_set_groups` is mutated in unit tests and could cause undefined test failures if they are executed sequentially. 

### Description of how you validated changes

Run the test in a single runner. 

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
