### PR TITLE
fix: add `DeletionProtection` to `AWS::Cognito::UserPool`

### DIFF
--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -9,6 +9,7 @@ class CognitoUserPool(Resource):
         "AdminCreateUserConfig": GeneratedProperty(),
         "AliasAttributes": GeneratedProperty(),
         "AutoVerifiedAttributes": GeneratedProperty(),
+        "DeletionProtection": GeneratedProperty(),
         "DeviceConfiguration": GeneratedProperty(),
         "EmailConfiguration": GeneratedProperty(),
         "EmailVerificationMessage": GeneratedProperty(),

--- a/tests/translator/input/cognito_user_pool_with_new_property_and_cognito_event.yaml
+++ b/tests/translator/input/cognito_user_pool_with_new_property_and_cognito_event.yaml
@@ -1,0 +1,19 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      DeletionProtection: ACTIVE
+
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.8
+      InlineCode: foo
+      Handler: bar
+      Events:
+        CognitoEvent:
+          Type: Cognito
+          Properties:
+            Trigger: CustomMessage
+            UserPool: !Ref MyUserPool

--- a/tests/translator/output/aws-cn/cognito_user_pool_with_new_property_and_cognito_event.json
+++ b/tests/translator/output/aws-cn/cognito_user_pool_with_new_property_and_cognito_event.json
@@ -1,0 +1,86 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "foo"
+        },
+        "Handler": "bar",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionCognitoPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "cognito-idp.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "MyUserPool",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyUserPool": {
+      "Properties": {
+        "DeletionProtection": "ACTIVE",
+        "LambdaConfig": {
+          "CustomMessage": {
+            "Fn::GetAtt": [
+              "MyFunction",
+              "Arn"
+            ]
+          }
+        }
+      },
+      "Type": "AWS::Cognito::UserPool"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/cognito_user_pool_with_new_property_and_cognito_event.json
+++ b/tests/translator/output/aws-us-gov/cognito_user_pool_with_new_property_and_cognito_event.json
@@ -1,0 +1,86 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "foo"
+        },
+        "Handler": "bar",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionCognitoPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "cognito-idp.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "MyUserPool",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyUserPool": {
+      "Properties": {
+        "DeletionProtection": "ACTIVE",
+        "LambdaConfig": {
+          "CustomMessage": {
+            "Fn::GetAtt": [
+              "MyFunction",
+              "Arn"
+            ]
+          }
+        }
+      },
+      "Type": "AWS::Cognito::UserPool"
+    }
+  }
+}

--- a/tests/translator/output/cognito_user_pool_with_new_property_and_cognito_event.json
+++ b/tests/translator/output/cognito_user_pool_with_new_property_and_cognito_event.json
@@ -1,0 +1,86 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "foo"
+        },
+        "Handler": "bar",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionCognitoPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "cognito-idp.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "MyUserPool",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyUserPool": {
+      "Properties": {
+        "DeletionProtection": "ACTIVE",
+        "LambdaConfig": {
+          "CustomMessage": {
+            "Fn::GetAtt": [
+              "MyFunction",
+              "Arn"
+            ]
+          }
+        }
+      },
+      "Type": "AWS::Cognito::UserPool"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

https://github.com/aws/serverless-application-model/issues/2581

### Description of changes

This is a quick fix to the issue, but we should fix the root cause which is that it validates the resource specified by a customer (see https://github.com/aws/serverless-application-model/issues/2581#issuecomment-1474422567). So this will keep happening for every new property. I'm toying with a longer-term fix in https://github.com/aws/serverless-application-model/pull/3040.

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
