### PR TITLE
fix: do not validate attributes on AWS::Cognito::UserPool

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -125,7 +125,7 @@ class Resource(ABC):
     # Validation isn't always desired, e.g. when creating from a customer-provided template resource,
     # which could contain new properties not in the model
     # See https://github.com/aws/serverless-application-model/issues/2581#issuecomment-1474422567
-    skip_validate_setattr: bool = False
+    validate_setattr: bool = True
 
     def __init__(
         self,
@@ -321,8 +321,8 @@ class Resource(ABC):
         if name in self._keywords or name in self.property_types:
             return super().__setattr__(name, value)
 
-        if self.skip_validate_setattr:
-            return
+        if not self.validate_setattr:
+            return None
 
         raise InvalidResourceException(
             self.logical_id,

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -122,6 +122,11 @@ class Resource(ABC):
     # }
     runtime_attrs: Dict[str, Callable[["Resource"], Any]] = {}  # TODO: replace Any with something more explicit
 
+    # Validation isn't always desired, e.g. when creating from a customer-provided template resource,
+    # which could contain new properties not in the model
+    # See https://github.com/aws/serverless-application-model/issues/2581#issuecomment-1474422567
+    skip_validate_setattr: bool = False
+
     def __init__(
         self,
         logical_id: Optional[Any],
@@ -315,6 +320,9 @@ class Resource(ABC):
         """
         if name in self._keywords or name in self.property_types:
             return super().__setattr__(name, value)
+
+        if self.skip_validate_setattr:
+            return
 
         raise InvalidResourceException(
             self.logical_id,

--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -36,3 +36,5 @@ class CognitoUserPool(Resource):
         "provider_name": lambda self: fnGetAtt(self.logical_id, "ProviderName"),
         "provider_url": lambda self: fnGetAtt(self.logical_id, "ProviderURL"),
     }
+
+    skip_validate_setattr = True


### PR DESCRIPTION
### Issue #, if available

https://github.com/aws/serverless-application-model/issues/2581

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
