### PR TITLE
chore: Enable DynamoDB on demand mode

### DIFF
--- a/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
+++ b/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
@@ -93,10 +93,7 @@ Resources:
       # Enable DDB streams
       StreamSpecification:
         StreamViewType: KEYS_ONLY
-
-      ProvisionedThroughput:
-        WriteCapacityUnits: 5
-        ReadCapacityUnits: 5
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
       - AttributeName: id
         AttributeType: S

--- a/integration/resources/templates/combination/function_with_all_event_types.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types.yaml
@@ -135,9 +135,7 @@ Resources:
       KeySchema:
       - AttributeName: id
         KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
+      BillingMode: PAY_PER_REQUEST
       StreamSpecification:
         StreamViewType: NEW_IMAGE
 Metadata:

--- a/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
@@ -124,9 +124,7 @@ Resources:
       KeySchema:
       - AttributeName: id
         KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
+      BillingMode: PAY_PER_REQUEST
       StreamSpecification:
         StreamViewType: NEW_IMAGE
 Metadata:

--- a/integration/resources/templates/combination/function_with_dynamodb.yaml
+++ b/integration/resources/templates/combination/function_with_dynamodb.yaml
@@ -24,17 +24,12 @@ Resources:
   MyTable:
     Type: AWS::DynamoDB::Table
     Properties:
-
       AttributeDefinitions:
       - {AttributeName: id, AttributeType: S}
-
       KeySchema:
       - {AttributeName: id, KeyType: HASH}
-
-      ProvisionedThroughput:
-        ReadCapacityUnits: '5'
-        WriteCapacityUnits: '5'
-
+      # Eanble on-demand capacity mode
+      BillingMode: PAY_PER_REQUEST
       StreamSpecification:
         StreamViewType: NEW_IMAGE
 


### PR DESCRIPTION
### Issue #, if available

### Description of changes
We had policy engine risks about not enabling on-demand or auto-scaling mode on dynamodb tables. Enable them in integ tests.

### Description of how you validated changes
Integ tests passed locally.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
