### PR TITLE
chore: adding some type checks as constants

### DIFF
--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -9,7 +9,7 @@ from samtranslator.model.exceptions import InvalidEventException
 from samtranslator.model.iam import IAMRolePolicies
 from samtranslator.model.intrinsics import is_intrinsic
 from samtranslator.model.lambda_ import LambdaEventSourceMapping
-from samtranslator.model.types import IS_DICT, IS_STR, PassThrough, is_type
+from samtranslator.model.types import IS_BOOL, IS_DICT, IS_INT, IS_LIST, IS_STR, PassThrough
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.utils.types import Intrinsicable
 from samtranslator.validator.value_validator import sam_expect
@@ -34,23 +34,23 @@ class PullEventSource(ResourceMacro, metaclass=ABCMeta):
     resource_type: str = None  # type: ignore
     relative_id: str  # overriding the Optional[str]: for event, relative id is not None
     property_types: Dict[str, PropertyType] = {
-        "BatchSize": PropertyType(False, is_type(int)),
+        "BatchSize": PropertyType(False, IS_INT),
         "StartingPosition": PassThroughProperty(False),
         "StartingPositionTimestamp": PassThroughProperty(False),
-        "Enabled": PropertyType(False, is_type(bool)),
-        "MaximumBatchingWindowInSeconds": PropertyType(False, is_type(int)),
-        "MaximumRetryAttempts": PropertyType(False, is_type(int)),
-        "BisectBatchOnFunctionError": PropertyType(False, is_type(bool)),
-        "MaximumRecordAgeInSeconds": PropertyType(False, is_type(int)),
+        "Enabled": PropertyType(False, IS_BOOL),
+        "MaximumBatchingWindowInSeconds": PropertyType(False, IS_INT),
+        "MaximumRetryAttempts": PropertyType(False, IS_INT),
+        "BisectBatchOnFunctionError": PropertyType(False, IS_BOOL),
+        "MaximumRecordAgeInSeconds": PropertyType(False, IS_INT),
         "DestinationConfig": PropertyType(False, IS_DICT),
-        "ParallelizationFactor": PropertyType(False, is_type(int)),
-        "Topics": PropertyType(False, is_type(list)),
-        "Queues": PropertyType(False, is_type(list)),
-        "SourceAccessConfigurations": PropertyType(False, is_type(list)),
+        "ParallelizationFactor": PropertyType(False, IS_INT),
+        "Topics": PropertyType(False, IS_LIST),
+        "Queues": PropertyType(False, IS_LIST),
+        "SourceAccessConfigurations": PropertyType(False, IS_LIST),
         "SecretsManagerKmsKeyId": PropertyType(False, IS_STR),
-        "TumblingWindowInSeconds": PropertyType(False, is_type(int)),
-        "FunctionResponseTypes": PropertyType(False, is_type(list)),
-        "KafkaBootstrapServers": PropertyType(False, is_type(list)),
+        "TumblingWindowInSeconds": PropertyType(False, IS_INT),
+        "FunctionResponseTypes": PropertyType(False, IS_LIST),
+        "KafkaBootstrapServers": PropertyType(False, IS_LIST),
         "FilterCriteria": PropertyType(False, IS_DICT),
         "ConsumerGroupId": PropertyType(False, IS_STR),
         "ScalingConfig": PropertyType(False, IS_DICT),
@@ -424,7 +424,7 @@ class MQ(PullEventSource):
     property_types: Dict[str, PropertyType] = {
         **PullEventSource.property_types,
         "Broker": PassThroughProperty(True),
-        "DynamicPolicyName": Property(False, is_type(bool)),
+        "DynamicPolicyName": Property(False, IS_BOOL),
     }
 
     Broker: PassThrough

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -19,7 +19,7 @@ from samtranslator.model.s3 import S3Bucket
 from samtranslator.model.sns import SNSSubscription
 from samtranslator.model.sqs import SQSQueue, SQSQueuePolicies, SQSQueuePolicy
 from samtranslator.model.tags.resource_tagging import get_tag_list
-from samtranslator.model.types import IS_DICT, IS_STR, PassThrough, dict_of, is_type, list_of, one_of
+from samtranslator.model.types import IS_BOOL, IS_DICT, IS_INT, IS_LIST, IS_STR, PassThrough, dict_of, list_of, one_of
 from samtranslator.open_api.open_api import OpenApiEditor
 from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.translator import logical_id_generator
@@ -105,7 +105,7 @@ class Schedule(PushEventSource):
         "Schedule": PropertyType(True, IS_STR),
         "RuleName": PropertyType(False, IS_STR),
         "Input": PropertyType(False, IS_STR),
-        "Enabled": PropertyType(False, is_type(bool)),
+        "Enabled": PropertyType(False, IS_BOOL),
         "State": PropertyType(False, IS_STR),
         "Name": PropertyType(False, IS_STR),
         "Description": PropertyType(False, IS_STR),
@@ -205,7 +205,7 @@ class CloudWatchEvent(PushEventSource):
         "Input": PropertyType(False, IS_STR),
         "InputPath": PropertyType(False, IS_STR),
         "Target": PropertyType(False, IS_DICT),
-        "Enabled": PropertyType(False, is_type(bool)),
+        "Enabled": PropertyType(False, IS_BOOL),
         "State": PropertyType(False, IS_STR),
     }
 
