### PR TITLE
Enable termination protection for companion stacks

### DIFF
--- a/integration/helpers/deployer/exceptions/exceptions.py
+++ b/integration/helpers/deployer/exceptions/exceptions.py
@@ -38,6 +38,16 @@ class DeployFailedError(UserException):
         super().__init__(message=message_fmt.format(stack_name=self.stack_name, msg=msg))
 
 
+class TerminationProtectionUpdateFailedError(UserException):
+    def __init__(self, stack_name, msg):
+        self.stack_name = stack_name
+        self.msg = msg
+
+        message_fmt = "Failed to update termination protection of the stack: {stack_name}, {msg}"
+
+        super().__init__(message=message_fmt.format(stack_name=self.stack_name, msg=msg))
+
+
 class DeployStackOutPutFailedError(UserException):
     def __init__(self, stack_name, msg):
         self.stack_name = stack_name

--- a/integration/helpers/stack.py
+++ b/integration/helpers/stack.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import botocore
 
 from integration.helpers.deployer.deployer import Deployer
-from integration.helpers.deployer.exceptions.exceptions import ThrottlingError
+from integration.helpers.deployer.exceptions.exceptions import ThrottlingError, TerminationProtectionUpdateFailedError
 from integration.helpers.deployer.utils.retry import retry_with_exponential_backoff_and_jitter
 from integration.helpers.resource import generate_suffix
 from integration.helpers.template import transform_template
@@ -54,6 +54,7 @@ class Stack:
                 self.deployer.wait_for_execute(self.stack_name, "UPDATE" if update else "CREATE")
 
         self._get_stack_description()
+        self._udpate_termination_protection()
         self.stack_resources = self.cfn_client.list_stack_resources(StackName=self.stack_name)
 
     @retry_with_exponential_backoff_and_jitter(ThrottlingError, 5, 360)
@@ -64,6 +65,12 @@ class Stack:
             if "Throttling" in str(ex):
                 raise ThrottlingError(stack_name=self.stack_name, msg=str(ex))
             raise
+
+    def _udpate_termination_protection(self, enable=True):
+        try:
+            self.cfn_client.update_termination_protection(EnableTerminationProtection=enable, StackName=self.stack_name)
+        except botocore.exceptions.ClientError as ex:
+            raise TerminationProtectionUpdateFailedError(stack_name=self.stack_name, msg=str(ex))
 
     @staticmethod
     def _generate_output_file_path(file_path, output_dir):


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Enable termination protection on companion stacks

### Description of how you validated changes
Integ tests passed
Verified that new companion stacks had termination protection on.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
