### PR TITLE
ci: Exclude samtranslator.internal from interface scan

### DIFF
--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -215,13 +215,19 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest="command")
     extract = subparsers.add_parser("extract", help="Extract public interfaces")
     extract.add_argument("--module", help="The module to extract public interfaces", type=str, default="samtranslator")
+    extract.add_argument(
+        "--skipped-modules",
+        help="The modules separated by ',' that should be skipped",
+        type=str,
+        default="samtranslator.internal",
+    )
     check = subparsers.add_parser("check", help="Check public interface changes")
     check.add_argument("original_json", help="The original public interface JSON file", type=Path)
     check.add_argument("new_json", help="The new public interface JSON file", type=Path)
     args = parser.parse_args()
 
     if args.command == "extract":
-        scanner = InterfaceScanner(skipped_modules=["samtranslator.internal"])
+        scanner = InterfaceScanner(skipped_modules=args.skipped_modules.split(","))
         scanner.scan_interfaces_recursively(args.module)
         _print(scanner.signatures, scanner.variables)
     elif args.command == "check":

--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -24,7 +24,7 @@ class InterfaceScanner:
     def __init__(self, skipped_modules: Optional[List[str]] = None) -> None:
         self.signatures: Dict[str, Union[inspect.Signature]] = {}
         self.variables: Set[str] = set()
-        self.skipped_modules: Set[str] = set(skipped_modules) or set()
+        self.skipped_modules: Set[str] = set(skipped_modules or [])
 
     def scan_interfaces_recursively(self, module_name: str) -> None:
         if module_name in self.skipped_modules:

--- a/bin/public_interface.py
+++ b/bin/public_interface.py
@@ -216,10 +216,11 @@ def main() -> None:
     extract = subparsers.add_parser("extract", help="Extract public interfaces")
     extract.add_argument("--module", help="The module to extract public interfaces", type=str, default="samtranslator")
     extract.add_argument(
-        "--skipped-modules",
-        help="The modules separated by ',' that should be skipped",
+        "--skipped-module",
+        help="The modules that should be skipped",
         type=str,
-        default="samtranslator.internal",
+        nargs="*",
+        default=["samtranslator.internal"],
     )
     check = subparsers.add_parser("check", help="Check public interface changes")
     check.add_argument("original_json", help="The original public interface JSON file", type=Path)
@@ -227,7 +228,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "extract":
-        scanner = InterfaceScanner(skipped_modules=args.skipped_modules.split(","))
+        scanner = InterfaceScanner(skipped_modules=args.skipped_module)
         scanner.scan_interfaces_recursively(args.module)
         _print(scanner.signatures, scanner.variables)
     elif args.command == "check":


### PR DESCRIPTION
### Issue #, if available

### Description of changes

See #3026, an example of unnecessary workflow failure

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
