### PR TITLE
chore: replace generated properties by GeneratedProperty()

### DIFF
--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -2,10 +2,10 @@ import json
 from re import match
 from typing import Any, Dict, List, Optional, Union
 
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.model.intrinsics import fnSub, ref
-from samtranslator.model.types import IS_DICT, IS_STR, PassThrough, is_type, list_of, one_of
+from samtranslator.model.types import PassThrough
 from samtranslator.translator import logical_id_generator
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.utils.py27hash_fix import Py27Dict, Py27UniStr
@@ -15,18 +15,18 @@ from samtranslator.validator.value_validator import sam_expect
 class ApiGatewayRestApi(Resource):
     resource_type = "AWS::ApiGateway::RestApi"
     property_types = {
-        "Body": PropertyType(False, IS_DICT),
-        "BodyS3Location": PropertyType(False, IS_DICT),
-        "CloneFrom": PropertyType(False, IS_STR),
-        "Description": PropertyType(False, IS_STR),
-        "FailOnWarnings": PropertyType(False, is_type(bool)),
-        "Name": PropertyType(False, IS_STR),
-        "Parameters": PropertyType(False, IS_DICT),
-        "EndpointConfiguration": PropertyType(False, IS_DICT),
-        "BinaryMediaTypes": PropertyType(False, is_type(list)),
-        "MinimumCompressionSize": PropertyType(False, is_type(int)),
-        "Mode": PropertyType(False, IS_STR),
-        "ApiKeySourceType": PropertyType(False, IS_STR),
+        "Body": GeneratedProperty(),
+        "BodyS3Location": GeneratedProperty(),
+        "CloneFrom": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "FailOnWarnings": GeneratedProperty(),
+        "Name": GeneratedProperty(),
+        "Parameters": GeneratedProperty(),
+        "EndpointConfiguration": GeneratedProperty(),
+        "BinaryMediaTypes": GeneratedProperty(),
+        "MinimumCompressionSize": GeneratedProperty(),
+        "Mode": GeneratedProperty(),
+        "ApiKeySourceType": GeneratedProperty(),
     }
 
     Body: Optional[Dict[str, Any]]
@@ -48,19 +48,19 @@ class ApiGatewayRestApi(Resource):
 class ApiGatewayStage(Resource):
     resource_type = "AWS::ApiGateway::Stage"
     property_types = {
-        "AccessLogSetting": PropertyType(False, IS_DICT),
-        "CacheClusterEnabled": PropertyType(False, is_type(bool)),
-        "CacheClusterSize": PropertyType(False, IS_STR),
-        "CanarySetting": PropertyType(False, IS_DICT),
-        "ClientCertificateId": PropertyType(False, IS_STR),
-        "DeploymentId": PropertyType(True, IS_STR),
-        "Description": PropertyType(False, IS_STR),
-        "RestApiId": PropertyType(True, IS_STR),
-        "StageName": PropertyType(True, one_of(IS_STR, IS_DICT)),
-        "Tags": PropertyType(False, list_of(IS_DICT)),
-        "TracingEnabled": PropertyType(False, is_type(bool)),
-        "Variables": PropertyType(False, IS_DICT),
-        "MethodSettings": PropertyType(False, is_type(list)),
+        "AccessLogSetting": GeneratedProperty(),
+        "CacheClusterEnabled": GeneratedProperty(),
+        "CacheClusterSize": GeneratedProperty(),
+        "CanarySetting": GeneratedProperty(),
+        "ClientCertificateId": GeneratedProperty(),
+        "DeploymentId": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "RestApiId": GeneratedProperty(),
+        "StageName": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
+        "TracingEnabled": GeneratedProperty(),
+        "Variables": GeneratedProperty(),
+        "MethodSettings": GeneratedProperty(),
     }
 
     runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}
@@ -71,7 +71,9 @@ class ApiGatewayStage(Resource):
 
 class ApiGatewayAccount(Resource):
     resource_type = "AWS::ApiGateway::Account"
-    property_types = {"CloudWatchRoleArn": PropertyType(False, one_of(IS_STR, IS_DICT))}
+    property_types = {
+        "CloudWatchRoleArn": GeneratedProperty(),
+    }
 
 
 class ApiGatewayDeployment(Resource):
