### PR TITLE
fix: Fix an issue when customer explicitly define ServerlessRestApi SAM API resource

### DIFF
--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -109,11 +109,14 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
         # If there are no implicit APIs, we will remove from the template later.
 
         # If the customer has explicitly defined a resource with the id of "ServerlessRestApi",
-        # capture it.  If the template ends up not defining any implicit api's, instead of just
+        # capture it. If the template ends up not defining any implicit api's, instead of just
         # removing the "ServerlessRestApi" resource, we just restore what the author defined.
-        self.existing_implicit_api_resource = copy.deepcopy(template.get(self.IMPLICIT_API_LOGICAL_ID))
+        # If the template also defines implicit api, we will need to build upon the explicitly
+        # defined api resource to make sure we don't lose information like Auth.
+        implicit_api_resource = template.get(self.IMPLICIT_API_LOGICAL_ID)
+        self.existing_implicit_api_resource = copy.deepcopy(implicit_api_resource)
 
-        template.set(self.IMPLICIT_API_LOGICAL_ID, self._generate_implicit_api_resource())
+        template.set(self.IMPLICIT_API_LOGICAL_ID, self._generate_implicit_api_resource(implicit_api_resource))
 
         errors = []
         for logicalId, resource in template.iterate(

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -88,7 +88,7 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def _generate_implicit_api_resource(self) -> Dict[str, Any]:
+    def _generate_implicit_api_resource(self, resource: Optional[SamResource]) -> Dict[str, Any]:
         """
         Helper function implemented by child classes that create a new implicit API resource
         """

--- a/samtranslator/plugins/api/implicit_http_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_http_api_plugin.py
@@ -84,7 +84,7 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin[Type[OpenApiEditor]]):
         # We could have made changes to the Events structure. Write it back to function
         function.properties["Events"].update(api_events)
 
-    def _generate_implicit_api_resource(self, _: SamResource) -> Dict[str, Any]:
+    def _generate_implicit_api_resource(self, _: Optional[SamResource]) -> Dict[str, Any]:
         """
         Uses the implicit API in this file to generate an Implicit API resource
         """

--- a/samtranslator/plugins/api/implicit_http_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_http_api_plugin.py
@@ -84,7 +84,7 @@ class ImplicitHttpApiPlugin(ImplicitApiPlugin[Type[OpenApiEditor]]):
         # We could have made changes to the Events structure. Write it back to function
         function.properties["Events"].update(api_events)
 
-    def _generate_implicit_api_resource(self) -> Dict[str, Any]:
+    def _generate_implicit_api_resource(self, _: SamResource) -> Dict[str, Any]:
         """
         Uses the implicit API in this file to generate an Implicit API resource
         """

--- a/samtranslator/plugins/api/implicit_rest_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_rest_api_plugin.py
@@ -83,7 +83,7 @@ class ImplicitRestApiPlugin(ImplicitApiPlugin[Type[SwaggerEditor]]):
         # to correctly generate CloudFormation API resource.
         """
         return (
-            resource
+            resource.to_dict()
             if resource and resource.type == self.SERVERLESS_API_RESOURCE_TYPE
             else ImplicitApiResource().to_dict()
         )

--- a/samtranslator/plugins/api/implicit_rest_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_rest_api_plugin.py
@@ -75,11 +75,18 @@ class ImplicitRestApiPlugin(ImplicitApiPlugin[Type[SwaggerEditor]]):
         # We could have made changes to the Events structure. Write it back to function
         function.properties["Events"].update(api_events)
 
-    def _generate_implicit_api_resource(self) -> Dict[str, Any]:
+    def _generate_implicit_api_resource(self, resource: Optional[SamResource]) -> Dict[str, Any]:
         """
-        Uses the implicit API in this file to generate an Implicit API resource
+        # If the customer has explicitly defined a SAM API resource with the id of "ServerlessRestApi",
+        # we cannot simply generate a implicit API resource with empty swagger since the customer
+        # defined API resource may contains properties like Auth and we need these properties
+        # to correctly generate CloudFormation API resource.
         """
-        return ImplicitApiResource().to_dict()
+        return (
+            resource
+            if resource and resource.type == self.SERVERLESS_API_RESOURCE_TYPE
+            else ImplicitApiResource().to_dict()
+        )
 
     def _get_api_definition_from_editor(self, editor: SwaggerEditor) -> Dict[str, Any]:
         """

