### PR TITLE
fix: Add MergeDefinitions property to Global Section

### DIFF
--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -62,6 +62,7 @@ class Globals:
             "DefinitionUri",
             "CacheClusterEnabled",
             "CacheClusterSize",
+            "MergeDefinitions",
             "Variables",
             "EndpointConfiguration",
             "MethodSettings",

--- a/tests/translator/input/api_merge_definitions_global.yaml
+++ b/tests/translator/input/api_merge_definitions_global.yaml
@@ -1,0 +1,60 @@
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Api:
+    MergeDefinitions: true
+
+Resources:
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      DefinitionBody:
+        swagger: '2.0'
+        info:
+          title: Example
+          version: '1'
+        paths:
+          /test:
+            get:
+              security:
+                MyAuthorizer2: []
+      Auth:
+        Authorizers:
+          MyAuthorizer:
+            UserPoolArn: !GetAtt MyCognitoUserPool.Arn
+
+          MyAuthorizer2:
+            UserPoolArn: !GetAtt MyCognitoUserPool2.Arn
+
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs14.x
+      InlineCode: |
+        exports.handler = async (event, context, callback) => {
+          return {
+            statusCode: 200,
+            body: 'Success'
+          }
+        }
+      Events:
+        MyEventV1:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApi
+            Path: /test
+            Method: get
+            Auth:
+              Authorizer: MyAuthorizer
+
+  MyCognitoUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: MyCognitoUserPoolRandomName
+
+  MyCognitoUserPool2:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: MyCognitoUserPoolRandomName2