@@ -486,7 +486,7 @@ class SNS(PushEventSource):
         "Topic": PropertyType(True, IS_STR),
         "Region": PropertyType(False, IS_STR),
         "FilterPolicy": PropertyType(False, dict_of(IS_STR, list_of(one_of(IS_STR, IS_DICT)))),
-        "SqsSubscription": PropertyType(False, one_of(is_type(bool), IS_DICT)),
+        "SqsSubscription": PropertyType(False, one_of(IS_BOOL, IS_DICT)),
         "RedrivePolicy": PropertyType(False, IS_DICT),
     }
 
@@ -630,7 +630,7 @@ class Api(PushEventSource):
         "Stage": PropertyType(False, IS_STR),
         "Auth": PropertyType(False, IS_DICT),
         "RequestModel": PropertyType(False, IS_DICT),
-        "RequestParameters": PropertyType(False, is_type(list)),
+        "RequestParameters": PropertyType(False, IS_LIST),
     }
 
     Path: str
@@ -1220,7 +1220,7 @@ class HttpApi(PushEventSource):
         "ApiId": PropertyType(False, IS_STR),
         "Stage": PropertyType(False, IS_STR),
         "Auth": PropertyType(False, IS_DICT),
-        "TimeoutInMillis": PropertyType(False, is_type(int)),
+        "TimeoutInMillis": PropertyType(False, IS_INT),
         "RouteSettings": PropertyType(False, IS_DICT),
         "PayloadFormatVersion": PropertyType(False, IS_STR),
     }

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -75,7 +75,18 @@ from samtranslator.model.role_utils import construct_role_for_resource
 from samtranslator.model.sns import SNSTopic, SNSTopicPolicy
 from samtranslator.model.sqs import SQSQueue, SQSQueuePolicy
 from samtranslator.model.stepfunctions import StateMachineGenerator
-from samtranslator.model.types import IS_DICT, IS_STR, PassThrough, any_type, dict_of, is_type, list_of, one_of
+from samtranslator.model.types import (
+    IS_BOOL,
+    IS_DICT,
+    IS_INT,
+    IS_LIST,
+    IS_STR,
+    PassThrough,
+    any_type,
+    dict_of,
+    list_of,
+    one_of,
+)
 from samtranslator.model.xray_utils import get_xray_managed_policy_name
 from samtranslator.translator import logical_id_generator
 from samtranslator.translator.arn_generator import ArnGenerator
@@ -126,7 +137,7 @@ class SamFunction(SamResourceMacro):
         # Intrinsic functions in value of Alias property are not supported, yet
         "AutoPublishAlias": PropertyType(False, one_of(IS_STR)),
         "AutoPublishCodeSha256": PropertyType(False, one_of(IS_STR)),
-        "AutoPublishAliasAllProperties": Property(False, is_type(bool)),
+        "AutoPublishAliasAllProperties": Property(False, IS_BOOL),
         "VersionDescription": PassThroughProperty(False),
         "ProvisionedConcurrencyConfig": PassThroughProperty(False),
         "FileSystemConfigs": PassThroughProperty(False),
@@ -1141,35 +1152,35 @@ class SamApi(SamResourceMacro):
         # Implicit APIs. For Explicit APIs, customer is expected to set integration URI themselves.
         # In the future, we might rename and expose this property to customers so they can have SAM manage Explicit APIs
         # Swagger.
