### PR TITLE
chore: Add sar_client_creator to ServerlessAppPlugin constructor

### DIFF
--- a/tests/plugins/application/test_serverless_app_plugin.py
+++ b/tests/plugins/application/test_serverless_app_plugin.py
@@ -93,6 +93,28 @@ class TestServerlessAppPlugin_init(TestCase):
         self.assertEqual(self.plugin._parameters, parameters)
 
 
+class TestServerlessAppPlugin_sar_client_creator(TestCase):
+    def setUp(self):
+        self.client_mock = Mock()
+
+        def sar_client_creator():
+            return self.client_mock("serverlessrepo")
+
+        self.sar_client_creator = sar_client_creator
+
+    def test_lazy_load(self):
+        plugin = ServerlessAppPlugin(sar_client_creator=self.sar_client_creator)
+        self.client_mock.assert_not_called()
+
+        self.assertEqual(plugin._sar_client, self.client_mock("serverlessrepo"))
+
+    def test_not_used_when_sar_client_provided(self):
+        sar_client = Mock()
+        plugin = ServerlessAppPlugin(sar_client_creator=self.sar_client_creator, sar_client=sar_client)
+        self.assertEqual(plugin._sar_client, sar_client)
+        self.client_mock.assert_not_called()
+
+
 class TestServerlessAppPlugin_on_before_transform_template_translate(TestCase):
     def setUp(self):
         client = boto3.client("serverlessrepo", region_name="us-east-1")


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Allow sar_client to be lazy created by passing a creator instead of sar client itself.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