--- a/tests/translator/output/api_merge_definitions_global.json
+++ b/tests/translator/output/api_merge_definitions_global.json
@@ -1,0 +1,178 @@
+{
+ "Resources": {
+  "MyFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+    },
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "MyFunctionRole",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs14.x",
+    "Tags": [
+     {
+      "Key": "lambda:createdBy",
+      "Value": "SAM"
+     }
+    ]
+   }
+  },
+  "MyCognitoUserPool": {
+   "Type": "AWS::Cognito::UserPool",
+   "Properties": {
+    "UserPoolName": "MyCognitoUserPoolRandomName"
+   }
+  },
+  "MyCognitoUserPool2": {
+   "Type": "AWS::Cognito::UserPool",
+   "Properties": {
+    "UserPoolName": "MyCognitoUserPoolRandomName2"
+   }
+  },
+  "MyFunctionMyEventV1PermissionProd": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Ref": "MyFunction"
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Sub": [
+      "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/test",
+      {
+       "__ApiId__": {
+        "Ref": "MyApi"
+       },
+       "__Stage__": "*"
+      }
+     ]
+    }
+   }
+  },
+  "MyApiProdStage": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "DeploymentId": {
+     "Ref": "MyApiDeploymentf4bf62db4c"
+    },
+    "RestApiId": {
+     "Ref": "MyApi"
+    },
+    "StageName": "Prod"
+   }
+  },
+  "MyFunctionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Action": [
+        "sts:AssumeRole"
+       ],
+       "Effect": "Allow",
+       "Principal": {
+        "Service": [
+         "lambda.amazonaws.com"
+        ]
+       }
+      }
+     ]
+    },
+    "ManagedPolicyArns": [
+     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    ],
+    "Tags": [
+     {
+      "Key": "lambda:createdBy",
+      "Value": "SAM"
+     }
+    ]
+   }
+  },
+  "MyApiDeploymentf4bf62db4c": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "Description": "RestApi deployment id: f4bf62db4c8bd0cbd8276f47c4280a81f4adec16",
+    "RestApiId": {
+     "Ref": "MyApi"
+    },
+    "StageName": "Stage"
+   }
+  },
+  "MyApi": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Body": {
+     "info": {
+      "version": "1",
+      "title": "Example"
+     },
+     "paths": {
+      "/test": {
+       "get": {
+        "security": [
+         {
+          "MyAuthorizer": []
+         }
+        ],
+        "x-amazon-apigateway-integration": {
+         "httpMethod": "POST",
+         "type": "aws_proxy",
+         "uri": {
+          "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+         }
+        },
+        "responses": {}
+       }
+      }
+     },
+     "swagger": "2.0",
+     "securityDefinitions": {
+      "MyAuthorizer2": {
+       "in": "header",
+       "type": "apiKey",
+       "name": "Authorization",
+       "x-amazon-apigateway-authorizer": {
+        "providerARNs": [
+         {
+          "Fn::GetAtt": [
+           "MyCognitoUserPool2",
+           "Arn"
+          ]
+         }
+        ],
+        "type": "cognito_user_pools"
+       },
+       "x-amazon-apigateway-authtype": "cognito_user_pools"
+      },
+      "MyAuthorizer": {
+       "in": "header",
+       "type": "apiKey",
+       "name": "Authorization",
+       "x-amazon-apigateway-authorizer": {
+        "providerARNs": [
+         {
+          "Fn::GetAtt": [
+           "MyCognitoUserPool",
+           "Arn"
+          ]
+         }
+        ],
+        "type": "cognito_user_pools"
+       },
+       "x-amazon-apigateway-authtype": "cognito_user_pools"
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/tests/translator/output/api_merge_definitions_global.json
+++ b/tests/translator/output/api_merge_definitions_global.json
@@ -1,178 +1,178 @@
 {
- "Resources": {
-  "MyFunction": {
-   "Type": "AWS::Lambda::Function",
-   "Properties": {
-    "Code": {
-     "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
-    },
-    "Handler": "index.handler",
-    "Role": {
-     "Fn::GetAtt": [
-      "MyFunctionRole",
-      "Arn"
-     ]
-    },
-    "Runtime": "nodejs14.x",
-    "Tags": [
-     {
-      "Key": "lambda:createdBy",
-      "Value": "SAM"
-     }
-    ]
-   }
-  },
-  "MyCognitoUserPool": {
-   "Type": "AWS::Cognito::UserPool",
-   "Properties": {
-    "UserPoolName": "MyCognitoUserPoolRandomName"
-   }
-  },
-  "MyCognitoUserPool2": {
-   "Type": "AWS::Cognito::UserPool",
-   "Properties": {
-    "UserPoolName": "MyCognitoUserPoolRandomName2"
-   }
-  },
-  "MyFunctionMyEventV1PermissionProd": {
-   "Type": "AWS::Lambda::Permission",
-   "Properties": {
-    "Action": "lambda:InvokeFunction",
-    "FunctionName": {
-     "Ref": "MyFunction"
-    },
-    "Principal": "apigateway.amazonaws.com",
-    "SourceArn": {
-     "Fn::Sub": [
-      "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/test",
-      {
-       "__ApiId__": {
-        "Ref": "MyApi"
-       },
-       "__Stage__": "*"
-      }
-     ]
-    }
-   }
-  },
-  "MyApiProdStage": {
-   "Type": "AWS::ApiGateway::Stage",
-   "Properties": {
-    "DeploymentId": {
-     "Ref": "MyApiDeploymentf4bf62db4c"
-    },
-    "RestApiId": {
-     "Ref": "MyApi"
-    },
-    "StageName": "Prod"
-   }
-  },
-  "MyFunctionRole": {
-   "Type": "AWS::IAM::Role",
-   "Properties": {
-    "AssumeRolePolicyDocument": {
-     "Version": "2012-10-17",
-     "Statement": [
-      {
-       "Action": [
-        "sts:AssumeRole"
-       ],
-       "Effect": "Allow",
-       "Principal": {
-        "Service": [
-         "lambda.amazonaws.com"
-        ]
-       }
-      }
-     ]
-    },
-    "ManagedPolicyArns": [
-     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-    ],
-    "Tags": [
-     {
-      "Key": "lambda:createdBy",
-      "Value": "SAM"
-     }
-    ]
-   }
-  },
-  "MyApiDeploymentf4bf62db4c": {
-   "Type": "AWS::ApiGateway::Deployment",
-   "Properties": {
-    "Description": "RestApi deployment id: f4bf62db4c8bd0cbd8276f47c4280a81f4adec16",
-    "RestApiId": {
-     "Ref": "MyApi"
-    },
-    "StageName": "Stage"
-   }
-  },
-  "MyApi": {
-   "Type": "AWS::ApiGateway::RestApi",
-   "Properties": {
-    "Body": {
-     "info": {
-      "version": "1",
-      "title": "Example"
-     },
-     "paths": {
-      "/test": {
-       "get": {
-        "security": [
-         {
-          "MyAuthorizer": []
-         }
-        ],
-        "x-amazon-apigateway-integration": {
-         "httpMethod": "POST",
-         "type": "aws_proxy",
-         "uri": {
-          "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-         }
-        },
-        "responses": {}
-       }
-      }
-     },
-     "swagger": "2.0",
-     "securityDefinitions": {
-      "MyAuthorizer2": {
-       "in": "header",
-       "type": "apiKey",
-       "name": "Authorization",
-       "x-amazon-apigateway-authorizer": {
-        "providerARNs": [
-         {
-          "Fn::GetAtt": [
-           "MyCognitoUserPool2",
-           "Arn"
-          ]
-         }
-        ],
-        "type": "cognito_user_pools"
-       },
-       "x-amazon-apigateway-authtype": "cognito_user_pools"
+  "Resources": {
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": "Example",
+            "version": "1"
+          },
+          "paths": {
+            "/test": {
+              "get": {
+                "responses": {},
+                "security": [
+                  {
+                    "MyAuthorizer": []
+                  }
+                ],
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "securityDefinitions": {
+            "MyAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyAuthorizer2": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool2",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            }
+          },
+          "swagger": "2.0"
+        }
       },
-      "MyAuthorizer": {
-       "in": "header",
-       "type": "apiKey",
-       "name": "Authorization",
-       "x-amazon-apigateway-authorizer": {
-        "providerARNs": [
-         {
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeploymentf4bf62db4c": {
+      "Properties": {
+        "Description": "RestApi deployment id: f4bf62db4c8bd0cbd8276f47c4280a81f4adec16",
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeploymentf4bf62db4c"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "MyCognitoUserPool": {
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    },
+    "MyCognitoUserPool2": {
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName2"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    },
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
           "Fn::GetAtt": [
-           "MyCognitoUserPool",
-           "Arn"
+            "MyFunctionRole",
+            "Arn"
           ]
-         }
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionMyEventV1PermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/test",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
-        "type": "cognito_user_pools"
-       },
-       "x-amazon-apigateway-authtype": "cognito_user_pools"
-      }
-     }
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
     }
-   }
   }
- }
 }

--- a/tests/translator/output/aws-cn/api_merge_definitions_global.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_global.json
@@ -1,7 +1,115 @@
 {
   "Resources": {
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": "Example",
+            "version": "1"
+          },
+          "paths": {
+            "/test": {
+              "get": {
+                "responses": {},
+                "security": [
+                  {
+                    "MyAuthorizer": []
+                  }
+                ],
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "securityDefinitions": {
+            "MyAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyAuthorizer2": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool2",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeployment98883622ba": {
+      "Properties": {
+        "Description": "RestApi deployment id: 98883622ba41d019a8468a439962db1f2f7ec6e4",
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment98883622ba"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "MyCognitoUserPool": {
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    },
+    "MyCognitoUserPool2": {
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName2"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    },
     "MyFunction": {
-      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
@@ -20,22 +128,10 @@
             "Value": "SAM"
           }
         ]
-      }
-    },
-    "MyCognitoUserPool": {
-      "Type": "AWS::Cognito::UserPool",
-      "Properties": {
-        "UserPoolName": "MyCognitoUserPoolRandomName"
-      }
-    },
-    "MyCognitoUserPool2": {
-      "Type": "AWS::Cognito::UserPool",
-      "Properties": {
-        "UserPoolName": "MyCognitoUserPoolRandomName2"
-      }
+      },
+      "Type": "AWS::Lambda::Function"
     },
     "MyFunctionMyEventV1PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -53,25 +149,12 @@
             }
           ]
         }
-      }
-    },
-    "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage",
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiDeployment98883622ba"
-        },
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "StageName": "Prod"
-      }
+      },
+      "Type": "AWS::Lambda::Permission"
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
@@ -84,7 +167,8 @@
                 ]
               }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -95,92 +179,8 @@
             "Value": "SAM"
           }
         ]
