### PR TITLE
feat: allow classes that inherit Resource to disable __setattr__ validation

### DIFF
--- a/tests/model/test_resource.py
+++ b/tests/model/test_resource.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+
+from samtranslator.model import Property, SamResourceMacro
+from samtranslator.model.exceptions import InvalidResourceException
+from samtranslator.model.types import IS_STR
+
+
+class DummyResourceWithValidation(SamResourceMacro):
+    # validate_setattr is set to True in Resource class by default
+    resource_type = "AWS::Serverless:DummyResource"
+    property_types = {"SomeProperty": Property(False, IS_STR), "AnotherProperty": Property(False, IS_STR)}
+
+    def to_cloudformation(self, **kwargs):
+        return []
+
+
+class DummyResourceNoValidation(SamResourceMacro):
+    resource_type = "AWS::Serverless:DummyResource"
+    property_types = {"SomeProperty": Property(False, IS_STR), "AnotherProperty": Property(False, IS_STR)}
+
+    validate_setattr = False
+
+    def to_cloudformation(self, **kwargs):
+        return []
+
+
+class TestResource(TestCase):
+    def test_create_instance_variable_when_validate_setattr_is_true(self):
+        resource = DummyResourceWithValidation("foo")
+        with self.assertRaises(InvalidResourceException):
+            resource.SomeExtraValue = "foo"
+
+    def test_create_instance_variable_when_validate_setattr_is_false(self):
+        resource = DummyResourceNoValidation("foo")
+
+        resource.SomeExtraValue = "foo"
+        resource.AnotherValue = "bar"
+        resource.RandomValue = "baz"


### PR DESCRIPTION
### Issue #, if available

### Description of changes
In the `Resource` class, we have an override on `__setattr__` that checks if the attribute that is being modified is in the `property_types` dictionary or `_keywords` set (logical_id, relative_id, etc...).

Because of this, we cannot create class variables that can be modified after initialization. An example of why this can be annoying for developers is if you have a state that you would like to track throughout the class, you must do so internally with a local variable. This change adds a new boolean attribute to `Resource`, `validate_setattr`. If set to True (which is default value), then validation will be performed as normal. When it's false, it will bypass the `property_types` and `_keywords` check and allow you to modify other class variables without trouble.

### Description of how you validated changes
Added unit tests where I created a dummy resource that inherits from `Resource`, with `validate_setattr` set to True and False in different cases.
### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
