### PR TITLE
chore: run test coverage command in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-fast:
 
 test-cov-report:
 	pytest --cov samtranslator --cov-report term-missing --cov-report html --cov-fail-under 95 -n auto tests/
-	open htmlcov/index.html
+	open htmlcov/index.html &> /dev/null || true
 
 integ-test:
 	pytest --no-cov integration/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ test-fast:
 	pytest -x --cov samtranslator --cov-report term-missing --cov-fail-under 95 -n auto tests/
 
 test-cov-report:
-	pytest --cov samtranslator --cov-report term-missing --cov-report html --cov-fail-under 95 tests/
+	pytest --cov samtranslator --cov-report term-missing --cov-report html --cov-fail-under 95 -n auto tests/
+	open htmlcov/index.html
 
 integ-test:
 	pytest --no-cov integration/


### PR DESCRIPTION
### Issue #, if available
N/A
### Description of changes

Run `make test-cov-report` in parallel (related PR: [#2222](https://github.com/aws/serverless-application-model/pull/2222)). Time to run test on my M1 macbook goes from 211 seconds to 48 seconds (~80% reduction). 

Also added command to automatically open html coverage report (for macs) which gives a better UI for seeing which parts of the codebase are covered through tests and which are missing.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
