### PR TITLE
chore: Add type to metrics code and deprecate CWMetricsPublisher

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,6 @@
 boto3>=1.19.5,==1.*
 jsonschema<5,>=3.2  # TODO: evaluate risk of removing jsonschema 3.x support
 typing_extensions>=4.4,<5 # 3.7 doesn't have Literal
-aws-lambda-powertools~=2.0
 
 # resource validation & schema generation
 pydantic~=1.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 boto3>=1.19.5,==1.*
 jsonschema<5,>=3.2  # TODO: evaluate risk of removing jsonschema 3.x support
 typing_extensions>=4.4,<5 # 3.7 doesn't have Literal
+aws-lambda-powertools~=2.0
 
 # resource validation & schema generation
 pydantic~=1.8

--- a/samtranslator/internal/deprecation_control.py
+++ b/samtranslator/internal/deprecation_control.py
@@ -23,7 +23,10 @@ def _make_message(message: str, replacement: Optional[str]) -> str:
     return f"{message}, please use {replacement}" if replacement else message
 
 
-def deprecated(replacement: Optional[str]) -> Callable[[Callable[PT, RT]], Callable[PT, RT]]:
+# TODO: make @deprecated able to decorate a class
+
+
+def deprecated(replacement: Optional[str] = None) -> Callable[[Callable[PT, RT]], Callable[PT, RT]]:
     """
     Mark a function/method as deprecated.
 

--- a/samtranslator/metrics/method_decorator.py
+++ b/samtranslator/metrics/method_decorator.py
@@ -76,7 +76,7 @@ def _send_cw_metric(prefix, name, execution_time_ms, func, args):  # type: ignor
     try:
         metric_name = _get_metric_name(prefix, name, func, args)  # type: ignore[no-untyped-call]
         LOG.debug("Execution took %sms for %s", execution_time_ms, metric_name)
-        MetricsMethodWrapperSingleton.get_instance().record_latency(metric_name, execution_time_ms)  # type: ignore[no-untyped-call]
+        MetricsMethodWrapperSingleton.get_instance().record_latency(metric_name, execution_time_ms)
     except Exception as e:
         LOG.warning("Failed to add metrics", exc_info=e)
 

--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -4,7 +4,11 @@ Helper classes to publish metrics
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
+
+from typing_extensions import TypedDict
+
+from samtranslator.internal.deprecation_control import deprecated
 
 LOG = logging.getLogger(__name__)
 
@@ -25,6 +29,7 @@ class MetricsPublisher(ABC):
 class CWMetricsPublisher(MetricsPublisher):
     BATCH_SIZE = 20
 
+    @deprecated()
     def __init__(self, cloudwatch_client) -> None:  # type: ignore[no-untyped-def]
         """
         Constructor
@@ -66,7 +71,7 @@ class DummyMetricsPublisher(MetricsPublisher):
     def __init__(self) -> None:
         MetricsPublisher.__init__(self)
 
-    def publish(self, namespace, metrics):  # type: ignore[no-untyped-def]
+    def publish(self, namespace: str, metrics: List["MetricDatum"]) -> None:
         """Do not publish any metric, this is a dummy publisher used for offline use."""
         LOG.debug(f"Dummy publisher ignoring {len(metrics)} metrices")
 
@@ -90,7 +95,14 @@ class MetricDatum:
     Class to hold Metric data.
     """
 
-    def __init__(self, name, value, unit, dimensions=None, timestamp=None) -> None:  # type: ignore[no-untyped-def]
+    def __init__(
+        self,
+        name: str,
+        value: Union[int, float],
+        unit: str,
+        dimensions: Optional[List["MetricDimension"]] = None,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
         """
         Constructor
 
@@ -116,6 +128,11 @@ class MetricDatum:
         }
 
 
+class MetricDimension(TypedDict):
+    Name: str
+    Value: Any
+
+
 class Metrics:
     def __init__(
         self, namespace: str = "ServerlessTransform", metrics_publisher: Optional[MetricsPublisher] = None
@@ -138,7 +155,14 @@ class Metrics:
             )
             self.publish()
 
-    def _record_metric(self, name, value, unit, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
+    def _record_metric(
+        self,
+        name: str,
+        value: Union[int, float],
+        unit: str,
+        dimensions: Optional[List["MetricDimension"]] = None,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
         """
         Create and save metric object in internal cache.
 
@@ -150,7 +174,13 @@ class Metrics:
         """
         self.metrics_cache.setdefault(name, []).append(MetricDatum(name, value, unit, dimensions, timestamp))
 
-    def record_count(self, name, value, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
+    def record_count(
+        self,
+        name: str,
+        value: int,
+        dimensions: Optional[List["MetricDimension"]] = None,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
         """
         Create metric with unit Count.
 
@@ -160,9 +190,15 @@ class Metrics:
         :param dimensions: array of dimensions applied to the metric
         :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self._record_metric(name, value, Unit.Count, dimensions, timestamp)  # type: ignore[no-untyped-call]
+        self._record_metric(name, value, Unit.Count, dimensions, timestamp)
 
-    def record_latency(self, name, value, dimensions=None, timestamp=None):  # type: ignore[no-untyped-def]
+    def record_latency(
+        self,
+        name: str,
+        value: Union[int, float],
+        dimensions: Optional[List["MetricDimension"]] = None,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
         """
         Create metric with unit Milliseconds.
 
@@ -172,7 +208,7 @@ class Metrics:
         :param dimensions: array of dimensions applied to the metric
         :param timestamp: timestamp of metric (datetime.datetime object)
         """
-        self._record_metric(name, value, Unit.Milliseconds, dimensions, timestamp)  # type: ignore[no-untyped-call]
+        self._record_metric(name, value, Unit.Milliseconds, dimensions, timestamp)
 
     def publish(self) -> None:
         """Calls publish method from the configured metrics publisher to publish metrics"""
@@ -184,7 +220,7 @@ class Metrics:
         self.metrics_publisher.publish(self.namespace, all_metrics)
         self.metrics_cache = {}
 
-    def get_metric(self, name):  # type: ignore[no-untyped-def]
+    def get_metric(self, name: str) -> List[MetricDatum]:
         """
         Returns a list of metrics from the internal cache for a metric name
 

--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -659,7 +659,7 @@ class SelfManagedKafka(PullEventSource):
         }
 
     @staticmethod
-    @deprecated(None)
+    @deprecated()
     def get_kms_policy(secrets_manager_kms_key_id: str) -> Dict[str, Any]:
         return {
             "Action": ["kms:Decrypt"],


### PR DESCRIPTION
### Issue #, if available

### Description of changes

I had to dig through usage to understand what `dimensions` looks like. Adding `MetricDimension` and other types.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
