### PR TITLE
chore: improve cfn-lint install

### DIFF
--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -7,7 +7,7 @@ VENV=.venv_cfn_lint
 # See https://github.com/aws/serverless-application-model/issues/1042
 if [ ! -d "${VENV}" ]; then
     python3 -m venv "${VENV}"
-    "${VENV}/bin/python" -m pip install cfn-lint==0.75.0 --quiet
 fi
 
+"${VENV}/bin/python" -m pip install cfn-lint==0.75.0 --upgrade --quiet
 "${VENV}/bin/cfn-lint" --format parseable


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Prevents issues where e.g. using same venv for a while and `cfn-lint` is updated, but it won't try to install it again, causing checks to fail.

Checked it's "pretty fast" to run it every time, so no significant impact on duration.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
