### PR TITLE
feat: scaffolding for improved pass-throughs in schema

### DIFF
--- a/samtranslator/internal/schema_source/aws_serverless_function.py
+++ b/samtranslator/internal/schema_source/aws_serverless_function.py
@@ -13,8 +13,7 @@ from samtranslator.internal.schema_source.common import (
     ResourceAttributes,
     SamIntrinsicable,
     get_prop,
-    passthrough,
-    prop_path,
+    passthrough_prop,
 )
 
 alexaskilleventproperties = get_prop("sam-property-function-alexaskill")
@@ -503,8 +502,8 @@ class Properties(BaseModel):
     DeadLetterQueue: Optional[DeadLetterQueueType] = prop("DeadLetterQueue")
     DeploymentPreference: Optional[DeploymentPreference] = prop("DeploymentPreference")
     Description: Optional[Description] = prop("Description")
-    Environment: Optional[Environment] = passthrough(prop_path("AWS::Lambda::Function", "Environment"))
-    EphemeralStorage: Optional[EphemeralStorage] = passthrough(prop_path("AWS::Lambda::Function", "EphemeralStorage"))
+    Environment: Optional[Environment] = passthrough_prop("AWS::Lambda::Function", "Environment")
+    EphemeralStorage: Optional[EphemeralStorage] = passthrough_prop("AWS::Lambda::Function", "EphemeralStorage")
     EventInvokeConfig: Optional[EventInvokeConfig] = prop("EventInvokeConfig")
     Events: Optional[
         Dict[
@@ -533,7 +532,7 @@ class Properties(BaseModel):
         ]
     ] = prop("Events")
     FileSystemConfigs: Optional[PassThroughProp] = prop("FileSystemConfigs")
-    FunctionName: Optional[PassThroughProp] = passthrough(prop_path("AWS::Lambda::Function", "FunctionName"))
+    FunctionName: Optional[PassThroughProp] = passthrough_prop("AWS::Lambda::Function", "FunctionName")
     FunctionUrlConfig: Optional[FunctionUrlConfig] = prop("FunctionUrlConfig")
     Handler: Optional[Handler] = prop("Handler")
     ImageConfig: Optional[PassThroughProp] = prop("ImageConfig")
@@ -568,7 +567,7 @@ class Globals(BaseModel):
     MemorySize: Optional[MemorySize] = prop("MemorySize")
     Timeout: Optional[Timeout] = prop("Timeout")
     VpcConfig: Optional[VpcConfig] = prop("VpcConfig")
-    Environment: Optional[Environment] = passthrough(prop_path("AWS::Lambda::Function", "Environment"))
+    Environment: Optional[Environment] = passthrough_prop("AWS::Lambda::Function", "Environment")
     Tags: Optional[Tags] = prop("Tags")
     Tracing: Optional[Tracing] = prop("Tracing")
     KmsKeyArn: Optional[KmsKeyArn] = prop("KmsKeyArn")
@@ -582,7 +581,7 @@ class Globals(BaseModel):
     AssumeRolePolicyDocument: Optional[AssumeRolePolicyDocument] = prop("AssumeRolePolicyDocument")
     EventInvokeConfig: Optional[EventInvokeConfig] = prop("EventInvokeConfig")
     Architectures: Optional[Architectures] = prop("Architectures")
-    EphemeralStorage: Optional[EphemeralStorage] = passthrough(prop_path("AWS::Lambda::Function", "EphemeralStorage"))
+    EphemeralStorage: Optional[EphemeralStorage] = passthrough_prop("AWS::Lambda::Function", "EphemeralStorage")
     SnapStart: Optional[SnapStart] = prop("SnapStart")
     RuntimeManagementConfig: Optional[RuntimeManagementConfig] = prop("RuntimeManagementConfig")
 

--- a/samtranslator/internal/schema_source/aws_serverless_function.py
+++ b/samtranslator/internal/schema_source/aws_serverless_function.py
@@ -13,6 +13,8 @@ from samtranslator.internal.schema_source.common import (
     ResourceAttributes,
     SamIntrinsicable,
     get_prop,
+    passthrough,
+    prop_path,
 )
 
 alexaskilleventproperties = get_prop("sam-property-function-alexaskill")