-      }
-    },
-    "MyApiDeployment98883622ba": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "Description": "RestApi deployment id: 98883622ba41d019a8468a439962db1f2f7ec6e4",
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "StageName": "Stage"
-      }
-    },
-    "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi",
-      "Properties": {
-        "Body": {
-          "info": {
-            "version": "1",
-            "title": "Example"
-          },
-          "paths": {
-            "/test": {
-              "get": {
-                "security": [
-                  {
-                    "MyAuthorizer": []
-                  }
-                ],
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                  }
-                },
-                "responses": {}
-              }
-            }
-          },
-          "swagger": "2.0",
-          "securityDefinitions": {
-            "MyAuthorizer2": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
-              "x-amazon-apigateway-authorizer": {
-                "providerARNs": [
-                  {
-                    "Fn::GetAtt": [
-                      "MyCognitoUserPool2",
-                      "Arn"
-                    ]
-                  }
-                ],
-                "type": "cognito_user_pools"
-              },
-              "x-amazon-apigateway-authtype": "cognito_user_pools"
-            },
-            "MyAuthorizer": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
-              "x-amazon-apigateway-authorizer": {
-                "providerARNs": [
-                  {
-                    "Fn::GetAtt": [
-                      "MyCognitoUserPool",
-                      "Arn"
-                    ]
-                  }
-                ],
-                "type": "cognito_user_pools"
-              },
-              "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }
-          }
-        },
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL"
-          ]
-        },
-        "Parameters": {
-          "endpointConfigurationTypes": "REGIONAL"
-        }
-      }
+      },
+      "Type": "AWS::IAM::Role"
     }
   }
 }

