### PR TITLE
Remove property validations for lambda resources

### DIFF
--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -1,38 +1,37 @@
 from typing import Any, Dict, List, Optional, Union
 
-from samtranslator.model import PassThroughProperty, PropertyType, Resource
+from samtranslator.model import PassThroughProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_DICT, IS_STR, any_type, is_type, list_of, one_of
 from samtranslator.utils.types import Intrinsicable
 
 
 class LambdaFunction(Resource):
     resource_type = "AWS::Lambda::Function"
     property_types = {
-        "Code": PropertyType(True, IS_DICT),
-        "PackageType": PropertyType(False, IS_STR),
-        "DeadLetterConfig": PropertyType(False, IS_DICT),
-        "Description": PropertyType(False, IS_STR),
-        "FunctionName": PropertyType(False, IS_STR),
-        "Handler": PropertyType(False, IS_STR),
-        "MemorySize": PropertyType(False, is_type(int)),
-        "Role": PropertyType(False, IS_STR),
-        "Runtime": PropertyType(False, IS_STR),
-        "Timeout": PropertyType(False, is_type(int)),
-        "VpcConfig": PropertyType(False, IS_DICT),
-        "Environment": PropertyType(False, IS_DICT),
-        "Tags": PropertyType(False, list_of(IS_DICT)),
-        "TracingConfig": PropertyType(False, IS_DICT),
-        "KmsKeyArn": PropertyType(False, one_of(IS_DICT, IS_STR)),
-        "Layers": PropertyType(False, list_of(one_of(IS_STR, IS_DICT))),
-        "ReservedConcurrentExecutions": PropertyType(False, any_type()),
-        "FileSystemConfigs": PropertyType(False, list_of(IS_DICT)),
-        "CodeSigningConfigArn": PropertyType(False, IS_STR),
-        "ImageConfig": PropertyType(False, IS_DICT),
-        "Architectures": PropertyType(False, list_of(one_of(IS_STR, IS_DICT))),
-        "SnapStart": PropertyType(False, IS_DICT),
-        "EphemeralStorage": PropertyType(False, IS_DICT),
-        "RuntimeManagementConfig": PropertyType(False, IS_DICT),
+        "Code": PassThroughProperty(True),
+        "PackageType": PassThroughProperty(False),
+        "DeadLetterConfig": PassThroughProperty(False),
+        "Description": PassThroughProperty(False),
+        "FunctionName": PassThroughProperty(False),
+        "Handler": PassThroughProperty(False),
+        "MemorySize": PassThroughProperty(False),
+        "Role": PassThroughProperty(False),
+        "Runtime": PassThroughProperty(False),
+        "Timeout": PassThroughProperty(False),
+        "VpcConfig": PassThroughProperty(False),
+        "Environment": PassThroughProperty(False),
+        "Tags": PassThroughProperty(False),
+        "TracingConfig": PassThroughProperty(False),
+        "KmsKeyArn": PassThroughProperty(False),
+        "Layers": PassThroughProperty(False),
+        "ReservedConcurrentExecutions": PassThroughProperty(False),
+        "FileSystemConfigs": PassThroughProperty(False),
+        "CodeSigningConfigArn": PassThroughProperty(False),
+        "ImageConfig": PassThroughProperty(False),
+        "Architectures": PassThroughProperty(False),
+        "SnapStart": PassThroughProperty(False),
+        "EphemeralStorage": PassThroughProperty(False),
+        "RuntimeManagementConfig": PassThroughProperty(False),
     }
 
     Code: Dict[str, Any]
