### PR TITLE
fix: Change DataSource Shape

### DIFF
--- a/integration/resources/expected/combination/graphqlapi_pipeline_resolver.json
+++ b/integration/resources/expected/combination/graphqlapi_pipeline_resolver.json
@@ -24,27 +24,27 @@
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "SuperCoolAPIDynamoDBDataSourcePostsDataSource",
+    "LogicalResourceId": "SuperCoolAPIDataSourceDynamoDbPostsDataSource",
     "ResourceType": "AWS::AppSync::DataSource"
   },
   {
-    "LogicalResourceId": "SuperCoolAPIDynamoDBDataSourcePostsDataSourceRole",
+    "LogicalResourceId": "SuperCoolAPIDataSourceDynamoDbPostsDataSourceRole",
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "SuperCoolAPIDynamoDBDataSourcePostsDataSourceToTableConnectorPolicy",
+    "LogicalResourceId": "SuperCoolAPIDataSourceDynamoDbPostsDataSourceToTableConnectorPolicy",
     "ResourceType": "AWS::IAM::ManagedPolicy"
   },
   {
-    "LogicalResourceId": "SuperCoolAPIDynamoDBDataSourcePostsLogDataSource",
+    "LogicalResourceId": "SuperCoolAPIDataSourceDynamoDbPostsLogDataSource",
     "ResourceType": "AWS::AppSync::DataSource"
   },
   {
-    "LogicalResourceId": "SuperCoolAPIDynamoDBDataSourcePostsLogDataSourceRole",
+    "LogicalResourceId": "SuperCoolAPIDataSourceDynamoDbPostsLogDataSourceRole",
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "SuperCoolAPIDynamoDBDataSourcePostsLogDataSourceToTableConnectorPolicy",
+    "LogicalResourceId": "SuperCoolAPIDataSourceDynamoDbPostsLogDataSourceToTableConnectorPolicy",
     "ResourceType": "AWS::IAM::ManagedPolicy"
   },
   {

--- a/integration/resources/templates/combination/graphqlapi_pipeline_resolver.yaml
+++ b/integration/resources/templates/combination/graphqlapi_pipeline_resolver.yaml
@@ -86,13 +86,14 @@ Resources:
         }
       Auth:
         Type: API_KEY
-      DynamoDBDataSources:
-        PostsDataSource:
-          TableName: !Ref DynamoDBPostsTable
-          TableArn: !GetAtt DynamoDBPostsTable.Arn
-        PostsLogDataSource:
-          TableName: !Ref DynamoDBPostsLogTable
-          TableArn: !GetAtt DynamoDBPostsLogTable.Arn
+      DataSources:
+        DynamoDB:
+          PostsDataSource:
+            TableName: !Ref DynamoDBPostsTable
+            TableArn: !GetAtt DynamoDBPostsTable.Arn
+          PostsLogDataSource:
+            TableName: !Ref DynamoDBPostsLogTable
+            TableArn: !GetAtt DynamoDBPostsLogTable.Arn
       Functions:
         createPostItem:
           Runtime:

--- a/integration/resources/templates/combination/graphqlapi_pipeline_resolver.yaml
+++ b/integration/resources/templates/combination/graphqlapi_pipeline_resolver.yaml
@@ -87,7 +87,7 @@ Resources:
       Auth:
         Type: API_KEY
       DataSources:
-        DynamoDB:
+        DynamoDb:
           PostsDataSource:
             TableName: !Ref DynamoDBPostsTable
             TableArn: !GetAtt DynamoDBPostsTable.Arn

--- a/samtranslator/internal/schema_source/aws_serverless_graphqlapi.py
+++ b/samtranslator/internal/schema_source/aws_serverless_graphqlapi.py
@@ -43,6 +43,10 @@ class DynamoDBDataSource(BaseModel):
     Versioned: Optional[PassThroughProp]
 
 
+class DataSources(BaseModel):
+    DynamoDB: Optional[Dict[str, DynamoDBDataSource]]
+
+
 class Runtime(BaseModel):
     Name: PassThroughProp
     Version: PassThroughProp
@@ -103,7 +107,7 @@ class Properties(BaseModel):
     SchemaInline: Optional[PassThroughProp]
     SchemaUri: Optional[PassThroughProp]
     Logging: Optional[Union[Logging, bool]]
