### PR TITLE
fix: Skip MQ Integ Test and add it to Transform Test

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -121,6 +121,7 @@ ignore_templates:
   - tests/translator/output/**/globals_for_function.json  # RuntimeManagementConfig
   - tests/translator/output/**/function_with_runtime_config.json  # RuntimeManagementConfig
   - tests/translator/output/**/managed_policies_minimal.json  # Intentionally has non-existent managed policy name
+  - tests/translator/output/**/function_with_mq.json  # Property "EventSourceArn" can Fn::GetAtt to a resource of types [AWS::DynamoDB::GlobalTable, AWS::DynamoDB::Table, AWS::Kinesis::Stream, AWS::Kinesis::StreamConsumer, AWS::SQS::Queue]
 ignore_checks:
   - E2531 # Deprecated runtime; not relevant for transform tests
   - W2531 # EOL runtime; not relevant for transform tests

--- a/integration/combination/test_function_with_mq.py
+++ b/integration/combination/test_function_with_mq.py
@@ -26,6 +26,10 @@ class TestFunctionWithMq(BaseTest):
         ]
     )
     def test_function_with_mq(self, file_name, mq_broker, mq_secret, subnet_key):
+        # Temporarily skip this test and we should either re-enable this once the AZ issue is fixed
+        # or once we figure out a way to trigger integ test only when transform output changes.
+        if subnet_key == "PreCreatedSubnetOne":
+            pytest.skip("Skipping this test to temporarily bypass AvailabilityZone issue.")
         companion_stack_outputs = self.companion_stack_outputs
         parameters = self.get_parameters(companion_stack_outputs, subnet_key)
         secret_name = mq_secret + "-" + generate_suffix()

--- a/tests/translator/input/function_with_mq.yaml
+++ b/tests/translator/input/function_with_mq.yaml
@@ -1,0 +1,167 @@
+Parameters:
+  MQBrokerUser:
+    Description: The user to access the Amazon MQ broker.
+    Type: String
+    Default: testBrokerUser
+    MinLength: 2
+    ConstraintDescription: The Amazon MQ broker user is required !
+  MQBrokerPassword:
+    Description: The password to access the Amazon MQ broker. Min 12 characters
+    Type: String
+    Default: testBrokerPassword
+    MinLength: 12
+    ConstraintDescription: The Amazon MQ broker password is required !
+    NoEcho: true
+  PreCreatedVpc:
+    Type: String
+  PreCreatedSubnetOne:
+    Type: String
+  MQBrokerUserSecretName:
+    Type: String
+  PreCreatedInternetGateway:
+    Type: String
+  MQBrokerName:
+    Description: The name of MQ Broker
+    Type: String
+    Default: TestMQBroker
+
+Resources:
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: PreCreatedVpc
+
+  Route:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId:
+        Ref: RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId:
+        Ref: PreCreatedInternetGateway
+
+  PublicSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId:
+        Ref: PreCreatedSubnetOne
+      RouteTableId:
+        Ref: RouteTable
+
+  MQSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Limits security group ingress and egress traffic for the Amazon
+        MQ instance
+      VpcId:
+        Ref: PreCreatedVpc
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 8162
+        ToPort: 8162
+        CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 61617
+        ToPort: 61617
+        CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 5671
+        ToPort: 5671
+        CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 61614
+        ToPort: 61614
+        CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 8883
+        ToPort: 8883
+        CidrIp: 0.0.0.0/0
+
+  MyLambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Action: [sts:AssumeRole]
+          Effect: Allow
+          Principal:
+            Service: [lambda.amazonaws.com]
+      Policies:
+      - PolicyName: IntegrationTestExecution
+        PolicyDocument:
+          Statement:
+          - Action: [ec2:CreateNetworkInterface, ec2:CreateNetworkInterfacePermission,
+              ec2:DeleteNetworkInterface, ec2:DeleteNetworkInterfacePermission, ec2:DetachNetworkInterface,
+              ec2:DescribeSubnets, ec2:DescribeNetworkInterfaces, ec2:DescribeVpcs,
+              ec2:DescribeInternetGateways, ec2:DescribeNetworkInterfacePermissions,
+              ec2:DescribeSecurityGroups, ec2:DescribeRouteTables, logs:CreateLogGroup,
+              logs:CreateLogStream, logs:PutLogEvents, kms:Decrypt, mq:DescribeBroker,
+              secretsmanager:GetSecretValue]
+            Effect: Allow
+            Resource: '*'
+      ManagedPolicyArns:
+      - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Tags:
+      - {Value: SAM, Key: lambda:createdBy}
+
+  MyMqBroker:
+    Properties:
+      BrokerName:
+        Ref: MQBrokerName
+      DeploymentMode: SINGLE_INSTANCE
+      EngineType: ACTIVEMQ
+      EngineVersion: 5.15.12
+      HostInstanceType: mq.t3.micro
+      Logs:
+        Audit: true
+        General: true
+      PubliclyAccessible: true
+      AutoMinorVersionUpgrade: false
+      SecurityGroups:
+      - Ref: MQSecurityGroup
+      SubnetIds:
+      - Ref: PreCreatedSubnetOne
+      Users:
+      - ConsoleAccess: true
+        Groups:
+        - admin
+        Username:
+          Ref: MQBrokerUser
+        Password:
+          Ref: MQBrokerPassword
+    Type: AWS::AmazonMQ::Broker
+    DependsOn: MyLambdaExecutionRole
+
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: nodejs14.x
+      Handler: index.handler
+      CodeUri: s3://bucket/key
+      Role:
+        Fn::GetAtt: [MyLambdaExecutionRole, Arn]
+      Events:
+        MyMqEvent:
+          Type: MQ
+          Properties:
+            Broker:
+              Fn::GetAtt: MyMqBroker.Arn
+            Queues:
+            - TestQueue
+            SourceAccessConfigurations:
+            - Type: BASIC_AUTH
+              URI:
+                Ref: MQBrokerUserSecret
+
+  MQBrokerUserSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name:
+        Ref: MQBrokerUserSecretName
+      SecretString:
+        Fn::Sub: '{"username":"${MQBrokerUser}","password":"${MQBrokerPassword}"}'
+      Description: SecretsManager Secret for broker user and password
+Metadata:
+  SamTransformTest: true

