### PR TITLE
chore: Add skip_using_service_detector to sns integ tests

### DIFF
--- a/integration/combination/test_function_with_sns.py
+++ b/integration/combination/test_function_with_sns.py
@@ -8,7 +8,9 @@ from integration.helpers.resource import current_region_does_not_support
 @skipIf(current_region_does_not_support([SNS]), "SNS is not supported in this testing region")
 class TestFunctionWithSns(BaseTest):
     def test_function_with_sns_bucket_trigger(self):
-        self.create_and_verify_stack("combination/function_with_sns")
+        template_file_path = "combination/function_with_sns"
+        self.skip_using_service_detector(template_file_path)
+        self.create_and_verify_stack(template_file_path)
 
         sns_client = self.client_provider.sns_client
 
@@ -33,7 +35,9 @@ class TestFunctionWithSns(BaseTest):
         self.assertEqual(sqs_subscription["TopicArn"], sns_topic_arn)
 
     def test_function_with_sns_intrinsics(self):
-        self.create_and_verify_stack("combination/function_with_sns_intrinsics")
+        template_file_path = "combination/function_with_sns_intrinsics"
+        self.skip_using_service_detector(template_file_path)
+        self.create_and_verify_stack(template_file_path)
 
         sns_client = self.client_provider.sns_client
 


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Follow up of #3015

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
