### PR TITLE
ci: Upgrade ruff to 0.0.253 and enable more rules

### DIFF
--- a/bin/parse_docs.py
+++ b/bin/parse_docs.py
@@ -20,7 +20,7 @@ from typing import Dict, Iterator, Tuple
 def parse(s: str) -> Iterator[Tuple[str, str]]:
     """Parse an AWS docs page in Markdown format, yielding each property."""
     # Prevent from parsing return values accidentally
-    s = stringbetween(s, "#\s+Properties", "#\s+Return values")
+    s = stringbetween(s, "#\\s+Properties", "#\\s+Return values")
     if not s:
         return
     parts = s.split("\n\n")
@@ -44,7 +44,7 @@ def remove_first_line(s: str) -> str:
 
 
 def convert_to_full_path(description: str, prefix: str) -> str:
-    pattern = re.compile("\(([#\.a-zA-Z0-9_-]+)\)")
+    pattern = re.compile("\\(([#\\.a-zA-Z0-9_-]+)\\)")
     matched_content = pattern.findall(description)
 
     for path in matched_content:

--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -162,7 +162,7 @@ def _only_new_optional_arguments_or_existing_arguments_optionalized_or_var_argum
     # it is an optional argument when it has a default value:
     return all(
         "default" in argument or argument["kind"] in ("VAR_KEYWORD", "VAR_POSITIONAL")
-            for argument in arguments[len(original_arguments) :]
+        for argument in arguments[len(original_arguments) :]
     )
 
 

--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -161,10 +161,8 @@ def _only_new_optional_arguments_or_existing_arguments_optionalized_or_var_argum
         return False
     # it is an optional argument when it has a default value:
     return all(
-        [
-            "default" in argument or argument["kind"] in ("VAR_KEYWORD", "VAR_POSITIONAL")
+        "default" in argument or argument["kind"] in ("VAR_KEYWORD", "VAR_POSITIONAL")
             for argument in arguments[len(original_arguments) :]
-        ]
     )
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ pytest-xdist>=2.5,<4
 pytest-env>=0.6,<1
 pytest-rerunfailures>=9.1,<12
 pyyaml~=6.0
