### PR TITLE
fix: Fix availability dip from API MergeDefinitions property

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -955,12 +955,16 @@ class Api(PushEventSource):
             )
 
         if merge_definitions:
-            api["DefinitionBody"] = self._get_merged_definitions(api_id, api["DefinitionBody"], editor.swagger)
+            api["DefinitionBody"] = self._get_merged_definitions(api_id, api["DefinitionBody"], editor, editor.swagger)
         else:
             api["DefinitionBody"] = editor.swagger
 
     def _get_merged_definitions(
-        self, api_id: str, source_definition_body: Dict[str, Any], dest_definition_body: Dict[str, Any]
+        self,
+        api_id: str,
+        source_definition_body: Dict[str, Any],
+        editor: SwaggerEditor,
+        dest_definition_body: Dict[str, Any],
     ) -> Dict[str, Any]:
         """
         Merge SAM generated swagger definition(dest_definition_body) into inline DefinitionBody(source_definition_body):
@@ -977,7 +981,9 @@ class Api(PushEventSource):
 
         sam_expect(path_method_body, api_id, f"DefinitionBody.paths.{self.Path}.{self.Method}").to_be_a_map()
 
-        generated_path_method_body = dest_definition_body["paths"][self.Path][self.Method]
+        # Normalized version of HTTP Method. It also handle API Gateway specific methods like "ANY"
+        method = editor._normalize_method_name(self.Method)
+        generated_path_method_body = dest_definition_body["paths"][self.Path][method]
         # this guarantees that the merged definition use SAM generated value for a conflicting key
         merged_path_method_body = {**path_method_body, **generated_path_method_body}
 

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -955,7 +955,7 @@ class Api(PushEventSource):
             )
 
         if merge_definitions:
-            api["DefinitionBody"] = self._get_merged_definitions(api_id, api["DefinitionBody"], editor, editor.swagger)
+            api["DefinitionBody"] = self._get_merged_definitions(api_id, api["DefinitionBody"], editor)
         else:
             api["DefinitionBody"] = editor.swagger
 
@@ -964,7 +964,6 @@ class Api(PushEventSource):
         api_id: str,
         source_definition_body: Dict[str, Any],
         editor: SwaggerEditor,
-        dest_definition_body: Dict[str, Any],
     ) -> Dict[str, Any]:
         """
         Merge SAM generated swagger definition(dest_definition_body) into inline DefinitionBody(source_definition_body):
@@ -983,6 +982,7 @@ class Api(PushEventSource):
 
         # Normalized version of HTTP Method. It also handle API Gateway specific methods like "ANY"
         method = editor._normalize_method_name(self.Method)
+        dest_definition_body = editor.swagger
         generated_path_method_body = dest_definition_body["paths"][self.Path][method]
         # this guarantees that the merged definition use SAM generated value for a conflicting key
         merged_path_method_body = {**path_method_body, **generated_path_method_body}

--- a/tests/translator/input/api_merge_definitions_with_any_method.yaml
+++ b/tests/translator/input/api_merge_definitions_with_any_method.yaml
@@ -1,0 +1,25 @@
+Resources:
+  WebhooksApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: live
+      MergeDefinitions: true
+      DefinitionBody:
+        swagger: 2
+        x-amazon-apigateway-policy:
+          Version: '2012-10-17'
+
+
+  WebhooksReceiver:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: code/handler
+      Runtime: python3.8
+      Events:
+        AllEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref WebhooksApi
+            Path: /proxy
+            Method: any

--- a/tests/translator/output/api_merge_definitions_with_any_method.json
+++ b/tests/translator/output/api_merge_definitions_with_any_method.json
@@ -1,0 +1,111 @@
+{
+  "Resources": {
+    "WebhooksApi": {
+      "Properties": {
+        "Body": {
+          "swagger": 2,
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17"
+          }
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "WebhooksApiDeployment472b94a845": {
+      "Properties": {
+        "Description": "RestApi deployment id: 472b94a845dac11081ca2890e848230a4e30a2aa",
+        "RestApiId": {
+          "Ref": "WebhooksApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "WebhooksApiliveStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "WebhooksApiDeployment472b94a845"
+        },
+        "RestApiId": {
+          "Ref": "WebhooksApi"
+        },
+        "StageName": "live"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "WebhooksReceiver": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "code/handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WebhooksReceiverRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "WebhooksReceiverAllEventPermissionlive": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "WebhooksReceiver"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/proxy",
+            {
+              "__ApiId__": {
+                "Ref": "WebhooksApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "WebhooksReceiverRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_merge_definitions_with_any_method.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_with_any_method.json
@@ -1,0 +1,119 @@
+{
+  "Resources": {
+    "WebhooksApi": {
+      "Properties": {
+        "Body": {
+          "swagger": 2,
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17"
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "WebhooksApiDeployment472b94a845": {
+      "Properties": {
+        "Description": "RestApi deployment id: 472b94a845dac11081ca2890e848230a4e30a2aa",
+        "RestApiId": {
+          "Ref": "WebhooksApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "WebhooksApiliveStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "WebhooksApiDeployment472b94a845"
+        },
+        "RestApiId": {
+          "Ref": "WebhooksApi"
+        },
+        "StageName": "live"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "WebhooksReceiver": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "code/handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WebhooksReceiverRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "WebhooksReceiverAllEventPermissionlive": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "WebhooksReceiver"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/proxy",
+            {
+              "__ApiId__": {
+                "Ref": "WebhooksApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "WebhooksReceiverRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_with_any_method.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_with_any_method.json
@@ -1,0 +1,119 @@
+{
+  "Resources": {
+    "WebhooksApi": {
+      "Properties": {
+        "Body": {
+          "swagger": 2,
+          "x-amazon-apigateway-policy": {
+            "Version": "2012-10-17"
+          }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "WebhooksApiDeployment472b94a845": {
+      "Properties": {
+        "Description": "RestApi deployment id: 472b94a845dac11081ca2890e848230a4e30a2aa",
+        "RestApiId": {
+          "Ref": "WebhooksApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "WebhooksApiliveStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "WebhooksApiDeployment472b94a845"
+        },
+        "RestApiId": {
+          "Ref": "WebhooksApi"
+        },
+        "StageName": "live"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "WebhooksReceiver": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "code/handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WebhooksReceiverRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "WebhooksReceiverAllEventPermissionlive": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "WebhooksReceiver"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/proxy",
+            {
+              "__ApiId__": {
+                "Ref": "WebhooksApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "WebhooksReceiverRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes
There is a new availability dip that happens because customers input `ANY/any/Any` for event source API methods. In the SAM generated open api definition, we will create a `x-amazon-apigateway-any-method`. 

This caused an availability dip because we're looking for `any` in dictionary and keyError happened. Fix it.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
