### PR TITLE
fix: Truncate Event Bridge Rule if Id is over 64 characters

### DIFF
--- a/samtranslator/model/events.py
+++ b/samtranslator/model/events.py
@@ -5,8 +5,8 @@ from samtranslator.model.intrinsics import fnGetAtt, ref
 
 # Event Rule Targets Id and Logical Id has maximum 64 characters limit
 # https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_Target.html
-EVENT_RULE_ID_MAX_LENGTH = 64
-EVENT_RULE_ID_EVENT_SUFFIX = "Event"
+EVENT_RULE_LOGICAL_ID_MAX_LENGTH = 64
+EVENT_RULE_LOGICAL_ID_EVENT_SUFFIX = "Event"
 
 
 class EventsRule(Resource):
@@ -33,19 +33,19 @@ class EventsRule(Resource):
     ) -> None:
         super().__init__(logical_id, relative_id, depends_on, attributes)
 
-        if len(self.logical_id) > EVENT_RULE_ID_MAX_LENGTH:
+        if len(self.logical_id) > EVENT_RULE_LOGICAL_ID_MAX_LENGTH:
             # Truncate logical id to satisfy the EVENT_RULE_ID_MAX_LENGTH limit
             self.logical_id = _truncate_with_suffix(
-                self.logical_id, EVENT_RULE_ID_MAX_LENGTH, EVENT_RULE_ID_EVENT_SUFFIX
+                self.logical_id, EVENT_RULE_LOGICAL_ID_MAX_LENGTH, EVENT_RULE_LOGICAL_ID_EVENT_SUFFIX
             )
 
 
 def generate_valid_target_id(logical_id: str, suffix: str) -> str:
     """Truncate Target Id if it is exceeding EVENT_RULE_ID_MAX_LENGTH limi."""
-    if len(logical_id) + len(suffix) <= EVENT_RULE_ID_MAX_LENGTH:
+    if len(logical_id) + len(suffix) <= EVENT_RULE_LOGICAL_ID_MAX_LENGTH:
         return logical_id + suffix
 
-    return _truncate_with_suffix(logical_id, EVENT_RULE_ID_MAX_LENGTH, suffix)
+    return _truncate_with_suffix(logical_id, EVENT_RULE_LOGICAL_ID_MAX_LENGTH, suffix)
 
 
 def _truncate_with_suffix(s: str, length: int, suffix: str) -> str:

--- a/samtranslator/model/events.py
+++ b/samtranslator/model/events.py
@@ -1,5 +1,12 @@
+from typing import Any, Dict, List, Optional
+
 from samtranslator.model import GeneratedProperty, Resource
 from samtranslator.model.intrinsics import fnGetAtt, ref
+
+# Event Rule Targets Id and Logical Id has maximum 64 characters limit
+# https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_Target.html
+EVENT_RULE_ID_MAX_LENGTH = 64
+EVENT_RULE_ID_EVENT_SUFFIX = "Event"
 
 
 class EventsRule(Resource):
@@ -16,3 +23,33 @@ class EventsRule(Resource):
     }
 
     runtime_attrs = {"rule_id": lambda self: ref(self.logical_id), "arn": lambda self: fnGetAtt(self.logical_id, "Arn")}