@@ -501,8 +503,8 @@ class Properties(BaseModel):
     DeadLetterQueue: Optional[DeadLetterQueueType] = prop("DeadLetterQueue")
     DeploymentPreference: Optional[DeploymentPreference] = prop("DeploymentPreference")
     Description: Optional[Description] = prop("Description")
-    Environment: Optional[Environment] = prop("Environment")
-    EphemeralStorage: Optional[EphemeralStorage] = prop("EphemeralStorage")
+    Environment: Optional[Environment] = passthrough(prop_path("AWS::Lambda::Function", "Environment"))
+    EphemeralStorage: Optional[EphemeralStorage] = passthrough(prop_path("AWS::Lambda::Function", "EphemeralStorage"))
     EventInvokeConfig: Optional[EventInvokeConfig] = prop("EventInvokeConfig")
     Events: Optional[
         Dict[
@@ -531,7 +533,7 @@ class Properties(BaseModel):
         ]
     ] = prop("Events")
     FileSystemConfigs: Optional[PassThroughProp] = prop("FileSystemConfigs")
-    FunctionName: Optional[PassThroughProp] = prop("FunctionName")
+    FunctionName: Optional[PassThroughProp] = passthrough(prop_path("AWS::Lambda::Function", "FunctionName"))
     FunctionUrlConfig: Optional[FunctionUrlConfig] = prop("FunctionUrlConfig")
     Handler: Optional[Handler] = prop("Handler")
     ImageConfig: Optional[PassThroughProp] = prop("ImageConfig")
@@ -566,7 +568,7 @@ class Globals(BaseModel):
     MemorySize: Optional[MemorySize] = prop("MemorySize")
     Timeout: Optional[Timeout] = prop("Timeout")
     VpcConfig: Optional[VpcConfig] = prop("VpcConfig")
-    Environment: Optional[Environment] = prop("Environment")
+    Environment: Optional[Environment] = passthrough(prop_path("AWS::Lambda::Function", "Environment"))
     Tags: Optional[Tags] = prop("Tags")
     Tracing: Optional[Tracing] = prop("Tracing")
     KmsKeyArn: Optional[KmsKeyArn] = prop("KmsKeyArn")
@@ -580,7 +582,7 @@ class Globals(BaseModel):
     AssumeRolePolicyDocument: Optional[AssumeRolePolicyDocument] = prop("AssumeRolePolicyDocument")
     EventInvokeConfig: Optional[EventInvokeConfig] = prop("EventInvokeConfig")
     Architectures: Optional[Architectures] = prop("Architectures")
-    EphemeralStorage: Optional[EphemeralStorage] = prop("EphemeralStorage")
+    EphemeralStorage: Optional[EphemeralStorage] = passthrough(prop_path("AWS::Lambda::Function", "EphemeralStorage"))
     SnapStart: Optional[SnapStart] = prop("SnapStart")
     RuntimeManagementConfig: Optional[RuntimeManagementConfig] = prop("RuntimeManagementConfig")
 

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -40,6 +40,25 @@ def get_prop(stem: str) -> Any:
     return partial(_get_prop, stem)
 
 
