### PR TITLE
fix: Decouple samtranslator.models and *.intrinsics and add import tests

### DIFF
--- a/samtranslator/internal/intrinsics.py
+++ b/samtranslator/internal/intrinsics.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict, Optional, Union
+
+from samtranslator.intrinsics.resolver import IntrinsicsResolver
+from samtranslator.model.exceptions import InvalidResourceException
+
+
+def resolve_string_parameter_in_resource(
+    logical_id: str,
+    intrinsics_resolver: IntrinsicsResolver,
+    parameter_value: Optional[Union[str, Dict[str, Any]]],
+    parameter_name: str,
+) -> Optional[Union[str, Dict[str, Any]]]:
+    """Try to resolve values in a resource from template parameters."""
+    if not parameter_value:
+        return parameter_value
+    value = intrinsics_resolver.resolve_parameter_refs(parameter_value)
+
+    if not isinstance(value, str) and not isinstance(value, dict):
+        raise InvalidResourceException(
+            logical_id,
+            "Could not resolve parameter for '{}' or parameter is not a String.".format(parameter_name),
+        )
+    return value

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -3,7 +3,7 @@ import inspect
 import re
 from abc import ABC, ABCMeta, abstractmethod
 from contextlib import suppress
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar
 
 from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Un
 from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError
 
-from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.model.exceptions import (
     ExpectedType,
     InvalidResourceException,
@@ -543,23 +542,6 @@ class SamResourceMacro(ResourceMacro, metaclass=ABCMeta):
                 "Please change the tag key in the "
                 "input.",
             )
-
-    def _resolve_string_parameter(
-        self,
-        intrinsics_resolver: IntrinsicsResolver,
-        parameter_value: Optional[Union[str, Dict[str, Any]]],
-        parameter_name: str,
-    ) -> Optional[Union[str, Dict[str, Any]]]:
-        if not parameter_value:
-            return parameter_value
-        value = intrinsics_resolver.resolve_parameter_refs(parameter_value)
-
-        if not isinstance(value, str) and not isinstance(value, dict):
-            raise InvalidResourceException(
-                self.logical_id,
-                "Could not resolve parameter for '{}' or parameter is not a String.".format(parameter_name),
-            )
-        return value
 
 
 class ResourceTypeResolver:

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Un
 from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError
 
+from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.model.exceptions import (
     ExpectedType,
     InvalidResourceException,
@@ -542,6 +543,23 @@ class SamResourceMacro(ResourceMacro, metaclass=ABCMeta):
                 "Please change the tag key in the "
                 "input.",
             )
+
+    def _resolve_string_parameter(
+        self,
+        intrinsics_resolver: IntrinsicsResolver,
+        parameter_value: Optional[Union[str, Dict[str, Any]]],
+        parameter_name: str,
+    ) -> Optional[Union[str, Dict[str, Any]]]:
+        if not parameter_value:
+            return parameter_value
+        value = intrinsics_resolver.resolve_parameter_refs(parameter_value)
+
+        if not isinstance(value, str) and not isinstance(value, dict):
+            raise InvalidResourceException(
+                self.logical_id,
+                "Could not resolve parameter for '{}' or parameter is not a String.".format(parameter_name),
+            )
+        return value
 
 
 class ResourceTypeResolver:

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -86,6 +86,7 @@ from .api.http_api_generator import HttpApiGenerator
 from .packagetype import IMAGE, ZIP
 from .s3_utils.uri_parser import construct_image_code_object, construct_s3_location_object
 from .tags.resource_tagging import get_tag_list
+from ..internal.intrinsics import resolve_string_parameter_in_resource
 
 _CONDITION_CHAR_LIMIT = 255
 