@@ -66,10 +65,10 @@ class LambdaFunction(Resource):
 class LambdaVersion(Resource):
     resource_type = "AWS::Lambda::Version"
     property_types = {
-        "CodeSha256": PropertyType(False, IS_STR),
-        "Description": PropertyType(False, IS_STR),
-        "FunctionName": PropertyType(True, one_of(IS_STR, IS_DICT)),
-        "RuntimeManagementConfig": PropertyType(False, IS_DICT),
+        "CodeSha256": PassThroughProperty(False),
+        "Description": PassThroughProperty(False),
+        "FunctionName": PassThroughProperty(True),
+        "RuntimeManagementConfig": PassThroughProperty(False),
     }
 
     runtime_attrs = {
@@ -81,11 +80,11 @@ class LambdaVersion(Resource):
 class LambdaAlias(Resource):
     resource_type = "AWS::Lambda::Alias"
     property_types = {
-        "Description": PropertyType(False, IS_STR),
-        "Name": PropertyType(False, IS_STR),
-        "FunctionName": PropertyType(True, one_of(IS_STR, IS_DICT)),
-        "FunctionVersion": PropertyType(True, one_of(IS_STR, IS_DICT)),
-        "ProvisionedConcurrencyConfig": PropertyType(False, IS_DICT),
+        "Description": PassThroughProperty(False),
+        "Name": PassThroughProperty(False),
+        "FunctionName": PassThroughProperty(True),
+        "FunctionVersion": PassThroughProperty(True),
+        "ProvisionedConcurrencyConfig": PassThroughProperty(False),
     }
 
     runtime_attrs = {"arn": lambda self: ref(self.logical_id)}
@@ -94,28 +93,28 @@ class LambdaAlias(Resource):
 class LambdaEventSourceMapping(Resource):
     resource_type = "AWS::Lambda::EventSourceMapping"
     property_types = {
-        "BatchSize": PropertyType(False, is_type(int)),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "EventSourceArn": PropertyType(False, IS_STR),
-        "FunctionName": PropertyType(True, IS_STR),
-        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
-        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),
-        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),
-        "DestinationConfig": PropertyType(False, IS_DICT),
-        "ParallelizationFactor": PropertyType(False, is_type(int)),
-        "StartingPosition": PropertyType(False, IS_STR),
+        "BatchSize": PassThroughProperty(False),
+        "Enabled": PassThroughProperty(False),
+        "EventSourceArn": PassThroughProperty(False),
+        "FunctionName": PassThroughProperty(True),
+        "MaximumBatchingWindowInSeconds": PassThroughProperty(False),
+        "MaximumRetryAttempts": PassThroughProperty(False),
+        "BisectBatchOnFunctionError": PassThroughProperty(False),
+        "MaximumRecordAgeInSeconds": PassThroughProperty(False),
+        "DestinationConfig": PassThroughProperty(False),
+        "ParallelizationFactor": PassThroughProperty(False),
+        "StartingPosition": PassThroughProperty(False),
         "StartingPositionTimestamp": PassThroughProperty(False),
-        "Topics": PropertyType(False, is_type(list)),
-        "Queues": PropertyType(False, is_type(list)),
-        "SourceAccessConfigurations": PropertyType(False, is_type(list)),
-        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),
-        "FunctionResponseTypes": PropertyType(False, is_type(list)),
-        "SelfManagedEventSource": PropertyType(False, IS_DICT),
-        "FilterCriteria": PropertyType(False, IS_DICT),
-        "AmazonManagedKafkaEventSourceConfig": PropertyType(False, IS_DICT),
-        "SelfManagedKafkaEventSourceConfig": PropertyType(False, IS_DICT),
-        "ScalingConfig": PropertyType(False, IS_DICT),
+        "Topics": PassThroughProperty(False),
+        "Queues": PassThroughProperty(False),
+        "SourceAccessConfigurations": PassThroughProperty(False),
+        "TumblingWindowInSeconds": PassThroughProperty(False),
+        "FunctionResponseTypes": PassThroughProperty(False),
+        "SelfManagedEventSource": PassThroughProperty(False),
+        "FilterCriteria": PassThroughProperty(False),
+        "AmazonManagedKafkaEventSourceConfig": PassThroughProperty(False),
+        "SelfManagedKafkaEventSourceConfig": PassThroughProperty(False),
+        "ScalingConfig": PassThroughProperty(False),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}
@@ -124,24 +123,24 @@ class LambdaEventSourceMapping(Resource):
 class LambdaPermission(Resource):
     resource_type = "AWS::Lambda::Permission"
     property_types = {
-        "Action": PropertyType(True, IS_STR),
-        "FunctionName": PropertyType(True, IS_STR),
-        "Principal": PropertyType(True, IS_STR),
-        "SourceAccount": PropertyType(False, IS_STR),
-        "SourceArn": PropertyType(False, IS_STR),
-        "EventSourceToken": PropertyType(False, IS_STR),
-        "FunctionUrlAuthType": PropertyType(False, IS_STR),
+        "Action": PassThroughProperty(True),
+        "FunctionName": PassThroughProperty(True),
+        "Principal": PassThroughProperty(True),
+        "SourceAccount": PassThroughProperty(False),
+        "SourceArn": PassThroughProperty(False),
+        "EventSourceToken": PassThroughProperty(False),
+        "FunctionUrlAuthType": PassThroughProperty(False),
     }
 
 
 class LambdaEventInvokeConfig(Resource):
     resource_type = "AWS::Lambda::EventInvokeConfig"
     property_types = {
-        "DestinationConfig": PropertyType(False, IS_DICT),
-        "FunctionName": PropertyType(True, IS_STR),
-        "MaximumEventAgeInSeconds": PropertyType(False, is_type(int)),
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
-        "Qualifier": PropertyType(True, IS_STR),
+        "DestinationConfig": PassThroughProperty(False),
+        "FunctionName": PassThroughProperty(True),
+        "MaximumEventAgeInSeconds": PassThroughProperty(False),
+        "MaximumRetryAttempts": PassThroughProperty(False),
+        "Qualifier": PassThroughProperty(True),
     }
 
 
