### PR TITLE
chore: more improved pass-through schemas

### DIFF
--- a/samtranslator/internal/schema_source/aws_serverless_api.py
+++ b/samtranslator/internal/schema_source/aws_serverless_api.py
@@ -12,7 +12,10 @@ from samtranslator.internal.schema_source.common import (
     ResourceAttributes,
     SamIntrinsicable,
     get_prop,
+    passthrough_prop,
 )
+
+PROPERTIES_STEM = "sam-resource-api"
 
 resourcepolicy = get_prop("sam-property-api-resourcepolicystatement")
 cognitoauthorizeridentity = get_prop("sam-property-api-cognitoauthorizationidentity")
@@ -28,7 +31,7 @@ route53 = get_prop("sam-property-api-route53configuration")
 domain = get_prop("sam-property-api-domainconfiguration")
 definitionuri = get_prop("sam-property-api-apidefinition")
 endpointconfiguration = get_prop("sam-property-api-endpointconfiguration")
-properties = get_prop("sam-resource-api")
+properties = get_prop(PROPERTIES_STEM)
 
 
 class ResourcePolicy(BaseModel):
@@ -180,53 +183,137 @@ AlwaysDeploy = Optional[bool]
 
 
 class Properties(BaseModel):
-    AccessLogSetting: Optional[AccessLogSetting] = properties("AccessLogSetting")
-    ApiKeySourceType: Optional[PassThroughProp] = properties("ApiKeySourceType")
+    AccessLogSetting: Optional[AccessLogSetting] = passthrough_prop(
+        PROPERTIES_STEM,
+        "AccessLogSetting",
+        ["AWS::ApiGateway::Stage", "Properties", "AccessLogSetting"],
+    )
+    ApiKeySourceType: Optional[PassThroughProp] = passthrough_prop(
+        PROPERTIES_STEM,
+        "ApiKeySourceType",
+        ["AWS::ApiGateway::RestApi", "Properties", "ApiKeySourceType"],
+    )
     Auth: Optional[Auth] = properties("Auth")
     BinaryMediaTypes: Optional[BinaryMediaTypes] = properties("BinaryMediaTypes")
-    CacheClusterEnabled: Optional[CacheClusterEnabled] = properties("CacheClusterEnabled")
-    CacheClusterSize: Optional[CacheClusterSize] = properties("CacheClusterSize")
-    CanarySetting: Optional[CanarySetting] = properties("CanarySetting")
+    CacheClusterEnabled: Optional[CacheClusterEnabled] = passthrough_prop(
+        PROPERTIES_STEM,
+        "CacheClusterEnabled",
+        ["AWS::ApiGateway::Stage", "Properties", "CacheClusterEnabled"],
+    )
+    CacheClusterSize: Optional[CacheClusterSize] = passthrough_prop(
+        PROPERTIES_STEM,
+        "CacheClusterSize",
+        ["AWS::ApiGateway::Stage", "Properties", "CacheClusterSize"],
+    )
+    CanarySetting: Optional[CanarySetting] = passthrough_prop(
+        PROPERTIES_STEM,
+        "CanarySetting",
+        ["AWS::ApiGateway::Stage", "Properties", "CanarySetting"],
+    )
     Cors: Optional[CorsType] = properties("Cors")
     DefinitionBody: Optional[DictStrAny] = properties("DefinitionBody")
     DefinitionUri: Optional[DefinitionUriType] = properties("DefinitionUri")
     MergeDefinitions: Optional[MergeDefinitions] = properties("MergeDefinitions")
-    Description: Optional[PassThroughProp] = properties("Description")
+    Description: Optional[PassThroughProp] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Description",
+        ["AWS::ApiGateway::Stage", "Properties", "Description"],
+    )
     DisableExecuteApiEndpoint: Optional[PassThroughProp] = properties("DisableExecuteApiEndpoint")
     Domain: Optional[Domain] = properties("Domain")
     EndpointConfiguration: Optional[EndpointConfigurationType] = properties("EndpointConfiguration")
-    FailOnWarnings: Optional[PassThroughProp] = properties("FailOnWarnings")
+    FailOnWarnings: Optional[PassThroughProp] = passthrough_prop(
+        PROPERTIES_STEM,
+        "FailOnWarnings",
+        ["AWS::ApiGateway::RestApi", "Properties", "FailOnWarnings"],
+    )
     GatewayResponses: Optional[GatewayResponses] = properties("GatewayResponses")
-    MethodSettings: Optional[MethodSettings] = properties("MethodSettings")
-    MinimumCompressionSize: Optional[MinimumCompressionSize] = properties("MinimumCompressionSize")
-    Mode: Optional[PassThroughProp] = properties("Mode")
+    MethodSettings: Optional[MethodSettings] = passthrough_prop(
+        PROPERTIES_STEM,
+        "MethodSettings",
+        ["AWS::ApiGateway::Stage", "Properties", "MethodSettings"],
+    )
+    MinimumCompressionSize: Optional[MinimumCompressionSize] = passthrough_prop(
+        PROPERTIES_STEM,
+        "MinimumCompressionSize",
+        ["AWS::ApiGateway::RestApi", "Properties", "MinimumCompressionSize"],
+    )
+    Mode: Optional[PassThroughProp] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Mode",
+        ["AWS::ApiGateway::RestApi", "Properties", "Mode"],
+    )
     Models: Optional[DictStrAny] = properties("Models")
-    Name: Optional[Name] = properties("Name")
+    Name: Optional[Name] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Name",
+        ["AWS::ApiGateway::RestApi", "Properties", "Name"],
+    )
     OpenApiVersion: Optional[OpenApiVersion] = properties("OpenApiVersion")
     StageName: SamIntrinsicable[str] = properties("StageName")
     Tags: Optional[DictStrAny] = properties("Tags")
-    TracingEnabled: Optional[TracingEnabled] = properties("TracingEnabled")
-    Variables: Optional[Variables] = properties("Variables")
+    TracingEnabled: Optional[TracingEnabled] = passthrough_prop(
+        PROPERTIES_STEM,
+        "TracingEnabled",
+        ["AWS::ApiGateway::Stage", "Properties", "TracingEnabled"],
+    )
+    Variables: Optional[Variables] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Variables",
+        ["AWS::ApiGateway::Stage", "Properties", "Variables"],
+    )
     AlwaysDeploy: Optional[AlwaysDeploy] = properties("AlwaysDeploy")
 
 
 class Globals(BaseModel):
     Auth: Optional[Auth] = properties("Auth")
-    Name: Optional[Name] = properties("Name")
+    Name: Optional[Name] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Name",
+        ["AWS::ApiGateway::RestApi", "Properties", "Name"],
+    )
     DefinitionUri: Optional[PassThroughProp] = properties("DefinitionUri")
-    CacheClusterEnabled: Optional[CacheClusterEnabled] = properties("CacheClusterEnabled")
-    CacheClusterSize: Optional[CacheClusterSize] = properties("CacheClusterSize")
+    CacheClusterEnabled: Optional[CacheClusterEnabled] = passthrough_prop(
+        PROPERTIES_STEM,
+        "CacheClusterEnabled",
+        ["AWS::ApiGateway::Stage", "Properties", "CacheClusterEnabled"],
+    )
+    CacheClusterSize: Optional[CacheClusterSize] = passthrough_prop(
+        PROPERTIES_STEM,
+        "CacheClusterSize",
+        ["AWS::ApiGateway::Stage", "Properties", "CacheClusterSize"],
+    )
     MergeDefinitions: Optional[MergeDefinitions] = properties("MergeDefinitions")
-    Variables: Optional[Variables] = properties("Variables")
+    Variables: Optional[Variables] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Variables",
+        ["AWS::ApiGateway::Stage", "Properties", "Variables"],
+    )
     EndpointConfiguration: Optional[PassThroughProp] = properties("EndpointConfiguration")
     MethodSettings: Optional[MethodSettings] = properties("MethodSettings")
     BinaryMediaTypes: Optional[BinaryMediaTypes] = properties("BinaryMediaTypes")
-    MinimumCompressionSize: Optional[MinimumCompressionSize] = properties("MinimumCompressionSize")
+    MinimumCompressionSize: Optional[MinimumCompressionSize] = passthrough_prop(
+        PROPERTIES_STEM,
+        "MinimumCompressionSize",
+        ["AWS::ApiGateway::RestApi", "Properties", "MinimumCompressionSize"],
+    )
     Cors: Optional[CorsType] = properties("Cors")
     GatewayResponses: Optional[GatewayResponses] = properties("GatewayResponses")
-    AccessLogSetting: Optional[AccessLogSetting] = properties("AccessLogSetting")
-    CanarySetting: Optional[CanarySetting] = properties("CanarySetting")
-    TracingEnabled: Optional[TracingEnabled] = properties("TracingEnabled")
+    AccessLogSetting: Optional[AccessLogSetting] = passthrough_prop(
+        PROPERTIES_STEM,
+        "AccessLogSetting",
+        ["AWS::ApiGateway::Stage", "Properties", "AccessLogSetting"],
+    )
+    CanarySetting: Optional[CanarySetting] = passthrough_prop(
+        PROPERTIES_STEM,
+        "CanarySetting",
+        ["AWS::ApiGateway::Stage", "Properties", "CanarySetting"],
+    )
+    TracingEnabled: Optional[TracingEnabled] = passthrough_prop(
+        PROPERTIES_STEM,
+        "TracingEnabled",
+        ["AWS::ApiGateway::Stage", "Properties", "TracingEnabled"],
+    )
     OpenApiVersion: Optional[OpenApiVersion] = properties("OpenApiVersion")
     Domain: Optional[Domain] = properties("Domain")
     AlwaysDeploy: Optional[AlwaysDeploy] = properties("AlwaysDeploy")

--- a/samtranslator/internal/schema_source/aws_serverless_function.py
+++ b/samtranslator/internal/schema_source/aws_serverless_function.py
@@ -17,6 +17,7 @@ from samtranslator.internal.schema_source.common import (
 )
 
 PROPERTIES_STEM = "sam-resource-function"
+DEPLOYMENT_PREFERENCE_STEM = "sam-property-function-deploymentpreference"
 
 alexaskilleventproperties = get_prop("sam-property-function-alexaskill")
 apiauth = get_prop("sam-property-function-apifunctionauth")