-        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),
+        "__MANAGE_SWAGGER": PropertyType(False, IS_BOOL),
         "Name": PropertyType(False, one_of(IS_STR, IS_DICT)),
         "StageName": PropertyType(True, one_of(IS_STR, IS_DICT)),
         "Tags": PropertyType(False, IS_DICT),
         "DefinitionBody": PropertyType(False, IS_DICT),
         "DefinitionUri": PropertyType(False, one_of(IS_STR, IS_DICT)),
-        "MergeDefinitions": Property(False, is_type(bool)),
-        "CacheClusterEnabled": PropertyType(False, is_type(bool)),
+        "MergeDefinitions": Property(False, IS_BOOL),
+        "CacheClusterEnabled": PropertyType(False, IS_BOOL),
         "CacheClusterSize": PropertyType(False, IS_STR),
         "Variables": PropertyType(False, IS_DICT),
         "EndpointConfiguration": PropertyType(False, one_of(IS_STR, IS_DICT)),
-        "MethodSettings": PropertyType(False, is_type(list)),
-        "BinaryMediaTypes": PropertyType(False, is_type(list)),
-        "MinimumCompressionSize": PropertyType(False, is_type(int)),
+        "MethodSettings": PropertyType(False, IS_LIST),
+        "BinaryMediaTypes": PropertyType(False, IS_LIST),
+        "MinimumCompressionSize": PropertyType(False, IS_INT),
         "Cors": PropertyType(False, one_of(IS_STR, IS_DICT)),
         "Auth": PropertyType(False, IS_DICT),
         "GatewayResponses": PropertyType(False, IS_DICT),
         "AccessLogSetting": PropertyType(False, IS_DICT),
         "CanarySetting": PropertyType(False, IS_DICT),
-        "TracingEnabled": PropertyType(False, is_type(bool)),
+        "TracingEnabled": PropertyType(False, IS_BOOL),
         "OpenApiVersion": PropertyType(False, IS_STR),
         "Models": PropertyType(False, IS_DICT),
         "Domain": PropertyType(False, IS_DICT),
-        "FailOnWarnings": PropertyType(False, is_type(bool)),
+        "FailOnWarnings": PropertyType(False, IS_BOOL),
         "Description": PropertyType(False, IS_STR),
         "Mode": PropertyType(False, IS_STR),
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
+        "DisableExecuteApiEndpoint": PropertyType(False, IS_BOOL),
         "ApiKeySourceType": PropertyType(False, IS_STR),
-        "AlwaysDeploy": Property(False, is_type(bool)),
+        "AlwaysDeploy": Property(False, IS_BOOL),
     }
 
     Name: Optional[Intrinsicable[str]]
@@ -1302,22 +1313,22 @@ class SamHttpApi(SamResourceMacro):
         # Implicit APIs. For Explicit APIs, this is managed by the DefaultDefinitionBody Plugin.
         # In the future, we might rename and expose this property to customers so they can have SAM manage Explicit APIs
         # Swagger.
-        "__MANAGE_SWAGGER": PropertyType(False, is_type(bool)),
+        "__MANAGE_SWAGGER": PropertyType(False, IS_BOOL),
         "Name": PassThroughProperty(False),
         "StageName": PropertyType(False, one_of(IS_STR, IS_DICT)),
         "Tags": PropertyType(False, IS_DICT),
         "DefinitionBody": PropertyType(False, IS_DICT),
         "DefinitionUri": PropertyType(False, one_of(IS_STR, IS_DICT)),
         "StageVariables": PropertyType(False, IS_DICT),
-        "CorsConfiguration": PropertyType(False, one_of(is_type(bool), IS_DICT)),
+        "CorsConfiguration": PropertyType(False, one_of(IS_BOOL, IS_DICT)),
         "AccessLogSettings": PropertyType(False, IS_DICT),
         "DefaultRouteSettings": PropertyType(False, IS_DICT),
         "Auth": PropertyType(False, IS_DICT),
         "RouteSettings": PropertyType(False, IS_DICT),
         "Domain": PropertyType(False, IS_DICT),
-        "FailOnWarnings": PropertyType(False, is_type(bool)),
+        "FailOnWarnings": PropertyType(False, IS_BOOL),
         "Description": PropertyType(False, IS_STR),