--- a/tests/translator/output/aws-cn/api_merge_definitions_global.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_global.json
@@ -1,0 +1,186 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyCognitoUserPool": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName"
+      }
+    },
+    "MyCognitoUserPool2": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName2"
+      }
+    },
+    "MyFunctionMyEventV1PermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/test",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment98883622ba"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyApiDeployment98883622ba": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 98883622ba41d019a8468a439962db1f2f7ec6e4",
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1",
+            "title": "Example"
+          },
+          "paths": {
+            "/test": {
+              "get": {
+                "security": [
+                  {
+                    "MyAuthorizer": []
+                  }
+                ],
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "MyAuthorizer2": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool2",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyAuthorizer": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_global.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_global.json
@@ -1,0 +1,186 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyCognitoUserPool": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName"
+      }
+    },
+    "MyCognitoUserPool2": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName2"
+      }
+    },
+    "MyFunctionMyEventV1PermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/test",
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment7c18f9ea0a"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "MyFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "MyApiDeployment7c18f9ea0a": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "Description": "RestApi deployment id: 7c18f9ea0a935c3bd3e079fee87d8c216a89b32f",
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Stage"
+      }
+    },
+    "MyApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1",
+            "title": "Example"
+          },
+          "paths": {
+            "/test": {
+              "get": {
+                "security": [
+                  {
+                    "MyAuthorizer": []
+                  }
+                ],
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                },
+                "responses": {}
+              }
+            }
+          },
+          "swagger": "2.0",
+          "securityDefinitions": {
+            "MyAuthorizer2": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool2",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyAuthorizer": {
+              "in": "header",
+              "type": "apiKey",
+              "name": "Authorization",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            }
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_global.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_global.json
@@ -1,7 +1,115 @@
 {
   "Resources": {
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": "Example",
+            "version": "1"
+          },
+          "paths": {
+            "/test": {
+              "get": {
+                "responses": {},
+                "security": [
+                  {
+                    "MyAuthorizer": []
+                  }
+                ],
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "securityDefinitions": {
+            "MyAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            },
+            "MyAuthorizer2": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "MyCognitoUserPool2",
+                      "Arn"
+                    ]
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeployment7c18f9ea0a": {
+      "Properties": {
+        "Description": "RestApi deployment id: 7c18f9ea0a935c3bd3e079fee87d8c216a89b32f",
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment7c18f9ea0a"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "MyCognitoUserPool": {
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    },
+    "MyCognitoUserPool2": {
+      "Properties": {
+        "UserPoolName": "MyCognitoUserPoolRandomName2"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    },
     "MyFunction": {
-      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
@@ -20,22 +128,10 @@
             "Value": "SAM"
           }
         ]
-      }
-    },
-    "MyCognitoUserPool": {
-      "Type": "AWS::Cognito::UserPool",
-      "Properties": {
-        "UserPoolName": "MyCognitoUserPoolRandomName"
-      }
-    },
-    "MyCognitoUserPool2": {
-      "Type": "AWS::Cognito::UserPool",
-      "Properties": {
-        "UserPoolName": "MyCognitoUserPoolRandomName2"
-      }
+      },
+      "Type": "AWS::Lambda::Function"
     },
     "MyFunctionMyEventV1PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -53,25 +149,12 @@
             }
           ]
         }
-      }
-    },
-    "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage",
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiDeployment7c18f9ea0a"
-        },
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "StageName": "Prod"
-      }
+      },
+      "Type": "AWS::Lambda::Permission"
     },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
@@ -84,7 +167,8 @@
                 ]
               }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -95,92 +179,8 @@
             "Value": "SAM"
           }
         ]
