### PR TITLE
chore: Get rid of py2 import stuff

### DIFF
--- a/integration/combination/test_api_settings.py
+++ b/integration/combination/test_api_settings.py
@@ -1,17 +1,12 @@
 import hashlib
+from pathlib import Path
 from unittest.case import skipIf
-
-from integration.config.service_names import REST_API
-from integration.helpers.resource import current_region_does_not_support
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
 
 from parameterized import parameterized
 
+from integration.config.service_names import REST_API
 from integration.helpers.base_test import BaseTest
+from integration.helpers.resource import current_region_does_not_support
 
 
 @skipIf(current_region_does_not_support([REST_API]), "Rest API is not supported in this testing region")

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from pathlib import Path
 
 import boto3
 import botocore
@@ -17,11 +18,6 @@ from integration.helpers.resource import (
 )
 from integration.helpers.stack import Stack
 from integration.helpers.yaml_utils import load_yaml
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
 
 LOG = logging.getLogger(__name__)
 

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -2,7 +2,10 @@ import json
 import logging
 import os
 import shutil
+from pathlib import Path
+from unittest.case import TestCase
 
+import boto3
 import botocore
 import pytest
 import requests
@@ -20,6 +23,7 @@ from tenacity import (
 
 from integration.config.logger_configurations import LoggingConfiguration
 from integration.helpers.client_provider import ClientProvider
+from integration.helpers.deployer.deployer import Deployer
 from integration.helpers.deployer.exceptions.exceptions import ThrottlingError
 from integration.helpers.deployer.utils.retry import retry_with_exponential_backoff_and_jitter
 from integration.helpers.exception import StatusCodeError
@@ -32,18 +36,8 @@ from integration.helpers.resource import (
     verify_stack_resources,
 )
 from integration.helpers.s3_uploader import S3Uploader
-from integration.helpers.yaml_utils import dump_yaml, load_yaml
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
-from unittest.case import TestCase
-
-import boto3
-
-from integration.helpers.deployer.deployer import Deployer
 from integration.helpers.template import transform_template
+from integration.helpers.yaml_utils import dump_yaml, load_yaml
 
 LOG = logging.getLogger(__name__)
 

--- a/integration/helpers/deployer/utils/artifact_exporter.py
+++ b/integration/helpers/deployer/utils/artifact_exporter.py
@@ -2,7 +2,6 @@
 Logic for uploading to S3 per Cloudformation Specific Resource
 This was ported over from the sam-cli repo
 """
-# pylint: disable=no-member
 
 # Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/integration/helpers/resource.py
+++ b/integration/helpers/resource.py
@@ -1,8 +1,13 @@
 import json
 import random
 import re
-import string  # pylint: disable=deprecated-module
+import string
+from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, Set
+
+import boto3
+from botocore.exceptions import NoRegionError
+from samtranslator.translator.logical_id_generator import LogicalIdGenerator
 
 from integration.config.service_names import (
     APP_SYNC,
@@ -17,15 +22,6 @@ from integration.config.service_names import (
     STATE_MACHINE_INLINE_DEFINITION,
 )
 from integration.helpers.yaml_utils import load_yaml
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
-
-import boto3
-from botocore.exceptions import NoRegionError
-from samtranslator.translator.logical_id_generator import LogicalIdGenerator
 
 # Length of the random suffix added at the end of the resources we create
 # to avoid collisions between tests

--- a/integration/helpers/stack.py
+++ b/integration/helpers/stack.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import botocore
 
 from integration.helpers.deployer.deployer import Deployer
@@ -5,11 +7,6 @@ from integration.helpers.deployer.exceptions.exceptions import ThrottlingError
 from integration.helpers.deployer.utils.retry import retry_with_exponential_backoff_and_jitter
 from integration.helpers.resource import generate_suffix
 from integration.helpers.template import transform_template
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
 
 
 class Stack:


### PR DESCRIPTION
### Issue #, if available

### Description of changes

you know

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