+
+    def __init__(
+        self,
+        logical_id: Optional[Any],
+        relative_id: Optional[str] = None,
+        depends_on: Optional[List[str]] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(logical_id, relative_id, depends_on, attributes)
+
+        if len(self.logical_id) > EVENT_RULE_ID_MAX_LENGTH:
+            # Truncate logical id to satisfy the EVENT_RULE_ID_MAX_LENGTH limit
+            self.logical_id = _truncate_with_suffix(
+                self.logical_id, EVENT_RULE_ID_MAX_LENGTH, EVENT_RULE_ID_EVENT_SUFFIX
+            )
+
+
+def generate_valid_target_id(logical_id: str, suffix: str) -> str:
+    """Truncate Target Id if it is exceeding EVENT_RULE_ID_MAX_LENGTH limi."""
+    if len(logical_id) + len(suffix) <= EVENT_RULE_ID_MAX_LENGTH:
+        return logical_id + suffix
+
+    return _truncate_with_suffix(logical_id, EVENT_RULE_ID_MAX_LENGTH, suffix)
+
+
+def _truncate_with_suffix(s: str, length: int, suffix: str) -> str:
+    """
+    Truncate string if input string + suffix exceeds length requirement
+    """
+    return s[: length - len(suffix)] + suffix

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, cast
 from samtranslator.metrics.method_decorator import cw_timer
 from samtranslator.model import Property, PropertyType, Resource, ResourceMacro
 from samtranslator.model.eventbridge_utils import EventBridgeRuleUtils
-from samtranslator.model.events import EventsRule
+from samtranslator.model.events import EventsRule, generate_valid_target_id
 from samtranslator.model.eventsources.push import Api as PushApi
 from samtranslator.model.exceptions import InvalidEventException
 from samtranslator.model.iam import IAMRole, IAMRolePolicies
@@ -16,6 +16,7 @@ from samtranslator.translator import logical_id_generator
 
 CONDITION = "Condition"
 SFN_EVETSOURCE_METRIC_PREFIX = "SFNEventSource"
+EVENT_RULE_SFN_TARGET_SUFFIX = "StepFunctionsTarget"
 
 
 class EventSource(ResourceMacro, metaclass=ABCMeta):
@@ -156,7 +157,9 @@ class Schedule(EventSource):
         :rtype: dict
         """
         target_id = (
-            self.Target["Id"] if self.Target and "Id" in self.Target else self.logical_id + "StepFunctionsTarget"
+            self.Target["Id"]
+            if self.Target and "Id" in self.Target
+            else generate_valid_target_id(self.logical_id, EVENT_RULE_SFN_TARGET_SUFFIX)
         )
         target = {
             "Arn": resource.get_runtime_attr("arn"),
@@ -249,7 +252,9 @@ class CloudWatchEvent(EventSource):
         :rtype: dict
         """
         target_id = (
-            self.Target["Id"] if self.Target and "Id" in self.Target else self.logical_id + "StepFunctionsTarget"
+            self.Target["Id"]
+            if self.Target and "Id" in self.Target
+            else generate_valid_target_id(self.logical_id, EVENT_RULE_SFN_TARGET_SUFFIX)
         )
         target = {
             "Arn": resource.get_runtime_attr("arn"),

--- a/tests/translator/input/event_bridge_rule_super_long_id.yaml
+++ b/tests/translator/input/event_bridge_rule_super_long_id.yaml
@@ -1,0 +1,43 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs14.x
+      InlineCode: |
+        exports.handler = async (event, context, callback) => {
+          return {
+            statusCode: 200,
+            body: 'Success'
+          }
+        }
+      Events:
+        QueryForAvailabilityWithUserExceptionEvent:
+          Type: Schedule
+          Properties:
+            Schedule: cron(05 12 * * ? *)
+
+  SuperSuperSuperSuperLongNameForStepFunction:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: MyStateMachine
+      Events:
+        SuperSuperSuperSuperLongNameForStepFunctionCWEventEvent:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              detail:
+                state:
+                - terminated
+        MyApiEvent:
+          Type: Api
+          Properties:
+            Path: /startMyExecution
+            Method: post
+      DefinitionUri:
+        Bucket: sam-demo-bucket
+        Key: my-state-machine.asl.json
+        Version: 3
+      Role: !Sub 'arn:${AWS::Partition}:iam::123456123456:role/service-role/SampleRole'

--- a/tests/translator/output/aws-cn/event_bridge_rule_super_long_id.json
+++ b/tests/translator/output/aws-cn/event_bridge_rule_super_long_id.json
@@ -1,0 +1,293 @@
+{
+  "Resources": {
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWiEvent": {
+      "Properties": {
+        "ScheduleExpression": "cron(05 12 * * ? *)",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException",
+                "Arn"
+              ]
+            },
+            "Id": "QueryForAvailabilityWithUserExceptionQueryForAvailabLambdaTarget"
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionEventPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException"
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWiEvent",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${SuperSuperSuperSuperLongNameForStepFunction}\"}"
+                    }
+                  },
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "type": "aws",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeploymentb7a8629302": {
+      "Properties": {
+        "Description": "RestApi deployment id: b7a86293027a9011b54502735b263ec03b6f17fd",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentb7a8629302"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunction": {
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my-state-machine.asl.json",
+          "Version": 3
+        },
+        "RoleArn": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::123456123456:role/service-role/SampleRole"
+        },
+        "StateMachineName": "MyStateMachine",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSEvent": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+            },
+            "Id": "SuperSuperSuperSuperLongNameForStepFunctionSuStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/event_bridge_rule_super_long_id.json
+++ b/tests/translator/output/aws-us-gov/event_bridge_rule_super_long_id.json
@@ -1,0 +1,293 @@
+{
+  "Resources": {
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWiEvent": {
+      "Properties": {
+        "ScheduleExpression": "cron(05 12 * * ? *)",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException",
+                "Arn"
+              ]
+            },
+            "Id": "QueryForAvailabilityWithUserExceptionQueryForAvailabLambdaTarget"
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionEventPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException"
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWiEvent",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${SuperSuperSuperSuperLongNameForStepFunction}\"}"
+                    }
+                  },
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "type": "aws",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeploymentb7a8629302": {
+      "Properties": {
+        "Description": "RestApi deployment id: b7a86293027a9011b54502735b263ec03b6f17fd",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentb7a8629302"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunction": {
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my-state-machine.asl.json",
+          "Version": 3
+        },
+        "RoleArn": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::123456123456:role/service-role/SampleRole"
+        },
+        "StateMachineName": "MyStateMachine",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSEvent": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+            },
+            "Id": "SuperSuperSuperSuperLongNameForStepFunctionSuStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/event_bridge_rule_super_long_id.json
+++ b/tests/translator/output/event_bridge_rule_super_long_id.json
@@ -1,0 +1,285 @@
+{
+  "Resources": {
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWiEvent": {
+      "Properties": {
+        "ScheduleExpression": "cron(05 12 * * ? *)",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException",
+                "Arn"
+              ]
+            },
+            "Id": "QueryForAvailabilityWithUserExceptionQueryForAvailabLambdaTarget"
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionEventPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserException"
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWiEvent",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "QueryForAvailabilityWithUserExceptionQueryForAvailabilityWithUserExceptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/startMyExecution": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  },
+                  "400": {
+                    "description": "Bad Request"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "credentials": {
+                    "Fn::GetAtt": [
+                      "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRole",
+                      "Arn"
+                    ]
+                  },
+                  "httpMethod": "POST",
+                  "requestTemplates": {
+                    "application/json": {
+                      "Fn::Sub": "{\"input\": \"$util.escapeJavaScript($input.json('$'))\", \"stateMachineArn\": \"${SuperSuperSuperSuperLongNameForStepFunction}\"}"
+                    }
+                  },
+                  "responses": {
+                    "200": {
+                      "statusCode": "200"
+                    },
+                    "400": {
+                      "statusCode": "400"
+                    }
+                  },
+                  "type": "aws",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartExecution"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeploymentb7a8629302": {
+      "Properties": {
+        "Description": "RestApi deployment id: b7a86293027a9011b54502735b263ec03b6f17fd",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentb7a8629302"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunction": {
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my-state-machine.asl.json",
+          "Version": 3
+        },
+        "RoleArn": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::123456123456:role/service-role/SampleRole"
+        },
+        "StateMachineName": "MyStateMachine",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "apigateway.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "SuperSuperSuperSuperLongNameForStepFunctionMyApiEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSEvent": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "state": [
+              "terminated"
+            ]
+          }
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+            },
+            "Id": "SuperSuperSuperSuperLongNameForStepFunctionSuStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "SuperSuperSuperSuperLongNameForStepFunction"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "SuperSuperSuperSuperLongNameForStepFunctionSuperSuperSuperSuperLongNameForStepFunctionCWEventEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available
https://github.com/aws/serverless-application-model/issues/2941

### Description of changes
According to the `Id` property in this documentation https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_Target.html, the max length is 64. Truncate it if it's too long.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