@@ -1571,11 +1572,17 @@ class SamLayerVersion(SamResourceMacro):
         :rtype: list
         """
         # Resolve intrinsics if applicable:
-        self.LayerName = self._resolve_string_parameter(intrinsics_resolver, self.LayerName, "LayerName")
-        self.LicenseInfo = self._resolve_string_parameter(intrinsics_resolver, self.LicenseInfo, "LicenseInfo")
-        self.Description = self._resolve_string_parameter(intrinsics_resolver, self.Description, "Description")
-        self.RetentionPolicy = self._resolve_string_parameter(
-            intrinsics_resolver, self.RetentionPolicy, "RetentionPolicy"
+        self.LayerName = resolve_string_parameter_in_resource(
+            self.logical_id, intrinsics_resolver, self.LayerName, "LayerName"
+        )
+        self.LicenseInfo = resolve_string_parameter_in_resource(
+            self.logical_id, intrinsics_resolver, self.LicenseInfo, "LicenseInfo"
+        )
+        self.Description = resolve_string_parameter_in_resource(
+            self.logical_id, intrinsics_resolver, self.Description, "Description"
+        )
+        self.RetentionPolicy = resolve_string_parameter_in_resource(
+            self.logical_id, intrinsics_resolver, self.RetentionPolicy, "RetentionPolicy"
         )
 
         # If nothing defined, this will be set to Retain

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -86,7 +86,6 @@ from .api.http_api_generator import HttpApiGenerator
 from .packagetype import IMAGE, ZIP
 from .s3_utils.uri_parser import construct_image_code_object, construct_s3_location_object
 from .tags.resource_tagging import get_tag_list
-from ..internal.intrinsics import resolve_string_parameter_in_resource
 
 _CONDITION_CHAR_LIMIT = 255
 
@@ -1572,17 +1571,11 @@ class SamLayerVersion(SamResourceMacro):
         :rtype: list
         """
         # Resolve intrinsics if applicable:
-        self.LayerName = resolve_string_parameter_in_resource(
-            self.logical_id, intrinsics_resolver, self.LayerName, "LayerName"
-        )
-        self.LicenseInfo = resolve_string_parameter_in_resource(
-            self.logical_id, intrinsics_resolver, self.LicenseInfo, "LicenseInfo"
-        )
-        self.Description = resolve_string_parameter_in_resource(
-            self.logical_id, intrinsics_resolver, self.Description, "Description"
-        )
-        self.RetentionPolicy = resolve_string_parameter_in_resource(
-            self.logical_id, intrinsics_resolver, self.RetentionPolicy, "RetentionPolicy"
+        self.LayerName = self._resolve_string_parameter(intrinsics_resolver, self.LayerName, "LayerName")
+        self.LicenseInfo = self._resolve_string_parameter(intrinsics_resolver, self.LicenseInfo, "LicenseInfo")
+        self.Description = self._resolve_string_parameter(intrinsics_resolver, self.Description, "Description")
+        self.RetentionPolicy = self._resolve_string_parameter(
+            intrinsics_resolver, self.RetentionPolicy, "RetentionPolicy"
         )
 
         # If nothing defined, this will be set to Retain

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -9,6 +9,7 @@ import samtranslator.model.eventsources.pull
 import samtranslator.model.eventsources.push
 import samtranslator.model.eventsources.scheduler
 from samtranslator.feature_toggle.feature_toggle import FeatureToggle
+from samtranslator.internal.intrinsics import resolve_string_parameter_in_resource
 from samtranslator.internal.types import GetManagedPolicyMap
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.metrics.method_decorator import cw_timer
@@ -86,7 +87,6 @@ from .api.http_api_generator import HttpApiGenerator
 from .packagetype import IMAGE, ZIP
 from .s3_utils.uri_parser import construct_image_code_object, construct_s3_location_object
 from .tags.resource_tagging import get_tag_list
-from ..internal.intrinsics import resolve_string_parameter_in_resource
 
 _CONDITION_CHAR_LIMIT = 255
 

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -70,10 +70,10 @@
         "InvokeRole": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "Specifies the `InvokeRole` to use for `AWS_IAM` authorization\\.  \n*Type*: String  \n*Required*: No  \n*Default*: `CALLER_CREDENTIALS`  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.  \n*Additional notes*: `CALLER_CREDENTIALS` maps to `arn:aws:iam::*:user/*`, which uses the caller credentials to invoke the endpoint\\.",
@@ -187,10 +187,10 @@
         "Version": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "For versioned objects, the version of the deployment package object to use\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`S3ObjectVersion`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-s3objectversion) property of the `AWS::Lambda::Function` `Code` data type\\.",
@@ -509,10 +509,10 @@
         "Role": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "An IAM role ARN that CodeDeploy will use for traffic shifting\\. An IAM role will not be created if this is provided\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -532,10 +532,10 @@
         "Type": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "There are two categories of deployment types at the moment: Linear and Canary\\. For more information about available deployment types see [Deploying serverless applications gradually](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/automating-updates-to-serverless-apps.html)\\.  \n*Type*: String  \n*Required*: Yes  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -965,10 +965,10 @@
         "Destination": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The Amazon Resource Name \\(ARN\\) of the destination resource\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is similar to the [`OnFailure`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-eventinvokeconfig-destinationconfig-onfailure.html#cfn-lambda-eventinvokeconfig-destinationconfig-onfailure-destination) property of an `AWS::Lambda::EventInvokeConfig` resource\\. SAM will add any necessary permissions to the auto\\-generated IAM Role associated with this function to access the resource referenced in this property\\.  \n*Additional notes*: If the type is Lambda/EventBridge, Destination is required\\.",
@@ -997,10 +997,10 @@
         "Destination": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The Amazon Resource Name \\(ARN\\) of the destination resource\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is similar to the [`OnSuccess`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-eventinvokeconfig-destinationconfig-onsuccess.html#cfn-lambda-eventinvokeconfig-destinationconfig-onsuccess-destination) property of an `AWS::Lambda::EventInvokeConfig` resource\\. SAM will add any necessary permissions to the auto\\-generated IAM Role associated with this function to access the resource referenced in this property\\.  \n*Additional notes*: If the type is Lambda/EventBridge, Destination is required\\.",
@@ -1145,10 +1145,10 @@
         "PostTraffic": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "Lambda function that is run after traffic shifting\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -1158,10 +1158,10 @@
         "PreTraffic": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "Lambda function that is run before traffic shifting\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -1229,10 +1229,10 @@
         "ApiId": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "Identifier of an [AWS::Serverless::HttpApi](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-httpapi.html) resource defined in this template\\.  \nIf not defined, a default [AWS::Serverless::HttpApi](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-httpapi.html) resource is created called `ServerlessHttpApi` using a generated OpenApi document containing a union of all paths and methods defined by Api events defined in this template that do not specify an `ApiId`\\.  \nThis cannot reference an [AWS::Serverless::HttpApi](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-httpapi.html) resource defined in another template\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -1264,10 +1264,10 @@
         "PayloadFormatVersion": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "Specifies the format of the payload sent to an integration\\.  \nNOTE: PayloadFormatVersion requires SAM to modify your OpenAPI definition, so it only works with inline OpenApi defined in the `DefinitionBody` property\\.  \n*Type*: String  \n*Required*: No  \n*Default*: 2\\.0  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -1583,10 +1583,10 @@
         "FunctionInvokeRole": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The ARN of the IAM role that has the credentials required for API Gateway to invoke the authorizer function\\. Specify this parameter if your function's resource\\-based policy doesn't grant API Gateway `lambda:InvokeFunction` permission\\.  \nThis is passed through to the `authorizerCredentials` section of an `x-amazon-apigateway-authorizer` in the `securitySchemes` section of an OpenAPI definition\\.  \nFor more information, see [Create a Lambda authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.example-create) in the *API Gateway Developer Guide*\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -2842,10 +2842,10 @@
         "BatchSize": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The maximum number of items to retrieve in a single batch for the SQS queue\\.  \n*Type*: String  \n*Required*: No  \n*Default*: 10  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -4529,10 +4529,10 @@
         "AutoPublishAlias": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The name of the Lambda alias\\. For more information about Lambda aliases, see [Lambda function aliases](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) in the *AWS Lambda Developer Guide*\\. For examples that use this property, see [Deploying serverless applications gradually](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/automating-updates-to-serverless-apps.html)\\.  \nAWS SAM generates [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html) and [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html) resources when this property is set\\. For information about this scenario, see [AutoPublishAlias property is specified](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-generated-resources-function.html#sam-specification-generated-resources-function-autopublishalias)\\. For general information about generated AWS CloudFormation resources, see [Generated AWS CloudFormation resources](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-generated-resources.html)\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -4787,10 +4787,10 @@
         "AutoPublishAlias": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The name of the Lambda alias\\. For more information about Lambda aliases, see [Lambda function aliases](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) in the *AWS Lambda Developer Guide*\\. For examples that use this property, see [Deploying serverless applications gradually](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/automating-updates-to-serverless-apps.html)\\.  \nAWS SAM generates [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html) and [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html) resources when this property is set\\. For information about this scenario, see [AutoPublishAlias property is specified](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-generated-resources-function.html#sam-specification-generated-resources-function-autopublishalias)\\. For general information about generated AWS CloudFormation resources, see [Generated AWS CloudFormation resources](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-generated-resources.html)\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -4804,10 +4804,10 @@
         "AutoPublishCodeSha256": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The string value that is used, along with the value in `CodeUri`, to determine whether a new Lambda version should be published\\. This property is only used when `AutoPublishAlias` is also defined\\.  \nThis property addresses a problem that occurs when an AWS SAM template has the following characteristics: the `DeploymentPreference` object is configured for gradual deployments \\(as described in [Deploying serverless applications gradually](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/automating-updates-to-serverless-apps.html)\\), the `AutoPublishAlias` property is set and doesn't change between deployments, and the `CodeUri` property is set and doesn't change between deployments\\.  \nThis scenario can occur when the deployment package stored in an Amazon Simple Storage Service \\(Amazon S3\\) location is replaced by a new deployment package that contains updated Lambda function code, but the `CodeUri` property remains unchanged \\(as opposed to the new deployment package being uploaded to a new Amazon S3 location and the `CodeUri` being changed to the new location\\)\\.  \nIn this scenario, to trigger the gradual deployment successfully, you must provide a unique value for `AutoPublishCodeSha256`\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -4817,10 +4817,10 @@
         "CodeSigningConfigArn": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The ARN of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html) resource, used to enable code signing for this function\\. For more information about code signing, see [Configuring code signing for AWS SAM applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/authoring-codesigning.html)\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CodeSigningConfigArn`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-codesigningconfigarn) property of an `AWS::Lambda::Function` resource\\.",
@@ -5139,10 +5139,10 @@
         "Role": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The ARN of an IAM role to use as this function's execution role\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is similar to the [`Role`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-role) property of an `AWS::Lambda::Function` resource\\. This is required in AWS CloudFormation but not in AWS SAM\\. If a role isn't specified, one is created for you with a logical ID of `<function-logical-id>Role`\\.",
@@ -6239,10 +6239,10 @@
         "RetentionPolicy": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "Specifies whether old versions of your LayerVersion are retained or deleted after an update\\.  \n*Valid values*: `Retain` or `Delete`  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.  \n*Additional notes*: When you specify `Retain`, AWS SAM adds a [Resource attributes](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-resource-attributes.html) of `DeletionPolicy: Retain` to the transformed `AWS::Lambda::LayerVersion` resource\\.",
@@ -6462,10 +6462,10 @@
         "RestApiId": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "object"
             },
             {
-              "type": "object"
+              "type": "string"
             }
           ],
           "description": "The identifier of a `RestApi` resource, which must contain an operation with the given path and method\\. Typically, this is set to reference an [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource that is defined in this template\\.  \nIf you don't define this property, AWS SAM creates a default [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource using a generated `OpenApi` document\\. That resource contains a union of all paths and methods defined by `Api` events in the same template that do not specify a `RestApiId`\\.  \nThis property can't reference an [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource that is defined in another template\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,27 @@
+import os
+import pkgutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+from unittest import TestCase
+
+from parameterized import parameterized
+
+_PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def scan_modules_recursively(module_name: str = "samtranslator") -> List[str]:
+    all_modules: List[str] = [module_name]
+    for submodule in pkgutil.iter_modules([os.path.join(_PROJECT_ROOT, module_name.replace(".", os.path.sep))]):
+        submodule_name = module_name + "." + submodule.name
+        all_modules += scan_modules_recursively(submodule_name)
+    return all_modules
+
+
+class TestImport(TestCase):
+    @parameterized.expand([(module_path,) for module_path in scan_modules_recursively()])
+    def test_import(self, module_path: str):
+        pipe = subprocess.Popen([sys.executable, "-c", f"import {module_path}"])
+        _, stderr = pipe.communicate()
+        self.assertEqual(pipe.returncode, 0, stderr.decode("utf-8"))

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -22,6 +22,6 @@ def scan_modules_recursively(module_name: str = "samtranslator") -> List[str]:
 class TestImport(TestCase):
     @parameterized.expand([(module_path,) for module_path in scan_modules_recursively()])
     def test_import(self, module_path: str):
-        pipe = subprocess.Popen([sys.executable, "-c", f"import {module_path}"])
+        pipe = subprocess.Popen([sys.executable, "-c", f"import {module_path}"], stderr=subprocess.PIPE)
         _, stderr = pipe.communicate()
         self.assertEqual(pipe.returncode, 0, stderr.decode("utf-8"))


### PR DESCRIPTION
### Issue #, if available

### Description of changes

#2975

`samtranslator.models.__init__` should not import `samtranslator.intrinsics.*` which in turn import `samtranslator.models.__init__`

### Description of how you validated changes

Added a new import test, without the fix, it will fail:

<img width="1640" alt="image" src="https://user-images.githubusercontent.com/3804518/221957486-d8b66af7-6b14-4434-ba1e-6dce852c0f03.png">


### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