+def prop_path(resource_type: str, path: str) -> str:
+    """
+    Convenience function to get the path to a property in the CloudFormation schema.
+    """
+    return f"definitions.{resource_type}.properties.Properties.properties.{path}"
+
+
+def passthrough(path: str) -> Any:
+    """
+    Specifies a pass-through field, where path is the path to the property in the
+    in the CloudFormation schema. Use `.` to delimitate keys in the path.
+    """
+    # We add a custom value to the schema containing the path to the pass-through
+    # documentation; the dict containing the value is replaced in the final schema
+    return Field(
+        __samPassThroughPath=path,
+    )
+
+
 def _get_prop(stem: str, name: str) -> Any:
     docs = _DOCS["properties"][stem][name]
     return Field(

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -40,31 +40,17 @@ def get_prop(stem: str) -> Any:
     return partial(_get_prop, stem)
 
 
-def get_prop_path(resource_type: str, path: str) -> str:
-    """
-    Convenience function to get the path to a property in the CloudFormation schema.
-    """
-    return f"definitions.{resource_type}.properties.Properties.properties.{path}"
-
-
-def passthrough(path: str) -> Any:
-    """
-    Specifies a pass-through field, where path is the path to the property in the
-    in the CloudFormation schema. Use `.` to delimitate keys in the path.
-    """
-    # We add a custom value to the schema containing the path to the pass-through
-    # documentation; the dict containing the value is replaced in the final schema
-    return Field(
-        __samPassThroughPath=path,
-    )
-
-
 def passthrough_prop(resource_type: str, path: str) -> Any:
     """
     Specifies a pass-through field, where resource_type is the CloudFormation
     resource type, and path is a `.`-delimitated path to the property.
     """
-    return passthrough(get_prop_path(resource_type, path))
+    prop_path = f"definitions.{resource_type}.properties.Properties.properties.{path}"
+    return Field(
+        # We add a custom value to the schema containing the path to the pass-through
+        # documentation; the dict containing the value is replaced in the final schema
+        __samPassThroughPath=prop_path,
+    )
 
 
 def _get_prop(stem: str, name: str) -> Any:

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -40,7 +40,7 @@ def get_prop(stem: str) -> Any:
     return partial(_get_prop, stem)
 
 
-def prop_path(resource_type: str, path: str) -> str:
+def get_prop_path(resource_type: str, path: str) -> str:
     """
     Convenience function to get the path to a property in the CloudFormation schema.
     """
@@ -57,6 +57,14 @@ def passthrough(path: str) -> Any:
     return Field(
         __samPassThroughPath=path,
     )
+
+
+def passthrough_prop(resource_type: str, path: str) -> Any:
+    """
+    Specifies a pass-through field, where resource_type is the CloudFormation
+    resource type, and path is a `.`-delimitated path to the property.
+    """
+    return passthrough(get_prop_path(resource_type, path))
 
 
 def _get_prop(stem: str, name: str) -> Any:

--- a/samtranslator/internal/schema_source/schema.py
+++ b/samtranslator/internal/schema_source/schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 import pydantic
 
@@ -79,6 +79,30 @@ def json_dumps(obj: Any) -> str:
     return json.dumps(obj, indent=2, sort_keys=True) + "\n"
 
 
+def _replace_in_dict(d: Dict[str, Any], keyword: str, replace: Callable[[Dict[str, Any]], Any]) -> Dict[str, Any]:
+    """
+    Replace any dict containing keyword.
+
+    replace() takes the containing dict as input, and returns its replacement.
+    """
+    if keyword in d:
+        d = replace(d)
+    for k, v in d.items():
+        if isinstance(v, dict):
+            d[k] = _replace_in_dict(v, keyword, replace)
+    return d
+
+
+def _deep_get(d: Dict[str, Any], path: str) -> Dict[str, Any]:
+    """
+    Returns value at path, where `.` in path delimitates the keys.
+    """
+    keys = path.split(".")
+    for k in keys:
+        d = d[k]
+    return d
+
+
 def _add_embedded_connectors(schema: Dict[str, Any]) -> None:
     """
     Add embedded Connectors resource attribute to supported CloudFormation resources.
@@ -123,6 +147,13 @@ def extend_with_cfn_schema(sam_schema: Dict[str, Any], cfn_schema: Dict[str, Any
         sam_defs[k] = cfn_defs[k]
 
     _add_embedded_connectors(sam_schema)
+
+    # Inject CloudFormation documentation to SAM pass-through properties
+    _replace_in_dict(
+        sam_schema,
+        "__samPassThroughPath",
+        lambda d: _deep_get(cfn_schema, d["__samPassThroughPath"]),
+    )
 
     # The unified schema should include all supported properties
     sam_schema["additionalProperties"] = False

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -4734,24 +4734,22 @@
           "title": "Description"
         },
         "Environment": {
+          "__samPassThroughPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.Environment",
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The configuration for the runtime environment\\.  \n*Type*: [Environment](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Environment`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "The configuration for the runtime environment\\.  \n*Type*: [Environment](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Environment`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) property of an `AWS::Lambda::Function` resource\\.",
           "title": "Environment"
         },
         "EphemeralStorage": {
+          "__samPassThroughPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.EphemeralStorage",
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "An object that specifies the disk space, in MB, available to your Lambda function in `/tmp`\\.  \nFor more information about this property, see [Lambda execution environment](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [EphemeralStorage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EphemeralStorage`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "An object that specifies the disk space, in MB, available to your Lambda function in `/tmp`\\.  \nFor more information about this property, see [Lambda execution environment](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [EphemeralStorage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EphemeralStorage`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage) property of an `AWS::Lambda::Function` resource\\.",
-          "title": "EphemeralStorage"
+          "title": "Ephemeralstorage"
         },
         "EventInvokeConfig": {
           "allOf": [
@@ -5031,24 +5029,22 @@
           "title": "Description"
         },
         "Environment": {
+          "__samPassThroughPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.Environment",
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The configuration for the runtime environment\\.  \n*Type*: [Environment](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Environment`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "The configuration for the runtime environment\\.  \n*Type*: [Environment](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Environment`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) property of an `AWS::Lambda::Function` resource\\.",
           "title": "Environment"
         },
         "EphemeralStorage": {
+          "__samPassThroughPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.EphemeralStorage",
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "An object that specifies the disk space, in MB, available to your Lambda function in `/tmp`\\.  \nFor more information about this property, see [Lambda execution environment](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [EphemeralStorage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EphemeralStorage`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "An object that specifies the disk space, in MB, available to your Lambda function in `/tmp`\\.  \nFor more information about this property, see [Lambda execution environment](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [EphemeralStorage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EphemeralStorage`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage) property of an `AWS::Lambda::Function` resource\\.",
-          "title": "EphemeralStorage"
+          "title": "Ephemeralstorage"
         },
         "EventInvokeConfig": {
           "allOf": [
@@ -5138,14 +5134,13 @@
           "title": "FileSystemConfigs"
         },
         "FunctionName": {
+          "__samPassThroughPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.FunctionName",
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "A name for the function\\. If you don't specify a name, a unique name is generated for you\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FunctionName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "A name for the function\\. If you don't specify a name, a unique name is generated for you\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FunctionName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname) property of an `AWS::Lambda::Function` resource\\.",
-          "title": "FunctionName"
+          "title": "Functionname"
         },
         "FunctionUrlConfig": {
           "allOf": [

--- a/tests/schema/test_validate_schema.py
+++ b/tests/schema/test_validate_schema.py
@@ -1,7 +1,6 @@
 import itertools
 import json
 from pathlib import Path
-from typing import Any, Dict
 from unittest import TestCase
 
 import pytest
@@ -74,15 +73,6 @@ def get_all_test_templates():
         + list(Path(PROJECT_ROOT, "integration/resources/templates").glob("**/*.yaml"))
         + list(Path(PROJECT_ROOT, "integration/resources/templates").glob("**/*.yml"))
     )
-
-
-def _dict_remove_keys(d: Dict[str, Any], keyword: str) -> Dict[str, Any]:
-    r = {}
-    for k, v in d.items():
-        if k == keyword:
-            continue
-        r[k] = _dict_remove_keys(v, keyword) if isinstance(v, dict) else v
-    return r
 
 
 SCHEMA_VALIDATION_TESTS = [str(f) for f in get_all_test_templates() if not should_skip_test(str(f))]

--- a/tests/schema/test_validate_schema.py
+++ b/tests/schema/test_validate_schema.py
@@ -1,9 +1,8 @@
-import copy
 import itertools
 import json
 from pathlib import Path
+from typing import Any, Dict
 from unittest import TestCase
-from typing import Dict, Any
 
 import pytest
 from jsonschema import validate


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Scaffolding to partly address limitation (3) in https://github.com/aws/serverless-application-model/discussions/2645:

> Pass-through values are not validated. Pass-through properties (e.g. [AccessLogSettings](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-httpapi.html#sam-httpapi-accesslogsettings)) are passed directly to underlying CloudFormation resources.

So instead of using the documentation from SAM, for pass-through properties we use the documentation straight from the source: from the actual property being passed-through to.

This means pass-through properties get accurate types, even for nested pass-throughs. Previously it would accept anything.

#### Before
<img width="418" alt="Screenshot 2023-03-23 at 13 56 56" src="https://user-images.githubusercontent.com/1280602/227358215-63c94150-7aec-4f5a-a31a-fa7d5ea919d8.png">

#### After
<img width="715" alt="Screenshot 2023-03-23 at 13 56 42" src="https://user-images.githubusercontent.com/1280602/227358141-51f21d3c-b70b-454d-b749-24743f7cae5c.png">

### Description of how you validated changes

Used schema modeline in VS Code, played around with templates that previously wouldn't have supported pass-throughs. With this change it shows the documentation straight from the source property.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