@@ -79,10 +81,10 @@ class ApiGatewayDeployment(Resource):
 
     resource_type = "AWS::ApiGateway::Deployment"
     property_types = {
-        "Description": PropertyType(False, IS_STR),
-        "RestApiId": PropertyType(True, IS_STR),
-        "StageDescription": PropertyType(False, IS_DICT),
-        "StageName": PropertyType(False, IS_STR),
+        "Description": GeneratedProperty(),
+        "RestApiId": GeneratedProperty(),
+        "StageDescription": GeneratedProperty(),
+        "StageName": GeneratedProperty(),
     }
 
     runtime_attrs = {"deployment_id": lambda self: ref(self.logical_id)}
@@ -200,13 +202,13 @@ class ApiGatewayResponse:
 class ApiGatewayDomainName(Resource):
     resource_type = "AWS::ApiGateway::DomainName"
     property_types = {
-        "RegionalCertificateArn": PropertyType(False, IS_STR),
-        "DomainName": PropertyType(True, IS_STR),
-        "EndpointConfiguration": PropertyType(False, IS_DICT),
-        "MutualTlsAuthentication": PropertyType(False, IS_DICT),
-        "SecurityPolicy": PropertyType(False, IS_STR),
-        "CertificateArn": PropertyType(False, IS_STR),
-        "OwnershipVerificationCertificateArn": PropertyType(False, IS_STR),
+        "RegionalCertificateArn": GeneratedProperty(),
+        "DomainName": GeneratedProperty(),
+        "EndpointConfiguration": GeneratedProperty(),
+        "MutualTlsAuthentication": GeneratedProperty(),
+        "SecurityPolicy": GeneratedProperty(),
+        "CertificateArn": GeneratedProperty(),
+        "OwnershipVerificationCertificateArn": GeneratedProperty(),
     }
 
     RegionalCertificateArn: Optional[PassThrough]
@@ -221,22 +223,22 @@ class ApiGatewayDomainName(Resource):
 class ApiGatewayBasePathMapping(Resource):
     resource_type = "AWS::ApiGateway::BasePathMapping"
     property_types = {
-        "BasePath": PropertyType(False, IS_STR),
-        "DomainName": PropertyType(True, IS_STR),
-        "RestApiId": PropertyType(False, IS_STR),
-        "Stage": PropertyType(False, IS_STR),
+        "BasePath": GeneratedProperty(),
+        "DomainName": GeneratedProperty(),
+        "RestApiId": GeneratedProperty(),
+        "Stage": GeneratedProperty(),
     }
 
 
 class ApiGatewayUsagePlan(Resource):
     resource_type = "AWS::ApiGateway::UsagePlan"
     property_types = {
-        "ApiStages": PropertyType(False, is_type(list)),
-        "Description": PropertyType(False, IS_STR),
-        "Quota": PropertyType(False, IS_DICT),
-        "Tags": PropertyType(False, list_of(dict)),
-        "Throttle": PropertyType(False, IS_DICT),
-        "UsagePlanName": PropertyType(False, IS_STR),
+        "ApiStages": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "Quota": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
+        "Throttle": GeneratedProperty(),
+        "UsagePlanName": GeneratedProperty(),
     }
     runtime_attrs = {"usage_plan_id": lambda self: ref(self.logical_id)}
 
