### PR TITLE
chore: add stricter typing to construct assume role policy function

### DIFF
--- a/samtranslator/model/iam.py
+++ b/samtranslator/model/iam.py
@@ -33,7 +33,7 @@ class IAMManagedPolicy(Resource):
 
 class IAMRolePolicies:
     @classmethod
-    def construct_assume_role_policy_for_service_principal(cls, service_principal):  # type: ignore[no-untyped-def]
+    def construct_assume_role_policy_for_service_principal(cls, service_principal: str) -> Dict[str, Any]:
         return {
             "Version": "2012-10-17",
             "Statement": [

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -63,7 +63,7 @@ class EventSource(ResourceMacro, metaclass=ABCMeta):
         """
         role_logical_id = self._generate_logical_id(prefix=prefix, suffix=suffix, resource_type="Role")  # type: ignore[no-untyped-call]
         event_role = IAMRole(role_logical_id, attributes=resource.get_passthrough_resource_attributes())
-        event_role.AssumeRolePolicyDocument = IAMRolePolicies.construct_assume_role_policy_for_service_principal(  # type: ignore[no-untyped-call]
+        event_role.AssumeRolePolicyDocument = IAMRolePolicies.construct_assume_role_policy_for_service_principal(
             self.principal
         )
         state_machine_arn = resource.get_runtime_attr("arn")


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Add typing to `construct_assume_role_policy_for_service_principal()`. Removed `# type: ignore` comments.

### Description of how you validated changes
Passes `make pr`.

### Checklist
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