-ruff==0.0.252  # loose the requirement once it is more stable
+ruff==0.0.253  # loose the requirement once it is more stable
 
 # Test requirements
 pytest>=6.2,<8

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,8 @@
 line-length = 999
 
 select = [
-    "E",  # Pyflakes
+    "E",  # pycodestyle
+    "W",  # pycodestyle
     "F",  # Pyflakes
     "PL", # pylint
     "I", # isort
@@ -17,6 +18,7 @@ select = [
     "SIM", # flake8-simplify
     "TID", # flake8-tidy-imports
     "RUF", # Ruff-specific rules
+    "YTT", # flake8-2020
 ]
 
 # Mininal python version we support is 3.7

--- a/samtranslator/feature_toggle/dialup.py
+++ b/samtranslator/feature_toggle/dialup.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 class BaseDialup(ABC):
     """BaseDialup class to provide an interface for all dialup classes"""
 
-    def __init__(self, region_config, **kwargs):  # type: ignore[no-untyped-def]
+    def __init__(self, region_config, **kwargs) -> None:  # type: ignore[no-untyped-def]
         self.region_config = region_config
 
     @abstractmethod
@@ -23,7 +23,7 @@ class DisabledDialup(BaseDialup):
     A dialup that is never enabled
     """
 
-    def __init__(self, region_config, **kwargs):  # type: ignore[no-untyped-def]
+    def __init__(self, region_config, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(region_config)  # type: ignore[no-untyped-call]
 
     def is_enabled(self) -> bool:
@@ -36,7 +36,7 @@ class ToggleDialup(BaseDialup):
     Example of region_config: { "type": "toggle", "enabled": True }
     """
 
-    def __init__(self, region_config, **kwargs):  # type: ignore[no-untyped-def]
+    def __init__(self, region_config, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(region_config)  # type: ignore[no-untyped-call]
         self.region_config = region_config
 
@@ -50,7 +50,7 @@ class SimpleAccountPercentileDialup(BaseDialup):
     Example of region_config: { "type": "account-percentile", "enabled-%": 20 }
     """
 
-    def __init__(self, region_config, account_id, feature_name, **kwargs):  # type: ignore[no-untyped-def]
+    def __init__(self, region_config, account_id, feature_name, **kwargs) -> None:  # type: ignore[no-untyped-def]
         super().__init__(region_config)  # type: ignore[no-untyped-call]
         self.account_id = account_id
         self.feature_name = feature_name

--- a/samtranslator/feature_toggle/dialup.py
+++ b/samtranslator/feature_toggle/dialup.py
@@ -24,7 +24,7 @@ class DisabledDialup(BaseDialup):
     """
 
     def __init__(self, region_config, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        super().__init__(region_config)  # type: ignore[no-untyped-call]
+        super().__init__(region_config)
 
     def is_enabled(self) -> bool:
         return False
@@ -37,7 +37,7 @@ class ToggleDialup(BaseDialup):
     """
 
     def __init__(self, region_config, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        super().__init__(region_config)  # type: ignore[no-untyped-call]
+        super().__init__(region_config)
         self.region_config = region_config
 
     def is_enabled(self):  # type: ignore[no-untyped-def]
@@ -51,7 +51,7 @@ class SimpleAccountPercentileDialup(BaseDialup):
     """
 
     def __init__(self, region_config, account_id, feature_name, **kwargs) -> None:  # type: ignore[no-untyped-def]
-        super().__init__(region_config)  # type: ignore[no-untyped-call]
+        super().__init__(region_config)
         self.account_id = account_id
         self.feature_name = feature_name
 

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -56,7 +56,7 @@ class FeatureToggle:
                 region_config, account_id=self.account_id, feature_name=feature_name
             )
         LOG.warning("Dialup type '{}' is None or is not supported.".format(dialup_type))
-        return DisabledDialup(region_config)  # type: ignore[no-untyped-call]
+        return DisabledDialup(region_config)
 
     def is_enabled(self, feature_name: str) -> bool:
         """

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -119,7 +119,7 @@ class FeatureToggleDefaultConfigProvider(FeatureToggleConfigProvider):
 class FeatureToggleLocalConfigProvider(FeatureToggleConfigProvider):
     """Feature toggle config provider which uses a local file. This is to facilitate local testing."""
 
-    def __init__(self, local_config_path):  # type: ignore[no-untyped-def]
+    def __init__(self, local_config_path) -> None:  # type: ignore[no-untyped-def]
         FeatureToggleConfigProvider.__init__(self)
         with open(local_config_path, "r", encoding="utf-8") as f:
             config_json = f.read()
@@ -134,7 +134,7 @@ class FeatureToggleAppConfigConfigProvider(FeatureToggleConfigProvider):
     """Feature toggle config provider which loads config from AppConfig."""
 
     @cw_timer(prefix="External", name="AppConfig")
-    def __init__(self, application_id, environment_id, configuration_profile_id, app_config_client=None):  # type: ignore[no-untyped-def]
+    def __init__(self, application_id, environment_id, configuration_profile_id, app_config_client=None) -> None:  # type: ignore[no-untyped-def]
         FeatureToggleConfigProvider.__init__(self)
         try:
             LOG.info("Loading feature toggle config from AppConfig...")

--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -148,7 +148,7 @@ class Metrics:
         :param dimensions: array of dimensions applied to the metric
         :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self.metrics_cache.setdefault(name, []).append(MetricDatum(name, value, unit, dimensions, timestamp))  # type: ignore[no-untyped-call]
+        self.metrics_cache.setdefault(name, []).append(MetricDatum(name, value, unit, dimensions, timestamp))
 
     def record_count(self, name, value, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
         """

--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -25,7 +25,7 @@ class MetricsPublisher(ABC):
 class CWMetricsPublisher(MetricsPublisher):
     BATCH_SIZE = 20
 
-    def __init__(self, cloudwatch_client):  # type: ignore[no-untyped-def]
+    def __init__(self, cloudwatch_client) -> None:  # type: ignore[no-untyped-def]
         """
         Constructor
 
@@ -90,7 +90,7 @@ class MetricDatum:
     Class to hold Metric data.
     """
 
-    def __init__(self, name, value, unit, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
+    def __init__(self, name, value, unit, dimensions=None, timestamp=None) -> None:  # type: ignore[no-untyped-def]
         """
         Constructor
 

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -548,7 +548,7 @@ class ResourceTypeResolver:
     """ResourceTypeResolver maps Resource Types to Resource classes, e.g. AWS::Serverless::Function to
     samtranslator.model.sam_resources.SamFunction."""
 
-    def __init__(self, *modules: Any):
+    def __init__(self, *modules: Any) -> None:
         """Initializes the ResourceTypeResolver from the given modules.
 
         :param modules: one or more Python modules containing Resource definitions
@@ -589,7 +589,7 @@ class ResourceTypeResolver:
 
 
 class ResourceResolver:
-    def __init__(self, resources: Dict[str, Any]):
+    def __init__(self, resources: Dict[str, Any]) -> None:
         """
         Instantiate the resolver
         :param dict resources: Map of resource

--- a/samtranslator/model/exceptions.py
+++ b/samtranslator/model/exceptions.py
@@ -32,7 +32,7 @@ class InvalidDocumentException(ExceptionWithMessage):
         causes -- list of errors which caused this document to be invalid
     """
 
-    def __init__(self, causes: Sequence[ExceptionWithMessage]):
+    def __init__(self, causes: Sequence[ExceptionWithMessage]) -> None:
         self._causes = list(causes)
         # Sometimes, the same error could be raised from different plugins,
         # so here we do a deduplicate based on the message:

--- a/samtranslator/model/resource_policies.py
+++ b/samtranslator/model/resource_policies.py
@@ -29,7 +29,7 @@ class ResourcePolicies:
 
     POLICIES_PROPERTY_NAME = "Policies"
 
-    def __init__(self, resource_properties: Dict[str, Any], policy_template_processor: Any = None):
+    def __init__(self, resource_properties: Dict[str, Any], policy_template_processor: Any = None) -> None:
         """
         Initialize with policies data from resource's properties
 

--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -57,7 +57,7 @@ class ServerlessAppPlugin(BasePlugin):
         wait_for_template_active_status: bool = False,
         validate_only: bool = False,
         parameters: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> None:
         """
         Initialize the plugin.
 

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+﻿from typing import Any, Dict, List
 
 from samtranslator.model.exceptions import ExceptionWithMessage
 from samtranslator.public.intrinsics import is_intrinsics
@@ -189,13 +189,13 @@ class Globals:
 
         _globals = {}
         if not isinstance(globals_dict, dict):
-            raise InvalidGlobalsSectionException(self._KEYWORD, "It must be a non-empty dictionary")  # type: ignore[no-untyped-call]
+            raise InvalidGlobalsSectionException(self._KEYWORD, "It must be a non-empty dictionary")
 
         for section_name, properties in globals_dict.items():
             resource_type = self._make_resource_type(section_name)  # type: ignore[no-untyped-call]
 
             if resource_type not in self.supported_properties:
-                raise InvalidGlobalsSectionException(  # type: ignore[no-untyped-call]
+                raise InvalidGlobalsSectionException(
                     self._KEYWORD,
                     "'{section}' is not supported. "
                     "Must be one of the following values - {supported}".format(
@@ -204,7 +204,7 @@ class Globals:
                 )
 
             if not isinstance(properties, dict):
-                raise InvalidGlobalsSectionException(self._KEYWORD, "Value of ${section} must be a dictionary")  # type: ignore[no-untyped-call]
+                raise InvalidGlobalsSectionException(self._KEYWORD, "Value of ${section} must be a dictionary")
 
             supported = self.supported_properties[resource_type]
             supported_displayed = [
@@ -212,7 +212,7 @@ class Globals:
             ]
             for key, _ in properties.items():
                 if key not in supported:
-                    raise InvalidGlobalsSectionException(  # type: ignore[no-untyped-call]
+                    raise InvalidGlobalsSectionException(
                         self._KEYWORD,
                         "'{key}' is not a supported property of '{section}'. "
                         "Must be one of the following values - {supported}".format(
@@ -221,7 +221,7 @@ class Globals:
                     )
 
             # Store all Global properties in a map with key being the AWS::Serverless::* resource type
-            _globals[resource_type] = GlobalProperties(properties)  # type: ignore[no-untyped-call]
+            _globals[resource_type] = GlobalProperties(properties)
 
         return _globals
 

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -95,7 +95,7 @@ class Globals:
         SamResourceType.Function.value: ["RuntimeManagementConfig"],
     }
 
-    def __init__(self, template):  # type: ignore[no-untyped-def]
+    def __init__(self, template) -> None:  # type: ignore[no-untyped-def]
         """
         Constructs an instance of this object
 
@@ -349,7 +349,7 @@ class GlobalProperties:
 
     """
 
-    def __init__(self, global_properties):  # type: ignore[no-untyped-def]
+    def __init__(self, global_properties) -> None:  # type: ignore[no-untyped-def]
         self.global_properties = global_properties
 
     def merge(self, local_properties):  # type: ignore[no-untyped-def]
@@ -471,7 +471,7 @@ class InvalidGlobalsSectionException(ExceptionWithMessage):
         message -- explanation of the error
     """
 
-    def __init__(self, logical_id, message):  # type: ignore[no-untyped-def]
+    def __init__(self, logical_id, message) -> None:  # type: ignore[no-untyped-def]
         self._logical_id = logical_id
         self._message = message
 

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -1,4 +1,4 @@
-﻿from typing import Any, Dict, List
+from typing import Any, Dict, List
 
 from samtranslator.model.exceptions import ExceptionWithMessage
 from samtranslator.public.intrinsics import is_intrinsics

--- a/samtranslator/plugins/globals/globals_plugin.py
+++ b/samtranslator/plugins/globals/globals_plugin.py
@@ -21,7 +21,7 @@ class GlobalsPlugin(BasePlugin):
         :param dict template_dict: SAM template as a dictionary
         """
         try:
-            global_section = Globals(template_dict)  # type: ignore[no-untyped-call]
+            global_section = Globals(template_dict)
         except InvalidGlobalsSectionException as ex:
             raise InvalidDocumentException([ex]) from ex
 

--- a/samtranslator/policy_template_processor/exceptions.py
+++ b/samtranslator/policy_template_processor/exceptions.py
@@ -3,7 +3,7 @@ class TemplateNotFoundException(Exception):
     Exception raised when a template with given name is not found
     """
 
-    def __init__(self, template_name):  # type: ignore[no-untyped-def]
+    def __init__(self, template_name) -> None:  # type: ignore[no-untyped-def]
         super().__init__(f"Template with name '{template_name}' is not found")
 
 
@@ -12,7 +12,7 @@ class InsufficientParameterValues(Exception):
     Exception raised when not every parameter in the template is given a value.
     """
 
-    def __init__(self, message):  # type: ignore[no-untyped-def]
+    def __init__(self, message) -> None:  # type: ignore[no-untyped-def]
         super().__init__(message)
 
 
@@ -21,5 +21,5 @@ class InvalidParameterValues(Exception):
     Exception raised when parameter values passed to this template is invalid
     """
 
-    def __init__(self, message):  # type: ignore[no-untyped-def]
+    def __init__(self, message) -> None:  # type: ignore[no-untyped-def]
         super().__init__(message)

--- a/samtranslator/policy_template_processor/processor.py
+++ b/samtranslator/policy_template_processor/processor.py
@@ -50,7 +50,7 @@ class PolicyTemplatesProcessor:
     # ./policy_templates.json
     DEFAULT_POLICY_TEMPLATES_FILE = policy_templates_data.POLICY_TEMPLATES_FILE
 
-    def __init__(self, policy_templates_dict: Dict[str, Any], schema: Optional[Dict[str, Any]] = None):
+    def __init__(self, policy_templates_dict: Dict[str, Any], schema: Optional[Dict[str, Any]] = None) -> None:
         """
         Initialize the class
 

--- a/samtranslator/policy_template_processor/processor.py
+++ b/samtranslator/policy_template_processor/processor.py
@@ -96,7 +96,7 @@ class PolicyTemplatesProcessor:
         """
 
         if not self.has(template_name):  # type: ignore[no-untyped-call]
-            raise TemplateNotFoundException(template_name)  # type: ignore[no-untyped-call]
+            raise TemplateNotFoundException(template_name)
 
         template = self.get(template_name)  # type: ignore[no-untyped-call]
         return template.to_statement(parameter_values)

--- a/samtranslator/policy_template_processor/template.py
+++ b/samtranslator/policy_template_processor/template.py
@@ -42,7 +42,7 @@ class Template:
         missing = self.missing_parameter_values(parameter_values)  # type: ignore[no-untyped-call]
         if len(missing) > 0:
             # str() of elements of list to prevent any `u` prefix from being displayed in user-facing error message
-            raise InsufficientParameterValues(  # type: ignore[no-untyped-call]
+            raise InsufficientParameterValues(
                 f"Following required parameters of template '{self.name}' don't have values: {[str(m) for m in missing]}"
             )
 
@@ -107,7 +107,7 @@ class Template:
         """
 
         if not self._is_valid_parameter_values(parameter_values):  # type: ignore[no-untyped-call]
-            raise InvalidParameterValues("Parameter values are required to process a policy template")  # type: ignore[no-untyped-call]
+            raise InvalidParameterValues("Parameter values are required to process a policy template")
 
         return list(set(self.parameters.keys()) - set(parameter_values.keys()))
 
@@ -134,4 +134,4 @@ class Template:
         parameters = template_values_dict.get("Parameters", {})
         definition = template_values_dict.get("Definition", {})
 
-        return Template(template_name, parameters, definition)  # type: ignore[no-untyped-call]
+        return Template(template_name, parameters, definition)

--- a/samtranslator/policy_template_processor/template.py
+++ b/samtranslator/policy_template_processor/template.py
@@ -12,7 +12,7 @@ class Template:
     Class representing a single policy template. It includes the name, parameters and template dictionary.
     """
 
-    def __init__(self, template_name, parameters, template_definition):  # type: ignore[no-untyped-def]
+    def __init__(self, template_name, parameters, template_definition) -> None:  # type: ignore[no-untyped-def]
         """
         Initialize a template.
         For simplicity, this method assumes that inputs have already been validated against the JSON Schema. So no

--- a/samtranslator/sdk/parameter.py
+++ b/samtranslator/sdk/parameter.py
@@ -12,7 +12,7 @@ class SamParameterValues:
     Class representing SAM parameter values.
     """
 
-    def __init__(self, parameter_values: Dict[Any, Any]):
+    def __init__(self, parameter_values: Dict[Any, Any]) -> None:
         """
         Initialize the object given the parameter values as a dictionary
 

--- a/samtranslator/validator/validator.py
+++ b/samtranslator/validator/validator.py
@@ -77,7 +77,7 @@ class SamTemplateValidator:
         str
             Validation errors separated by commas ","
         """
-        validator = SamTemplateValidator(schema)  # type: ignore[no-untyped-call]
+        validator = SamTemplateValidator(schema)
 
         return ", ".join(validator.get_errors(template_dict))  # type: ignore[no-untyped-call]
 

--- a/samtranslator/validator/validator.py
+++ b/samtranslator/validator/validator.py
@@ -18,7 +18,7 @@ class SamTemplateValidator:
     # Example: "u'integer'" -> "'integer'"
     UNICODE_TYPE_REGEX = re.compile("u('[^']+')")
 
-    def __init__(self, schema=None):  # type: ignore[no-untyped-def]
+    def __init__(self, schema=None) -> None:  # type: ignore[no-untyped-def]
         """
         Constructor
 


### PR DESCRIPTION
### Issue #, if available

### Description of changes

An arbitrary change to trigger something

For the auto fix:

```
>>> "#\s+Properties" == "#\\s+Properties"
True
```

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
