### PR TITLE
fix: Avoid hardcoded eventbus name in integ test

### DIFF
--- a/integration/resources/templates/combination/connector_function_to_eventbus_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_eventbus_write.yaml
@@ -46,7 +46,7 @@ Resources:
   EventBus:
     Type: AWS::Events::EventBus
     Properties:
-      Name: TestEventBus
+      Name: !Sub "${AWS::StackName}-EventBus"
 
   Connector:
     Type: AWS::Serverless::Connector


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Hardcoding resource name could prevent future tests from running when previous ones are not cleaned up properly. This PR reduces such risk.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
