### PR TITLE
chore: Use TypeGuard to avoid unncessary type casts

### DIFF
--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
 from typing import Any, Dict, Iterable, List, Optional
 
+from typing_extensions import TypeGuard
+
 from samtranslator.model import ResourceResolver
 from samtranslator.model.apigateway import ApiGatewayRestApi
 from samtranslator.model.apigatewayv2 import ApiGatewayV2HttpApi
@@ -45,7 +47,7 @@ class ConnectorResourceError(Exception):
     """
 
 
-def _is_nonblank_str(s: Any) -> bool:
+def _is_nonblank_str(s: Any) -> TypeGuard[str]:
     return s and isinstance(s, str)
 
 
@@ -123,7 +125,7 @@ def get_resource_reference(
 
         # profiles.json only support CFN resource type.
         # We need to convert SAM resource types to corresponding CFN resource type
-        resource_type = _SAM_TO_CFN_RESOURCE_TYPE.get(str(resource_type), str(resource_type))
+        resource_type = _SAM_TO_CFN_RESOURCE_TYPE.get(resource_type, resource_type)
 
         return ConnectorResourceReference(
             logical_id=None,
@@ -146,8 +148,6 @@ def get_resource_reference(
     resource_type = resource.get("Type")
     if not _is_nonblank_str(resource_type):
         raise ConnectorResourceError("'Type' is missing or not a string.")
-    resource_type = str(resource_type)
-
     properties = resource.get("Properties", {})
 
     arn = _get_resource_arn(logical_id, resource_type)


### PR DESCRIPTION
### Issue #, if available

### Description of changes

This change will get rid of `str()` casting without these errors:

```
samtranslator/model/connector/connector.py:151: error: Argument 2 to "_get_resource_arn" has incompatible type "Optional[Any]"; expected "str"  [arg-type]
samtranslator/model/connector/connector.py:153: error: Argument 3 to "_get_resource_role_name" has incompatible type "Optional[Any]"; expected "str"  [arg-type]
samtranslator/model/connector/connector.py:155: error: Argument 2 to "_get_resource_queue_url" has incompatible type "Optional[Any]"; expected "str"  [arg-type]
samtranslator/model/connector/connector.py:157: error: Argument 2 to "_get_resource_id" has incompatible type "Optional[Any]"; expected "str"  [arg-type]
samtranslator/model/connector/connector.py:159: error: Argument 2 to "_get_resource_name" has incompatible type "Optional[Any]"; expected "str"  [arg-type]
samtranslator/model/connector/connector.py:161: error: Argument 1 to "_get_resource_qualifier" has incompatible type "Optional[Any]"; expected "str"  [arg-type]
Found 6 errors in 1 file (checked 159 source files)
```

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