-    DynamoDBDataSources: Optional[Dict[str, DynamoDBDataSource]]
+    DataSources: Optional[DataSources]
     ResolverCodeSettings: Optional[ResolverCodeSettings]
     Functions: Optional[Dict[str, Function]]
     AppSyncResolvers: Optional[Dict[str, Dict[str, AppSyncResolver]]]

--- a/samtranslator/internal/schema_source/aws_serverless_graphqlapi.py
+++ b/samtranslator/internal/schema_source/aws_serverless_graphqlapi.py
@@ -44,7 +44,7 @@ class DynamoDBDataSource(BaseModel):
 
 
 class DataSources(BaseModel):
-    DynamoDB: Optional[Dict[str, DynamoDBDataSource]]
+    DynamoDb: Optional[Dict[str, DynamoDBDataSource]]
 
 
 class Runtime(BaseModel):

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -2144,7 +2144,7 @@ class SamGraphQLApi(SamResourceMacro):
         "SchemaInline": Property(False, IS_STR),
         "SchemaUri": Property(False, IS_STR),
         "Logging": Property(False, one_of(IS_DICT, IS_BOOL)),
-        "DynamoDBDataSources": Property(False, IS_DICT),
+        "DataSources": Property(False, IS_DICT),
         "ResolverCodeSettings": Property(False, IS_DICT),
         "Functions": Property(False, IS_DICT),
         "AppSyncResolvers": Property(False, IS_DICT),
@@ -2157,7 +2157,7 @@ class SamGraphQLApi(SamResourceMacro):
     SchemaInline: Optional[str]
     SchemaUri: Optional[str]
     Logging: Optional[Union[Dict[str, Any], bool]]
-    DynamoDBDataSources: Optional[Dict[str, Dict[str, Any]]]
+    DataSources: Optional[Dict[str, Dict[str, Dict[str, Any]]]]
     ResolverCodeSettings: Optional[Dict[str, Any]]
     Functions: Optional[Dict[str, Dict[str, Any]]]
     AppSyncResolvers: Optional[Dict[str, Dict[str, Dict[str, Any]]]]
@@ -2190,9 +2190,9 @@ class SamGraphQLApi(SamResourceMacro):
         if cloudwatch_role:
             resources.append(cloudwatch_role)
 
-        if model.DynamoDBDataSources:
-            ddb_datasource_resources = self._construct_ddb_datasources(model.DynamoDBDataSources, api_id, kwargs)
-            resources.extend(ddb_datasource_resources)
+        if model.DataSources:
+            datasource_resources = self._construct_datasource_resources(model.DataSources, api_id, kwargs)
+            resources.extend(datasource_resources)
 
         if model.ResolverCodeSettings:
             self._set_resolver_code_settings(model.ResolverCodeSettings)
@@ -2307,12 +2307,24 @@ class SamGraphQLApi(SamResourceMacro):
 
         return schema
 
-    def _construct_ddb_datasources(
+    def _construct_datasource_resources(
         self,
-        ddb_datasources: Dict[str, aws_serverless_graphqlapi.DynamoDBDataSource],
+        datasources: aws_serverless_graphqlapi.DataSources,
         api_id: Intrinsicable[str],
         kwargs: Dict[str, Any],
     ) -> List[Resource]:
+        ddb_datasources = self._construct_ddb_datasources(datasources.DynamoDB, api_id, kwargs)
+        return [*ddb_datasources]
+
+    def _construct_ddb_datasources(
+        self,
+        ddb_datasources: Optional[Dict[str, aws_serverless_graphqlapi.DynamoDBDataSource]],
+        api_id: Intrinsicable[str],
+        kwargs: Dict[str, Any],
+    ) -> List[Resource]:
+        if not ddb_datasources:
+            return []
+
         resources: List[Resource] = []
 
         for relative_id, ddb_datasource in ddb_datasources.items():

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -2313,7 +2313,7 @@ class SamGraphQLApi(SamResourceMacro):
         api_id: Intrinsicable[str],
         kwargs: Dict[str, Any],
     ) -> List[Resource]:
-        ddb_datasources = self._construct_ddb_datasources(datasources.DynamoDB, api_id, kwargs)
+        ddb_datasources = self._construct_ddb_datasources(datasources.DynamoDb, api_id, kwargs)
         return [*ddb_datasources]
 
     def _construct_ddb_datasources(

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -2328,7 +2328,7 @@ class SamGraphQLApi(SamResourceMacro):
         resources: List[Resource] = []
 
         for relative_id, ddb_datasource in ddb_datasources.items():
-            datasource_logical_id = f"{self.logical_id}DynamoDBDataSource{relative_id}"
+            datasource_logical_id = f"{self.logical_id}DataSourceDynamoDb{relative_id}"
             cfn_datasource = DataSource(
                 logical_id=datasource_logical_id, depends_on=self.depends_on, attributes=self.resource_attributes
             )
@@ -2368,7 +2368,7 @@ class SamGraphQLApi(SamResourceMacro):
         # If the user doesn't have their own role, then we will create for them if TableArn is defined.
         table_arn = passthrough_value(
             sam_expect(
-                ddb_datasource.TableArn, relative_id, f"DynamoDBDataSources.{relative_id}.TableArn"
+                ddb_datasource.TableArn, relative_id, f"DataSources.DynamoDb.{relative_id}.TableArn"
             ).to_not_be_none(
                 "'TableArn' must be defined to create the role and policy if 'ServiceRoleArn' is not defined."
             )

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -501,7 +501,7 @@
     "DataSources": {
       "additionalProperties": false,
       "properties": {
-        "DynamoDB": {
+        "DynamoDb": {
           "additionalProperties": {
             "$ref": "#/definitions/DynamoDBDataSource"
           },

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -498,6 +498,20 @@
       "title": "Cors",
       "type": "object"
     },
+    "DataSources": {
+      "additionalProperties": false,
+      "properties": {
+        "DynamoDB": {
+          "additionalProperties": {
+            "$ref": "#/definitions/DynamoDBDataSource"
+          },
+          "title": "Dynamodb",
+          "type": "object"
+        }
+      },
+      "title": "DataSources",
+      "type": "object"
+    },
     "DeadLetterQueue": {
       "additionalProperties": false,
       "properties": {
@@ -6178,12 +6192,8 @@
         "Auth": {
           "$ref": "#/definitions/samtranslator__internal__schema_source__aws_serverless_graphqlapi__Auth"
         },
-        "DynamoDBDataSources": {
-          "additionalProperties": {
-            "$ref": "#/definitions/DynamoDBDataSource"
-          },
-          "title": "Dynamodbdatasources",
-          "type": "object"
+        "DataSources": {
+          "$ref": "#/definitions/DataSources"
         },
         "Functions": {
           "additionalProperties": {

--- a/tests/translator/input/error_graphqlapi.yaml
+++ b/tests/translator/input/error_graphqlapi.yaml
@@ -80,7 +80,7 @@ Resources:
         key1: value1
         key2: value2
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             TableName: some-table
 
@@ -95,7 +95,7 @@ Resources:
       Auth:
         Type: AWS_IAM
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             TableName: some-table
             TableArn: big-arn
@@ -115,7 +115,7 @@ Resources:
       Auth:
         Type: AWS_IAM
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             TableName: some-table
             TableArn: big-arn
@@ -139,7 +139,7 @@ Resources:
       Auth:
         Type: AWS_IAM
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             TableName: some-table
             TableArn: big-arn
@@ -174,7 +174,7 @@ Resources:
       Auth:
         Type: AWS_IAM
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             TableName: some-table
             TableArn: big-arn
@@ -193,7 +193,7 @@ Resources:
       Auth:
         Type: AWS_IAM
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             TableName: some-table
             TableArn: big-arn

--- a/tests/translator/input/error_graphqlapi.yaml
+++ b/tests/translator/input/error_graphqlapi.yaml
@@ -79,9 +79,10 @@ Resources:
       Tags:
         key1: value1
         key2: value2
-      DynamoDBDataSources:
-        MyDataSource:
-          TableName: some-table
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            TableName: some-table
 
   IdDefinedWithOtherProperties:
     Type: AWS::Serverless::GraphQLApi
@@ -93,10 +94,11 @@ Resources:
         }
       Auth:
         Type: AWS_IAM
-      DynamoDBDataSources:
-        MyDataSource:
-          TableName: some-table
-          TableArn: big-arn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            TableName: some-table
+            TableArn: big-arn
       Functions:
         IdNotMutuallyExclusive:
           Id: some-id
@@ -112,10 +114,11 @@ Resources:
         }
       Auth:
         Type: AWS_IAM
-      DynamoDBDataSources:
-        MyDataSource:
-          TableName: some-table
-          TableArn: big-arn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            TableName: some-table
+            TableArn: big-arn
       Functions:
         BothCodeProperties:
           DataSource: MyDataSource
@@ -135,10 +138,11 @@ Resources:
         }
       Auth:
         Type: AWS_IAM
-      DynamoDBDataSources:
-        MyDataSource:
-          TableName: some-table
-          TableArn: big-arn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            TableName: some-table
+            TableArn: big-arn
       Functions:
         BothCodeProperties:
           DataSource: MyDataSource
@@ -169,10 +173,11 @@ Resources:
         }
       Auth:
         Type: AWS_IAM
-      DynamoDBDataSources:
-        MyDataSource:
-          TableName: some-table
-          TableArn: big-arn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            TableName: some-table
+            TableArn: big-arn
       Functions:
         BothCodeProperties:
           DataSource: MyDataSource
@@ -187,10 +192,11 @@ Resources:
         }
       Auth:
         Type: AWS_IAM
-      DynamoDBDataSources:
-        MyDataSource:
-          TableName: some-table
-          TableArn: big-arn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            TableName: some-table
+            TableArn: big-arn
       Functions:
         NoRuntime:
           DataSource: MyDataSource

--- a/tests/translator/input/graphqlapi_ddb_datasource_all_properties.yaml
+++ b/tests/translator/input/graphqlapi_ddb_datasource_all_properties.yaml
@@ -15,7 +15,7 @@ Resources:
         key1: value1
         key2: value2
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             TableName: some-table
             ServiceRoleArn: some-arn

--- a/tests/translator/input/graphqlapi_ddb_datasource_all_properties.yaml
+++ b/tests/translator/input/graphqlapi_ddb_datasource_all_properties.yaml
@@ -14,16 +14,17 @@ Resources:
       Tags:
         key1: value1
         key2: value2
-      DynamoDBDataSources:
-        MyDataSource:
-          TableName: some-table
-          ServiceRoleArn: some-arn
-          Name: AwesomeDataSourceName
-          Description: This data source is special to me
-          Region: na-west-2
-          UseCallerCredentials: true
-          Versioned: true
-          DeltaSync:
-            BaseTableTTL: '60'
-            DeltaSyncTableName: '60'
-            DeltaSyncTableTTL: '60'
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            TableName: some-table
+            ServiceRoleArn: some-arn
+            Name: AwesomeDataSourceName
+            Description: This data source is special to me
+            Region: na-west-2
+            UseCallerCredentials: true
+            Versioned: true
+            DeltaSync:
+              BaseTableTTL: '60'
+              DeltaSyncTableName: '60'
+              DeltaSyncTableTTL: '60'

--- a/tests/translator/input/graphqlapi_ddb_datasource_connector.yaml
+++ b/tests/translator/input/graphqlapi_ddb_datasource_connector.yaml
@@ -15,7 +15,7 @@ Resources:
         key1: value1
         key2: value2
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             TableName: some-table
             TableArn: big-arn

--- a/tests/translator/input/graphqlapi_ddb_datasource_connector.yaml
+++ b/tests/translator/input/graphqlapi_ddb_datasource_connector.yaml
@@ -14,10 +14,11 @@ Resources:
       Tags:
         key1: value1
         key2: value2
-      DynamoDBDataSources:
-        MyDataSource:
-          TableName: some-table
-          TableArn: big-arn
-        AnotherDataSource:
-          TableName: cool-table
-          TableArn: table-arn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            TableName: some-table
+            TableArn: big-arn
+          AnotherDataSource:
+            TableName: cool-table
+            TableArn: table-arn

--- a/tests/translator/input/graphqlapi_function_datasource_property.yaml
+++ b/tests/translator/input/graphqlapi_function_datasource_property.yaml
@@ -11,7 +11,7 @@ Resources:
       Auth:
         Type: AWS_IAM
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             Name: MyDataSource
             TableName: SomeTable

--- a/tests/translator/input/graphqlapi_function_datasource_property.yaml
+++ b/tests/translator/input/graphqlapi_function_datasource_property.yaml
@@ -10,11 +10,12 @@ Resources:
         }
       Auth:
         Type: AWS_IAM
-      DynamoDBDataSources:
-        MyDataSource:
-          Name: MyDataSource
-          TableName: SomeTable
-          ServiceRoleArn: SomeRoleArn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            Name: MyDataSource
+            TableName: SomeTable
+            ServiceRoleArn: SomeRoleArn
       Functions:
         MyFunction:
           InlineCode: this is my epic code

--- a/tests/translator/input/graphqlapi_function_overwrite_resolver_code_settings.yaml
+++ b/tests/translator/input/graphqlapi_function_overwrite_resolver_code_settings.yaml
@@ -11,7 +11,7 @@ Resources:
       Auth:
         Type: AWS_IAM
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             Name: MyDataSource
             TableName: SomeTable

--- a/tests/translator/input/graphqlapi_function_overwrite_resolver_code_settings.yaml
+++ b/tests/translator/input/graphqlapi_function_overwrite_resolver_code_settings.yaml
@@ -10,11 +10,12 @@ Resources:
         }
       Auth:
         Type: AWS_IAM
-      DynamoDBDataSources:
-        MyDataSource:
-          Name: MyDataSource
-          TableName: SomeTable
-          ServiceRoleArn: SomeRoleArn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            Name: MyDataSource
+            TableName: SomeTable
+            ServiceRoleArn: SomeRoleArn
       ResolverCodeSettings:
         CodeRootPath: path/to/my/code
         Runtime:

--- a/tests/translator/input/graphqlapi_function_use_resolver_code_settings.yaml
+++ b/tests/translator/input/graphqlapi_function_use_resolver_code_settings.yaml
@@ -11,7 +11,7 @@ Resources:
       Auth:
         Type: AWS_IAM
       DataSources:
-        DynamoDB:
+        DynamoDb:
           MyDataSource:
             Name: MyDataSource
             TableName: SomeTable

--- a/tests/translator/input/graphqlapi_function_use_resolver_code_settings.yaml
+++ b/tests/translator/input/graphqlapi_function_use_resolver_code_settings.yaml
@@ -10,11 +10,12 @@ Resources:
         }
       Auth:
         Type: AWS_IAM
-      DynamoDBDataSources:
-        MyDataSource:
-          Name: MyDataSource
-          TableName: SomeTable
-          ServiceRoleArn: SomeRoleArn
+      DataSources:
+        DynamoDB:
+          MyDataSource:
+            Name: MyDataSource
+            TableName: SomeTable
+            ServiceRoleArn: SomeRoleArn
       ResolverCodeSettings:
         CodeRootPath: path/to/my/code
         Runtime:

--- a/tests/translator/output/aws-cn/graphqlapi_ddb_datasource_all_properties.json
+++ b/tests/translator/output/aws-cn/graphqlapi_ddb_datasource_all_properties.json
@@ -53,7 +53,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [

--- a/tests/translator/output/aws-cn/graphqlapi_ddb_datasource_connector.json
+++ b/tests/translator/output/aws-cn/graphqlapi_ddb_datasource_connector.json
@@ -53,7 +53,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -70,7 +70,7 @@
         "Name": "AnotherDataSource",
         "ServiceRoleArn": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole",
+            "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole",
             "Arn"
           ]
         },
@@ -78,7 +78,7 @@
       },
       "Type": "AWS::AppSync::DataSource"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -99,10 +99,10 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceToTableConnectorPolicy": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceToTableConnectorPolicy": {
       "Metadata": {
         "aws:sam:connectors": {
-          "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceToTableConnector": {
+          "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceToTableConnector": {
             "Destination": {
               "Type": "AWS::DynamoDB::Table"
             },
@@ -165,13 +165,13 @@
         },
         "Roles": [
           {
-            "Ref": "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole"
+            "Ref": "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole"
           }
         ]
       },
       "Type": "AWS::IAM::ManagedPolicy"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -188,7 +188,7 @@
         "Name": "MyDataSource",
         "ServiceRoleArn": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole",
             "Arn"
           ]
         },
@@ -196,7 +196,7 @@
       },
       "Type": "AWS::AppSync::DataSource"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -217,10 +217,10 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSourceToTableConnectorPolicy": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSourceToTableConnectorPolicy": {
       "Metadata": {
         "aws:sam:connectors": {
-          "SuperCoolAPIDynamoDBDataSourceMyDataSourceToTableConnector": {
+          "SuperCoolAPIDataSourceDynamoDbMyDataSourceToTableConnector": {
             "Destination": {
               "Type": "AWS::DynamoDB::Table"
             },
@@ -283,7 +283,7 @@
         },
         "Roles": [
           {
-            "Ref": "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole"
+            "Ref": "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole"
           }
         ]
       },

--- a/tests/translator/output/aws-cn/graphqlapi_function_datasource_property.json
+++ b/tests/translator/output/aws-cn/graphqlapi_function_datasource_property.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "Code": "this is my epic code",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },

--- a/tests/translator/output/aws-cn/graphqlapi_function_overwrite_resolver_code_settings.json
+++ b/tests/translator/output/aws-cn/graphqlapi_function_overwrite_resolver_code_settings.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "CodeS3Location": "not-code-settings-uri",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },

--- a/tests/translator/output/aws-cn/graphqlapi_function_use_resolver_code_settings.json
+++ b/tests/translator/output/aws-cn/graphqlapi_function_use_resolver_code_settings.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "CodeS3Location": "path/to/my/code/functions/MyFunction.js",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },

--- a/tests/translator/output/aws-us-gov/graphqlapi_ddb_datasource_all_properties.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_ddb_datasource_all_properties.json
@@ -53,7 +53,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [

--- a/tests/translator/output/aws-us-gov/graphqlapi_ddb_datasource_connector.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_ddb_datasource_connector.json
@@ -53,7 +53,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -70,7 +70,7 @@
         "Name": "AnotherDataSource",
         "ServiceRoleArn": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole",
+            "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole",
             "Arn"
           ]
         },
@@ -78,7 +78,7 @@
       },
       "Type": "AWS::AppSync::DataSource"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -99,10 +99,10 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceToTableConnectorPolicy": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceToTableConnectorPolicy": {
       "Metadata": {
         "aws:sam:connectors": {
-          "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceToTableConnector": {
+          "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceToTableConnector": {
             "Destination": {
               "Type": "AWS::DynamoDB::Table"
             },
@@ -165,13 +165,13 @@
         },
         "Roles": [
           {
-            "Ref": "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole"
+            "Ref": "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole"
           }
         ]
       },
       "Type": "AWS::IAM::ManagedPolicy"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -188,7 +188,7 @@
         "Name": "MyDataSource",
         "ServiceRoleArn": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole",
             "Arn"
           ]
         },
@@ -196,7 +196,7 @@
       },
       "Type": "AWS::AppSync::DataSource"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -217,10 +217,10 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSourceToTableConnectorPolicy": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSourceToTableConnectorPolicy": {
       "Metadata": {
         "aws:sam:connectors": {
-          "SuperCoolAPIDynamoDBDataSourceMyDataSourceToTableConnector": {
+          "SuperCoolAPIDataSourceDynamoDbMyDataSourceToTableConnector": {
             "Destination": {
               "Type": "AWS::DynamoDB::Table"
             },
@@ -283,7 +283,7 @@
         },
         "Roles": [
           {
-            "Ref": "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole"
+            "Ref": "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole"
           }
         ]
       },

--- a/tests/translator/output/aws-us-gov/graphqlapi_function_datasource_property.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_function_datasource_property.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "Code": "this is my epic code",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },

--- a/tests/translator/output/aws-us-gov/graphqlapi_function_overwrite_resolver_code_settings.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_function_overwrite_resolver_code_settings.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "CodeS3Location": "not-code-settings-uri",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },

--- a/tests/translator/output/aws-us-gov/graphqlapi_function_use_resolver_code_settings.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_function_use_resolver_code_settings.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "CodeS3Location": "path/to/my/code/functions/MyFunction.js",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },

--- a/tests/translator/output/graphqlapi_ddb_datasource_all_properties.json
+++ b/tests/translator/output/graphqlapi_ddb_datasource_all_properties.json
@@ -53,7 +53,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [

--- a/tests/translator/output/graphqlapi_ddb_datasource_connector.json
+++ b/tests/translator/output/graphqlapi_ddb_datasource_connector.json
@@ -53,7 +53,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -70,7 +70,7 @@
         "Name": "AnotherDataSource",
         "ServiceRoleArn": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole",
+            "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole",
             "Arn"
           ]
         },
@@ -78,7 +78,7 @@
       },
       "Type": "AWS::AppSync::DataSource"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -99,10 +99,10 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceToTableConnectorPolicy": {
+    "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceToTableConnectorPolicy": {
       "Metadata": {
         "aws:sam:connectors": {
-          "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceToTableConnector": {
+          "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceToTableConnector": {
             "Destination": {
               "Type": "AWS::DynamoDB::Table"
             },
@@ -165,13 +165,13 @@
         },
         "Roles": [
           {
-            "Ref": "SuperCoolAPIDynamoDBDataSourceAnotherDataSourceRole"
+            "Ref": "SuperCoolAPIDataSourceDynamoDbAnotherDataSourceRole"
           }
         ]
       },
       "Type": "AWS::IAM::ManagedPolicy"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -188,7 +188,7 @@
         "Name": "MyDataSource",
         "ServiceRoleArn": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole",
             "Arn"
           ]
         },
@@ -196,7 +196,7 @@
       },
       "Type": "AWS::AppSync::DataSource"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -217,10 +217,10 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSourceToTableConnectorPolicy": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSourceToTableConnectorPolicy": {
       "Metadata": {
         "aws:sam:connectors": {
-          "SuperCoolAPIDynamoDBDataSourceMyDataSourceToTableConnector": {
+          "SuperCoolAPIDataSourceDynamoDbMyDataSourceToTableConnector": {
             "Destination": {
               "Type": "AWS::DynamoDB::Table"
             },
@@ -283,7 +283,7 @@
         },
         "Roles": [
           {
-            "Ref": "SuperCoolAPIDynamoDBDataSourceMyDataSourceRole"
+            "Ref": "SuperCoolAPIDataSourceDynamoDbMyDataSourceRole"
           }
         ]
       },

--- a/tests/translator/output/graphqlapi_function_datasource_property.json
+++ b/tests/translator/output/graphqlapi_function_datasource_property.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "Code": "this is my epic code",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },

--- a/tests/translator/output/graphqlapi_function_overwrite_resolver_code_settings.json
+++ b/tests/translator/output/graphqlapi_function_overwrite_resolver_code_settings.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "CodeS3Location": "not-code-settings-uri",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },

--- a/tests/translator/output/graphqlapi_function_use_resolver_code_settings.json
+++ b/tests/translator/output/graphqlapi_function_use_resolver_code_settings.json
@@ -42,7 +42,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "SuperCoolAPIDynamoDBDataSourceMyDataSource": {
+    "SuperCoolAPIDataSourceDynamoDbMyDataSource": {
       "Properties": {
         "ApiId": {
           "Fn::GetAtt": [
@@ -73,7 +73,7 @@
         "CodeS3Location": "path/to/my/code/functions/MyFunction.js",
         "DataSourceName": {
           "Fn::GetAtt": [
-            "SuperCoolAPIDynamoDBDataSourceMyDataSource",
+            "SuperCoolAPIDataSourceDynamoDbMyDataSource",
             "Name"
           ]
         },


### PR DESCRIPTION
### Description of changes
Modified how users define DataSources in `Serverless::GraphQLApi`. Now, all DataSources will be held under one parent property, `DataSources`, with specifier properties underneath for the specific ones (currently only `DynamoDb` is supported).

### Description of how you validated changes
Modified transform tests and integration tests with new shape. Passes `make pr`.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [x] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