-      }
-    },
-    "MyApiDeployment7c18f9ea0a": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Properties": {
-        "Description": "RestApi deployment id: 7c18f9ea0a935c3bd3e079fee87d8c216a89b32f",
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "StageName": "Stage"
-      }
-    },
-    "MyApi": {
-      "Type": "AWS::ApiGateway::RestApi",
-      "Properties": {
-        "Body": {
-          "info": {
-            "version": "1",
-            "title": "Example"
-          },
-          "paths": {
-            "/test": {
-              "get": {
-                "security": [
-                  {
-                    "MyAuthorizer": []
-                  }
-                ],
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                  }
-                },
-                "responses": {}
-              }
-            }
-          },
-          "swagger": "2.0",
-          "securityDefinitions": {
-            "MyAuthorizer2": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
-              "x-amazon-apigateway-authorizer": {
-                "providerARNs": [
-                  {
-                    "Fn::GetAtt": [
-                      "MyCognitoUserPool2",
-                      "Arn"
-                    ]
-                  }
-                ],
-                "type": "cognito_user_pools"
-              },
-              "x-amazon-apigateway-authtype": "cognito_user_pools"
-            },
-            "MyAuthorizer": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
-              "x-amazon-apigateway-authorizer": {
-                "providerARNs": [
-                  {
-                    "Fn::GetAtt": [
-                      "MyCognitoUserPool",
-                      "Arn"
-                    ]
-                  }
-                ],
-                "type": "cognito_user_pools"
-              },
-              "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }
-          }
-        },
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL"
-          ]
-        },
-        "Parameters": {
-          "endpointConfigurationTypes": "REGIONAL"
-        }
-      }
+      },
+      "Type": "AWS::IAM::Role"
     }
   }
 }

--- a/tests/translator/output/error_globals_api_with_stage_name.json
+++ b/tests/translator/output/error_globals_api_with_stage_name.json
@@ -4,9 +4,9 @@
     "Number of errors found: 1. ",
     "'Globals' section is invalid. ",
     "'StageName' is not a supported property of 'Api'. ",
-    "Must be one of the following values - ['Auth', 'Name', 'DefinitionUri', 'CacheClusterEnabled', 'CacheClusterSize', 'Variables', 'EndpointConfiguration', 'MethodSettings', 'BinaryMediaTypes', 'MinimumCompressionSize', 'Cors', 'GatewayResponses', 'AccessLogSetting', 'CanarySetting', 'TracingEnabled', 'OpenApiVersion', 'Domain']"
+    "Must be one of the following values - ['Auth', 'Name', 'DefinitionUri', 'CacheClusterEnabled', 'CacheClusterSize', 'MergeDefinitions', 'Variables', 'EndpointConfiguration', 'MethodSettings', 'BinaryMediaTypes', 'MinimumCompressionSize', 'Cors', 'GatewayResponses', 'AccessLogSetting', 'CanarySetting', 'TracingEnabled', 'OpenApiVersion', 'Domain']"
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. 'Globals' section is invalid. 'StageName' is not a supported property of 'Api'. Must be one of the following values - ['Auth', 'Name', 'DefinitionUri', 'CacheClusterEnabled', 'CacheClusterSize', 'Variables', 'EndpointConfiguration', 'MethodSettings', 'BinaryMediaTypes', 'MinimumCompressionSize', 'Cors', 'GatewayResponses', 'AccessLogSetting', 'CanarySetting', 'TracingEnabled', 'OpenApiVersion', 'Domain']",
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. 'Globals' section is invalid. 'StageName' is not a supported property of 'Api'. Must be one of the following values - ['Auth', 'Name', 'DefinitionUri', 'CacheClusterEnabled', 'CacheClusterSize', 'MergeDefinitions', 'Variables', 'EndpointConfiguration', 'MethodSettings', 'BinaryMediaTypes', 'MinimumCompressionSize', 'Cors', 'GatewayResponses', 'AccessLogSetting', 'CanarySetting', 'TracingEnabled', 'OpenApiVersion', 'Domain']",
   "errors": [
     {
       "errorMessage": "'Globals' section is invalid. 'StageName' is not a supported property of 'Api'. Must be one of the following values - ['Auth', 'Name', 'DefinitionUri', 'CacheClusterEnabled', 'CacheClusterSize', 'Variables', 'EndpointConfiguration', 'MethodSettings', 'BinaryMediaTypes', 'Cors', 'GatewayResponses', 'AccessLogSetting', 'CanarySetting', 'OpenApiVersion', 'Domain']"


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Add merge definitions to global and add transform tests

Already added MergeDefinitions property to our schema in the previous PR #2943. However, I never added support or tests related for globals, so in schema it says we support MergeDefinitions as a global, but we actually don't. Fixing it.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
