### PR TITLE
fix: Connector "Type" cannot be Serverless resource types

### DIFF
--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -28,7 +28,7 @@ ConnectorResourceReference = namedtuple(
     ],
 )
 
-SAM_TO_CFN_RESOURCE_TYPE = {
+_SAM_TO_CFN_RESOURCE_TYPE = {
     SamResourceType.Function.value: LambdaFunction.resource_type,
     SamResourceType.StateMachine.value: StepFunctionsStateMachine.resource_type,
     SamResourceType.Api.value: ApiGatewayRestApi.resource_type,
@@ -105,11 +105,6 @@ def _is_valid_resource_reference(obj: Dict[str, Any]) -> bool:
     return id_provided != non_id_provided
 
 
-def get_underlying_cfn_resource_type(resource_type: str) -> str:
-    """profiles.json only support CFN resource type. We need to convert SAM resource types to corresponding CFN resource type"""
-    return SAM_TO_CFN_RESOURCE_TYPE.get(resource_type, resource_type)
-
-
 def get_resource_reference(
     obj: Dict[str, Any], resource_resolver: ResourceResolver, connecting_obj: Dict[str, Any]
 ) -> ConnectorResourceReference:
@@ -125,7 +120,10 @@ def get_resource_reference(
         resource_type = obj.get("Type")
         if not _is_nonblank_str(resource_type):
             raise ConnectorResourceError("'Type' is missing or not a string.")
-        resource_type = get_underlying_cfn_resource_type(str(resource_type))
+
+        # profiles.json only support CFN resource type.
+        # We need to convert SAM resource types to corresponding CFN resource type
+        resource_type = _SAM_TO_CFN_RESOURCE_TYPE.get(str(resource_type), str(resource_type))
 
         return ConnectorResourceReference(
             logical_id=None,

--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -2,7 +2,15 @@ from collections import namedtuple
 from typing import Any, Dict, Iterable, List, Optional
 
 from samtranslator.model import ResourceResolver
+from samtranslator.model.apigateway import ApiGatewayRestApi
+from samtranslator.model.apigatewayv2 import ApiGatewayV2HttpApi
+from samtranslator.model.dynamodb import DynamoDBTable
 from samtranslator.model.intrinsics import fnGetAtt, get_logical_id_from_intrinsic, ref
+from samtranslator.model.lambda_ import (
+    LambdaFunction,
+)
+from samtranslator.model.stepfunctions import StepFunctionsStateMachine
+from samtranslator.public.sdk.resource import SamResourceType
 from samtranslator.utils.utils import as_array, insert_unique
 
 # TODO: Switch to dataclass
@@ -19,6 +27,14 @@ ConnectorResourceReference = namedtuple(
         "qualifier",
     ],
 )
+
+SAM_TO_CFN_RESOURCE_TYPE = {
+    SamResourceType.Function.value: LambdaFunction.resource_type,
+    SamResourceType.StateMachine.value: StepFunctionsStateMachine.resource_type,
+    SamResourceType.Api.value: ApiGatewayRestApi.resource_type,
+    SamResourceType.HttpApi.value: ApiGatewayV2HttpApi.resource_type,
+    SamResourceType.SimpleTable.value: DynamoDBTable.resource_type,
+}
 
 UNSUPPORTED_CONNECTOR_PROFILE_TYPE = "UNSUPPORTED_CONNECTOR_PROFILE_TYPE"
 
@@ -90,14 +106,8 @@ def _is_valid_resource_reference(obj: Dict[str, Any]) -> bool:
 
 
 def get_underlying_cfn_resource_type(resource_type: str) -> str:
-    sam_to_cfn_types = {
-        "AWS::Serverless::Function": "AWS::Lambda::Function",
-        "AWS::Serverless::StateMachine": "AWS::StepFunctions::StateMachine",
-        "AWS::Serverless::Api": "AWS::ApiGateway::RestApi",
-        "AWS::Serverless::SimpleTable": "AWS::DynamoDB::Table",
-        "AWS::Serverless::HttpApi": "AWS::ApiGatewayV2::Api",
-    }
-    return sam_to_cfn_types.get(resource_type, resource_type)
+    """profiles.json only support CFN resource type. We need to convert SAM resource types to corresponding CFN resource type"""
+    return SAM_TO_CFN_RESOURCE_TYPE.get(resource_type, resource_type)
 
 
 def get_resource_reference(
@@ -113,7 +123,6 @@ def get_resource_reference(
     # If Id is not provided, all values must come from overrides.
     if not logical_id:
         resource_type = obj.get("Type")
-
         if not _is_nonblank_str(resource_type):
             raise ConnectorResourceError("'Type' is missing or not a string.")
         resource_type = get_underlying_cfn_resource_type(str(resource_type))

--- a/tests/translator/input/connector_with_non_id_source_and_destination.yaml
+++ b/tests/translator/input/connector_with_non_id_source_and_destination.yaml
@@ -1,0 +1,110 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  MyRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action: sts:AssumeRole
+          Principal:
+            Service: lambda.amazonaws.com
+      ManagedPolicyArns:
+      - arn:{AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  SamFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: nodejs14.x
+      Handler: index.handler
+      Role: !GetAtt MyRole.Arn
+      InlineCode: |
+        const AWS = require('aws-sdk');
+        exports.handler = async (event) => {
+          console.log(JSON.stringify(event));
+        };
+
+  SamTable:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: NoteId
+        Type: String
+
+  SamStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      # Express state machine support sync execution
+      # which allows us to get the error message quickly in trigger function.
+      Type: EXPRESS
+      Role: !GetAtt MyRole.Arn
+      Definition:
+        StartAt: MyLambdaState
+        States:
+          MyLambdaState:
+            Type: Task
+            Resource: !GetAtt StateMachineFunction.Arn
+            End: true
+
+  SamApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      DefinitionUri: s3://sam-demo-bucket/webpage_swagger.json
+      Description: my description
+
+  SamHttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: Prod
+
+  Connector1:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source:
+        Type: AWS::Serverless::Function
+        RoleName: MyRole
+      Destination:
+        Type: AWS::Serverless::SimpleTable
+        Arn: !GetAtt SamTable.Arn
+      Permissions:
+      - Read
+
+  Connector2:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source:
+        Type: AWS::Serverless::Api
+        ResourceId: !Ref SamApi
+        Qualifier: Prod/GET/foobar
+      Destination:
+        Type: AWS::Serverless::Function
+        Arn: !GetAtt SamFunction.Arn
+      Permissions:
+      - Write
+
+  Connector3:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source:
+        Type: AWS::Serverless::StateMachine
+        RoleName: MyRole
+      Destination:
+        Type: AWS::Serverless::Function
+        Arn: !GetAtt SamFunction.Arn
+      Permissions:
+      - Write
+
+  Connector4:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source:
+        Type: AWS::Serverless::HttpApi
+        ResourceId: !Ref SamHttpApi
+        Qualifier: Prod/GET/foobar
+      Destination:
+        Type: AWS::Serverless::Function
+        Arn: !GetAtt SamFunction.Arn
+      Permissions:
+      - Write

--- a/tests/translator/input/connector_with_non_id_source_and_destination.yaml
+++ b/tests/translator/input/connector_with_non_id_source_and_destination.yaml
@@ -44,7 +44,7 @@ Resources:
         States:
           MyLambdaState:
             Type: Task
-            Resource: !GetAtt StateMachineFunction.Arn
+            Resource: !GetAtt SamFunction.Arn
             End: true
 
   SamApi:

--- a/tests/translator/output/aws-cn/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/aws-cn/connector_with_non_id_source_and_destination.json
@@ -306,7 +306,7 @@
         "DefinitionSubstitutions": {
           "definition_substitution_1": {
             "Fn::GetAtt": [
-              "StateMachineFunction",
+              "SamFunction",
               "Arn"
             ]
           }

--- a/tests/translator/output/aws-cn/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/aws-cn/connector_with_non_id_source_and_destination.json
@@ -1,0 +1,349 @@
+{
+  "Resources": {
+    "Connector1Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector1": {
+            "Destination": {
+              "Type": "AWS::DynamoDB::Table"
+            },
+            "Source": {
+              "Type": "AWS::Lambda::Function"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchGetItem",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:PartiQLSelect"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SamTable",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::GetAtt": [
+                          "SamTable",
+                          "Arn"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          "MyRole"
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "Connector2WriteLambdaPermission": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector2": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::ApiGateway::RestApi"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SamFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${SourceResourceId}/${SourceQualifier}",
+            {
+              "SourceQualifier": "Prod/GET/foobar",
+              "SourceResourceId": {
+                "Ref": "SamApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "Connector3Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector3": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::StepFunctions::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "lambda:InvokeAsync",
+                "lambda:InvokeFunction"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SamFunction",
+                    "Arn"
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          "MyRole"
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "Connector4WriteLambdaPermission": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector4": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::ApiGatewayV2::Api"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SamFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${SourceResourceId}/${SourceQualifier}",
+            {
+              "SourceQualifier": "Prod/GET/foobar",
+              "SourceResourceId": {
+                "Ref": "SamHttpApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:{AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SamApi": {
+      "Properties": {
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        },
+        "Description": "my description",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "SamApiDeploymentf117c932f7": {
+      "Properties": {
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "RestApiId": {
+          "Ref": "SamApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "SamApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "SamApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "SamApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "SamFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "const AWS = require('aws-sdk');\nexports.handler = async (event) => {\n  console.log(JSON.stringify(event));\n};\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "SamHttpApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {},
+          "tags": [
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Api"
+    },
+    "SamHttpApiProdStage": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "SamHttpApi"
+        },
+        "AutoDeploy": true,
+        "StageName": "Prod",
+        "Tags": {
+          "httpapi:createdBy": "SAM"
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Stage"
+    },
+    "SamStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"MyLambdaState\",",
+              "    \"States\": {",
+              "        \"MyLambdaState\": {",
+              "            \"End\": true,",
+              "            \"Resource\": \"${definition_substitution_1}\",",
+              "            \"Type\": \"Task\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "DefinitionSubstitutions": {
+          "definition_substitution_1": {
+            "Fn::GetAtt": [
+              "StateMachineFunction",
+              "Arn"
+            ]
+          }
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyRole",
+            "Arn"
+          ]
+        },
+        "StateMachineType": "EXPRESS",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "SamTable": {
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "NoteId",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "NoteId",
+            "KeyType": "HASH"
+          }
+        ]
+      },
+      "Type": "AWS::DynamoDB::Table"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/aws-us-gov/connector_with_non_id_source_and_destination.json
@@ -306,7 +306,7 @@
         "DefinitionSubstitutions": {
           "definition_substitution_1": {
             "Fn::GetAtt": [
-              "StateMachineFunction",
+              "SamFunction",
               "Arn"
             ]
           }

--- a/tests/translator/output/aws-us-gov/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/aws-us-gov/connector_with_non_id_source_and_destination.json
@@ -1,0 +1,349 @@
+{
+  "Resources": {
+    "Connector1Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector1": {
+            "Destination": {
+              "Type": "AWS::DynamoDB::Table"
+            },
+            "Source": {
+              "Type": "AWS::Lambda::Function"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchGetItem",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:PartiQLSelect"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SamTable",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::GetAtt": [
+                          "SamTable",
+                          "Arn"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          "MyRole"
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "Connector2WriteLambdaPermission": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector2": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::ApiGateway::RestApi"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SamFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${SourceResourceId}/${SourceQualifier}",
+            {
+              "SourceQualifier": "Prod/GET/foobar",
+              "SourceResourceId": {
+                "Ref": "SamApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "Connector3Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector3": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::StepFunctions::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "lambda:InvokeAsync",
+                "lambda:InvokeFunction"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SamFunction",
+                    "Arn"
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          "MyRole"
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "Connector4WriteLambdaPermission": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector4": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::ApiGatewayV2::Api"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SamFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${SourceResourceId}/${SourceQualifier}",
+            {
+              "SourceQualifier": "Prod/GET/foobar",
+              "SourceResourceId": {
+                "Ref": "SamHttpApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:{AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SamApi": {
+      "Properties": {
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        },
+        "Description": "my description",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "SamApiDeploymentf117c932f7": {
+      "Properties": {
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "RestApiId": {
+          "Ref": "SamApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "SamApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "SamApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "SamApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "SamFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "const AWS = require('aws-sdk');\nexports.handler = async (event) => {\n  console.log(JSON.stringify(event));\n};\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "SamHttpApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {},
+          "tags": [
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Api"
+    },
+    "SamHttpApiProdStage": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "SamHttpApi"
+        },
+        "AutoDeploy": true,
+        "StageName": "Prod",
+        "Tags": {
+          "httpapi:createdBy": "SAM"
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Stage"
+    },
+    "SamStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"MyLambdaState\",",
+              "    \"States\": {",
+              "        \"MyLambdaState\": {",
+              "            \"End\": true,",
+              "            \"Resource\": \"${definition_substitution_1}\",",
+              "            \"Type\": \"Task\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "DefinitionSubstitutions": {
+          "definition_substitution_1": {
+            "Fn::GetAtt": [
+              "StateMachineFunction",
+              "Arn"
+            ]
+          }
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyRole",
+            "Arn"
+          ]
+        },
+        "StateMachineType": "EXPRESS",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "SamTable": {
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "NoteId",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "NoteId",
+            "KeyType": "HASH"
+          }
+        ]
+      },
+      "Type": "AWS::DynamoDB::Table"
+    }
+  }
+}

--- a/tests/translator/output/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/connector_with_non_id_source_and_destination.json
@@ -1,0 +1,341 @@
+{
+  "Resources": {
+    "Connector1Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector1": {
+            "Destination": {
+              "Type": "AWS::DynamoDB::Table"
+            },
+            "Source": {
+              "Type": "AWS::Lambda::Function"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchGetItem",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:PartiQLSelect"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SamTable",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::GetAtt": [
+                          "SamTable",
+                          "Arn"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          "MyRole"
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "Connector2WriteLambdaPermission": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector2": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::ApiGateway::RestApi"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SamFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${SourceResourceId}/${SourceQualifier}",
+            {
+              "SourceQualifier": "Prod/GET/foobar",
+              "SourceResourceId": {
+                "Ref": "SamApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "Connector3Policy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector3": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::StepFunctions::StateMachine"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "lambda:InvokeAsync",
+                "lambda:InvokeFunction"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "SamFunction",
+                    "Arn"
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          "MyRole"
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "Connector4WriteLambdaPermission": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "Connector4": {
+            "Destination": {
+              "Type": "AWS::Lambda::Function"
+            },
+            "Source": {
+              "Type": "AWS::ApiGatewayV2::Api"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SamFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${SourceResourceId}/${SourceQualifier}",
+            {
+              "SourceQualifier": "Prod/GET/foobar",
+              "SourceResourceId": {
+                "Ref": "SamHttpApi"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:{AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SamApi": {
+      "Properties": {
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        },
+        "Description": "my description"
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "SamApiDeploymentf117c932f7": {
+      "Properties": {
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "RestApiId": {
+          "Ref": "SamApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "SamApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "SamApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "SamApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "SamFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "const AWS = require('aws-sdk');\nexports.handler = async (event) => {\n  console.log(JSON.stringify(event));\n};\n"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "SamHttpApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {},
+          "tags": [
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Api"
+    },
+    "SamHttpApiProdStage": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "SamHttpApi"
+        },
+        "AutoDeploy": true,
+        "StageName": "Prod",
+        "Tags": {
+          "httpapi:createdBy": "SAM"
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Stage"
+    },
+    "SamStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"StartAt\": \"MyLambdaState\",",
+              "    \"States\": {",
+              "        \"MyLambdaState\": {",
+              "            \"End\": true,",
+              "            \"Resource\": \"${definition_substitution_1}\",",
+              "            \"Type\": \"Task\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "DefinitionSubstitutions": {
+          "definition_substitution_1": {
+            "Fn::GetAtt": [
+              "StateMachineFunction",
+              "Arn"
+            ]
+          }
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyRole",
+            "Arn"
+          ]
+        },
+        "StateMachineType": "EXPRESS",
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "SamTable": {
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "NoteId",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "NoteId",
+            "KeyType": "HASH"
+          }
+        ]
+      },
+      "Type": "AWS::DynamoDB::Table"
+    }
+  }
+}

--- a/tests/translator/output/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/connector_with_non_id_source_and_destination.json
@@ -298,7 +298,7 @@
         "DefinitionSubstitutions": {
           "definition_substitution_1": {
             "Fn::GetAtt": [
-              "StateMachineFunction",
+              "SamFunction",
               "Arn"
             ]
           }


### PR DESCRIPTION
### Issue #, if available

### Description of changes
There is a connector bug when using `RoleName` + `Type`.
```
MyReadConnector:
    Type: AWS::Serverless::Connector
    Properties:
      Source:
        Type: AWS::Serverless::Function
        RoleName: MyRole
      Destination:
        Id: MyTable
      Permissions:
      - Read
 ```
Because we didn't input `Id`, it will directly use `Type` and try to find a profile using `AWS::Serverless::Function` to `AWS::DynamoDB::Table`. It will fail because not such profile is found. We should be using `AWS::lambda::Function` instead.

### Description of how you validated changes
Added tests

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