--- a/tests/translator/input/api_with_name_ServerlessRestApi.yaml
+++ b/tests/translator/input/api_with_name_ServerlessRestApi.yaml
@@ -1,0 +1,43 @@
+Resources:
+  ServerlessRestApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: AWS Api Gateway
+      StageName: !Ref ApiGatewayStageName
+      FailOnWarnings: true
+      Auth:
+        DefaultAuthorizer: BasicAuthorizer
+        AddDefaultAuthorizerToCorsPreflight: false
+        Authorizers:
+          BasicAuthorizer:
+            FunctionPayloadType: TOKEN
+            FunctionArn: !GetAtt MyFunction.Arn
+            Identity:
+              Header: Authorization
+              ValidationExpression: ^[Bb]earer [-0-9a-zA-z\.]*$
+              ReauthorizeEvery: 0
+
+  #### Division ####
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs18.x
+      InlineCode: |
+        exports.handler = async (event, context, callback) => {
+          return {
+            statusCode: 200,
+            body: 'Success'
+          }
+        }
+      Architectures:
+      - x86_64
+      MemorySize: 128
+      Events:
+        Api:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: ServerlessRestApi
+            Path: /divisions
+            Method: GET

--- a/tests/translator/input/api_with_name_ServerlessRestApi.yaml
+++ b/tests/translator/input/api_with_name_ServerlessRestApi.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       Name: AWS Api Gateway
-      StageName: !Ref ApiGatewayStageName
+      StageName: Prod
       FailOnWarnings: true
       Auth:
         DefaultAuthorizer: BasicAuthorizer

--- a/tests/translator/output/api_with_name_ServerlessRestApi.json
+++ b/tests/translator/output/api_with_name_ServerlessRestApi.json
@@ -26,7 +26,7 @@
       },
       "Type": "AWS::Lambda::Function"
     },
-    "MyFunctionApiPermissionStage": {
+    "MyFunctionApiPermissionProd": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -171,7 +171,7 @@
       },
       "Type": "AWS::ApiGateway::Deployment"
     },
-    "ServerlessRestApiStage": {
+    "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
           "Ref": "ServerlessRestApiDeployment7b59c160df"
@@ -179,9 +179,7 @@
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
-        "StageName": {
-          "Ref": "ApiGatewayStageName"
-        }
+        "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage"
     }