-        "DisableExecuteApiEndpoint": PropertyType(False, is_type(bool)),
+        "DisableExecuteApiEndpoint": PropertyType(False, IS_BOOL),
     }
 
     Name: Optional[Any]
@@ -1406,7 +1417,7 @@ class SamSimpleTable(SamResourceMacro):
     resource_type = "AWS::Serverless::SimpleTable"
     property_types = {
         "PrimaryKey": PropertyType(False, dict_of(IS_STR, IS_STR)),
-        "ProvisionedThroughput": PropertyType(False, dict_of(IS_STR, one_of(is_type(int), IS_DICT))),
+        "ProvisionedThroughput": PropertyType(False, dict_of(IS_STR, one_of(IS_INT, IS_DICT))),
         "TableName": PropertyType(False, one_of(IS_STR, IS_DICT)),
         "Tags": PropertyType(False, IS_DICT),
         "SSESpecification": PropertyType(False, IS_DICT),
@@ -1484,7 +1495,7 @@ class SamApplication(SamResourceMacro):
         "Parameters": PropertyType(False, IS_DICT),
         "NotificationARNs": PropertyType(False, list_of(one_of(IS_STR, IS_DICT))),
         "Tags": PropertyType(False, IS_DICT),
-        "TimeoutInMinutes": PropertyType(False, is_type(int)),
+        "TimeoutInMinutes": PropertyType(False, IS_INT),
     }
 
     Location: Union[str, Dict[str, Any]]

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -10,7 +10,7 @@ from samtranslator.model.eventsources.push import Api as PushApi
 from samtranslator.model.exceptions import InvalidEventException
 from samtranslator.model.iam import IAMRole, IAMRolePolicies
 from samtranslator.model.intrinsics import fnSub
-from samtranslator.model.types import IS_DICT, IS_STR, PassThrough, is_type
+from samtranslator.model.types import IS_BOOL, IS_DICT, IS_STR, PassThrough
 from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.translator import logical_id_generator
 
@@ -86,7 +86,7 @@ class Schedule(EventSource):
     property_types = {
         "Schedule": PropertyType(True, IS_STR),
         "Input": PropertyType(False, IS_STR),
-        "Enabled": PropertyType(False, is_type(bool)),
+        "Enabled": PropertyType(False, IS_BOOL),
         "State": PropertyType(False, IS_STR),
         "Name": PropertyType(False, IS_STR),
         "Description": PropertyType(False, IS_STR),
@@ -294,7 +294,7 @@ class Api(EventSource):
         "RestApiId": PropertyType(True, IS_STR),
         "Stage": PropertyType(False, IS_STR),
         "Auth": PropertyType(False, IS_DICT),
-        "UnescapeMappingTemplate": Property(False, is_type(bool)),
+        "UnescapeMappingTemplate": Property(False, IS_BOOL),
     }
 
     Path: str

--- a/samtranslator/model/types.py
+++ b/samtranslator/model/types.py
@@ -46,6 +46,9 @@ def is_type(valid_type: Type[Any]) -> Validator:
 
 IS_DICT = is_type(dict)
 IS_STR = is_type(str)
+IS_BOOL = is_type(bool)
+IS_LIST = is_type(list)
+IS_INT = is_type(int)
 
 
 def list_of(validate_item: Union[Type[Any], Validator]) -> Validator:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,5 @@
 import pytest
-from samtranslator.model.types import dict_of, is_type, list_of, one_of
+from samtranslator.model.types import IS_INT, dict_of, is_type, list_of, one_of
 
 
 class DummyType(object):
@@ -83,11 +83,11 @@ def test_dict_of_validator(value, key_type, value_type, should_pass):
     "value,validators,should_pass",
     [
         # Value of first expected type
-        (1, [is_type(int), list_of(is_type(int))], True),
+        (1, [IS_INT, list_of(IS_INT)], True),
         # Value of second expected type
-        ([1, 2, 3], [is_type(int), list_of(is_type(int))], True),
+        ([1, 2, 3], [IS_INT, list_of(IS_INT)], True),
         # Value of neither expected type
-        ("Hello, World!", [is_type(int), list_of(is_type(int))], False),
+        ("Hello, World!", [IS_INT, list_of(IS_INT)], False),
     ],
 )
 def test_one_of_validator(value, validators, should_pass):


### PR DESCRIPTION
### Issue #, if available
Adding type check `IS_BOOL`, `IS_INT` and `IS_LIST`
### Description of changes

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
