### PR TITLE
fix: Shorten Location IndexName property

### DIFF
--- a/integration/combination/test_connectors.py
+++ b/integration/combination/test_connectors.py
@@ -50,7 +50,6 @@ class TestConnectors(BaseTest):
             ("combination/connector_event_rule_to_eb_custom_write",),
             ("combination/connector_event_rule_to_lambda_write",),
             ("combination/connector_event_rule_to_lambda_write_multiple",),
-            ("combination/connector_function_to_location_place_index",),
             ("combination/connector_mix_destination",),
             ("combination/connector_sqs_to_function",),
             ("combination/connector_sns_to_function_write",),
@@ -62,6 +61,30 @@ class TestConnectors(BaseTest):
     def test_connector_by_invoking_a_function(self, template_file_path):
         self.skip_using_service_detector(template_file_path)
         self.create_and_verify_stack(template_file_path)
+
+        lambda_function_name = self.get_physical_id_by_logical_id("TriggerFunction")
+        lambda_client = self.client_provider.lambda_client
+
+        request_params = {
+            "FunctionName": lambda_function_name,
+            "InvocationType": "RequestResponse",
+            "Payload": "{}",
+        }
+        response = lambda_client.invoke(**request_params)
+        self.assertEqual(response.get("StatusCode"), 200)
+        self.assertEqual(response.get("FunctionError"), None)
+
+    @parameterized.expand(
+        [
+            ("combination/connector_function_to_location_place_index",),
+        ]
+    )
+    @retry_once
+    def test_connector_by_invoking_a_function_with_parameters(self, template_file_path):
+        parameters = []
+        parameters.append(self.generate_parameter("IndexName", f"PlaceIndex-{generate_suffix()}"))
+        self.skip_using_service_detector(template_file_path)
+        self.create_and_verify_stack(template_file_path, parameters)
 
         lambda_function_name = self.get_physical_id_by_logical_id("TriggerFunction")
         lambda_client = self.client_provider.lambda_client

--- a/integration/resources/templates/combination/connector_function_to_location_place_index.yaml
+++ b/integration/resources/templates/combination/connector_function_to_location_place_index.yaml
@@ -1,5 +1,10 @@
 Transform: AWS::Serverless-2016-10-31-test
 
+Parameters:
+  IndexName: 
+    Type: String
+    Default: PlaceIndex
+
 Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
@@ -35,14 +40,14 @@ Resources:
           )
       Environment:
         Variables:
-          LOCATION_INDEX: !Sub ${AWS::StackName}-PI
+          LOCATION_INDEX: !Ref IndexName
 
 
   MyPlace:
     Type: AWS::Location::PlaceIndex
     Properties:
       DataSource: Here
-      IndexName: !Sub ${AWS::StackName}-PI
+      IndexName: !Ref IndexName
 
   MyConnector:
     Type: AWS::Serverless::Connector


### PR DESCRIPTION
### Issue #, if available

### Description of changes
FeatureToggle integ test failed due to `Properties validation failed for resource MyPlace with message: #/IndexName: expected maxLength: 100, actual: 106`. The IndexName was too long. Shorten it by using random characters instead of stack name.

### Description of how you validated changes
Local test succeeded.
<img width="1326" alt="Screen Shot 2023-03-27 at 1 57 14 PM" src="https://user-images.githubusercontent.com/28763956/228064794-b8673979-8b1b-4d36-9787-102012588ed9.png">

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
