### PR TITLE
ci: ignore unused parameter cfn-lint rule

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -125,3 +125,4 @@ ignore_checks:
   - E2531 # Deprecated runtime; not relevant for transform tests
   - W2531 # EOL runtime; not relevant for transform tests
   - E3001 # Invalid or unsupported Type; common in transform tests since they focus on SAM resources
+  - W2001 # Parameter not used


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Notice workflow failure in https://github.com/aws/serverless-application-model/pull/2998. At glance, the parameters are used, so I'm not sure what `cfn-lint` is complaining about. In any case, the rule is of no meaningful consequence, so getting rid of some red tape.

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
