### PR TITLE
chore: do not load managed policies if already ARN

### DIFF
--- a/samtranslator/model/role_utils/role_constructor.py
+++ b/samtranslator/model/role_utils/role_constructor.py
@@ -43,6 +43,12 @@ def _get_managed_policy_arn(
         if arn:
             return arn
 
+    # If it's already an ARN, we're done
+    # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+    is_arn = name.startswith("arn:")
+    if is_arn:
+        return name
+
     # Caller-provided function to get managed policy map (fallback)
     if get_managed_policy_map:
         fallback_managed_policy_map = get_managed_policy_map()

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -736,6 +736,58 @@ class TestTemplateValidation(TestCase):
         self.assertEqual(function_arn, expected_arn)
         self.assertEqual(sfn_arn, expected_arn)
 
+    # test to make sure with arn it doesnt load, with non-arn it does
+    @parameterized.expand(
+        [
+            (["SomeNonArnThing"], 1),
+            (["SomeNonArnThing", "AnotherNonArnThing"], 1),
+            (["aws:looks:like:an:ARN:but-not-really"], 1),
+            (["arn:looks:like:an:ARN:foo"], 0),
+            (["arn:looks:like:an:ARN:foo", "Mixing_things_v2"], 1),
+            (["arn:looks:like:an:ARN", "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0e9801d129EXAMPLE"], 0),
+        ]
+    )
+    @patch("boto3.session.Session.region_name", "ap-southeast-1")
+    @patch("botocore.client.ClientEndpointBridge._check_default_region", mock_get_region)
+    def test_managed_policies_arn_not_loaded(self, policies, load_policy_count):
+        class ManagedPolicyLoader:
+            def __init__(self):
+                self.call_count = 0
+
+            def load(self):
+                self.call_count += 1
+                return {}
+
+        managed_policy_loader = ManagedPolicyLoader()
+
+        with patch("samtranslator.internal.managed_policies._BUNDLED_MANAGED_POLICIES", {}):
+            transform(
+                {
+                    "Resources": {
+                        "MyFunction": {
+                            "Type": "AWS::Serverless::Function",
+                            "Properties": {
+                                "Handler": "foo",
+                                "InlineCode": "bar",
+                                "Runtime": "nodejs14.x",
+                                "Policies": policies,
+                            },
+                        },
+                        "MyStateMachine": {
+                            "Type": "AWS::Serverless::StateMachine",
+                            "Properties": {
+                                "DefinitionUri": "s3://egg/baz",
+                                "Policies": policies,
+                            },
+                        },
+                    }
+                },
+                {},
+                managed_policy_loader,
+            )
+
+        self.assertEqual(load_policy_count, managed_policy_loader.call_count)
+
     @parameterized.expand(
         [
             # All combinations, bundled map takes precedence


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Avoids calling `get_managed_policy_map` when the input is clearly already an ARN.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