@@ -150,12 +149,12 @@ class LambdaLayerVersion(Resource):
 
     resource_type = "AWS::Lambda::LayerVersion"
     property_types = {
-        "Content": PropertyType(True, IS_DICT),
-        "Description": PropertyType(False, IS_STR),
-        "LayerName": PropertyType(False, IS_STR),
-        "CompatibleArchitectures": PropertyType(False, list_of(one_of(IS_STR, IS_DICT))),
-        "CompatibleRuntimes": PropertyType(False, list_of(one_of(IS_STR, IS_DICT))),
-        "LicenseInfo": PropertyType(False, IS_STR),
+        "Content": PassThroughProperty(True),
+        "Description": PassThroughProperty(False),
+        "LayerName": PassThroughProperty(False),
+        "CompatibleArchitectures": PassThroughProperty(False),
+        "CompatibleRuntimes": PassThroughProperty(False),
+        "LicenseInfo": PassThroughProperty(False),
     }
 
     Content: Dict[str, Any]
@@ -171,7 +170,7 @@ class LambdaLayerVersion(Resource):
 class LambdaUrl(Resource):
     resource_type = "AWS::Lambda::Url"
     property_types = {
-        "TargetFunctionArn": PropertyType(True, one_of(IS_STR, IS_DICT)),
-        "AuthType": PropertyType(True, IS_STR),
-        "Cors": PropertyType(False, IS_DICT),
+        "TargetFunctionArn": PassThroughProperty(True),
+        "AuthType": PassThroughProperty(True),
+        "Cors": PassThroughProperty(False),
     }

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-from samtranslator.model import GeneratedProperty, GeneratedProperty, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
 from samtranslator.utils.types import Intrinsicable
 