@@ -26,7 +27,7 @@ cloudwatchlogseventproperties = get_prop("sam-property-function-cloudwatchlogs")
 codeuri = get_prop("sam-property-function-functioncode")
 cognitoeventproperties = get_prop("sam-property-function-cognito")
 deadletterconfig = get_prop("sam-property-function-deadletterconfig")
-deploymentpreference = get_prop("sam-property-function-deploymentpreference")
+deploymentpreference = get_prop(DEPLOYMENT_PREFERENCE_STEM)
 dlq = get_prop("sam-property-function-deadletterqueue")
 documentdbeventproperties = get_prop("sam-property-function-documentdb")
 dynamodbeventproperties = get_prop("sam-property-function-dynamodb")
@@ -46,7 +47,7 @@ iotruleeventproperties = get_prop("sam-property-function-iotrule")
 kinesiseventproperties = get_prop("sam-property-function-kinesis")
 mqeventproperties = get_prop("sam-property-function-mq")
 mskeventproperties = get_prop("sam-property-function-msk")
-prop = get_prop("sam-resource-function")
+prop = get_prop(PROPERTIES_STEM)
 requestmodel = get_prop("sam-property-function-requestmodel")
 requestparameters = get_prop("sam-property-function-requestparameter")
 resourcepolicy = get_prop("sam-property-api-resourcepolicystatement")
@@ -89,7 +90,11 @@ class DeploymentPreference(BaseModel):
     Hooks: Optional[Hooks] = deploymentpreference("Hooks")
     PassthroughCondition: Optional[SamIntrinsicable[bool]] = deploymentpreference("PassthroughCondition")
     Role: Optional[SamIntrinsicable[str]] = deploymentpreference("Role")
-    TriggerConfigurations: Optional[PassThroughProp] = deploymentpreference("TriggerConfigurations")
+    TriggerConfigurations: Optional[PassThroughProp] = passthrough_prop(
+        DEPLOYMENT_PREFERENCE_STEM,
+        "TriggerConfigurations",
+        ["AWS::CodeDeploy::DeploymentGroup", "Properties", "TriggerConfigurations"],
+    )
     Type: Optional[SamIntrinsicable[str]] = deploymentpreference(
         "Type"
     )  # TODO: Should investigate whether this is a required field. This is a required field on documentation. However, we don't seem to use this field.

--- a/samtranslator/internal/schema_source/aws_serverless_function.py
+++ b/samtranslator/internal/schema_source/aws_serverless_function.py
@@ -494,28 +494,38 @@ RuntimeManagementConfig = Optional[PassThroughProp]  # TODO: check the type
 
 
 class Properties(BaseModel):
-    Architectures: Optional[Architectures] = prop("Architectures")
+    Architectures: Optional[Architectures] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Architectures",
+        ["AWS::Lambda::Function", "Properties", "Architectures"],
+    )
     AssumeRolePolicyDocument: Optional[AssumeRolePolicyDocument] = prop("AssumeRolePolicyDocument")
     AutoPublishAlias: Optional[AutoPublishAlias] = prop("AutoPublishAlias")
     AutoPublishAliasAllProperties: Optional[AutoPublishAliasAllProperties] = prop("AutoPublishAliasAllProperties")
     AutoPublishCodeSha256: Optional[SamIntrinsicable[str]] = prop("AutoPublishCodeSha256")
-    CodeSigningConfigArn: Optional[SamIntrinsicable[str]] = prop("CodeSigningConfigArn")
+    CodeSigningConfigArn: Optional[SamIntrinsicable[str]] = passthrough_prop(
+        PROPERTIES_STEM,
+        "CodeSigningConfigArn",
+        ["AWS::Lambda::Function", "Properties", "CodeSigningConfigArn"],
+    )
     CodeUri: Optional[CodeUriType] = prop("CodeUri")
     DeadLetterQueue: Optional[DeadLetterQueueType] = prop("DeadLetterQueue")
     DeploymentPreference: Optional[DeploymentPreference] = prop("DeploymentPreference")
-    Description: Optional[Description] = prop("Description")
+    Description: Optional[Description] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Description",
+        ["AWS::Lambda::Function", "Properties", "Description"],
+    )
     # TODO: Make the notation shorter; resource type and SAM/CFN property names usually same
     Environment: Optional[Environment] = passthrough_prop(
         PROPERTIES_STEM,
         "Environment",
-        "AWS::Lambda::Function",
-        "Environment",
+        ["AWS::Lambda::Function", "Properties", "Environment"],
     )
     EphemeralStorage: Optional[EphemeralStorage] = passthrough_prop(
         PROPERTIES_STEM,
         "EphemeralStorage",
-        "AWS::Lambda::Function",
-        "EphemeralStorage",
+        ["AWS::Lambda::Function", "Properties", "EphemeralStorage"],
     )
     EventInvokeConfig: Optional[EventInvokeConfig] = prop("EventInvokeConfig")
     Events: Optional[
@@ -544,22 +554,32 @@ class Properties(BaseModel):
             ],
         ]
     ] = prop("Events")
-    FileSystemConfigs: Optional[PassThroughProp] = prop("FileSystemConfigs")
+    FileSystemConfigs: Optional[PassThroughProp] = passthrough_prop(
+        PROPERTIES_STEM,
+        "FileSystemConfigs",
+        ["AWS::Lambda::Function", "Properties", "FileSystemConfigs"],
+    )
     FunctionName: Optional[PassThroughProp] = passthrough_prop(
         PROPERTIES_STEM,
         "FunctionName",
-        "AWS::Lambda::Function",
-        "FunctionName",
+        ["AWS::Lambda::Function", "Properties", "FunctionName"],
     )
     FunctionUrlConfig: Optional[FunctionUrlConfig] = prop("FunctionUrlConfig")
     Handler: Optional[Handler] = passthrough_prop(
         PROPERTIES_STEM,
         "Handler",
-        "AWS::Lambda::Function",
-        "Handler",
+        ["AWS::Lambda::Function", "Properties", "Handler"],
     )
-    ImageConfig: Optional[PassThroughProp] = prop("ImageConfig")
-    ImageUri: Optional[PassThroughProp] = prop("ImageUri")
+    ImageConfig: Optional[PassThroughProp] = passthrough_prop(
+        PROPERTIES_STEM,
+        "ImageConfig",
+        ["AWS::Lambda::Function", "Properties", "ImageConfig"],
+    )
+    ImageUri: Optional[PassThroughProp] = passthrough_prop(
+        PROPERTIES_STEM,
+        "ImageUri",
+        ["AWS::Lambda::Function.Code", "ImageUri"],
+    )
     InlineCode: Optional[PassThroughProp] = prop("InlineCode")
     KmsKeyArn: Optional[KmsKeyArn] = prop("KmsKeyArn")
     Layers: Optional[Layers] = prop("Layers")
@@ -568,29 +588,25 @@ class Properties(BaseModel):
     RolePath: Optional[RolePath] = passthrough_prop(
         PROPERTIES_STEM,
         "RolePath",
-        "AWS::IAM::Role",
-        "Path",
+        ["AWS::IAM::Role", "Properties", "Path"],
     )
     PermissionsBoundary: Optional[PermissionsBoundary] = passthrough_prop(
         PROPERTIES_STEM,
         "PermissionsBoundary",
-        "AWS::IAM::Role",
-        "PermissionsBoundary",
+        ["AWS::IAM::Role", "Properties", "PermissionsBoundary"],
     )
     Policies: Optional[Union[str, DictStrAny, List[Union[str, DictStrAny]]]] = prop("Policies")
     ProvisionedConcurrencyConfig: Optional[ProvisionedConcurrencyConfig] = passthrough_prop(
         PROPERTIES_STEM,
         "ProvisionedConcurrencyConfig",
-        "AWS::Lambda::Alias",
-        "ProvisionedConcurrencyConfig",
+        ["AWS::Lambda::Alias", "Properties", "ProvisionedConcurrencyConfig"],
     )
     ReservedConcurrentExecutions: Optional[ReservedConcurrentExecutions] = prop("ReservedConcurrentExecutions")
     Role: Optional[SamIntrinsicable[str]] = prop("Role")
     Runtime: Optional[Runtime] = passthrough_prop(
         PROPERTIES_STEM,
         "Runtime",
-        "AWS::Lambda::Function",
-        "Runtime",
+        ["AWS::Lambda::Function", "Properties", "Runtime"],
     )
     SnapStart: Optional[SnapStart] = prop("SnapStart")
     RuntimeManagementConfig: Optional[RuntimeManagementConfig] = prop("RuntimeManagementConfig")
@@ -605,14 +621,12 @@ class Globals(BaseModel):
     Handler: Optional[Handler] = passthrough_prop(
         PROPERTIES_STEM,
         "Handler",
-        "AWS::Lambda::Function",
-        "Handler",
+        ["AWS::Lambda::Function", "Properties", "Handler"],
     )
     Runtime: Optional[Runtime] = passthrough_prop(
         PROPERTIES_STEM,
         "Runtime",
-        "AWS::Lambda::Function",
-        "Runtime",
+        ["AWS::Lambda::Function", "Properties", "Runtime"],
     )
     CodeUri: Optional[CodeUriType] = prop("CodeUri")
     DeadLetterQueue: Optional[DeadLetterQueueType] = prop("DeadLetterQueue")
@@ -623,8 +637,7 @@ class Globals(BaseModel):
     Environment: Optional[Environment] = passthrough_prop(
         PROPERTIES_STEM,
         "Environment",
-        "AWS::Lambda::Function",
-        "Environment",
+        ["AWS::Lambda::Function", "Properties", "Environment"],
     )
     Tags: Optional[Tags] = prop("Tags")
     Tracing: Optional[Tracing] = prop("Tracing")
