### PR TITLE
fix: appsync-ddb connector integ tests

### DIFF
--- a/integration/resources/expected/combination/connector_appsync_to_table.json
+++ b/integration/resources/expected/combination/connector_appsync_to_table.json
@@ -1,0 +1,38 @@
+[
+  {
+    "LogicalResourceId": "NotesTable",
+    "ResourceType": "AWS::DynamoDB::Table"
+  },
+  {
+    "LogicalResourceId": "DynamoDBRole",
+    "ResourceType": "AWS::IAM::Role"
+  },
+  {
+    "LogicalResourceId": "AppSyncApi",
+    "ResourceType": "AWS::AppSync::GraphQLApi"
+  },
+  {
+    "LogicalResourceId": "ApiKey",
+    "ResourceType": "AWS::AppSync::ApiKey"
+  },
+  {
+    "LogicalResourceId": "ApiSchema",
+    "ResourceType": "AWS::AppSync::GraphQLSchema"
+  },
+  {
+    "LogicalResourceId": "NotesTableDataSource",
+    "ResourceType": "AWS::AppSync::DataSource"
+  },
+  {
+    "LogicalResourceId": "TriggerFunction",
+    "ResourceType": "AWS::Lambda::Function"
+  },
+  {
+    "LogicalResourceId": "TriggerFunctionRole",
+    "ResourceType": "AWS::IAM::Role"
+  },
+  {
+    "LogicalResourceId": "DataSourceToTableConnectorPolicy",
+    "ResourceType": "AWS::IAM::ManagedPolicy"
+  }
+]

--- a/integration/resources/templates/combination/connector_appsync_to_table.yaml
+++ b/integration/resources/templates/combination/connector_appsync_to_table.yaml
@@ -1,19 +1,14 @@
 Resources:
   NotesTable:
-    Type: AWS::DynamoDB::Table
+    Type: AWS::Serverless::SimpleTable
     Properties:
-      TableName: notes-table
-      AttributeDefinitions:
-      - AttributeName: UserId
-        AttributeType: S
-      KeySchema:
-      - AttributeName: NoteId
-        KeyType: HASH
+      PrimaryKey:
+        Name: NoteId
+        Type: String
 
   DynamoDBRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: appsync-dynamodb-role
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
### Issue #, if available

### Description of changes
I initially didn't run the integ test and forgot to include the list of required resources.

### Description of how you validated changes
Running integ test for AppSync -> DDB connector

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
