### PR TITLE
chore: Upgrade ruff to 0.0.261 and enable Path rules

### DIFF
--- a/bin/json-format.py
+++ b/bin/json-format.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """JSON file formatter (without prettier)."""
-import os
 import sys
+from pathlib import Path
 
-my_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, my_path + "/..")
+# To allow this script to be executed from other directories
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
 import json
 from typing import Type

--- a/bin/transform-test-error-json-format.py
+++ b/bin/transform-test-error-json-format.py
@@ -5,13 +5,13 @@ Transform test error JSON file formatter (without prettier).
 It makes error json easier to review by breaking down "errorMessage"
 into list of strings (delimiter: ". ").
 """
-import os
 import sys
+from pathlib import Path
 
 from typing_extensions import Final
 
-my_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, my_path + "/..")
+# To allow this script to be executed from other directories
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
 import json
 from typing import Type

--- a/bin/yaml-format.py
+++ b/bin/yaml-format.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 """JSON file formatter (without prettier)."""
-import os
 import sys
+from pathlib import Path
 from textwrap import dedent
 
-my_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, my_path + "/..")
+# To allow this script to be executed from other directories
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent))
 
 import re
 from io import StringIO

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ pytest-xdist>=2.5,<4
 pytest-env>=0.6,<1
 pytest-rerunfailures>=9.1,<12
 pyyaml~=6.0
-ruff==0.0.259  # loose the requirement once it is more stable
+ruff==0.0.261  # loose the requirement once it is more stable
 
 # Test requirements
 pytest>=6.2,<8

--- a/ruff.toml
+++ b/ruff.toml
@@ -21,6 +21,7 @@ select = [
     "YTT", # flake8-2020
     "UP", # pyupgrade
     "C4", # flake8-comprehensions
+    "PTH", # flake8-use-pathlib
 ]
 
 # Mininal python version we support is 3.7

--- a/samtranslator/feature_toggle/feature_toggle.py
+++ b/samtranslator/feature_toggle/feature_toggle.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
 import boto3
@@ -119,10 +120,9 @@ class FeatureToggleDefaultConfigProvider(FeatureToggleConfigProvider):
 class FeatureToggleLocalConfigProvider(FeatureToggleConfigProvider):
     """Feature toggle config provider which uses a local file. This is to facilitate local testing."""
 
-    def __init__(self, local_config_path) -> None:  # type: ignore[no-untyped-def]
+    def __init__(self, local_config_path: str) -> None:
         FeatureToggleConfigProvider.__init__(self)
-        with open(local_config_path, encoding="utf-8") as f:
-            config_json = f.read()
+        config_json = Path(local_config_path).read_text(encoding="utf-8")
         self.feature_toggle_config = cast(Dict[str, Any], json.loads(config_json))
 
     @property

--- a/samtranslator/internal/managed_policies.py
+++ b/samtranslator/internal/managed_policies.py
@@ -1,9 +1,8 @@
 import json
-import os
 from pathlib import Path
 from typing import Dict, Optional
 
-with Path(os.path.dirname(os.path.abspath(__file__)), "data", "aws_managed_policies.json").open(encoding="utf-8") as f:
+with (Path(__file__).absolute().parent / "data" / "aws_managed_policies.json").open(encoding="utf-8") as f:
     _BUNDLED_MANAGED_POLICIES: Dict[str, Dict[str, str]] = json.load(f)
 
 

--- a/samtranslator/internal/schema_source/common.py
+++ b/samtranslator/internal/schema_source/common.py
@@ -1,5 +1,4 @@
 import json
-import os
 from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TypeVar, Union
@@ -32,8 +31,8 @@ DictStrAny = Dict[str, Any]
 
 LenientBaseModel = pydantic.BaseModel
 
-_docdir = os.path.dirname(os.path.abspath(__file__))
-_DOCS = json.loads(Path(_docdir, "sam-docs.json").read_bytes())
+_docdir = Path(__file__).absolute().parent
+_DOCS = json.loads((_docdir / "sam-docs.json").read_bytes())
 
 
 def get_prop(stem: str) -> Any:

--- a/samtranslator/model/connector_profiles/profile.py
+++ b/samtranslator/model/connector_profiles/profile.py
@@ -1,12 +1,13 @@
 import copy
 import json
-import os
 import re
+from pathlib import Path
 from typing import Any, Dict
 
 ConnectorProfile = Dict[str, Any]
 
-with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "profiles.json"), encoding="utf-8") as f:
+_PROFILE_FILE = Path(__file__).absolute().parent / "profiles.json"
+with _PROFILE_FILE.open(encoding="utf-8") as f:
     PROFILE: ConnectorProfile = json.load(f)
 
 

--- a/samtranslator/policy_template_processor/processor.py
+++ b/samtranslator/policy_template_processor/processor.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 import jsonschema
@@ -148,11 +149,11 @@ class PolicyTemplatesProcessor:
         return PolicyTemplatesProcessor._read_json(PolicyTemplatesProcessor.SCHEMA_LOCATION)
 
     @staticmethod
-    def _read_json(filepath: str) -> Any:
+    def _read_json(filepath: Path) -> Any:
         """
         Helper method to read a JSON file
         :param filepath: Path to the file
         :return dict: Dictionary containing file data
         """
-        with open(filepath, encoding="utf-8") as fp:
+        with filepath.open(encoding="utf-8") as fp:
             return json.load(fp)

--- a/samtranslator/policy_templates_data/__init__.py
+++ b/samtranslator/policy_templates_data/__init__.py
@@ -1,9 +1,9 @@
-import os
+from pathlib import Path
 
-_thisdir = os.path.dirname(os.path.abspath(__file__))
+_thisdir = Path(__file__).absolute().parent
 
 # ./schema.json
-SCHEMA_FILE = os.path.join(_thisdir, "schema.json")
+SCHEMA_FILE = _thisdir / "schema.json"
 
 # ./policy_templates.json
-POLICY_TEMPLATES_FILE = os.path.join(_thisdir, "policy_templates.json")
+POLICY_TEMPLATES_FILE = _thisdir / "policy_templates.json"

--- a/samtranslator/validator/sam_schema/__init__.py
+++ b/samtranslator/validator/sam_schema/__init__.py
@@ -1,8 +1,8 @@
-import os
+from pathlib import Path
 
-SCHEMA_DIR = os.path.dirname(os.path.abspath(__file__))
+SCHEMA_DIR = Path(__file__).absolute().parent
 
 # ./schema.json
-SCHEMA_FILE = os.path.join(SCHEMA_DIR, "schema.json")
+SCHEMA_FILE = SCHEMA_DIR / "schema.json"
 # ./schema_new.json
-SCHEMA_NEW_FILE = os.path.join(SCHEMA_DIR, "schema_new.json")
+SCHEMA_NEW_FILE = SCHEMA_DIR / "schema_new.json"

--- a/samtranslator/validator/validator.py
+++ b/samtranslator/validator/validator.py
@@ -1,6 +1,8 @@
 import json
 import os
 import re
+from pathlib import Path
+from typing import Any
 
 import jsonschema
 
@@ -28,7 +30,7 @@ class SamTemplateValidator:
             Path to a schema to use for validation, by default None, the default schema.json will be used
         """
         if not schema:
