### PR TITLE
chore: integration test for Lambda resolver in Serverless::GraphQLApi

### DIFF
--- a/integration/combination/test_graphqlapi_lambda_resolver.py
+++ b/integration/combination/test_graphqlapi_lambda_resolver.py
@@ -32,7 +32,7 @@ def execute_and_verify_appsync_query(url, api_key, query):
 @skipIf(current_region_does_not_support([APP_SYNC]), "AppSync is not supported in this testing region")
 class TestGraphQLApiPipelineResolver(BaseTest):
     def test_api(self):
-        file_name = "combination/graphqlapi_lambda_datasource"
+        file_name = "combination/graphqlapi_lambda_resolver"
         self.create_and_verify_stack(file_name)
 
         outputs = self.get_stack_outputs()

--- a/integration/combination/test_graphqlapi_lambda_resolver.py
+++ b/integration/combination/test_graphqlapi_lambda_resolver.py
@@ -69,7 +69,7 @@ class TestGraphQLApiPipelineResolver(BaseTest):
         self.assertEqual(add_post["title"], title)
         self.assertEqual(add_post["content"], content)
 
-        query = f"""
+        query = """
             query getPost {{
               getPost(id:"1") {{
                 id

--- a/integration/combination/test_graphqlapi_lambda_resolver.py
+++ b/integration/combination/test_graphqlapi_lambda_resolver.py
@@ -1,0 +1,101 @@
+import json
+from unittest.case import skipIf
+
+import requests
+
+from integration.config.service_names import APP_SYNC
+from integration.helpers.base_test import BaseTest
+from integration.helpers.resource import current_region_does_not_support
+
+
+def execute_and_verify_appsync_query(url, api_key, query):
+    """
+    Executes a query to an AppSync GraphQLApi.
+
+    Also checks that the response is 200 and does not contain errors before returning.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+    }
+    payload = {"query": query}
+
+    response = requests.post(url, json=payload, headers=headers)
+    response.raise_for_status()
+    data = response.json()
+    if "errors" in data:
+        raise Exception(json.dumps(data["errors"]))
+
+    return data
+
+
+@skipIf(current_region_does_not_support([APP_SYNC]), "AppSync is not supported in this testing region")
+class TestGraphQLApiPipelineResolver(BaseTest):
+    def test_api(self):
+        file_name = "combination/graphqlapi_lambda_datasource"
+        self.create_and_verify_stack(file_name)
+
+        outputs = self.get_stack_outputs()
+
+        author = "AUTHORNAME"
+        title = "Our first post!"
+        content = "This is our first post."
+
+        query = f"""
+            mutation addPost {{
+              addPost(
+                id: 100
+                author: "{author}"
+                title: "{title}"
+                content: "{content}"
+              ) {{
+                id
+                author
+                title
+                content
+              }}
+            }}
+        """
+
+        url = outputs["SuperCoolAPI"]
+        api_key = outputs["SuperCoolAPIMyApiKey"]
+
+        response = execute_and_verify_appsync_query(url, api_key, query)
+
+        add_post = response["data"]["addPost"]
+
+        self.assertEqual(add_post["id"], "100")
+        self.assertEqual(add_post["author"], author)
+        self.assertEqual(add_post["title"], title)
+        self.assertEqual(add_post["content"], content)
+
+        query = f"""
+            query getPost {{
+              getPost(id:"1") {{
+                id
+                author
+                title
+                content
+                ups
+                downs
+              }}
+            }}
+        """
+
+        response = execute_and_verify_appsync_query(url, api_key, query)
+
+        get_post = response["data"]["getPost"]
+
+        # These values are hardcoded inside the Lambda function for a post with id "1".
+        author = "Author1"
+        title = "First book"
+        content = "Book 1 has this content"
+        ups = 100
+        downs = 10
+
+        self.assertEqual(get_post["id"], "1")
+        self.assertEqual(get_post["author"], author)
+        self.assertEqual(get_post["title"], title)
+        self.assertEqual(get_post["content"], content)
+        self.assertEqual(get_post["ups"], ups)
+        self.assertEqual(get_post["downs"], downs)

--- a/integration/resources/expected/combination/graphqlapi_lambda_resolver.json
+++ b/integration/resources/expected/combination/graphqlapi_lambda_resolver.json
@@ -1,51 +1,50 @@
 [
-    {
-      "LogicalResourceId": "MyLambdaFunction",
-      "ResourceType": "AWS::Lambda::Function"
-    },
-    {
-      "LogicalResourceId": "LambdaFunctionRole",
-      "ResourceType": "AWS::IAM::Role"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPI",
-      "ResourceType": "AWS::AppSync::GraphQLApi"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPISchema",
-      "ResourceType": "AWS::AppSync::GraphQLSchema"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPICloudWatchRole",
-      "ResourceType": "AWS::IAM::Role"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPIMyApiKey",
-      "ResourceType": "AWS::AppSync::ApiKey"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSource",
-      "ResourceType": "AWS::AppSync::DataSource"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSourceRole",
-      "ResourceType": "AWS::IAM::Role"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSourceToLambdaConnectorPolicy",
-      "ResourceType": "AWS::IAM::ManagedPolicy"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPIlambdaInvoker",
-      "ResourceType": "AWS::AppSync::FunctionConfiguration"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPIMutationaddPost",
-      "ResourceType": "AWS::AppSync::Resolver"
-    },
-    {
-      "LogicalResourceId": "SuperCoolAPIQuerygetPost",
-      "ResourceType": "AWS::AppSync::Resolver"
-    }
+  {
+    "LogicalResourceId": "MyLambdaFunction",
+    "ResourceType": "AWS::Lambda::Function"
+  },
+  {
+    "LogicalResourceId": "LambdaFunctionRole",
+    "ResourceType": "AWS::IAM::Role"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPI",
+    "ResourceType": "AWS::AppSync::GraphQLApi"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPISchema",
+    "ResourceType": "AWS::AppSync::GraphQLSchema"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPICloudWatchRole",
+    "ResourceType": "AWS::IAM::Role"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPIMyApiKey",
+    "ResourceType": "AWS::AppSync::ApiKey"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSource",
+    "ResourceType": "AWS::AppSync::DataSource"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSourceRole",
+    "ResourceType": "AWS::IAM::Role"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSourceToLambdaConnectorPolicy",
+    "ResourceType": "AWS::IAM::ManagedPolicy"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPIlambdaInvoker",
+    "ResourceType": "AWS::AppSync::FunctionConfiguration"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPIMutationaddPost",
+    "ResourceType": "AWS::AppSync::Resolver"
+  },
+  {
+    "LogicalResourceId": "SuperCoolAPIQuerygetPost",
+    "ResourceType": "AWS::AppSync::Resolver"
+  }
 ]
-  

--- a/integration/resources/expected/combination/graphqlapi_lambda_resolver.json
+++ b/integration/resources/expected/combination/graphqlapi_lambda_resolver.json
@@ -1,0 +1,51 @@
+[
+    {
+      "LogicalResourceId": "MyLambdaFunction",
+      "ResourceType": "AWS::Lambda::Function"
+    },
+    {
+      "LogicalResourceId": "LambdaFunctionRole",
+      "ResourceType": "AWS::IAM::Role"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPI",
+      "ResourceType": "AWS::AppSync::GraphQLApi"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPISchema",
+      "ResourceType": "AWS::AppSync::GraphQLSchema"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPICloudWatchRole",
+      "ResourceType": "AWS::IAM::Role"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPIMyApiKey",
+      "ResourceType": "AWS::AppSync::ApiKey"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSource",
+      "ResourceType": "AWS::AppSync::DataSource"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSourceRole",
+      "ResourceType": "AWS::IAM::Role"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPILambdaMyLambdaDataSourceToLambdaConnectorPolicy",
+      "ResourceType": "AWS::IAM::ManagedPolicy"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPIlambdaInvoker",
+      "ResourceType": "AWS::AppSync::FunctionConfiguration"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPIMutationaddPost",
+      "ResourceType": "AWS::AppSync::Resolver"
+    },
+    {
+      "LogicalResourceId": "SuperCoolAPIQuerygetPost",
+      "ResourceType": "AWS::AppSync::Resolver"
+    }
+]
+  

--- a/integration/resources/templates/combination/graphqlapi_lambda_resolver.yaml
+++ b/integration/resources/templates/combination/graphqlapi_lambda_resolver.yaml
@@ -41,7 +41,7 @@ Resources:
             - lambda.amazonaws.com
           Action:
           - sts:AssumeRole
-      Path: "/"
+      Path: /
       Policies:
       - PolicyName: AppendToLogsPolicy
         PolicyDocument:
@@ -52,7 +52,7 @@ Resources:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: "*"
+            Resource: '*'
 
   SuperCoolAPI:
     Type: AWS::Serverless::GraphQLApi

--- a/integration/resources/templates/combination/graphqlapi_lambda_resolver.yaml
+++ b/integration/resources/templates/combination/graphqlapi_lambda_resolver.yaml
@@ -1,0 +1,133 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: AwsLambdaMinimalExample
+      Handler: index.handler
+      Runtime: nodejs14.x
+      Role: !GetAtt LambdaFunctionRole.Arn
+      Code:
+        ZipFile: |
+          exports.handler = async (event) => {
+            console.log('Received event {}', JSON.stringify(event, 3))
+
+            const posts = {
+              1: { id: '1', title: 'First book', author: 'Author1', content: 'Book 1 has this content', ups: '100', downs: '10', },
+            }
+
+            console.log('Got an Invoke Request.')
+            let result
+            switch (event.field) {
+              case 'getPost':
+                return posts[event.arguments.id]
+              case 'addPost':
+                // return the arguments back
+                return event.arguments
+              default:
+                throw new Error('Unknown field, unable to resolve ' + event.field)
+            }
+          }
+
+  LambdaFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"
+      Policies:
+      - PolicyName: AppendToLogsPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: "*"
+
+  SuperCoolAPI:
+    Type: AWS::Serverless::GraphQLApi
+    Properties:
+      Name: MyApi
+      SchemaInline: |
+        schema {
+            query: Query
+            mutation: Mutation
+        }
+        type Query {
+            getPost(id:ID!): Post
+        }
+        type Mutation {
+            addPost(id: ID!, author: String!, title: String, content: String): Post!
+        }
+        type Post {
+            id: ID!
+            author: String!
+            title: String
+            content: String
+            ups: Int
+            downs: Int
+        }
+      Auth:
+        Type: API_KEY
+      ApiKey:
+        MyApiKey:
+          Description: my api key
+      DataSources:
+        Lambda:
+          MyLambdaDataSource:
+            FunctionArn: !GetAtt MyLambdaFunction.Arn
+      Functions:
+        lambdaInvoker:
+          Runtime:
+            Name: APPSYNC_JS
+            Version: 1.0.0
+          DataSource: MyLambdaDataSource
+          InlineCode: |
+            import { util } from '@aws-appsync/utils';
+
+            export function request(ctx) {
+              const {source, args} = ctx
+              return {
+                operation: 'Invoke',
+                payload: { field: ctx.info.fieldName, arguments: args, source },
+              };
+            }
+
+            export function response(ctx) {
+              return ctx.result;
+            }
+      AppSyncResolvers:
+        Mutation:
+          addPost:
+            Runtime:
+              Name: APPSYNC_JS
+              Version: 1.0.0
+            Functions:
+            - lambdaInvoker
+        Query:
+          getPost:
+            Runtime:
+              Name: APPSYNC_JS
+              Version: 1.0.0
+            Functions:
+            - lambdaInvoker
+
+Outputs:
+  SuperCoolAPI:
+    Description: AppSync API
+    Value: !GetAtt SuperCoolAPI.GraphQLUrl
+  SuperCoolAPIMyApiKey:
+    Description: API Key for authentication
+    Value: !GetAtt SuperCoolAPIMyApiKey.ApiKey
+Metadata:
+  SamTransformTest: true


### PR DESCRIPTION
### Description of changes
Added an integration test for `Serverless::GraphQLApi` that has a resolver which contains a function with a Lambda datasource.

### Description of how you validated changes
Integration test runs successfully.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