@@ -635,25 +648,26 @@ class Globals(BaseModel):
     RolePath: Optional[RolePath] = passthrough_prop(
         PROPERTIES_STEM,
         "RolePath",
-        "AWS::IAM::Role",
-        "Path",
+        ["AWS::IAM::Role", "Properties", "Path"],
     )
     PermissionsBoundary: Optional[PermissionsBoundary] = passthrough_prop(
         PROPERTIES_STEM,
         "PermissionsBoundary",
-        "AWS::IAM::Role",
-        "PermissionsBoundary",
+        ["AWS::IAM::Role", "Properties", "PermissionsBoundary"],
     )
     ReservedConcurrentExecutions: Optional[ReservedConcurrentExecutions] = prop("ReservedConcurrentExecutions")
     ProvisionedConcurrencyConfig: Optional[ProvisionedConcurrencyConfig] = prop("ProvisionedConcurrencyConfig")
     AssumeRolePolicyDocument: Optional[AssumeRolePolicyDocument] = prop("AssumeRolePolicyDocument")
     EventInvokeConfig: Optional[EventInvokeConfig] = prop("EventInvokeConfig")
-    Architectures: Optional[Architectures] = prop("Architectures")
+    Architectures: Optional[Architectures] = passthrough_prop(
+        PROPERTIES_STEM,
+        "Architectures",
+        ["AWS::Lambda::Function", "Properties", "Architectures"],
+    )
     EphemeralStorage: Optional[EphemeralStorage] = passthrough_prop(
         PROPERTIES_STEM,
         "EphemeralStorage",
-        "AWS::Lambda::Function",
-        "EphemeralStorage",
+        ["AWS::Lambda::Function", "Properties", "EphemeralStorage"],
     )
     SnapStart: Optional[SnapStart] = prop("SnapStart")
     RuntimeManagementConfig: Optional[RuntimeManagementConfig] = prop("RuntimeManagementConfig")

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -45,7 +45,6 @@ def passthrough_prop(sam_docs_stem: str, sam_docs_name: str, prop_path: List[str
     Specifies a pass-through field, where resource_type is the CloudFormation
     resource type, and path is a `#`-delimitated path to the property.
     """
-    # need to change separator... sometimes contains dot
     prop_path = f"definitions#" + f"#properties#".join(prop_path)
     docs = _DOCS["properties"][sam_docs_stem][sam_docs_name]
     return Field(

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -45,7 +45,7 @@ def passthrough_prop(sam_docs_stem: str, sam_docs_name: str, prop_path: List[str
     Specifies a pass-through field, where resource_type is the CloudFormation
     resource type, and path is a `#`-delimitated path to the property.
     """
-    prop_path = f"definitions#" + f"#properties#".join(prop_path)
+    prop_path = "definitions#" + "#properties#".join(prop_path)
     docs = _DOCS["properties"][sam_docs_stem][sam_docs_name]
     return Field(
         # We add a custom value to the schema containing the path to the pass-through

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -50,6 +50,7 @@ def passthrough_prop(sam_docs_stem: str, sam_docs_name: str, prop_path: List[str
         path.extend(["properties", s])
     docs = _DOCS["properties"][sam_docs_stem][sam_docs_name]
     return Field(
+        title=sam_docs_name,
         # We add a custom value to the schema containing the path to the pass-through
         # documentation; the dict containing the value is replaced in the final schema
         __samPassThrough={

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -2,7 +2,7 @@ import json
 import os
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 import pydantic
 from pydantic import Extra, Field
@@ -40,12 +40,13 @@ def get_prop(stem: str) -> Any:
     return partial(_get_prop, stem)
 
 
-def passthrough_prop(sam_docs_stem: str, sam_docs_name: str, resource_type: str, prop_path: str) -> Any:
+def passthrough_prop(sam_docs_stem: str, sam_docs_name: str, prop_path: List[str]) -> Any:
     """
     Specifies a pass-through field, where resource_type is the CloudFormation
-    resource type, and path is a `.`-delimitated path to the property.
+    resource type, and path is a `#`-delimitated path to the property.
     """
-    prop_path = f"definitions.{resource_type}.properties.Properties.properties.{prop_path}"
+    # need to change separator... sometimes contains dot
+    prop_path = f"definitions#" + f"#properties#".join(prop_path)
     docs = _DOCS["properties"][sam_docs_stem][sam_docs_name]
     return Field(
         # We add a custom value to the schema containing the path to the pass-through

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -43,9 +43,11 @@ def get_prop(stem: str) -> Any:
 def passthrough_prop(sam_docs_stem: str, sam_docs_name: str, prop_path: List[str]) -> Any:
     """
     Specifies a pass-through field, where resource_type is the CloudFormation
-    resource type, and path is a `#`-delimitated path to the property.
+    resource type, and path is the list of keys to the property.
     """
-    path = "definitions#" + "#properties#".join(prop_path)
+    path = ["definitions", prop_path[0]]
+    for s in prop_path[1:]:
+        path.extend(["properties", s])
     docs = _DOCS["properties"][sam_docs_stem][sam_docs_name]
     return Field(
         # We add a custom value to the schema containing the path to the pass-through

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -45,14 +45,14 @@ def passthrough_prop(sam_docs_stem: str, sam_docs_name: str, prop_path: List[str
     Specifies a pass-through field, where resource_type is the CloudFormation
     resource type, and path is a `#`-delimitated path to the property.
     """
-    prop_path = "definitions#" + "#properties#".join(prop_path)
+    path = "definitions#" + "#properties#".join(prop_path)
     docs = _DOCS["properties"][sam_docs_stem][sam_docs_name]
     return Field(
         # We add a custom value to the schema containing the path to the pass-through
         # documentation; the dict containing the value is replaced in the final schema
         __samPassThrough={
             # To know at schema build-time where to find the property schema
-            "schemaPath": prop_path,
+            "schemaPath": path,
             # Use SAM docs at the top-level pass-through; it can include useful SAM-specific information
             "markdownDescriptionOverride": docs,
         },

--- a/samtranslator/internal/schema_source/schema.py
+++ b/samtranslator/internal/schema_source/schema.py
@@ -94,12 +94,11 @@ def _replace_in_dict(d: Dict[str, Any], keyword: str, replace: Callable[[Dict[st
     return d
 
 
-def _deep_get(d: Dict[str, Any], path: str) -> Dict[str, Any]:
+def _deep_get(d: Dict[str, Any], path: List[str]) -> Dict[str, Any]:
     """
-    Returns value at path, where `#` in path delimitates the keys.
+    Returns value at path defined by the keys in `path`.
     """
-    keys = path.split("#")
-    for k in keys:
+    for k in path:
         d = d[k]
     return d
 

--- a/samtranslator/internal/schema_source/schema.py
+++ b/samtranslator/internal/schema_source/schema.py
@@ -96,9 +96,9 @@ def _replace_in_dict(d: Dict[str, Any], keyword: str, replace: Callable[[Dict[st
 
 def _deep_get(d: Dict[str, Any], path: str) -> Dict[str, Any]:
     """
-    Returns value at path, where `.` in path delimitates the keys.
+    Returns value at path, where `#` in path delimitates the keys.
     """
-    keys = path.split(".")
+    keys = path.split("#")
     for k in keys:
         d = d[k]
     return d

--- a/samtranslator/internal/schema_source/schema.py
+++ b/samtranslator/internal/schema_source/schema.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 import pydantic
 

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -522,7 +522,14 @@
         "TriggerConfigurations": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A list of trigger configurations you want to associate with the deployment group\\. Used to notify an SNS topic on lifecycle events\\.  \n*Type*: List  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TriggerConfigurations`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html#cfn-codedeploy-deploymentgroup-triggerconfigurations) property of an `AWS::CodeDeploy::DeploymentGroup` resource\\.",
-            "schemaPath": "definitions#AWS::CodeDeploy::DeploymentGroup#properties#Properties#properties#TriggerConfigurations"
+            "schemaPath": [
+              "definitions",
+              "AWS::CodeDeploy::DeploymentGroup",
+              "properties",
+              "Properties",
+              "properties",
+              "TriggerConfigurations"
+            ]
           },
           "allOf": [
             {
@@ -3354,7 +3361,14 @@
         "AccessLogSetting": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Configures Access Log Setting for a stage\\.  \n*Type*: [AccessLogSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`AccessLogSetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#AccessLogSetting"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "AccessLogSetting"
+            ]
           },
           "allOf": [
             {
@@ -3392,7 +3406,14 @@
         "CacheClusterEnabled": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Indicates whether caching is enabled for the stage\\. To cache responses, you must also set `CachingEnabled` to `true` under `MethodSettings`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclusterenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CacheClusterEnabled"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "CacheClusterEnabled"
+            ]
           },
           "allOf": [
             {
@@ -3404,7 +3425,14 @@
         "CacheClusterSize": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The stage's cache cluster size\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclustersize) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CacheClusterSize"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "CacheClusterSize"
+            ]
           },
           "allOf": [
             {
@@ -3416,7 +3444,14 @@
         "CanarySetting": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Configure a canary setting to a stage of a regular deployment\\.  \n*Type*: [CanarySetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CanarySetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CanarySetting"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "CanarySetting"
+            ]
           },
           "allOf": [
             {
@@ -3496,7 +3531,14 @@
         "MinimumCompressionSize": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Allow compression of response bodies based on client's Accept\\-Encoding header\\. Compression is triggered when response body size is greater than or equal to your configured threshold\\. The maximum body size threshold is 10 MB \\(10,485,760 Bytes\\)\\. \\- The following compression types are supported: gzip, deflate, and identity\\.  \n*Type*: Integer  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MinimumCompressionSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-minimumcompressionsize) property of an `AWS::ApiGateway::RestApi` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#MinimumCompressionSize"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::RestApi",
+              "properties",
+              "Properties",
+              "properties",
+              "MinimumCompressionSize"
+            ]
           },
           "allOf": [
             {
@@ -3508,7 +3550,14 @@
         "Name": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A name for the API Gateway RestApi resource  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Name`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-name) property of an `AWS::ApiGateway::RestApi` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#Name"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::RestApi",
+              "properties",
+              "Properties",
+              "properties",
+              "Name"
+            ]
           },
           "allOf": [
             {
@@ -3533,7 +3582,14 @@
         "TracingEnabled": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Indicates whether active tracing with X\\-Ray is enabled for the stage\\. For more information about X\\-Ray, see [Tracing user requests to REST APIs using X\\-Ray](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) in the *API Gateway Developer Guide*\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TracingEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-tracingenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#TracingEnabled"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "TracingEnabled"
+            ]
           },
           "allOf": [
             {
@@ -3545,7 +3601,14 @@
         "Variables": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A map \\(string to string\\) that defines the stage variables, where the variable name is the key and the variable value is the value\\. Variable names are limited to alphanumeric characters\\. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&=,-]+`\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Variables`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#Variables"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "Variables"
+            ]
           },
           "allOf": [
             {
@@ -3564,7 +3627,14 @@
         "AccessLogSetting": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Configures Access Log Setting for a stage\\.  \n*Type*: [AccessLogSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`AccessLogSetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#AccessLogSetting"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "AccessLogSetting"
+            ]
           },
           "allOf": [
             {
@@ -3582,7 +3652,14 @@
         "ApiKeySourceType": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The source of the API key for metering requests according to a usage plan\\. Valid values are `HEADER` and `AUTHORIZER`\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ApiKeySourceType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-apikeysourcetype) property of an `AWS::ApiGateway::RestApi` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#ApiKeySourceType"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::RestApi",
+              "properties",
+              "Properties",
+              "properties",
+              "ApiKeySourceType"
+            ]
           },
           "allOf": [
             {
@@ -3614,7 +3691,14 @@
         "CacheClusterEnabled": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Indicates whether caching is enabled for the stage\\. To cache responses, you must also set `CachingEnabled` to `true` under `MethodSettings`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclusterenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CacheClusterEnabled"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "CacheClusterEnabled"
+            ]
           },
           "allOf": [
             {
@@ -3626,7 +3710,14 @@
         "CacheClusterSize": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The stage's cache cluster size\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclustersize) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CacheClusterSize"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "CacheClusterSize"
+            ]
           },
           "allOf": [
             {
@@ -3638,7 +3729,14 @@
         "CanarySetting": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Configure a canary setting to a stage of a regular deployment\\.  \n*Type*: [CanarySetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CanarySetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CanarySetting"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "CanarySetting"
+            ]
           },
           "allOf": [
             {
@@ -3685,7 +3783,14 @@
         "Description": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A description of the Api resource\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Description`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-description) property of an `AWS::ApiGateway::RestApi` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#Description"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "Description"
+            ]
           },
           "allOf": [
             {
@@ -3730,7 +3835,14 @@
         "FailOnWarnings": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Specifies whether to roll back the API creation \\(`true`\\) or not \\(`false`\\) when a warning is encountered\\. The default value is `false`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FailOnWarnings`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-failonwarnings) property of an `AWS::ApiGateway::RestApi` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#FailOnWarnings"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::RestApi",
+              "properties",
+              "Properties",
+              "properties",
+              "FailOnWarnings"
+            ]
           },
           "allOf": [
             {
@@ -3754,7 +3866,14 @@
         "MethodSettings": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Configures all settings for API stage including Logging, Metrics, CacheTTL, Throttling\\.  \n*Type*: List of [ MethodSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MethodSettings`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-methodsettings) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#MethodSettings"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "MethodSettings"
+            ]
           },
           "allOf": [
             {
@@ -3766,7 +3885,14 @@
         "MinimumCompressionSize": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Allow compression of response bodies based on client's Accept\\-Encoding header\\. Compression is triggered when response body size is greater than or equal to your configured threshold\\. The maximum body size threshold is 10 MB \\(10,485,760 Bytes\\)\\. \\- The following compression types are supported: gzip, deflate, and identity\\.  \n*Type*: Integer  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MinimumCompressionSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-minimumcompressionsize) property of an `AWS::ApiGateway::RestApi` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#MinimumCompressionSize"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::RestApi",
+              "properties",
+              "Properties",
+              "properties",
+              "MinimumCompressionSize"
+            ]
           },
           "allOf": [
             {
@@ -3778,7 +3904,14 @@
         "Mode": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "This property applies only when you use OpenAPI to define your REST API\\. The `Mode` determines how API Gateway handles resource updates\\. For more information, see [Mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-mode) property of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html) resource type\\.  \n*Valid values*: `overwrite` or `merge`  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Mode`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-mode) property of an `AWS::ApiGateway::RestApi` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#Mode"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::RestApi",
+              "properties",
+              "Properties",
+              "properties",
+              "Mode"
+            ]
           },
           "allOf": [
             {
@@ -3796,7 +3929,14 @@
         "Name": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A name for the API Gateway RestApi resource  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Name`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-name) property of an `AWS::ApiGateway::RestApi` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#Name"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::RestApi",
+              "properties",
+              "Properties",
+              "properties",
+              "Name"
+            ]
           },
           "allOf": [
             {
@@ -3840,7 +3980,14 @@
         "TracingEnabled": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "Indicates whether active tracing with X\\-Ray is enabled for the stage\\. For more information about X\\-Ray, see [Tracing user requests to REST APIs using X\\-Ray](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) in the *API Gateway Developer Guide*\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TracingEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-tracingenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#TracingEnabled"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "TracingEnabled"
+            ]
           },
           "allOf": [
             {
@@ -3852,7 +3999,14 @@
         "Variables": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A map \\(string to string\\) that defines the stage variables, where the variable name is the key and the variable value is the value\\. Variable names are limited to alphanumeric characters\\. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&=,-]+`\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Variables`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables) property of an `AWS::ApiGateway::Stage` resource\\.",
-            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#Variables"
+            "schemaPath": [
+              "definitions",
+              "AWS::ApiGateway::Stage",
+              "properties",
+              "Properties",
+              "properties",
+              "Variables"
+            ]
           },
           "allOf": [
             {
@@ -4705,7 +4859,14 @@
         "Architectures": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The instruction set architecture for the function\\.  \nFor more information about this property, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) in the *AWS Lambda Developer Guide*\\.  \n*Valid values*: One of `x86_64` or `arm64`  \n*Type*: List  \n*Required*: No  \n*Default*: `x86_64`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Architectures`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Architectures"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Architectures"
+            ]
           },
           "allOf": [
             {
@@ -4782,7 +4943,14 @@
         "Environment": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The configuration for the runtime environment\\.  \n*Type*: [Environment](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Environment`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Environment"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Environment"
+            ]
           },
           "allOf": [
             {
@@ -4794,7 +4962,14 @@
         "EphemeralStorage": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "An object that specifies the disk space, in MB, available to your Lambda function in `/tmp`\\.  \nFor more information about this property, see [Lambda execution environment](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [EphemeralStorage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EphemeralStorage`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#EphemeralStorage"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "EphemeralStorage"
+            ]
           },
           "allOf": [
             {
@@ -4816,7 +4991,14 @@
         "Handler": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The function within your code that is called to begin execution\\. This property is only required if the `PackageType` property is set to `Zip`\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Handler`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-handler) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Handler"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Handler"
+            ]
           },
           "allOf": [
             {
@@ -4858,7 +5040,14 @@
         "PermissionsBoundary": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The ARN of a permissions boundary to use for this function's execution role\\. This property works only if the role is generated for you\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`PermissionsBoundary`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-permissionsboundary) property of an `AWS::IAM::Role` resource\\.",
-            "schemaPath": "definitions#AWS::IAM::Role#properties#Properties#properties#PermissionsBoundary"
+            "schemaPath": [
+              "definitions",
+              "AWS::IAM::Role",
+              "properties",
+              "Properties",
+              "properties",
+              "PermissionsBoundary"
+            ]
           },
           "allOf": [
             {
@@ -4890,7 +5079,14 @@
         "RolePath": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The path to the function's IAM execution role\\.  \nUse this property when the role is generated for you\\. Do not use when the role is specified with the `Role` property\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Path`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-path) property of an `AWS::IAM::Role` resource\\.",
-            "schemaPath": "definitions#AWS::IAM::Role#properties#Properties#properties#Path"
+            "schemaPath": [
+              "definitions",
+              "AWS::IAM::Role",
+              "properties",
+              "Properties",
+              "properties",
+              "Path"
+            ]
           },
           "allOf": [
             {
@@ -4902,7 +5098,14 @@
         "Runtime": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The identifier of the function's [runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)\\. This property is only required if the `PackageType` property is set to `Zip`\\.  \nIf you specify the `provided` identifier for this property, you can use the `Metadata` resource attribute to instruct AWS SAM to build the custom runtime that this function requires\\. For more information about building custom runtimes, see [Building custom runtimes](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/building-custom-runtimes.html)\\.\n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Runtime"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Runtime"
+            ]
           },
           "allOf": [
             {
@@ -4984,7 +5187,14 @@
         "Architectures": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The instruction set architecture for the function\\.  \nFor more information about this property, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) in the *AWS Lambda Developer Guide*\\.  \n*Valid values*: One of `x86_64` or `arm64`  \n*Type*: List  \n*Required*: No  \n*Default*: `x86_64`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Architectures`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Architectures"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Architectures"
+            ]
           },
           "allOf": [
             {
@@ -5034,7 +5244,14 @@
         "CodeSigningConfigArn": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The ARN of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html) resource, used to enable code signing for this function\\. For more information about code signing, see [Configuring code signing for AWS SAM applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/authoring-codesigning.html)\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CodeSigningConfigArn`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-codesigningconfigarn) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#CodeSigningConfigArn"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "CodeSigningConfigArn"
+            ]
           },
           "anyOf": [
             {
@@ -5085,7 +5302,14 @@
         "Description": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A description of the function\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Description`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-description) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Description"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Description"
+            ]
           },
           "allOf": [
             {
@@ -5097,7 +5321,14 @@
         "Environment": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The configuration for the runtime environment\\.  \n*Type*: [Environment](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Environment`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Environment"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Environment"
+            ]
           },
           "allOf": [
             {
@@ -5109,7 +5340,14 @@
         "EphemeralStorage": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "An object that specifies the disk space, in MB, available to your Lambda function in `/tmp`\\.  \nFor more information about this property, see [Lambda execution environment](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [EphemeralStorage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EphemeralStorage`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#EphemeralStorage"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "EphemeralStorage"
+            ]
           },
           "allOf": [
             {
@@ -5198,7 +5436,14 @@
         "FileSystemConfigs": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "List of [FileSystemConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html) objects that specify the connection settings for an Amazon Elastic File System \\(Amazon EFS\\) file system\\.  \nIf your template contains an [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html) resource, you must also specify a `DependsOn` resource attribute to ensure that the mount target is created or updated before the function\\.  \n*Type*: List  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FileSystemConfigs`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-filesystemconfigs) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#FileSystemConfigs"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "FileSystemConfigs"
+            ]
           },
           "allOf": [
             {
@@ -5210,7 +5455,14 @@
         "FunctionName": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A name for the function\\. If you don't specify a name, a unique name is generated for you\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FunctionName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#FunctionName"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "FunctionName"
+            ]
           },
           "allOf": [
             {
@@ -5232,7 +5484,14 @@
         "Handler": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The function within your code that is called to begin execution\\. This property is only required if the `PackageType` property is set to `Zip`\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Handler`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-handler) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Handler"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Handler"
+            ]
           },
           "allOf": [
             {
@@ -5244,7 +5503,14 @@
         "ImageConfig": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The object used to configure Lambda container image settings\\. For more information, see [Using container images with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [ImageConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ImageConfig`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#ImageConfig"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "ImageConfig"
+            ]
           },
           "allOf": [
             {
@@ -5256,7 +5522,12 @@
         "ImageUri": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The URI of the Amazon Elastic Container Registry \\(Amazon ECR\\) repository for the Lambda function's container image\\. This property only applies if the `PackageType` property is set to `Image`, otherwise it is ignored\\. For more information, see [Using container images with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the *AWS Lambda Developer Guide*\\.  \nIf the `PackageType` property is set to `Image`, then either `ImageUri` is required, or you must build your application with necessary `Metadata` entries in the AWS SAM template file\\. For more information, see [Building applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-build.html)\\.\nBuilding your application with necessary `Metadata` entries takes precedence over `ImageUri`, so if you specify both then `ImageUri` is ignored\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ImageUri`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-imageuri) property of the `AWS::Lambda::Function` `Code` data type\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function.Code#properties#ImageUri"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function.Code",
+              "properties",
+              "ImageUri"
+            ]
           },
           "allOf": [
             {
@@ -5318,7 +5589,14 @@
         "PermissionsBoundary": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The ARN of a permissions boundary to use for this function's execution role\\. This property works only if the role is generated for you\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`PermissionsBoundary`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-permissionsboundary) property of an `AWS::IAM::Role` resource\\.",
-            "schemaPath": "definitions#AWS::IAM::Role#properties#Properties#properties#PermissionsBoundary"
+            "schemaPath": [
+              "definitions",
+              "AWS::IAM::Role",
+              "properties",
+              "Properties",
+              "properties",
+              "PermissionsBoundary"
+            ]
           },
           "allOf": [
             {
@@ -5356,7 +5634,14 @@
         "ProvisionedConcurrencyConfig": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The provisioned concurrency configuration of a function's alias\\.  \n`ProvisionedConcurrencyConfig` can be specified only if the `AutoPublishAlias` is set\\. Otherwise, an error results\\.\n*Type*: [ProvisionedConcurrencyConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html#cfn-lambda-alias-provisionedconcurrencyconfig)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ProvisionedConcurrencyConfig`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html#cfn-lambda-alias-provisionedconcurrencyconfig) property of an `AWS::Lambda::Alias` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Alias#properties#Properties#properties#ProvisionedConcurrencyConfig"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Alias",
+              "properties",
+              "Properties",
+              "properties",
+              "ProvisionedConcurrencyConfig"
+            ]
           },
           "allOf": [
             {
@@ -5391,7 +5676,14 @@
         "RolePath": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The path to the function's IAM execution role\\.  \nUse this property when the role is generated for you\\. Do not use when the role is specified with the `Role` property\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Path`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-path) property of an `AWS::IAM::Role` resource\\.",
-            "schemaPath": "definitions#AWS::IAM::Role#properties#Properties#properties#Path"
+            "schemaPath": [
+              "definitions",
+              "AWS::IAM::Role",
+              "properties",
+              "Properties",
+              "properties",
+              "Path"
+            ]
           },
           "allOf": [
             {
@@ -5403,7 +5695,14 @@
         "Runtime": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The identifier of the function's [runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)\\. This property is only required if the `PackageType` property is set to `Zip`\\.  \nIf you specify the `provided` identifier for this property, you can use the `Metadata` resource attribute to instruct AWS SAM to build the custom runtime that this function requires\\. For more information about building custom runtimes, see [Building custom runtimes](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/building-custom-runtimes.html)\\.\n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Runtime"
+            "schemaPath": [
+              "definitions",
+              "AWS::Lambda::Function",
+              "properties",
+              "Properties",
+              "properties",
+              "Runtime"
+            ]
           },
           "allOf": [
             {

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -520,14 +520,16 @@
           "title": "Role"
         },
         "TriggerConfigurations": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "A list of trigger configurations you want to associate with the deployment group\\. Used to notify an SNS topic on lifecycle events\\.  \n*Type*: List  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TriggerConfigurations`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html#cfn-codedeploy-deploymentgroup-triggerconfigurations) property of an `AWS::CodeDeploy::DeploymentGroup` resource\\.",
+            "schemaPath": "definitions#AWS::CodeDeploy::DeploymentGroup#properties#Properties#properties#TriggerConfigurations"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "A list of trigger configurations you want to associate with the deployment group\\. Used to notify an SNS topic on lifecycle events\\.  \n*Type*: List  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TriggerConfigurations`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html#cfn-codedeploy-deploymentgroup-triggerconfigurations) property of an `AWS::CodeDeploy::DeploymentGroup` resource\\.",
-          "markdownDescription": "A list of trigger configurations you want to associate with the deployment group\\. Used to notify an SNS topic on lifecycle events\\.  \n*Type*: List  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TriggerConfigurations`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html#cfn-codedeploy-deploymentgroup-triggerconfigurations) property of an `AWS::CodeDeploy::DeploymentGroup` resource\\.",
-          "title": "TriggerConfigurations"
+          "title": "Triggerconfigurations"
         },
         "Type": {
           "anyOf": [

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -3352,14 +3352,16 @@
       "additionalProperties": false,
       "properties": {
         "AccessLogSetting": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Configures Access Log Setting for a stage\\.  \n*Type*: [AccessLogSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`AccessLogSetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#AccessLogSetting"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Configures Access Log Setting for a stage\\.  \n*Type*: [AccessLogSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`AccessLogSetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Configures Access Log Setting for a stage\\.  \n*Type*: [AccessLogSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`AccessLogSetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "AccessLogSetting"
+          "title": "Accesslogsetting"
         },
         "AlwaysDeploy": {
           "description": "Always deploys the API, even when no changes to the API have been detected\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -3388,34 +3390,40 @@
           "title": "BinaryMediaTypes"
         },
         "CacheClusterEnabled": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Indicates whether caching is enabled for the stage\\. To cache responses, you must also set `CachingEnabled` to `true` under `MethodSettings`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclusterenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CacheClusterEnabled"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Indicates whether caching is enabled for the stage\\. To cache responses, you must also set `CachingEnabled` to `true` under `MethodSettings`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclusterenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Indicates whether caching is enabled for the stage\\. To cache responses, you must also set `CachingEnabled` to `true` under `MethodSettings`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclusterenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "CacheClusterEnabled"
+          "title": "Cacheclusterenabled"
         },
         "CacheClusterSize": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "The stage's cache cluster size\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclustersize) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CacheClusterSize"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The stage's cache cluster size\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclustersize) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "The stage's cache cluster size\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclustersize) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "CacheClusterSize"
+          "title": "Cacheclustersize"
         },
         "CanarySetting": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Configure a canary setting to a stage of a regular deployment\\.  \n*Type*: [CanarySetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CanarySetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CanarySetting"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Configure a canary setting to a stage of a regular deployment\\.  \n*Type*: [CanarySetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CanarySetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Configure a canary setting to a stage of a regular deployment\\.  \n*Type*: [CanarySetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CanarySetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "CanarySetting"
+          "title": "Canarysetting"
         },
         "Cors": {
           "anyOf": [
@@ -3486,23 +3494,27 @@
           "title": "MethodSettings"
         },
         "MinimumCompressionSize": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Allow compression of response bodies based on client's Accept\\-Encoding header\\. Compression is triggered when response body size is greater than or equal to your configured threshold\\. The maximum body size threshold is 10 MB \\(10,485,760 Bytes\\)\\. \\- The following compression types are supported: gzip, deflate, and identity\\.  \n*Type*: Integer  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MinimumCompressionSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-minimumcompressionsize) property of an `AWS::ApiGateway::RestApi` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#MinimumCompressionSize"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Allow compression of response bodies based on client's Accept\\-Encoding header\\. Compression is triggered when response body size is greater than or equal to your configured threshold\\. The maximum body size threshold is 10 MB \\(10,485,760 Bytes\\)\\. \\- The following compression types are supported: gzip, deflate, and identity\\.  \n*Type*: Integer  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MinimumCompressionSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-minimumcompressionsize) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "markdownDescription": "Allow compression of response bodies based on client's Accept\\-Encoding header\\. Compression is triggered when response body size is greater than or equal to your configured threshold\\. The maximum body size threshold is 10 MB \\(10,485,760 Bytes\\)\\. \\- The following compression types are supported: gzip, deflate, and identity\\.  \n*Type*: Integer  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MinimumCompressionSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-minimumcompressionsize) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "title": "MinimumCompressionSize"
+          "title": "Minimumcompressionsize"
         },
         "Name": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "A name for the API Gateway RestApi resource  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Name`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-name) property of an `AWS::ApiGateway::RestApi` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#Name"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "A name for the API Gateway RestApi resource  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Name`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-name) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "markdownDescription": "A name for the API Gateway RestApi resource  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Name`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-name) property of an `AWS::ApiGateway::RestApi` resource\\.",
           "title": "Name"
         },
         "OpenApiVersion": {
@@ -3519,23 +3531,27 @@
           "title": "OpenApiVersion"
         },
         "TracingEnabled": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Indicates whether active tracing with X\\-Ray is enabled for the stage\\. For more information about X\\-Ray, see [Tracing user requests to REST APIs using X\\-Ray](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) in the *API Gateway Developer Guide*\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TracingEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-tracingenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#TracingEnabled"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Indicates whether active tracing with X\\-Ray is enabled for the stage\\. For more information about X\\-Ray, see [Tracing user requests to REST APIs using X\\-Ray](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) in the *API Gateway Developer Guide*\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TracingEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-tracingenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Indicates whether active tracing with X\\-Ray is enabled for the stage\\. For more information about X\\-Ray, see [Tracing user requests to REST APIs using X\\-Ray](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) in the *API Gateway Developer Guide*\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TracingEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-tracingenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "TracingEnabled"
+          "title": "Tracingenabled"
         },
         "Variables": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "A map \\(string to string\\) that defines the stage variables, where the variable name is the key and the variable value is the value\\. Variable names are limited to alphanumeric characters\\. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&=,-]+`\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Variables`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#Variables"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "A map \\(string to string\\) that defines the stage variables, where the variable name is the key and the variable value is the value\\. Variable names are limited to alphanumeric characters\\. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&=,-]+`\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Variables`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "A map \\(string to string\\) that defines the stage variables, where the variable name is the key and the variable value is the value\\. Variable names are limited to alphanumeric characters\\. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&=,-]+`\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Variables`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables) property of an `AWS::ApiGateway::Stage` resource\\.",
           "title": "Variables"
         }
       },
@@ -3546,14 +3562,16 @@
       "additionalProperties": false,
       "properties": {
         "AccessLogSetting": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Configures Access Log Setting for a stage\\.  \n*Type*: [AccessLogSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`AccessLogSetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#AccessLogSetting"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Configures Access Log Setting for a stage\\.  \n*Type*: [AccessLogSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`AccessLogSetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Configures Access Log Setting for a stage\\.  \n*Type*: [AccessLogSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`AccessLogSetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-accesslogsetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "AccessLogSetting"
+          "title": "Accesslogsetting"
         },
         "AlwaysDeploy": {
           "description": "Always deploys the API, even when no changes to the API have been detected\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -3562,14 +3580,16 @@
           "type": "boolean"
         },
         "ApiKeySourceType": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "The source of the API key for metering requests according to a usage plan\\. Valid values are `HEADER` and `AUTHORIZER`\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ApiKeySourceType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-apikeysourcetype) property of an `AWS::ApiGateway::RestApi` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#ApiKeySourceType"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The source of the API key for metering requests according to a usage plan\\. Valid values are `HEADER` and `AUTHORIZER`\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ApiKeySourceType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-apikeysourcetype) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "markdownDescription": "The source of the API key for metering requests according to a usage plan\\. Valid values are `HEADER` and `AUTHORIZER`\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ApiKeySourceType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-apikeysourcetype) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "title": "ApiKeySourceType"
+          "title": "Apikeysourcetype"
         },
         "Auth": {
           "allOf": [
@@ -3592,34 +3612,40 @@
           "title": "BinaryMediaTypes"
         },
         "CacheClusterEnabled": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Indicates whether caching is enabled for the stage\\. To cache responses, you must also set `CachingEnabled` to `true` under `MethodSettings`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclusterenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CacheClusterEnabled"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Indicates whether caching is enabled for the stage\\. To cache responses, you must also set `CachingEnabled` to `true` under `MethodSettings`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclusterenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Indicates whether caching is enabled for the stage\\. To cache responses, you must also set `CachingEnabled` to `true` under `MethodSettings`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclusterenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "CacheClusterEnabled"
+          "title": "Cacheclusterenabled"
         },
         "CacheClusterSize": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "The stage's cache cluster size\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclustersize) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CacheClusterSize"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The stage's cache cluster size\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclustersize) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "The stage's cache cluster size\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CacheClusterSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-cacheclustersize) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "CacheClusterSize"
+          "title": "Cacheclustersize"
         },
         "CanarySetting": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Configure a canary setting to a stage of a regular deployment\\.  \n*Type*: [CanarySetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CanarySetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#CanarySetting"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Configure a canary setting to a stage of a regular deployment\\.  \n*Type*: [CanarySetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CanarySetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Configure a canary setting to a stage of a regular deployment\\.  \n*Type*: [CanarySetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CanarySetting`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-canarysetting) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "CanarySetting"
+          "title": "Canarysetting"
         },
         "Cors": {
           "anyOf": [
@@ -3657,13 +3683,15 @@
           "title": "DefinitionUri"
         },
         "Description": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "A description of the Api resource\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Description`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-description) property of an `AWS::ApiGateway::RestApi` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#Description"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "A description of the Api resource\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Description`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-description) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "markdownDescription": "A description of the Api resource\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Description`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-description) property of an `AWS::ApiGateway::RestApi` resource\\.",
           "title": "Description"
         },
         "DisableExecuteApiEndpoint": {
@@ -3700,14 +3728,16 @@
           "title": "EndpointConfiguration"
         },
         "FailOnWarnings": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Specifies whether to roll back the API creation \\(`true`\\) or not \\(`false`\\) when a warning is encountered\\. The default value is `false`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FailOnWarnings`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-failonwarnings) property of an `AWS::ApiGateway::RestApi` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#FailOnWarnings"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Specifies whether to roll back the API creation \\(`true`\\) or not \\(`false`\\) when a warning is encountered\\. The default value is `false`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FailOnWarnings`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-failonwarnings) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "markdownDescription": "Specifies whether to roll back the API creation \\(`true`\\) or not \\(`false`\\) when a warning is encountered\\. The default value is `false`\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FailOnWarnings`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-failonwarnings) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "title": "FailOnWarnings"
+          "title": "Failonwarnings"
         },
         "GatewayResponses": {
           "description": "Configures Gateway Responses for an API\\. Gateway Responses are responses returned by API Gateway, either directly or through the use of Lambda Authorizers\\. For more information, see the documentation for the [Api Gateway OpenApi extension for Gateway Responses](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-gateway-responses.html)\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -3722,33 +3752,39 @@
           "type": "boolean"
         },
         "MethodSettings": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Configures all settings for API stage including Logging, Metrics, CacheTTL, Throttling\\.  \n*Type*: List of [ MethodSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MethodSettings`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-methodsettings) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#MethodSettings"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Configures all settings for API stage including Logging, Metrics, CacheTTL, Throttling\\.  \n*Type*: List of [ MethodSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MethodSettings`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-methodsettings) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Configures all settings for API stage including Logging, Metrics, CacheTTL, Throttling\\.  \n*Type*: List of [ MethodSetting](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MethodSettings`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-methodsettings) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "MethodSettings"
+          "title": "Methodsettings"
         },
         "MinimumCompressionSize": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Allow compression of response bodies based on client's Accept\\-Encoding header\\. Compression is triggered when response body size is greater than or equal to your configured threshold\\. The maximum body size threshold is 10 MB \\(10,485,760 Bytes\\)\\. \\- The following compression types are supported: gzip, deflate, and identity\\.  \n*Type*: Integer  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MinimumCompressionSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-minimumcompressionsize) property of an `AWS::ApiGateway::RestApi` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#MinimumCompressionSize"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Allow compression of response bodies based on client's Accept\\-Encoding header\\. Compression is triggered when response body size is greater than or equal to your configured threshold\\. The maximum body size threshold is 10 MB \\(10,485,760 Bytes\\)\\. \\- The following compression types are supported: gzip, deflate, and identity\\.  \n*Type*: Integer  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MinimumCompressionSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-minimumcompressionsize) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "markdownDescription": "Allow compression of response bodies based on client's Accept\\-Encoding header\\. Compression is triggered when response body size is greater than or equal to your configured threshold\\. The maximum body size threshold is 10 MB \\(10,485,760 Bytes\\)\\. \\- The following compression types are supported: gzip, deflate, and identity\\.  \n*Type*: Integer  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`MinimumCompressionSize`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-minimumcompressionsize) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "title": "MinimumCompressionSize"
+          "title": "Minimumcompressionsize"
         },
         "Mode": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "This property applies only when you use OpenAPI to define your REST API\\. The `Mode` determines how API Gateway handles resource updates\\. For more information, see [Mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-mode) property of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html) resource type\\.  \n*Valid values*: `overwrite` or `merge`  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Mode`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-mode) property of an `AWS::ApiGateway::RestApi` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#Mode"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "This property applies only when you use OpenAPI to define your REST API\\. The `Mode` determines how API Gateway handles resource updates\\. For more information, see [Mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-mode) property of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html) resource type\\.  \n*Valid values*: `overwrite` or `merge`  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Mode`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-mode) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "markdownDescription": "This property applies only when you use OpenAPI to define your REST API\\. The `Mode` determines how API Gateway handles resource updates\\. For more information, see [Mode](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-mode) property of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html) resource type\\.  \n*Valid values*: `overwrite` or `merge`  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Mode`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-mode) property of an `AWS::ApiGateway::RestApi` resource\\.",
           "title": "Mode"
         },
         "Models": {
@@ -3758,13 +3794,15 @@
           "type": "object"
         },
         "Name": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "A name for the API Gateway RestApi resource  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Name`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-name) property of an `AWS::ApiGateway::RestApi` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::RestApi#properties#Properties#properties#Name"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "A name for the API Gateway RestApi resource  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Name`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-name) property of an `AWS::ApiGateway::RestApi` resource\\.",
-          "markdownDescription": "A name for the API Gateway RestApi resource  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Name`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-name) property of an `AWS::ApiGateway::RestApi` resource\\.",
           "title": "Name"
         },
         "OpenApiVersion": {
@@ -3800,23 +3838,27 @@
           "type": "object"
         },
         "TracingEnabled": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "Indicates whether active tracing with X\\-Ray is enabled for the stage\\. For more information about X\\-Ray, see [Tracing user requests to REST APIs using X\\-Ray](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) in the *API Gateway Developer Guide*\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TracingEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-tracingenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#TracingEnabled"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "Indicates whether active tracing with X\\-Ray is enabled for the stage\\. For more information about X\\-Ray, see [Tracing user requests to REST APIs using X\\-Ray](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) in the *API Gateway Developer Guide*\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TracingEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-tracingenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "Indicates whether active tracing with X\\-Ray is enabled for the stage\\. For more information about X\\-Ray, see [Tracing user requests to REST APIs using X\\-Ray](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) in the *API Gateway Developer Guide*\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`TracingEnabled`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-tracingenabled) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "title": "TracingEnabled"
+          "title": "Tracingenabled"
         },
         "Variables": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "A map \\(string to string\\) that defines the stage variables, where the variable name is the key and the variable value is the value\\. Variable names are limited to alphanumeric characters\\. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&=,-]+`\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Variables`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables) property of an `AWS::ApiGateway::Stage` resource\\.",
+            "schemaPath": "definitions#AWS::ApiGateway::Stage#properties#Properties#properties#Variables"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "A map \\(string to string\\) that defines the stage variables, where the variable name is the key and the variable value is the value\\. Variable names are limited to alphanumeric characters\\. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&=,-]+`\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Variables`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables) property of an `AWS::ApiGateway::Stage` resource\\.",
-          "markdownDescription": "A map \\(string to string\\) that defines the stage variables, where the variable name is the key and the variable value is the value\\. Variable names are limited to alphanumeric characters\\. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&=,-]+`\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Variables`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-variables) property of an `AWS::ApiGateway::Stage` resource\\.",
           "title": "Variables"
         }
       },

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -536,7 +536,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Triggerconfigurations"
+          "title": "TriggerConfigurations"
         },
         "Type": {
           "anyOf": [
@@ -3375,7 +3375,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Accesslogsetting"
+          "title": "AccessLogSetting"
         },
         "AlwaysDeploy": {
           "description": "Always deploys the API, even when no changes to the API have been detected\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -3420,7 +3420,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Cacheclusterenabled"
+          "title": "CacheClusterEnabled"
         },
         "CacheClusterSize": {
           "__samPassThrough": {
@@ -3439,7 +3439,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Cacheclustersize"
+          "title": "CacheClusterSize"
         },
         "CanarySetting": {
           "__samPassThrough": {
@@ -3458,7 +3458,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Canarysetting"
+          "title": "CanarySetting"
         },
         "Cors": {
           "anyOf": [
@@ -3545,7 +3545,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Minimumcompressionsize"
+          "title": "MinimumCompressionSize"
         },
         "Name": {
           "__samPassThrough": {
@@ -3596,7 +3596,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Tracingenabled"
+          "title": "TracingEnabled"
         },
         "Variables": {
           "__samPassThrough": {
@@ -3641,7 +3641,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Accesslogsetting"
+          "title": "AccessLogSetting"
         },
         "AlwaysDeploy": {
           "description": "Always deploys the API, even when no changes to the API have been detected\\.  \n*Type*: Boolean  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -3666,7 +3666,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Apikeysourcetype"
+          "title": "ApiKeySourceType"
         },
         "Auth": {
           "allOf": [
@@ -3705,7 +3705,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Cacheclusterenabled"
+          "title": "CacheClusterEnabled"
         },
         "CacheClusterSize": {
           "__samPassThrough": {
@@ -3724,7 +3724,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Cacheclustersize"
+          "title": "CacheClusterSize"
         },
         "CanarySetting": {
           "__samPassThrough": {
@@ -3743,7 +3743,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Canarysetting"
+          "title": "CanarySetting"
         },
         "Cors": {
           "anyOf": [
@@ -3849,7 +3849,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Failonwarnings"
+          "title": "FailOnWarnings"
         },
         "GatewayResponses": {
           "description": "Configures Gateway Responses for an API\\. Gateway Responses are responses returned by API Gateway, either directly or through the use of Lambda Authorizers\\. For more information, see the documentation for the [Api Gateway OpenApi extension for Gateway Responses](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-gateway-responses.html)\\.  \n*Type*: Map  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
@@ -3880,7 +3880,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Methodsettings"
+          "title": "MethodSettings"
         },
         "MinimumCompressionSize": {
           "__samPassThrough": {
@@ -3899,7 +3899,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Minimumcompressionsize"
+          "title": "MinimumCompressionSize"
         },
         "Mode": {
           "__samPassThrough": {
@@ -3994,7 +3994,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Tracingenabled"
+          "title": "TracingEnabled"
         },
         "Variables": {
           "__samPassThrough": {
@@ -4976,7 +4976,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Ephemeralstorage"
+          "title": "EphemeralStorage"
         },
         "EventInvokeConfig": {
           "allOf": [
@@ -5054,7 +5054,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Permissionsboundary"
+          "title": "PermissionsBoundary"
         },
         "ProvisionedConcurrencyConfig": {
           "allOf": [
@@ -5093,7 +5093,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Rolepath"
+          "title": "RolePath"
         },
         "Runtime": {
           "__samPassThrough": {
@@ -5261,7 +5261,7 @@
               "type": "string"
             }
           ],
-          "title": "Codesigningconfigarn"
+          "title": "CodeSigningConfigArn"
         },
         "CodeUri": {
           "anyOf": [
@@ -5354,7 +5354,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Ephemeralstorage"
+          "title": "EphemeralStorage"
         },
         "EventInvokeConfig": {
           "allOf": [
@@ -5450,7 +5450,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Filesystemconfigs"
+          "title": "FileSystemConfigs"
         },
         "FunctionName": {
           "__samPassThrough": {
@@ -5469,7 +5469,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Functionname"
+          "title": "FunctionName"
         },
         "FunctionUrlConfig": {
           "allOf": [
@@ -5517,7 +5517,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Imageconfig"
+          "title": "ImageConfig"
         },
         "ImageUri": {
           "__samPassThrough": {
@@ -5534,7 +5534,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Imageuri"
+          "title": "ImageUri"
         },
         "InlineCode": {
           "allOf": [
@@ -5603,7 +5603,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Permissionsboundary"
+          "title": "PermissionsBoundary"
         },
         "Policies": {
           "anyOf": [
@@ -5648,7 +5648,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Provisionedconcurrencyconfig"
+          "title": "ProvisionedConcurrencyConfig"
         },
         "ReservedConcurrentExecutions": {
           "allOf": [
@@ -5690,7 +5690,7 @@
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "title": "Rolepath"
+          "title": "RolePath"
         },
         "Runtime": {
           "__samPassThrough": {

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -4659,13 +4659,15 @@
       "additionalProperties": false,
       "properties": {
         "Architectures": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "The instruction set architecture for the function\\.  \nFor more information about this property, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) in the *AWS Lambda Developer Guide*\\.  \n*Valid values*: One of `x86_64` or `arm64`  \n*Type*: List  \n*Required*: No  \n*Default*: `x86_64`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Architectures`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures) property of an `AWS::Lambda::Function` resource\\.",
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Architectures"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The instruction set architecture for the function\\.  \nFor more information about this property, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) in the *AWS Lambda Developer Guide*\\.  \n*Valid values*: One of `x86_64` or `arm64`  \n*Type*: List  \n*Required*: No  \n*Default*: `x86_64`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Architectures`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "The instruction set architecture for the function\\.  \nFor more information about this property, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) in the *AWS Lambda Developer Guide*\\.  \n*Valid values*: One of `x86_64` or `arm64`  \n*Type*: List  \n*Required*: No  \n*Default*: `x86_64`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Architectures`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures) property of an `AWS::Lambda::Function` resource\\.",
           "title": "Architectures"
         },
         "AssumeRolePolicyDocument": {
@@ -4736,7 +4738,7 @@
         "Environment": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The configuration for the runtime environment\\.  \n*Type*: [Environment](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Environment`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.Environment"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Environment"
           },
           "allOf": [
             {
@@ -4748,7 +4750,7 @@
         "EphemeralStorage": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "An object that specifies the disk space, in MB, available to your Lambda function in `/tmp`\\.  \nFor more information about this property, see [Lambda execution environment](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [EphemeralStorage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EphemeralStorage`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.EphemeralStorage"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#EphemeralStorage"
           },
           "allOf": [
             {
@@ -4770,7 +4772,7 @@
         "Handler": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The function within your code that is called to begin execution\\. This property is only required if the `PackageType` property is set to `Zip`\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Handler`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-handler) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.Handler"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Handler"
           },
           "allOf": [
             {
@@ -4812,7 +4814,7 @@
         "PermissionsBoundary": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The ARN of a permissions boundary to use for this function's execution role\\. This property works only if the role is generated for you\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`PermissionsBoundary`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-permissionsboundary) property of an `AWS::IAM::Role` resource\\.",
-            "schemaPath": "definitions.AWS::IAM::Role.properties.Properties.properties.PermissionsBoundary"
+            "schemaPath": "definitions#AWS::IAM::Role#properties#Properties#properties#PermissionsBoundary"
           },
           "allOf": [
             {
@@ -4844,7 +4846,7 @@
         "RolePath": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The path to the function's IAM execution role\\.  \nUse this property when the role is generated for you\\. Do not use when the role is specified with the `Role` property\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Path`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-path) property of an `AWS::IAM::Role` resource\\.",
-            "schemaPath": "definitions.AWS::IAM::Role.properties.Properties.properties.Path"
+            "schemaPath": "definitions#AWS::IAM::Role#properties#Properties#properties#Path"
           },
           "allOf": [
             {
@@ -4856,7 +4858,7 @@
         "Runtime": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The identifier of the function's [runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)\\. This property is only required if the `PackageType` property is set to `Zip`\\.  \nIf you specify the `provided` identifier for this property, you can use the `Metadata` resource attribute to instruct AWS SAM to build the custom runtime that this function requires\\. For more information about building custom runtimes, see [Building custom runtimes](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/building-custom-runtimes.html)\\.\n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.Runtime"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Runtime"
           },
           "allOf": [
             {
@@ -4936,13 +4938,15 @@
       "additionalProperties": false,
       "properties": {
         "Architectures": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "The instruction set architecture for the function\\.  \nFor more information about this property, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) in the *AWS Lambda Developer Guide*\\.  \n*Valid values*: One of `x86_64` or `arm64`  \n*Type*: List  \n*Required*: No  \n*Default*: `x86_64`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Architectures`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures) property of an `AWS::Lambda::Function` resource\\.",
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Architectures"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The instruction set architecture for the function\\.  \nFor more information about this property, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) in the *AWS Lambda Developer Guide*\\.  \n*Valid values*: One of `x86_64` or `arm64`  \n*Type*: List  \n*Required*: No  \n*Default*: `x86_64`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Architectures`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "The instruction set architecture for the function\\.  \nFor more information about this property, see [Lambda instruction set architectures](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) in the *AWS Lambda Developer Guide*\\.  \n*Valid values*: One of `x86_64` or `arm64`  \n*Type*: List  \n*Required*: No  \n*Default*: `x86_64`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Architectures`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-architectures) property of an `AWS::Lambda::Function` resource\\.",
           "title": "Architectures"
         },
         "AssumeRolePolicyDocument": {
@@ -4984,6 +4988,10 @@
           "title": "AutoPublishCodeSha256"
         },
         "CodeSigningConfigArn": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "The ARN of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html) resource, used to enable code signing for this function\\. For more information about code signing, see [Configuring code signing for AWS SAM applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/authoring-codesigning.html)\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CodeSigningConfigArn`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-codesigningconfigarn) property of an `AWS::Lambda::Function` resource\\.",
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#CodeSigningConfigArn"
+          },
           "anyOf": [
             {
               "type": "object"
@@ -4992,9 +5000,7 @@
               "type": "string"
             }
           ],
-          "description": "The ARN of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html) resource, used to enable code signing for this function\\. For more information about code signing, see [Configuring code signing for AWS SAM applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/authoring-codesigning.html)\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CodeSigningConfigArn`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-codesigningconfigarn) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "The ARN of the [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-codesigningconfig.html) resource, used to enable code signing for this function\\. For more information about code signing, see [Configuring code signing for AWS SAM applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/authoring-codesigning.html)\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`CodeSigningConfigArn`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-codesigningconfigarn) property of an `AWS::Lambda::Function` resource\\.",
-          "title": "CodeSigningConfigArn"
+          "title": "Codesigningconfigarn"
         },
         "CodeUri": {
           "anyOf": [
@@ -5033,19 +5039,21 @@
           "title": "DeploymentPreference"
         },
         "Description": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "A description of the function\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Description`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-description) property of an `AWS::Lambda::Function` resource\\.",
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Description"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "A description of the function\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Description`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-description) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "A description of the function\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Description`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-description) property of an `AWS::Lambda::Function` resource\\.",
           "title": "Description"
         },
         "Environment": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The configuration for the runtime environment\\.  \n*Type*: [Environment](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Environment`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.Environment"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Environment"
           },
           "allOf": [
             {
@@ -5057,7 +5065,7 @@
         "EphemeralStorage": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "An object that specifies the disk space, in MB, available to your Lambda function in `/tmp`\\.  \nFor more information about this property, see [Lambda execution environment](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [EphemeralStorage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`EphemeralStorage`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-ephemeralstorage) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.EphemeralStorage"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#EphemeralStorage"
           },
           "allOf": [
             {
@@ -5144,19 +5152,21 @@
           "type": "object"
         },
         "FileSystemConfigs": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "List of [FileSystemConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html) objects that specify the connection settings for an Amazon Elastic File System \\(Amazon EFS\\) file system\\.  \nIf your template contains an [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html) resource, you must also specify a `DependsOn` resource attribute to ensure that the mount target is created or updated before the function\\.  \n*Type*: List  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FileSystemConfigs`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-filesystemconfigs) property of an `AWS::Lambda::Function` resource\\.",
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#FileSystemConfigs"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "List of [FileSystemConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html) objects that specify the connection settings for an Amazon Elastic File System \\(Amazon EFS\\) file system\\.  \nIf your template contains an [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html) resource, you must also specify a `DependsOn` resource attribute to ensure that the mount target is created or updated before the function\\.  \n*Type*: List  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FileSystemConfigs`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-filesystemconfigs) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "List of [FileSystemConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-filesystemconfig.html) objects that specify the connection settings for an Amazon Elastic File System \\(Amazon EFS\\) file system\\.  \nIf your template contains an [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-mounttarget.html) resource, you must also specify a `DependsOn` resource attribute to ensure that the mount target is created or updated before the function\\.  \n*Type*: List  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FileSystemConfigs`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-filesystemconfigs) property of an `AWS::Lambda::Function` resource\\.",
-          "title": "FileSystemConfigs"
+          "title": "Filesystemconfigs"
         },
         "FunctionName": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "A name for the function\\. If you don't specify a name, a unique name is generated for you\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`FunctionName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.FunctionName"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#FunctionName"
           },
           "allOf": [
             {
@@ -5178,7 +5188,7 @@
         "Handler": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The function within your code that is called to begin execution\\. This property is only required if the `PackageType` property is set to `Zip`\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Handler`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-handler) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.Handler"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Handler"
           },
           "allOf": [
             {
@@ -5188,24 +5198,28 @@
           "title": "Handler"
         },
         "ImageConfig": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "The object used to configure Lambda container image settings\\. For more information, see [Using container images with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [ImageConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ImageConfig`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig) property of an `AWS::Lambda::Function` resource\\.",
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#ImageConfig"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The object used to configure Lambda container image settings\\. For more information, see [Using container images with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [ImageConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ImageConfig`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig) property of an `AWS::Lambda::Function` resource\\.",
-          "markdownDescription": "The object used to configure Lambda container image settings\\. For more information, see [Using container images with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the *AWS Lambda Developer Guide*\\.  \n*Type*: [ImageConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ImageConfig`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig) property of an `AWS::Lambda::Function` resource\\.",
-          "title": "ImageConfig"
+          "title": "Imageconfig"
         },
         "ImageUri": {
+          "__samPassThrough": {
+            "markdownDescriptionOverride": "The URI of the Amazon Elastic Container Registry \\(Amazon ECR\\) repository for the Lambda function's container image\\. This property only applies if the `PackageType` property is set to `Image`, otherwise it is ignored\\. For more information, see [Using container images with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the *AWS Lambda Developer Guide*\\.  \nIf the `PackageType` property is set to `Image`, then either `ImageUri` is required, or you must build your application with necessary `Metadata` entries in the AWS SAM template file\\. For more information, see [Building applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-build.html)\\.\nBuilding your application with necessary `Metadata` entries takes precedence over `ImageUri`, so if you specify both then `ImageUri` is ignored\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ImageUri`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-imageuri) property of the `AWS::Lambda::Function` `Code` data type\\.",
+            "schemaPath": "definitions#AWS::Lambda::Function.Code#properties#ImageUri"
+          },
           "allOf": [
             {
               "$ref": "#/definitions/PassThroughProp"
             }
           ],
-          "description": "The URI of the Amazon Elastic Container Registry \\(Amazon ECR\\) repository for the Lambda function's container image\\. This property only applies if the `PackageType` property is set to `Image`, otherwise it is ignored\\. For more information, see [Using container images with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the *AWS Lambda Developer Guide*\\.  \nIf the `PackageType` property is set to `Image`, then either `ImageUri` is required, or you must build your application with necessary `Metadata` entries in the AWS SAM template file\\. For more information, see [Building applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-build.html)\\.\nBuilding your application with necessary `Metadata` entries takes precedence over `ImageUri`, so if you specify both then `ImageUri` is ignored\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ImageUri`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-imageuri) property of the `AWS::Lambda::Function` `Code` data type\\.",
-          "markdownDescription": "The URI of the Amazon Elastic Container Registry \\(Amazon ECR\\) repository for the Lambda function's container image\\. This property only applies if the `PackageType` property is set to `Image`, otherwise it is ignored\\. For more information, see [Using container images with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the *AWS Lambda Developer Guide*\\.  \nIf the `PackageType` property is set to `Image`, then either `ImageUri` is required, or you must build your application with necessary `Metadata` entries in the AWS SAM template file\\. For more information, see [Building applications](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-build.html)\\.\nBuilding your application with necessary `Metadata` entries takes precedence over `ImageUri`, so if you specify both then `ImageUri` is ignored\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ImageUri`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-imageuri) property of the `AWS::Lambda::Function` `Code` data type\\.",
-          "title": "ImageUri"
+          "title": "Imageuri"
         },
         "InlineCode": {
           "allOf": [
@@ -5260,7 +5274,7 @@
         "PermissionsBoundary": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The ARN of a permissions boundary to use for this function's execution role\\. This property works only if the role is generated for you\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`PermissionsBoundary`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-permissionsboundary) property of an `AWS::IAM::Role` resource\\.",
-            "schemaPath": "definitions.AWS::IAM::Role.properties.Properties.properties.PermissionsBoundary"
+            "schemaPath": "definitions#AWS::IAM::Role#properties#Properties#properties#PermissionsBoundary"
           },
           "allOf": [
             {
@@ -5298,7 +5312,7 @@
         "ProvisionedConcurrencyConfig": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The provisioned concurrency configuration of a function's alias\\.  \n`ProvisionedConcurrencyConfig` can be specified only if the `AutoPublishAlias` is set\\. Otherwise, an error results\\.\n*Type*: [ProvisionedConcurrencyConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html#cfn-lambda-alias-provisionedconcurrencyconfig)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`ProvisionedConcurrencyConfig`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html#cfn-lambda-alias-provisionedconcurrencyconfig) property of an `AWS::Lambda::Alias` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Alias.properties.Properties.properties.ProvisionedConcurrencyConfig"
+            "schemaPath": "definitions#AWS::Lambda::Alias#properties#Properties#properties#ProvisionedConcurrencyConfig"
           },
           "allOf": [
             {
@@ -5333,7 +5347,7 @@
         "RolePath": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The path to the function's IAM execution role\\.  \nUse this property when the role is generated for you\\. Do not use when the role is specified with the `Role` property\\.  \n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Path`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-path) property of an `AWS::IAM::Role` resource\\.",
-            "schemaPath": "definitions.AWS::IAM::Role.properties.Properties.properties.Path"
+            "schemaPath": "definitions#AWS::IAM::Role#properties#Properties#properties#Path"
           },
           "allOf": [
             {
@@ -5345,7 +5359,7 @@
         "Runtime": {
           "__samPassThrough": {
             "markdownDescriptionOverride": "The identifier of the function's [runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)\\. This property is only required if the `PackageType` property is set to `Zip`\\.  \nIf you specify the `provided` identifier for this property, you can use the `Metadata` resource attribute to instruct AWS SAM to build the custom runtime that this function requires\\. For more information about building custom runtimes, see [Building custom runtimes](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/building-custom-runtimes.html)\\.\n*Type*: String  \n*Required*: Conditional  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime) property of an `AWS::Lambda::Function` resource\\.",
-            "schemaPath": "definitions.AWS::Lambda::Function.properties.Properties.properties.Runtime"
+            "schemaPath": "definitions#AWS::Lambda::Function#properties#Properties#properties#Runtime"
           },
           "allOf": [
             {


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Had to change how the pass-through schema is referenced, as it's not as nicely consistent as I initially expected.

The end change is in `schema.json`.

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