@@ -8,30 +8,30 @@ from samtranslator.utils.types import Intrinsicable
 class LambdaFunction(Resource):
     resource_type = "AWS::Lambda::Function"
     property_types = {
-        "Code": GeneratedProperty(True),
-        "PackageType": GeneratedProperty(False),
-        "DeadLetterConfig": GeneratedProperty(False),
-        "Description": GeneratedProperty(False),
-        "FunctionName": GeneratedProperty(False),
-        "Handler": GeneratedProperty(False),
-        "MemorySize": GeneratedProperty(False),
-        "Role": GeneratedProperty(False),
-        "Runtime": GeneratedProperty(False),
-        "Timeout": GeneratedProperty(False),
-        "VpcConfig": GeneratedProperty(False),
-        "Environment": GeneratedProperty(False),
-        "Tags": GeneratedProperty(False),
-        "TracingConfig": GeneratedProperty(False),
-        "KmsKeyArn": GeneratedProperty(False),
-        "Layers": GeneratedProperty(False),
-        "ReservedConcurrentExecutions": GeneratedProperty(False),
-        "FileSystemConfigs": GeneratedProperty(False),
-        "CodeSigningConfigArn": GeneratedProperty(False),
-        "ImageConfig": GeneratedProperty(False),
-        "Architectures": GeneratedProperty(False),
-        "SnapStart": GeneratedProperty(False),
-        "EphemeralStorage": GeneratedProperty(False),
-        "RuntimeManagementConfig": GeneratedProperty(False),
+        "Code": GeneratedProperty(),
+        "PackageType": GeneratedProperty(),
+        "DeadLetterConfig": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "FunctionName": GeneratedProperty(),
+        "Handler": GeneratedProperty(),
+        "MemorySize": GeneratedProperty(),
+        "Role": GeneratedProperty(),
+        "Runtime": GeneratedProperty(),
+        "Timeout": GeneratedProperty(),
+        "VpcConfig": GeneratedProperty(),
+        "Environment": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
+        "TracingConfig": GeneratedProperty(),
+        "KmsKeyArn": GeneratedProperty(),
+        "Layers": GeneratedProperty(),
+        "ReservedConcurrentExecutions": GeneratedProperty(),
+        "FileSystemConfigs": GeneratedProperty(),
+        "CodeSigningConfigArn": GeneratedProperty(),
+        "ImageConfig": GeneratedProperty(),
+        "Architectures": GeneratedProperty(),
+        "SnapStart": GeneratedProperty(),
+        "EphemeralStorage": GeneratedProperty(),
+        "RuntimeManagementConfig": GeneratedProperty(),
     }
 
     Code: Dict[str, Any]