--- a/tests/translator/output/aws-cn/function_with_mq.json
+++ b/tests/translator/output/aws-cn/function_with_mq.json
@@ -1,0 +1,278 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MQBrokerName": {
+      "Default": "TestMQBroker",
+      "Description": "The name of MQ Broker",
+      "Type": "String"
+    },
+    "MQBrokerPassword": {
+      "ConstraintDescription": "The Amazon MQ broker password is required !",
+      "Default": "testBrokerPassword",
+      "Description": "The password to access the Amazon MQ broker. Min 12 characters",
+      "MinLength": 12,
+      "NoEcho": true,
+      "Type": "String"
+    },
+    "MQBrokerUser": {
+      "ConstraintDescription": "The Amazon MQ broker user is required !",
+      "Default": "testBrokerUser",
+      "Description": "The user to access the Amazon MQ broker.",
+      "MinLength": 2,
+      "Type": "String"
+    },
+    "MQBrokerUserSecretName": {
+      "Type": "String"
+    },
+    "PreCreatedInternetGateway": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedVpc": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MQBrokerUserSecret": {
+      "Properties": {
+        "Description": "SecretsManager Secret for broker user and password",
+        "Name": {
+          "Ref": "MQBrokerUserSecretName"
+        },
+        "SecretString": {
+          "Fn::Sub": "{\"username\":\"${MQBrokerUser}\",\"password\":\"${MQBrokerPassword}\"}"
+        }
+      },
+      "Type": "AWS::SecretsManager::Secret"
+    },
+    "MQSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Limits security group ingress and egress traffic for the Amazon MQ instance",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 8162,
+            "IpProtocol": "tcp",
+            "ToPort": 8162
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 61617,
+            "IpProtocol": "tcp",
+            "ToPort": 61617
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 5671,
+            "IpProtocol": "tcp",
+            "ToPort": 5671
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 61614,
+            "IpProtocol": "tcp",
+            "ToPort": 61614
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 8883,
+            "IpProtocol": "tcp",
+            "ToPort": 8883
+          }
+        ],
+        "VpcId": {
+          "Ref": "PreCreatedVpc"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    "MyLambdaExecutionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          }
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "ec2:CreateNetworkInterface",
+                    "ec2:CreateNetworkInterfacePermission",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DeleteNetworkInterfacePermission",
+                    "ec2:DetachNetworkInterface",
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DescribeVpcs",
+                    "ec2:DescribeInternetGateways",
+                    "ec2:DescribeNetworkInterfacePermissions",
+                    "ec2:DescribeSecurityGroups",
+                    "ec2:DescribeRouteTables",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "kms:Decrypt",
+                    "mq:DescribeBroker",
+                    "secretsmanager:GetSecretValue"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ]
+            },
+            "PolicyName": "IntegrationTestExecution"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionMyMqEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": "MyMqBroker.Arn"
+        },
+        "FunctionName": {
+          "Ref": "MyLambdaFunction"
+        },
+        "Queues": [
+          "TestQueue"
+        ],
+        "SourceAccessConfigurations": [
+          {
+            "Type": "BASIC_AUTH",
+            "URI": {
+              "Ref": "MQBrokerUserSecret"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "MyMqBroker": {
+      "DependsOn": "MyLambdaExecutionRole",
+      "Properties": {
+        "AutoMinorVersionUpgrade": false,
+        "BrokerName": {
+          "Ref": "MQBrokerName"
+        },
+        "DeploymentMode": "SINGLE_INSTANCE",
+        "EngineType": "ACTIVEMQ",
+        "EngineVersion": "5.15.12",
+        "HostInstanceType": "mq.t3.micro",
+        "Logs": {
+          "Audit": true,
+          "General": true
+        },
+        "PubliclyAccessible": true,
+        "SecurityGroups": [
+          {
+            "Ref": "MQSecurityGroup"
+          }
+        ],
+        "SubnetIds": [
+          {
+            "Ref": "PreCreatedSubnetOne"
+          }
+        ],
+        "Users": [
+          {
+            "ConsoleAccess": true,
+            "Groups": [
+              "admin"
+            ],
+            "Password": {
+              "Ref": "MQBrokerPassword"
+            },
+            "Username": {
+              "Ref": "MQBrokerUser"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::AmazonMQ::Broker"
+    },
+    "PublicSubnetRouteTableAssociation": {
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "SubnetId": {
+          "Ref": "PreCreatedSubnetOne"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    },
+    "Route": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "PreCreatedInternetGateway"
+        },
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        }
+      },
+      "Type": "AWS::EC2::Route"
+    },
+    "RouteTable": {
+      "Properties": {
+        "VpcId": {
+          "Ref": "PreCreatedVpc"
+        }
+      },
+      "Type": "AWS::EC2::RouteTable"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/function_with_mq.json
+++ b/tests/translator/output/aws-us-gov/function_with_mq.json
@@ -1,0 +1,278 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MQBrokerName": {
+      "Default": "TestMQBroker",
+      "Description": "The name of MQ Broker",
+      "Type": "String"
+    },
+    "MQBrokerPassword": {
+      "ConstraintDescription": "The Amazon MQ broker password is required !",
+      "Default": "testBrokerPassword",
+      "Description": "The password to access the Amazon MQ broker. Min 12 characters",
+      "MinLength": 12,
+      "NoEcho": true,
+      "Type": "String"
+    },
+    "MQBrokerUser": {
+      "ConstraintDescription": "The Amazon MQ broker user is required !",
+      "Default": "testBrokerUser",
+      "Description": "The user to access the Amazon MQ broker.",
+      "MinLength": 2,
+      "Type": "String"
+    },
+    "MQBrokerUserSecretName": {
+      "Type": "String"
+    },
+    "PreCreatedInternetGateway": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedVpc": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MQBrokerUserSecret": {
+      "Properties": {
+        "Description": "SecretsManager Secret for broker user and password",
+        "Name": {
+          "Ref": "MQBrokerUserSecretName"
+        },
+        "SecretString": {
+          "Fn::Sub": "{\"username\":\"${MQBrokerUser}\",\"password\":\"${MQBrokerPassword}\"}"
+        }
+      },
+      "Type": "AWS::SecretsManager::Secret"
+    },
+    "MQSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Limits security group ingress and egress traffic for the Amazon MQ instance",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 8162,
+            "IpProtocol": "tcp",
+            "ToPort": 8162
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 61617,
+            "IpProtocol": "tcp",
+            "ToPort": 61617
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 5671,
+            "IpProtocol": "tcp",
+            "ToPort": 5671
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 61614,
+            "IpProtocol": "tcp",
+            "ToPort": 61614
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 8883,
+            "IpProtocol": "tcp",
+            "ToPort": 8883
+          }
+        ],
+        "VpcId": {
+          "Ref": "PreCreatedVpc"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    "MyLambdaExecutionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          }
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "ec2:CreateNetworkInterface",
+                    "ec2:CreateNetworkInterfacePermission",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DeleteNetworkInterfacePermission",
+                    "ec2:DetachNetworkInterface",
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DescribeVpcs",
+                    "ec2:DescribeInternetGateways",
+                    "ec2:DescribeNetworkInterfacePermissions",
+                    "ec2:DescribeSecurityGroups",
+                    "ec2:DescribeRouteTables",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "kms:Decrypt",
+                    "mq:DescribeBroker",
+                    "secretsmanager:GetSecretValue"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ]
+            },
+            "PolicyName": "IntegrationTestExecution"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionMyMqEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": "MyMqBroker.Arn"
+        },
+        "FunctionName": {
+          "Ref": "MyLambdaFunction"
+        },
+        "Queues": [
+          "TestQueue"
+        ],
+        "SourceAccessConfigurations": [
+          {
+            "Type": "BASIC_AUTH",
+            "URI": {
+              "Ref": "MQBrokerUserSecret"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "MyMqBroker": {
+      "DependsOn": "MyLambdaExecutionRole",
+      "Properties": {
+        "AutoMinorVersionUpgrade": false,
+        "BrokerName": {
+          "Ref": "MQBrokerName"
+        },
+        "DeploymentMode": "SINGLE_INSTANCE",
+        "EngineType": "ACTIVEMQ",
+        "EngineVersion": "5.15.12",
+        "HostInstanceType": "mq.t3.micro",
+        "Logs": {
+          "Audit": true,
+          "General": true
+        },
+        "PubliclyAccessible": true,
+        "SecurityGroups": [
+          {
+            "Ref": "MQSecurityGroup"
+          }
+        ],
+        "SubnetIds": [
+          {
+            "Ref": "PreCreatedSubnetOne"
+          }
+        ],
+        "Users": [
+          {
+            "ConsoleAccess": true,
+            "Groups": [
+              "admin"
+            ],
+            "Password": {
+              "Ref": "MQBrokerPassword"
+            },
+            "Username": {
+              "Ref": "MQBrokerUser"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::AmazonMQ::Broker"
+    },
+    "PublicSubnetRouteTableAssociation": {
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "SubnetId": {
+          "Ref": "PreCreatedSubnetOne"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    },
+    "Route": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "PreCreatedInternetGateway"
+        },
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        }
+      },
+      "Type": "AWS::EC2::Route"
+    },
+    "RouteTable": {
+      "Properties": {
+        "VpcId": {
+          "Ref": "PreCreatedVpc"
+        }
+      },
+      "Type": "AWS::EC2::RouteTable"
+    }
+  }
+}

--- a/tests/translator/output/function_with_mq.json
+++ b/tests/translator/output/function_with_mq.json
@@ -1,0 +1,278 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MQBrokerName": {
+      "Default": "TestMQBroker",
+      "Description": "The name of MQ Broker",
+      "Type": "String"
+    },
+    "MQBrokerPassword": {
+      "ConstraintDescription": "The Amazon MQ broker password is required !",
+      "Default": "testBrokerPassword",
+      "Description": "The password to access the Amazon MQ broker. Min 12 characters",
+      "MinLength": 12,
+      "NoEcho": true,
+      "Type": "String"
+    },
+    "MQBrokerUser": {
+      "ConstraintDescription": "The Amazon MQ broker user is required !",
+      "Default": "testBrokerUser",
+      "Description": "The user to access the Amazon MQ broker.",
+      "MinLength": 2,
+      "Type": "String"
+    },
+    "MQBrokerUserSecretName": {
+      "Type": "String"
+    },
+    "PreCreatedInternetGateway": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedVpc": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MQBrokerUserSecret": {
+      "Properties": {
+        "Description": "SecretsManager Secret for broker user and password",
+        "Name": {
+          "Ref": "MQBrokerUserSecretName"
+        },
+        "SecretString": {
+          "Fn::Sub": "{\"username\":\"${MQBrokerUser}\",\"password\":\"${MQBrokerPassword}\"}"
+        }
+      },
+      "Type": "AWS::SecretsManager::Secret"
+    },
+    "MQSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Limits security group ingress and egress traffic for the Amazon MQ instance",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 8162,
+            "IpProtocol": "tcp",
+            "ToPort": 8162
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 61617,
+            "IpProtocol": "tcp",
+            "ToPort": 61617
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 5671,
+            "IpProtocol": "tcp",
+            "ToPort": 5671
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 61614,
+            "IpProtocol": "tcp",
+            "ToPort": 61614
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "FromPort": 8883,
+            "IpProtocol": "tcp",
+            "ToPort": 8883
+          }
+        ],
+        "VpcId": {
+          "Ref": "PreCreatedVpc"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    "MyLambdaExecutionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          }
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "ec2:CreateNetworkInterface",
+                    "ec2:CreateNetworkInterfacePermission",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DeleteNetworkInterfacePermission",
+                    "ec2:DetachNetworkInterface",
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DescribeVpcs",
+                    "ec2:DescribeInternetGateways",
+                    "ec2:DescribeNetworkInterfacePermissions",
+                    "ec2:DescribeSecurityGroups",
+                    "ec2:DescribeRouteTables",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "kms:Decrypt",
+                    "mq:DescribeBroker",
+                    "secretsmanager:GetSecretValue"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ]
+            },
+            "PolicyName": "IntegrationTestExecution"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionMyMqEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": "MyMqBroker.Arn"
+        },
+        "FunctionName": {
+          "Ref": "MyLambdaFunction"
+        },
+        "Queues": [
+          "TestQueue"
+        ],
+        "SourceAccessConfigurations": [
+          {
+            "Type": "BASIC_AUTH",
+            "URI": {
+              "Ref": "MQBrokerUserSecret"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "MyMqBroker": {
+      "DependsOn": "MyLambdaExecutionRole",
+      "Properties": {
+        "AutoMinorVersionUpgrade": false,
+        "BrokerName": {
+          "Ref": "MQBrokerName"
+        },
+        "DeploymentMode": "SINGLE_INSTANCE",
+        "EngineType": "ACTIVEMQ",
+        "EngineVersion": "5.15.12",
+        "HostInstanceType": "mq.t3.micro",
+        "Logs": {
+          "Audit": true,
+          "General": true
+        },
+        "PubliclyAccessible": true,
+        "SecurityGroups": [
+          {
+            "Ref": "MQSecurityGroup"
+          }
+        ],
+        "SubnetIds": [
+          {
+            "Ref": "PreCreatedSubnetOne"
+          }
+        ],
+        "Users": [
+          {
+            "ConsoleAccess": true,
+            "Groups": [
+              "admin"
+            ],
+            "Password": {
+              "Ref": "MQBrokerPassword"
+            },
+            "Username": {
+              "Ref": "MQBrokerUser"
+            }
+          }
+        ]
+      },
+      "Type": "AWS::AmazonMQ::Broker"
+    },
+    "PublicSubnetRouteTableAssociation": {
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "SubnetId": {
+          "Ref": "PreCreatedSubnetOne"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    },
+    "Route": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "PreCreatedInternetGateway"
+        },
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        }
+      },
+      "Type": "AWS::EC2::Route"
+    },
+    "RouteTable": {
+      "Properties": {
+        "VpcId": {
+          "Ref": "PreCreatedVpc"
+        }
+      },
+      "Type": "AWS::EC2::RouteTable"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Pipeline failure due to MQ integ test failed.
```
Availability Zone [eu-central-1a] of requested subnet [subnet-0c75dfefaf31287d0] does not support broker instance type [mq.t3.micro]. Specify a subnet in a different Availability Zone. (Service: AmazonMQInternal; Status Code: 400; Error Code: BadRequestException; Request ID: 5e8bff7d-9412-4263-a8ce-e3997b90e941; Proxy: null)
```
Temporarily disable the test and add it as a transform test.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