--- a/tests/translator/output/api_with_name_ServerlessRestApi.json
+++ b/tests/translator/output/api_with_name_ServerlessRestApi.json
@@ -1,0 +1,189 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionApiPermissionStage": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/divisions",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/divisions": {
+              "get": {
+                "responses": {},
+                "security": [
+                  {
+                    "BasicAuthorizer": []
+                  }
+                ],
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "securityDefinitions": {
+            "BasicAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "authorizerResultTtlInSeconds": 0,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": {
+                        "Fn::GetAtt": [
+                          "MyFunction",
+                          "Arn"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "identityValidationExpression": "^[Bb]earer [-0-9a-zA-z\\.]*$",
+                "type": "token"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            }
+          },
+          "swagger": "2.0"
+        },
+        "FailOnWarnings": true,
+        "Name": "AWS Api Gateway"
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiBasicAuthorizerAuthorizerPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "MyFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "ServerlessRestApiDeployment7b59c160df": {
+      "Properties": {
+        "Description": "RestApi deployment id: 7b59c160dfaa91c3c7fa9fbe799272a1f8179ce4",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment7b59c160df"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": {
+          "Ref": "ApiGatewayStageName"
+        }
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_name_ServerlessRestApi.json
+++ b/tests/translator/output/aws-cn/api_with_name_ServerlessRestApi.json
@@ -1,0 +1,197 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionApiPermissionStage": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/divisions",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/divisions": {
+              "get": {
+                "responses": {},
+                "security": [
+                  {
+                    "BasicAuthorizer": []
+                  }
+                ],
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "securityDefinitions": {
+            "BasicAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "authorizerResultTtlInSeconds": 0,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": {
+                        "Fn::GetAtt": [
+                          "MyFunction",
+                          "Arn"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "identityValidationExpression": "^[Bb]earer [-0-9a-zA-z\\.]*$",
+                "type": "token"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "FailOnWarnings": true,
+        "Name": "AWS Api Gateway",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiBasicAuthorizerAuthorizerPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "MyFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "ServerlessRestApiDeployment78ea3fdd86": {
+      "Properties": {
+        "Description": "RestApi deployment id: 78ea3fdd8601338c8c2a5aac7030b4c89a24b530",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment78ea3fdd86"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": {
+          "Ref": "ApiGatewayStageName"
+        }
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_name_ServerlessRestApi.json
+++ b/tests/translator/output/aws-cn/api_with_name_ServerlessRestApi.json
@@ -26,7 +26,7 @@
       },
       "Type": "AWS::Lambda::Function"
     },
-    "MyFunctionApiPermissionStage": {
+    "MyFunctionApiPermissionProd": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -179,7 +179,7 @@
       },
       "Type": "AWS::ApiGateway::Deployment"
     },
-    "ServerlessRestApiStage": {
+    "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
           "Ref": "ServerlessRestApiDeployment78ea3fdd86"
@@ -187,9 +187,7 @@
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
-        "StageName": {
-          "Ref": "ApiGatewayStageName"
-        }
+        "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage"
     }

--- a/tests/translator/output/aws-us-gov/api_with_name_ServerlessRestApi.json
+++ b/tests/translator/output/aws-us-gov/api_with_name_ServerlessRestApi.json
@@ -26,7 +26,7 @@
       },
       "Type": "AWS::Lambda::Function"
     },
-    "MyFunctionApiPermissionStage": {
+    "MyFunctionApiPermissionProd": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -179,7 +179,7 @@
       },
       "Type": "AWS::ApiGateway::Deployment"
     },
-    "ServerlessRestApiStage": {
+    "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
           "Ref": "ServerlessRestApiDeployment13f1733bb3"
@@ -187,9 +187,7 @@
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
-        "StageName": {
-          "Ref": "ApiGatewayStageName"
-        }
+        "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage"
     }

--- a/tests/translator/output/aws-us-gov/api_with_name_ServerlessRestApi.json
+++ b/tests/translator/output/aws-us-gov/api_with_name_ServerlessRestApi.json
@@ -1,0 +1,197 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionApiPermissionStage": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/divisions",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/divisions": {
+              "get": {
+                "responses": {},
+                "security": [
+                  {
+                    "BasicAuthorizer": []
+                  }
+                ],
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "securityDefinitions": {
+            "BasicAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "authorizerResultTtlInSeconds": 0,
+                "authorizerUri": {
+                  "Fn::Sub": [
+                    "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${__FunctionArn__}/invocations",
+                    {
+                      "__FunctionArn__": {
+                        "Fn::GetAtt": [
+                          "MyFunction",
+                          "Arn"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "identityValidationExpression": "^[Bb]earer [-0-9a-zA-z\\.]*$",
+                "type": "token"
+              },
+              "x-amazon-apigateway-authtype": "custom"
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "FailOnWarnings": true,
+        "Name": "AWS Api Gateway",
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiBasicAuthorizerAuthorizerPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "MyFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "ServerlessRestApiDeployment13f1733bb3": {
+      "Properties": {
+        "Description": "RestApi deployment id: 13f1733bb3c3a94e2a8ae0fb6c47a8b31c4fec0a",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment13f1733bb3"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": {
+          "Ref": "ApiGatewayStageName"
+        }
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/test_api_resource.py
+++ b/tests/translator/test_api_resource.py
@@ -95,7 +95,7 @@ def test_redeploy_implicit_api():
 @patch("boto3.session.Session.region_name", "ap-southeast-1")
 def translate_and_find_deployment_ids(manifest):
     parameter_values = get_template_parameter_values()
-    output_fragment = transform(manifest, parameter_values, mock_policy_loader)
+    output_fragment = transform(manifest.copy(), parameter_values, mock_policy_loader)
     print(json.dumps(output_fragment, indent=2))
 
     deployment_ids = set()


### PR DESCRIPTION
### Issue #, if available
https://github.com/aws/serverless-application-model/issues/2960

### Description of changes
There was a bug when customers explicitly define a SAM API with logical id "ServerlessRestApi". Our implementation will ignore properties like `Auth` and resulted in no authorizer being defined.

Consider 
```
Resources:
  ServerlessRestApi:
    Type: AWS::Serverless::Api
    Properties:
      Name: AWS Api Gateway
      StageName: !Ref ApiGatewayStageName
      FailOnWarnings: true
      Auth:
        DefaultAuthorizer: BasicAuthorizer
        AddDefaultAuthorizerToCorsPreflight: false
        Authorizers:
          BasicAuthorizer:
            FunctionPayloadType: TOKEN
            FunctionArn: !GetAtt MyFunction.Arn
            Identity:
              Header: Authorization
              ValidationExpression: ^[Bb]earer [-0-9a-zA-z\.]*$
              ReauthorizeEvery: 0

  #### Division ####
  MyFunction:
    Type: AWS::Serverless::Function
    Properties:
      Handler: index.handler
      Runtime: nodejs18.x
      InlineCode: |
        exports.handler = async (event, context, callback) => {
          return {
            statusCode: 200,
            body: 'Success'
          }
        }
      Architectures:
      - x86_64
      MemorySize: 128
      Events:
        Api:
          Type: Api
          Properties:
            RestApiId:
              Ref: ServerlessRestApi
            Path: /divisions
            Method: GET
```

The deployed API does not create authorizers. The issue is because the customer explicitly defined a SAM API resource with the id of "ServerlessRestApi", the current implementation improperly handles this scenario and we will lose some information like `Auth` in the generated json template.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