@@ -65,10 +65,10 @@ class LambdaFunction(Resource):
 class LambdaVersion(Resource):
     resource_type = "AWS::Lambda::Version"
     property_types = {
-        "CodeSha256": GeneratedProperty(False),
-        "Description": GeneratedProperty(False),
-        "FunctionName": GeneratedProperty(True),
-        "RuntimeManagementConfig": GeneratedProperty(False),
+        "CodeSha256": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "FunctionName": GeneratedProperty(),
+        "RuntimeManagementConfig": GeneratedProperty(),
     }
 
     runtime_attrs = {
@@ -80,11 +80,11 @@ class LambdaVersion(Resource):
 class LambdaAlias(Resource):
     resource_type = "AWS::Lambda::Alias"
     property_types = {
-        "Description": GeneratedProperty(False),
-        "Name": GeneratedProperty(False),
-        "FunctionName": GeneratedProperty(True),
-        "FunctionVersion": GeneratedProperty(True),
-        "ProvisionedConcurrencyConfig": GeneratedProperty(False),
+        "Description": GeneratedProperty(),
+        "Name": GeneratedProperty(),
+        "FunctionName": GeneratedProperty(),
+        "FunctionVersion": GeneratedProperty(),
+        "ProvisionedConcurrencyConfig": GeneratedProperty(),
     }
 
     runtime_attrs = {"arn": lambda self: ref(self.logical_id)}
@@ -93,28 +93,28 @@ class LambdaAlias(Resource):
 class LambdaEventSourceMapping(Resource):
     resource_type = "AWS::Lambda::EventSourceMapping"
     property_types = {
-        "BatchSize": GeneratedProperty(False),
-        "Enabled": GeneratedProperty(False),
-        "EventSourceArn": GeneratedProperty(False),
-        "FunctionName": GeneratedProperty(True),
-        "MaximumBatchingWindowInSeconds": GeneratedProperty(False),
-        "MaximumRetryAttempts": GeneratedProperty(False),
-        "BisectBatchOnFunctionError": GeneratedProperty(False),
-        "MaximumRecordAgeInSeconds": GeneratedProperty(False),
-        "DestinationConfig": GeneratedProperty(False),
-        "ParallelizationFactor": GeneratedProperty(False),
-        "StartingPosition": GeneratedProperty(False),
-        "StartingPositionTimestamp": GeneratedProperty(False),
-        "Topics": GeneratedProperty(False),
-        "Queues": GeneratedProperty(False),
-        "SourceAccessConfigurations": GeneratedProperty(False),
-        "TumblingWindowInSeconds": GeneratedProperty(False),
-        "FunctionResponseTypes": GeneratedProperty(False),
-        "SelfManagedEventSource": GeneratedProperty(False),
-        "FilterCriteria": GeneratedProperty(False),
-        "AmazonManagedKafkaEventSourceConfig": GeneratedProperty(False),
-        "SelfManagedKafkaEventSourceConfig": GeneratedProperty(False),
-        "ScalingConfig": GeneratedProperty(False),
+        "BatchSize": GeneratedProperty(),
+        "Enabled": GeneratedProperty(),
+        "EventSourceArn": GeneratedProperty(),
+        "FunctionName": GeneratedProperty(),
+        "MaximumBatchingWindowInSeconds": GeneratedProperty(),
+        "MaximumRetryAttempts": GeneratedProperty(),
+        "BisectBatchOnFunctionError": GeneratedProperty(),
+        "MaximumRecordAgeInSeconds": GeneratedProperty(),
+        "DestinationConfig": GeneratedProperty(),
+        "ParallelizationFactor": GeneratedProperty(),
+        "StartingPosition": GeneratedProperty(),
+        "StartingPositionTimestamp": GeneratedProperty(),
+        "Topics": GeneratedProperty(),
+        "Queues": GeneratedProperty(),
+        "SourceAccessConfigurations": GeneratedProperty(),
+        "TumblingWindowInSeconds": GeneratedProperty(),
+        "FunctionResponseTypes": GeneratedProperty(),
+        "SelfManagedEventSource": GeneratedProperty(),
+        "FilterCriteria": GeneratedProperty(),
+        "AmazonManagedKafkaEventSourceConfig": GeneratedProperty(),
+        "SelfManagedKafkaEventSourceConfig": GeneratedProperty(),
+        "ScalingConfig": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}
@@ -123,24 +123,24 @@ class LambdaEventSourceMapping(Resource):
 class LambdaPermission(Resource):
     resource_type = "AWS::Lambda::Permission"
     property_types = {
-        "Action": GeneratedProperty(True),
-        "FunctionName": GeneratedProperty(True),
-        "Principal": GeneratedProperty(True),
-        "SourceAccount": GeneratedProperty(False),
-        "SourceArn": GeneratedProperty(False),
-        "EventSourceToken": GeneratedProperty(False),
-        "FunctionUrlAuthType": GeneratedProperty(False),
+        "Action": GeneratedProperty(),
+        "FunctionName": GeneratedProperty(),
+        "Principal": GeneratedProperty(),
+        "SourceAccount": GeneratedProperty(),
+        "SourceArn": GeneratedProperty(),
+        "EventSourceToken": GeneratedProperty(),
+        "FunctionUrlAuthType": GeneratedProperty(),
     }
 
 
 class LambdaEventInvokeConfig(Resource):
     resource_type = "AWS::Lambda::EventInvokeConfig"
     property_types = {
-        "DestinationConfig": GeneratedProperty(False),
-        "FunctionName": GeneratedProperty(True),
-        "MaximumEventAgeInSeconds": GeneratedProperty(False),
-        "MaximumRetryAttempts": GeneratedProperty(False),
-        "Qualifier": GeneratedProperty(True),
+        "DestinationConfig": GeneratedProperty(),
+        "FunctionName": GeneratedProperty(),
+        "MaximumEventAgeInSeconds": GeneratedProperty(),
+        "MaximumRetryAttempts": GeneratedProperty(),
+        "Qualifier": GeneratedProperty(),
     }
 
 
@@ -149,12 +149,12 @@ class LambdaLayerVersion(Resource):
 
     resource_type = "AWS::Lambda::LayerVersion"
     property_types = {
-        "Content": GeneratedProperty(True),
-        "Description": GeneratedProperty(False),
-        "LayerName": GeneratedProperty(False),
-        "CompatibleArchitectures": GeneratedProperty(False),
-        "CompatibleRuntimes": GeneratedProperty(False),
-        "LicenseInfo": GeneratedProperty(False),
+        "Content": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "LayerName": GeneratedProperty(),
+        "CompatibleArchitectures": GeneratedProperty(),
+        "CompatibleRuntimes": GeneratedProperty(),
+        "LicenseInfo": GeneratedProperty(),
     }
 
     Content: Dict[str, Any]
@@ -170,7 +170,7 @@ class LambdaLayerVersion(Resource):
 class LambdaUrl(Resource):
     resource_type = "AWS::Lambda::Url"
     property_types = {
-        "TargetFunctionArn": GeneratedProperty(True),
-        "AuthType": GeneratedProperty(True),
-        "Cors": GeneratedProperty(False),
+        "TargetFunctionArn": GeneratedProperty(),
+        "AuthType": GeneratedProperty(),
+        "Cors": GeneratedProperty(),
     }

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-from samtranslator.model import PassThroughProperty, Resource
+from samtranslator.model import GeneratedProperty, GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
 from samtranslator.utils.types import Intrinsicable
 
@@ -8,30 +8,30 @@ from samtranslator.utils.types import Intrinsicable
 class LambdaFunction(Resource):
     resource_type = "AWS::Lambda::Function"
     property_types = {
-        "Code": PassThroughProperty(True),
-        "PackageType": PassThroughProperty(False),
-        "DeadLetterConfig": PassThroughProperty(False),
-        "Description": PassThroughProperty(False),
-        "FunctionName": PassThroughProperty(False),
-        "Handler": PassThroughProperty(False),
-        "MemorySize": PassThroughProperty(False),
-        "Role": PassThroughProperty(False),
-        "Runtime": PassThroughProperty(False),
-        "Timeout": PassThroughProperty(False),
-        "VpcConfig": PassThroughProperty(False),
-        "Environment": PassThroughProperty(False),
-        "Tags": PassThroughProperty(False),
-        "TracingConfig": PassThroughProperty(False),
-        "KmsKeyArn": PassThroughProperty(False),
-        "Layers": PassThroughProperty(False),
-        "ReservedConcurrentExecutions": PassThroughProperty(False),
-        "FileSystemConfigs": PassThroughProperty(False),
-        "CodeSigningConfigArn": PassThroughProperty(False),
-        "ImageConfig": PassThroughProperty(False),
-        "Architectures": PassThroughProperty(False),
-        "SnapStart": PassThroughProperty(False),
-        "EphemeralStorage": PassThroughProperty(False),
-        "RuntimeManagementConfig": PassThroughProperty(False),
+        "Code": GeneratedProperty(True),
+        "PackageType": GeneratedProperty(False),
+        "DeadLetterConfig": GeneratedProperty(False),
+        "Description": GeneratedProperty(False),
+        "FunctionName": GeneratedProperty(False),
+        "Handler": GeneratedProperty(False),
+        "MemorySize": GeneratedProperty(False),
+        "Role": GeneratedProperty(False),
+        "Runtime": GeneratedProperty(False),
+        "Timeout": GeneratedProperty(False),
+        "VpcConfig": GeneratedProperty(False),
+        "Environment": GeneratedProperty(False),
+        "Tags": GeneratedProperty(False),
+        "TracingConfig": GeneratedProperty(False),
+        "KmsKeyArn": GeneratedProperty(False),
+        "Layers": GeneratedProperty(False),
+        "ReservedConcurrentExecutions": GeneratedProperty(False),
+        "FileSystemConfigs": GeneratedProperty(False),
+        "CodeSigningConfigArn": GeneratedProperty(False),
+        "ImageConfig": GeneratedProperty(False),
+        "Architectures": GeneratedProperty(False),
+        "SnapStart": GeneratedProperty(False),
+        "EphemeralStorage": GeneratedProperty(False),
+        "RuntimeManagementConfig": GeneratedProperty(False),
     }
 
     Code: Dict[str, Any]
@@ -65,10 +65,10 @@ class LambdaFunction(Resource):
 class LambdaVersion(Resource):
     resource_type = "AWS::Lambda::Version"
     property_types = {
-        "CodeSha256": PassThroughProperty(False),
-        "Description": PassThroughProperty(False),
-        "FunctionName": PassThroughProperty(True),
-        "RuntimeManagementConfig": PassThroughProperty(False),
+        "CodeSha256": GeneratedProperty(False),
+        "Description": GeneratedProperty(False),
+        "FunctionName": GeneratedProperty(True),
+        "RuntimeManagementConfig": GeneratedProperty(False),
     }
 
     runtime_attrs = {
@@ -80,11 +80,11 @@ class LambdaVersion(Resource):
 class LambdaAlias(Resource):
     resource_type = "AWS::Lambda::Alias"
     property_types = {
-        "Description": PassThroughProperty(False),
-        "Name": PassThroughProperty(False),
-        "FunctionName": PassThroughProperty(True),
-        "FunctionVersion": PassThroughProperty(True),
-        "ProvisionedConcurrencyConfig": PassThroughProperty(False),
+        "Description": GeneratedProperty(False),
+        "Name": GeneratedProperty(False),
+        "FunctionName": GeneratedProperty(True),
+        "FunctionVersion": GeneratedProperty(True),
+        "ProvisionedConcurrencyConfig": GeneratedProperty(False),
     }
 
     runtime_attrs = {"arn": lambda self: ref(self.logical_id)}
@@ -93,28 +93,28 @@ class LambdaAlias(Resource):
 class LambdaEventSourceMapping(Resource):
     resource_type = "AWS::Lambda::EventSourceMapping"
     property_types = {
-        "BatchSize": PassThroughProperty(False),
-        "Enabled": PassThroughProperty(False),
-        "EventSourceArn": PassThroughProperty(False),
-        "FunctionName": PassThroughProperty(True),
-        "MaximumBatchingWindowInSeconds": PassThroughProperty(False),
-        "MaximumRetryAttempts": PassThroughProperty(False),
-        "BisectBatchOnFunctionError": PassThroughProperty(False),
-        "MaximumRecordAgeInSeconds": PassThroughProperty(False),
-        "DestinationConfig": PassThroughProperty(False),
-        "ParallelizationFactor": PassThroughProperty(False),
-        "StartingPosition": PassThroughProperty(False),
-        "StartingPositionTimestamp": PassThroughProperty(False),
-        "Topics": PassThroughProperty(False),
-        "Queues": PassThroughProperty(False),
-        "SourceAccessConfigurations": PassThroughProperty(False),
-        "TumblingWindowInSeconds": PassThroughProperty(False),
-        "FunctionResponseTypes": PassThroughProperty(False),
-        "SelfManagedEventSource": PassThroughProperty(False),
-        "FilterCriteria": PassThroughProperty(False),
-        "AmazonManagedKafkaEventSourceConfig": PassThroughProperty(False),
-        "SelfManagedKafkaEventSourceConfig": PassThroughProperty(False),
-        "ScalingConfig": PassThroughProperty(False),
+        "BatchSize": GeneratedProperty(False),
+        "Enabled": GeneratedProperty(False),
+        "EventSourceArn": GeneratedProperty(False),
+        "FunctionName": GeneratedProperty(True),
+        "MaximumBatchingWindowInSeconds": GeneratedProperty(False),
+        "MaximumRetryAttempts": GeneratedProperty(False),
+        "BisectBatchOnFunctionError": GeneratedProperty(False),
+        "MaximumRecordAgeInSeconds": GeneratedProperty(False),
+        "DestinationConfig": GeneratedProperty(False),
+        "ParallelizationFactor": GeneratedProperty(False),
+        "StartingPosition": GeneratedProperty(False),
+        "StartingPositionTimestamp": GeneratedProperty(False),
+        "Topics": GeneratedProperty(False),
+        "Queues": GeneratedProperty(False),
+        "SourceAccessConfigurations": GeneratedProperty(False),
+        "TumblingWindowInSeconds": GeneratedProperty(False),
+        "FunctionResponseTypes": GeneratedProperty(False),
+        "SelfManagedEventSource": GeneratedProperty(False),
+        "FilterCriteria": GeneratedProperty(False),
+        "AmazonManagedKafkaEventSourceConfig": GeneratedProperty(False),
+        "SelfManagedKafkaEventSourceConfig": GeneratedProperty(False),
+        "ScalingConfig": GeneratedProperty(False),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}
@@ -123,24 +123,24 @@ class LambdaEventSourceMapping(Resource):
 class LambdaPermission(Resource):
     resource_type = "AWS::Lambda::Permission"
     property_types = {
-        "Action": PassThroughProperty(True),
-        "FunctionName": PassThroughProperty(True),
-        "Principal": PassThroughProperty(True),
-        "SourceAccount": PassThroughProperty(False),
-        "SourceArn": PassThroughProperty(False),
-        "EventSourceToken": PassThroughProperty(False),
-        "FunctionUrlAuthType": PassThroughProperty(False),
+        "Action": GeneratedProperty(True),
+        "FunctionName": GeneratedProperty(True),
+        "Principal": GeneratedProperty(True),
+        "SourceAccount": GeneratedProperty(False),
+        "SourceArn": GeneratedProperty(False),
+        "EventSourceToken": GeneratedProperty(False),
+        "FunctionUrlAuthType": GeneratedProperty(False),
     }
 
 
 class LambdaEventInvokeConfig(Resource):
     resource_type = "AWS::Lambda::EventInvokeConfig"
     property_types = {
-        "DestinationConfig": PassThroughProperty(False),
-        "FunctionName": PassThroughProperty(True),
-        "MaximumEventAgeInSeconds": PassThroughProperty(False),
-        "MaximumRetryAttempts": PassThroughProperty(False),
-        "Qualifier": PassThroughProperty(True),
+        "DestinationConfig": GeneratedProperty(False),
+        "FunctionName": GeneratedProperty(True),
+        "MaximumEventAgeInSeconds": GeneratedProperty(False),
+        "MaximumRetryAttempts": GeneratedProperty(False),
+        "Qualifier": GeneratedProperty(True),
     }
 
 
@@ -149,12 +149,12 @@ class LambdaLayerVersion(Resource):
 
     resource_type = "AWS::Lambda::LayerVersion"
     property_types = {
-        "Content": PassThroughProperty(True),
-        "Description": PassThroughProperty(False),
-        "LayerName": PassThroughProperty(False),
-        "CompatibleArchitectures": PassThroughProperty(False),
-        "CompatibleRuntimes": PassThroughProperty(False),
-        "LicenseInfo": PassThroughProperty(False),
+        "Content": GeneratedProperty(True),
+        "Description": GeneratedProperty(False),
+        "LayerName": GeneratedProperty(False),
+        "CompatibleArchitectures": GeneratedProperty(False),
+        "CompatibleRuntimes": GeneratedProperty(False),
+        "LicenseInfo": GeneratedProperty(False),
     }
 
     Content: Dict[str, Any]
@@ -170,7 +170,7 @@ class LambdaLayerVersion(Resource):
 class LambdaUrl(Resource):
     resource_type = "AWS::Lambda::Url"
     property_types = {
-        "TargetFunctionArn": PassThroughProperty(True),
-        "AuthType": PassThroughProperty(True),
-        "Cors": PassThroughProperty(False),
+        "TargetFunctionArn": GeneratedProperty(True),
+        "AuthType": GeneratedProperty(True),
+        "Cors": GeneratedProperty(False),
     }

--- a/tests/translator/input/function_string_memorysize.yaml
+++ b/tests/translator/input/function_string_memorysize.yaml
@@ -1,0 +1,8 @@
+Resources:
+  MinimalFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: hello.handler
+      Runtime: python3.7
+      MemorySize: '700'

--- a/tests/translator/output/aws-cn/function_string_memorysize.json
+++ b/tests/translator/output/aws-cn/function_string_memorysize.json
@@ -1,0 +1,58 @@
+{
+  "Resources": {
+    "MinimalFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Handler": "hello.handler",
+        "MemorySize": "700",
+        "Role": {
+          "Fn::GetAtt": [
+            "MinimalFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MinimalFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/function_string_memorysize.json
+++ b/tests/translator/output/aws-us-gov/function_string_memorysize.json
@@ -1,0 +1,58 @@
+{
+  "Resources": {
+    "MinimalFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Handler": "hello.handler",
+        "MemorySize": "700",
+        "Role": {
+          "Fn::GetAtt": [
+            "MinimalFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MinimalFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/function_string_memorysize.json
+++ b/tests/translator/output/function_string_memorysize.json
@@ -1,0 +1,58 @@
+{
+  "Resources": {
+    "MinimalFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Handler": "hello.handler",
+        "MemorySize": "700",
+        "Role": {
+          "Fn::GetAtt": [
+            "MinimalFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MinimalFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes
A customer is reporting `AWS::Lambda::Function` supports string-type integers for memory size but `AWS::Serverless::Function` doesn't support it. So it's time to get rid of the property validations.

### Description of how you validated changes
Deploying the transformed templates.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
