### PR TITLE
chore: Upgrade ruff to 0.0.263 and enable more rules

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ pytest-xdist>=2.5,<4
 pytest-env>=0.6,<1
 pytest-rerunfailures>=9.1,<12
 pyyaml~=6.0
-ruff==0.0.261  # loose the requirement once it is more stable
+ruff==0.0.263  # loose the requirement once it is more stable
 
 # Test requirements
 pytest>=6.2,<8

--- a/ruff.toml
+++ b/ruff.toml
@@ -22,6 +22,9 @@ select = [
     "UP", # pyupgrade
     "C4", # flake8-comprehensions
     "PTH", # flake8-use-pathlib
+    "G", # flake8-logging-format
+    "INP", # flake8-no-pep420
+    "T20", # flake8-print
 ]
 
 # Mininal python version we support is 3.7
@@ -33,7 +36,16 @@ keep-runtime-typing = true
 
 [per-file-ignores]
 # python scripts in bin/ needs some python path configurations before import
-"bin/*.py" = ["E402"]  # E402: module-import-not-at-top-of-file
+"bin/*.py" = [
+    # E402: module-import-not-at-top-of-file
+    "E402",
+    # S603: `subprocess` call: check for execution of untrusted input
+    # these are dev tools and do not have risks of malicious inputs.
+    "S603",
+    # T201 `print` found
+    # print() is allowed in bin/ as they are dev tools.
+    "T201",
+]
 
 [pylint]
 max-args = 6  # We have many functions reaching 6 args


### PR DESCRIPTION
### Issue #, if available

### Description of changes

as described

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