@@ -244,22 +246,22 @@ class ApiGatewayUsagePlan(Resource):
 class ApiGatewayUsagePlanKey(Resource):
     resource_type = "AWS::ApiGateway::UsagePlanKey"
     property_types = {
-        "KeyId": PropertyType(True, IS_STR),
-        "KeyType": PropertyType(True, IS_STR),
-        "UsagePlanId": PropertyType(True, IS_STR),
+        "KeyId": GeneratedProperty(),
+        "KeyType": GeneratedProperty(),
+        "UsagePlanId": GeneratedProperty(),
     }
 
 
 class ApiGatewayApiKey(Resource):
     resource_type = "AWS::ApiGateway::ApiKey"
     property_types = {
-        "CustomerId": PropertyType(False, IS_STR),
-        "Description": PropertyType(False, IS_STR),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "GenerateDistinctId": PropertyType(False, is_type(bool)),
-        "Name": PropertyType(False, IS_STR),
-        "StageKeys": PropertyType(False, is_type(list)),
-        "Value": PropertyType(False, IS_STR),
+        "CustomerId": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "Enabled": GeneratedProperty(),
+        "GenerateDistinctId": GeneratedProperty(),
+        "Name": GeneratedProperty(),
+        "StageKeys": GeneratedProperty(),
+        "Value": GeneratedProperty(),
     }
 
     runtime_attrs = {"api_key_id": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, List, Optional, Union
 
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.exceptions import ExpectedType, InvalidResourceException
 from samtranslator.model.intrinsics import fnSub, ref
-from samtranslator.model.types import IS_DICT, IS_STR, PassThrough, is_type, list_of, one_of
+from samtranslator.model.types import PassThrough
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.utils.types import Intrinsicable
 from samtranslator.validator.value_validator import sam_expect
@@ -14,13 +14,13 @@ APIGATEWAY_AUTHORIZER_KEY = "x-amazon-apigateway-authorizer"
 class ApiGatewayV2HttpApi(Resource):
     resource_type = "AWS::ApiGatewayV2::Api"
     property_types = {
-        "Body": PropertyType(False, IS_DICT),
-        "BodyS3Location": PropertyType(False, IS_DICT),
-        "Description": PropertyType(False, IS_STR),
-        "FailOnWarnings": PropertyType(False, is_type(bool)),
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
-        "BasePath": PropertyType(False, IS_STR),
-        "CorsConfiguration": PropertyType(False, IS_DICT),
+        "Body": GeneratedProperty(),
+        "BodyS3Location": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "FailOnWarnings": GeneratedProperty(),
+        "DisableExecuteApiEndpoint": GeneratedProperty(),
+        "BasePath": GeneratedProperty(),
+        "CorsConfiguration": GeneratedProperty(),
     }
 
     runtime_attrs = {"http_api_id": lambda self: ref(self.logical_id)}
@@ -29,16 +29,16 @@ class ApiGatewayV2HttpApi(Resource):
 class ApiGatewayV2Stage(Resource):
     resource_type = "AWS::ApiGatewayV2::Stage"
     property_types = {
-        "AccessLogSettings": PropertyType(False, IS_DICT),
-        "DefaultRouteSettings": PropertyType(False, IS_DICT),
-        "RouteSettings": PropertyType(False, IS_DICT),
-        "ClientCertificateId": PropertyType(False, IS_STR),
-        "Description": PropertyType(False, IS_STR),
-        "ApiId": PropertyType(True, IS_STR),
-        "StageName": PropertyType(False, one_of(IS_STR, IS_DICT)),
-        "Tags": PropertyType(False, IS_DICT),
-        "StageVariables": PropertyType(False, IS_DICT),
-        "AutoDeploy": PropertyType(False, is_type(bool)),
+        "AccessLogSettings": GeneratedProperty(),
+        "DefaultRouteSettings": GeneratedProperty(),
+        "RouteSettings": GeneratedProperty(),
+        "ClientCertificateId": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "ApiId": GeneratedProperty(),
+        "StageName": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
+        "StageVariables": GeneratedProperty(),
+        "AutoDeploy": GeneratedProperty(),
     }
 
     runtime_attrs = {"stage_name": lambda self: ref(self.logical_id)}
@@ -47,10 +47,10 @@ class ApiGatewayV2Stage(Resource):
 class ApiGatewayV2DomainName(Resource):
     resource_type = "AWS::ApiGatewayV2::DomainName"
     property_types = {
-        "DomainName": PropertyType(True, IS_STR),
-        "DomainNameConfigurations": PropertyType(False, list_of(IS_DICT)),
-        "MutualTlsAuthentication": PropertyType(False, IS_DICT),
-        "Tags": PropertyType(False, IS_DICT),
+        "DomainName": GeneratedProperty(),
+        "DomainNameConfigurations": GeneratedProperty(),
+        "MutualTlsAuthentication": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
     }
 
     DomainName: Intrinsicable[str]
@@ -62,10 +62,10 @@ class ApiGatewayV2DomainName(Resource):
 class ApiGatewayV2ApiMapping(Resource):
     resource_type = "AWS::ApiGatewayV2::ApiMapping"
     property_types = {
-        "ApiId": PropertyType(True, IS_STR),
-        "ApiMappingKey": PropertyType(False, IS_STR),
-        "DomainName": PropertyType(True, IS_STR),
-        "Stage": PropertyType(True, IS_STR),
+        "ApiId": GeneratedProperty(),
+        "ApiMappingKey": GeneratedProperty(),
+        "DomainName": GeneratedProperty(),
+        "Stage": GeneratedProperty(),
     }
 
 

--- a/samtranslator/model/cloudformation.py
+++ b/samtranslator/model/cloudformation.py
@@ -1,17 +1,16 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import ref
-from samtranslator.model.types import IS_DICT, IS_STR, is_type, list_of, one_of
 
 
 class NestedStack(Resource):
     resource_type = "AWS::CloudFormation::Stack"
     # TODO: support passthrough parameters for stacks (Conditions, etc)
     property_types = {
-        "TemplateURL": PropertyType(True, IS_STR),
-        "Parameters": PropertyType(False, IS_DICT),
-        "NotificationARNs": PropertyType(False, list_of(one_of(IS_STR, IS_DICT))),
-        "Tags": PropertyType(False, list_of(IS_DICT)),
-        "TimeoutInMinutes": PropertyType(False, is_type(int)),
+        "TemplateURL": GeneratedProperty(),
+        "Parameters": GeneratedProperty(),
+        "NotificationARNs": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
+        "TimeoutInMinutes": GeneratedProperty(),
     }
 
     runtime_attrs = {"stack_id": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/codedeploy.py
+++ b/samtranslator/model/codedeploy.py
@@ -1,11 +1,12 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import ref
-from samtranslator.model.types import IS_DICT, IS_STR, is_type, one_of
 
 
 class CodeDeployApplication(Resource):
     resource_type = "AWS::CodeDeploy::Application"
-    property_types = {"ComputePlatform": PropertyType(False, one_of(IS_STR, IS_DICT))}
+    property_types = {
+        "ComputePlatform": GeneratedProperty(),
+    }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}
 
@@ -13,13 +14,13 @@ class CodeDeployApplication(Resource):
 class CodeDeployDeploymentGroup(Resource):
     resource_type = "AWS::CodeDeploy::DeploymentGroup"
     property_types = {
-        "AlarmConfiguration": PropertyType(False, IS_DICT),
-        "ApplicationName": PropertyType(True, one_of(IS_STR, IS_DICT)),
-        "AutoRollbackConfiguration": PropertyType(False, IS_DICT),
-        "DeploymentConfigName": PropertyType(False, one_of(IS_STR, IS_DICT)),
-        "DeploymentStyle": PropertyType(False, IS_DICT),
-        "ServiceRoleArn": PropertyType(True, one_of(IS_STR, IS_DICT)),
-        "TriggerConfigurations": PropertyType(False, is_type(list)),
+        "AlarmConfiguration": GeneratedProperty(),
+        "ApplicationName": GeneratedProperty(),
+        "AutoRollbackConfiguration": GeneratedProperty(),
+        "DeploymentConfigName": GeneratedProperty(),
+        "DeploymentStyle": GeneratedProperty(),
+        "ServiceRoleArn": GeneratedProperty(),
+        "TriggerConfigurations": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -1,34 +1,33 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_DICT, IS_STR, list_of
 
 
 class CognitoUserPool(Resource):
     resource_type = "AWS::Cognito::UserPool"
     property_types = {
-        "AccountRecoverySetting": PropertyType(False, IS_DICT),
-        "AdminCreateUserConfig": PropertyType(False, IS_DICT),
-        "AliasAttributes": PropertyType(False, list_of(IS_STR)),
-        "AutoVerifiedAttributes": PropertyType(False, list_of(IS_STR)),
-        "DeviceConfiguration": PropertyType(False, IS_DICT),
-        "EmailConfiguration": PropertyType(False, IS_DICT),
-        "EmailVerificationMessage": PropertyType(False, IS_STR),
-        "EmailVerificationSubject": PropertyType(False, IS_STR),
-        "EnabledMfas": PropertyType(False, list_of(IS_STR)),
-        "LambdaConfig": PropertyType(False, IS_DICT),
-        "MfaConfiguration": PropertyType(False, IS_STR),
-        "Policies": PropertyType(False, IS_DICT),
-        "Schema": PropertyType(False, list_of(dict)),
-        "SmsAuthenticationMessage": PropertyType(False, IS_STR),
-        "SmsConfiguration": PropertyType(False, IS_DICT),
-        "SmsVerificationMessage": PropertyType(False, IS_STR),
-        "UserAttributeUpdateSettings": PropertyType(False, IS_DICT),
-        "UsernameAttributes": PropertyType(False, list_of(IS_STR)),
-        "UsernameConfiguration": PropertyType(False, IS_DICT),
-        "UserPoolAddOns": PropertyType(False, list_of(dict)),
-        "UserPoolName": PropertyType(False, IS_STR),
-        "UserPoolTags": PropertyType(False, IS_DICT),
-        "VerificationMessageTemplate": PropertyType(False, IS_DICT),
+        "AccountRecoverySetting": GeneratedProperty(),
+        "AdminCreateUserConfig": GeneratedProperty(),
+        "AliasAttributes": GeneratedProperty(),
+        "AutoVerifiedAttributes": GeneratedProperty(),
+        "DeviceConfiguration": GeneratedProperty(),
+        "EmailConfiguration": GeneratedProperty(),
+        "EmailVerificationMessage": GeneratedProperty(),
+        "EmailVerificationSubject": GeneratedProperty(),
+        "EnabledMfas": GeneratedProperty(),
+        "LambdaConfig": GeneratedProperty(),
+        "MfaConfiguration": GeneratedProperty(),
+        "Policies": GeneratedProperty(),
+        "Schema": GeneratedProperty(),
+        "SmsAuthenticationMessage": GeneratedProperty(),
+        "SmsConfiguration": GeneratedProperty(),
+        "SmsVerificationMessage": GeneratedProperty(),
+        "UserAttributeUpdateSettings": GeneratedProperty(),
+        "UsernameAttributes": GeneratedProperty(),
+        "UsernameConfiguration": GeneratedProperty(),
+        "UserPoolAddOns": GeneratedProperty(),
+        "UserPoolName": GeneratedProperty(),
+        "UserPoolTags": GeneratedProperty(),
+        "VerificationMessageTemplate": GeneratedProperty(),
     }
 
     runtime_attrs = {

--- a/samtranslator/model/dynamodb.py
+++ b/samtranslator/model/dynamodb.py
@@ -1,21 +1,20 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_DICT, IS_STR, dict_of, is_type, list_of, one_of
 
 
 class DynamoDBTable(Resource):
     resource_type = "AWS::DynamoDB::Table"
     property_types = {
-        "AttributeDefinitions": PropertyType(True, list_of(IS_DICT)),
-        "GlobalSecondaryIndexes": PropertyType(False, list_of(IS_DICT)),
-        "KeySchema": PropertyType(False, list_of(IS_DICT)),
-        "LocalSecondaryIndexes": PropertyType(False, list_of(IS_DICT)),
-        "ProvisionedThroughput": PropertyType(False, dict_of(IS_STR, one_of(is_type(int), IS_DICT))),
-        "StreamSpecification": PropertyType(False, IS_DICT),
-        "TableName": PropertyType(False, one_of(IS_STR, IS_DICT)),
-        "Tags": PropertyType(False, list_of(IS_DICT)),
-        "SSESpecification": PropertyType(False, IS_DICT),
-        "BillingMode": PropertyType(False, IS_STR),
+        "AttributeDefinitions": GeneratedProperty(),
+        "GlobalSecondaryIndexes": GeneratedProperty(),
+        "KeySchema": GeneratedProperty(),
+        "LocalSecondaryIndexes": GeneratedProperty(),
+        "ProvisionedThroughput": GeneratedProperty(),
+        "StreamSpecification": GeneratedProperty(),
+        "TableName": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
+        "SSESpecification": GeneratedProperty(),
+        "BillingMode": GeneratedProperty(),
     }
 
     runtime_attrs = {

--- a/samtranslator/model/events.py
+++ b/samtranslator/model/events.py
@@ -1,19 +1,18 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_DICT, IS_STR, list_of
 
 
 class EventsRule(Resource):
     resource_type = "AWS::Events::Rule"
     property_types = {
-        "Description": PropertyType(False, IS_STR),
-        "EventBusName": PropertyType(False, IS_STR),
-        "EventPattern": PropertyType(False, IS_DICT),
-        "Name": PropertyType(False, IS_STR),
-        "RoleArn": PropertyType(False, IS_STR),
-        "ScheduleExpression": PropertyType(False, IS_STR),
-        "State": PropertyType(False, IS_STR),
-        "Targets": PropertyType(False, list_of(IS_DICT)),
+        "Description": GeneratedProperty(),
+        "EventBusName": GeneratedProperty(),
+        "EventPattern": GeneratedProperty(),
+        "Name": GeneratedProperty(),
+        "RoleArn": GeneratedProperty(),
+        "ScheduleExpression": GeneratedProperty(),
+        "State": GeneratedProperty(),
+        "Targets": GeneratedProperty(),
     }
 
     runtime_attrs = {"rule_id": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}

--- a/samtranslator/model/iam.py
+++ b/samtranslator/model/iam.py
@@ -1,19 +1,18 @@
 from typing import Any, Dict
 
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_DICT, IS_STR, is_type, list_of
 
 
 class IAMRole(Resource):
     resource_type = "AWS::IAM::Role"
     property_types = {
-        "AssumeRolePolicyDocument": PropertyType(True, IS_DICT),
-        "ManagedPolicyArns": PropertyType(False, is_type(list)),
-        "Path": PropertyType(False, IS_STR),
-        "Policies": PropertyType(False, is_type(list)),
-        "PermissionsBoundary": PropertyType(False, IS_STR),
-        "Tags": PropertyType(False, list_of(IS_DICT)),
+        "AssumeRolePolicyDocument": GeneratedProperty(),
+        "ManagedPolicyArns": GeneratedProperty(),
+        "Path": GeneratedProperty(),
+        "Policies": GeneratedProperty(),
+        "PermissionsBoundary": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
@@ -22,13 +21,13 @@ class IAMRole(Resource):
 class IAMManagedPolicy(Resource):
     resource_type = "AWS::IAM::ManagedPolicy"
     property_types = {
-        "Description": PropertyType(False, IS_STR),
-        "Groups": PropertyType(False, IS_STR),
-        "PolicyDocument": PropertyType(True, IS_DICT),
-        "ManagedPolicyName": PropertyType(False, IS_STR),
-        "Path": PropertyType(False, IS_STR),
-        "Roles": PropertyType(False, is_type(list)),
-        "Users": PropertyType(False, list_of(IS_STR)),
+        "Description": GeneratedProperty(),
+        "Groups": GeneratedProperty(),
+        "PolicyDocument": GeneratedProperty(),
+        "ManagedPolicyName": GeneratedProperty(),
+        "Path": GeneratedProperty(),
+        "Roles": GeneratedProperty(),
+        "Users": GeneratedProperty(),
     }
 
 

--- a/samtranslator/model/iot.py
+++ b/samtranslator/model/iot.py
@@ -1,10 +1,11 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_DICT
 
 
 class IotTopicRule(Resource):
     resource_type = "AWS::IoT::TopicRule"
-    property_types = {"TopicRulePayload": PropertyType(False, IS_DICT)}
+    property_types = {
+        "TopicRulePayload": GeneratedProperty(),
+    }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}

--- a/samtranslator/model/log.py
+++ b/samtranslator/model/log.py
@@ -1,14 +1,13 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_STR
 
 
 class SubscriptionFilter(Resource):
     resource_type = "AWS::Logs::SubscriptionFilter"
     property_types = {
-        "LogGroupName": PropertyType(True, IS_STR),
-        "FilterPattern": PropertyType(True, IS_STR),
-        "DestinationArn": PropertyType(True, IS_STR),
+        "LogGroupName": GeneratedProperty(),
+        "FilterPattern": GeneratedProperty(),
+        "DestinationArn": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}

--- a/samtranslator/model/route53.py
+++ b/samtranslator/model/route53.py
@@ -1,16 +1,15 @@
 from typing import Any, List, Optional
 
-from samtranslator.model import PropertyType, Resource
-from samtranslator.model.types import IS_STR, is_type
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.utils.types import Intrinsicable
 
 
 class Route53RecordSetGroup(Resource):
     resource_type = "AWS::Route53::RecordSetGroup"
     property_types = {
-        "HostedZoneId": PropertyType(False, IS_STR),
-        "HostedZoneName": PropertyType(False, IS_STR),
-        "RecordSets": PropertyType(False, is_type(list)),
+        "HostedZoneId": GeneratedProperty(),
+        "HostedZoneName": GeneratedProperty(),
+        "RecordSets": GeneratedProperty(),
     }
 
     HostedZoneId: Optional[Intrinsicable[str]]

--- a/samtranslator/model/s3.py
+++ b/samtranslator/model/s3.py
@@ -1,31 +1,30 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_DICT, IS_STR, any_type, is_type
 
 
 class S3Bucket(Resource):
     resource_type = "AWS::S3::Bucket"
     property_types = {
-        "AccessControl": PropertyType(False, any_type()),
-        "AccelerateConfiguration": PropertyType(False, any_type()),
-        "AnalyticsConfigurations": PropertyType(False, any_type()),
-        "BucketEncryption": PropertyType(False, any_type()),
-        "BucketName": PropertyType(False, IS_STR),
-        "CorsConfiguration": PropertyType(False, any_type()),
-        "IntelligentTieringConfigurations": PropertyType(False, any_type()),
-        "InventoryConfigurations": PropertyType(False, any_type()),
-        "LifecycleConfiguration": PropertyType(False, any_type()),
-        "LoggingConfiguration": PropertyType(False, any_type()),
-        "MetricsConfigurations": PropertyType(False, any_type()),
-        "NotificationConfiguration": PropertyType(False, IS_DICT),
-        "ObjectLockConfiguration": PropertyType(False, any_type()),
-        "ObjectLockEnabled": PropertyType(False, any_type()),
-        "OwnershipControls": PropertyType(False, any_type()),
-        "PublicAccessBlockConfiguration": PropertyType(False, IS_DICT),
-        "ReplicationConfiguration": PropertyType(False, any_type()),
-        "Tags": PropertyType(False, is_type(list)),
-        "VersioningConfiguration": PropertyType(False, any_type()),
-        "WebsiteConfiguration": PropertyType(False, any_type()),
+        "AccessControl": GeneratedProperty(),
+        "AccelerateConfiguration": GeneratedProperty(),
+        "AnalyticsConfigurations": GeneratedProperty(),
+        "BucketEncryption": GeneratedProperty(),
+        "BucketName": GeneratedProperty(),
+        "CorsConfiguration": GeneratedProperty(),
+        "IntelligentTieringConfigurations": GeneratedProperty(),
+        "InventoryConfigurations": GeneratedProperty(),
+        "LifecycleConfiguration": GeneratedProperty(),
+        "LoggingConfiguration": GeneratedProperty(),
+        "MetricsConfigurations": GeneratedProperty(),
+        "NotificationConfiguration": GeneratedProperty(),
+        "ObjectLockConfiguration": GeneratedProperty(),
+        "ObjectLockEnabled": GeneratedProperty(),
+        "OwnershipControls": GeneratedProperty(),
+        "PublicAccessBlockConfiguration": GeneratedProperty(),
+        "ReplicationConfiguration": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
+        "VersioningConfiguration": GeneratedProperty(),
+        "WebsiteConfiguration": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}

--- a/samtranslator/model/scheduler.py
+++ b/samtranslator/model/scheduler.py
@@ -1,24 +1,23 @@
 from typing import Any, Dict, Optional
 
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt
-from samtranslator.model.types import IS_DICT, IS_STR
 
 
 class SchedulerSchedule(Resource):
     resource_type = "AWS::Scheduler::Schedule"
     property_types = {
-        "ScheduleExpression": PropertyType(True, IS_STR),
-        "FlexibleTimeWindow": PropertyType(True, IS_DICT),
-        "Name": PropertyType(True, IS_STR),
-        "State": PropertyType(False, IS_STR),
-        "Description": PropertyType(False, IS_STR),
-        "StartDate": PropertyType(False, IS_STR),
-        "EndDate": PropertyType(False, IS_STR),
-        "ScheduleExpressionTimezone": PropertyType(False, IS_STR),
-        "GroupName": PropertyType(False, IS_STR),
-        "KmsKeyArn": PropertyType(False, IS_STR),
-        "Target": PropertyType(True, IS_DICT),
+        "ScheduleExpression": GeneratedProperty(),
+        "FlexibleTimeWindow": GeneratedProperty(),
+        "Name": GeneratedProperty(),
+        "State": GeneratedProperty(),
+        "Description": GeneratedProperty(),
+        "StartDate": GeneratedProperty(),
+        "EndDate": GeneratedProperty(),
+        "ScheduleExpressionTimezone": GeneratedProperty(),
+        "GroupName": GeneratedProperty(),
+        "KmsKeyArn": GeneratedProperty(),
+        "Target": GeneratedProperty(),
     }
 
     ScheduleExpression: str

--- a/samtranslator/model/sns.py
+++ b/samtranslator/model/sns.py
@@ -1,26 +1,30 @@
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import ref
-from samtranslator.model.types import IS_DICT, IS_STR, list_of
 
 
 class SNSSubscription(Resource):
     resource_type = "AWS::SNS::Subscription"
     property_types = {
-        "Endpoint": PropertyType(True, IS_STR),
-        "Protocol": PropertyType(True, IS_STR),
-        "TopicArn": PropertyType(True, IS_STR),
-        "Region": PropertyType(False, IS_STR),
-        "FilterPolicy": PropertyType(False, IS_DICT),
-        "RedrivePolicy": PropertyType(False, IS_DICT),
+        "Endpoint": GeneratedProperty(),
+        "Protocol": GeneratedProperty(),
+        "TopicArn": GeneratedProperty(),
+        "Region": GeneratedProperty(),
+        "FilterPolicy": GeneratedProperty(),
+        "RedrivePolicy": GeneratedProperty(),
     }
 
 
 class SNSTopicPolicy(Resource):
     resource_type = "AWS::SNS::TopicPolicy"
-    property_types = {"PolicyDocument": PropertyType(True, IS_DICT), "Topics": PropertyType(True, list_of(str))}
+    property_types = {
+        "PolicyDocument": GeneratedProperty(),
+        "Topics": GeneratedProperty(),
+    }
 
 
 class SNSTopic(Resource):
     resource_type = "AWS::SNS::Topic"
-    property_types = {"TopicName": PropertyType(False, IS_STR)}
+    property_types = {
+        "TopicName": GeneratedProperty(),
+    }
     runtime_attrs = {"arn": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/sqs.py
+++ b/samtranslator/model/sqs.py
@@ -1,8 +1,7 @@
 from typing import Dict
 
-from samtranslator.model import PropertyType, Resource
+from samtranslator.model import GeneratedProperty, PropertyType, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
-from samtranslator.model.types import IS_DICT, list_of
 
 
 class SQSQueue(Resource):
@@ -16,7 +15,10 @@ class SQSQueue(Resource):
 
 class SQSQueuePolicy(Resource):
     resource_type = "AWS::SQS::QueuePolicy"
-    property_types = {"PolicyDocument": PropertyType(True, IS_DICT), "Queues": PropertyType(True, list_of(str))}
+    property_types = {
+        "PolicyDocument": GeneratedProperty(),
+        "Queues": GeneratedProperty(),
+    }
     runtime_attrs = {"arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
 
 


### PR DESCRIPTION
### Issue #, if available

### Description of changes

`PropertyType` checks the type at runtime, which means there's a risk (as we've already observed) of us failing to transform a valid template. Also it adds overhead.

Instead, using `GeneratedProperty()` there are no runtime checks. We should instead rely on regular types and testing to make sure what we generate is correct.

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