-            schema = self._read_json(sam_schema.SCHEMA_NEW_FILE)  # type: ignore[no-untyped-call]
+            schema = self._read_json(sam_schema.SCHEMA_NEW_FILE)
 
         # Helps resolve the $Ref to external files
         # For cross platform resolving, we have to load the sub schemas into
@@ -36,11 +38,11 @@ class SamTemplateValidator:
         # of referencing inside a "$ref" of a schema as this will lead to mixups
         # on Windows because of different path separator: \\ instead of /
         schema_store = {}
-        definitions_dir = os.path.join(sam_schema.SCHEMA_DIR, "definitions")
+        definitions_dir = sam_schema.SCHEMA_DIR / "definitions"
 
         for sub_schema in os.listdir(definitions_dir):
             if sub_schema.endswith(".json"):
-                with open(os.path.join(definitions_dir, sub_schema), encoding="utf-8") as f:
+                with (definitions_dir / sub_schema).open(encoding="utf-8") as f:
                     schema_content = f.read()
                 schema_store[sub_schema] = json.loads(schema_content)
 
@@ -173,13 +175,13 @@ class SamTemplateValidator:
 
         return final_message
 
-    def _read_json(self, filepath):  # type: ignore[no-untyped-def]
+    def _read_json(self, filepath: Path) -> Any:
         """
         Returns the content of a JSON file
 
         Parameters
         ----------
-        filepath : str
+        filepath : Path
             File path
 
         Returns
@@ -187,7 +189,7 @@ class SamTemplateValidator:
         dict
             Dictionary representing the JSON content
         """
-        with open(filepath, encoding="utf-8") as fp:
+        with filepath.open(encoding="utf-8") as fp:
             return json.load(fp)
 
 

--- a/tests/policy_template_processor/test_processor.py
+++ b/tests/policy_template_processor/test_processor.py
@@ -211,18 +211,17 @@ class TestPolicyTemplateProcessor(TestCase):
 
     @patch.object(json, "loads")
     def test_read_json_must_read_from_file(self, json_loads_mock):
-        filepath = "some file"
+        filepath = Mock()
 
         json_return = "something"
         json_loads_mock.return_value = json_return
 
-        open_mock = mock_open()
-        with patch("samtranslator.policy_template_processor.processor.open", open_mock):
-            result = PolicyTemplatesProcessor._read_json(filepath)
-            self.assertEqual(result, json_return)
+        open_mock = filepath.open = mock_open()
+        result = PolicyTemplatesProcessor._read_json(filepath)
+        self.assertEqual(result, json_return)
 
-            open_mock.assert_called_once_with(filepath, encoding="utf-8")
-            self.assertEqual(1, json_loads_mock.call_count)
+        open_mock.assert_called_once_with(filepath, encoding="utf-8")
+        self.assertEqual(1, json_loads_mock.call_count)
 
     @patch.object(PolicyTemplatesProcessor, "_read_json")
     def test_read_schema_must_use_default_schema_location(self, _read_file_mock):


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
