### PR TITLE
chore: add `Policies` test with every type

### DIFF
--- a/tests/translator/input/managed_policies_everything.yaml
+++ b/tests/translator/input/managed_policies_everything.yaml
@@ -1,4 +1,15 @@
+Parameters:
+  SomeParameter:
+    Type: String
+Conditions:
+  SomeCondition: !Equals [!Ref SomeParameter, true]
 Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  MyManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument: {}
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -16,17 +27,16 @@ Resources:
       - arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough
       - arn:looks:like::an/arn-also-passed-through
       # Intrinsic (pass-through)
-      - !Sub SomethingPassThrough
-      - !If [SomeCondition, !Ref NewSecurityGroup, !Ref ExistingSecurityGroup]
+      - !Sub "${MyQueue}WhateverPassThrough"
+      - !If [SomeCondition, !Ref MyManagedPolicy, !Ref MyManagedPolicy]
       # Policy template (added to Policies property of Role)
       - SQSPollerPolicy:
-          QueueName: !Ref SomeQueue
+          QueueName: !Ref MyQueue
       # Dynamic references (pass-through)
       # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
       - '{{resolve:ssm:passedthrough:2}}'
-      - '{{resolve:ssm-secure:PassedThrough:10}}'
       # Inline statement (added to Policies property of Role)
-      - {Statement: {Some: Statement}}
+      - {Statement: {Effect: Allow, Action: '*', Resource: '*'}}
 
   MyStateMachine:
     Type: AWS::Serverless::StateMachine
@@ -43,14 +53,13 @@ Resources:
       - arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough
       - arn:looks:like::an/arn-also-passed-through
       # Intrinsic (pass-through)
-      - !Sub SomethingPassThrough
-      - !If [SomeCondition, !Ref NewSecurityGroup, !Ref ExistingSecurityGroup]
+      - !Sub "${MyQueue}WhateverPassThrough"
+      - !If [SomeCondition, !Ref MyManagedPolicy, !Ref MyManagedPolicy]
       # Policy template (added to Policies property of Role)
       - SQSPollerPolicy:
-          QueueName: !Ref SomeQueue
+          QueueName: !Ref MyQueue
       # Dynamic references (pass-through)
       # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
       - '{{resolve:ssm:passedthrough:2}}'
-      - '{{resolve:ssm-secure:PassedThrough:10}}'
       # Inline statement (added to Policies property of Role)
-      - {Statement: {Some: Statement}}
+      - {Statement: {Effect: Allow, Action: '*', Resource: '*'}}

--- a/tests/translator/input/managed_policies_everything.yaml
+++ b/tests/translator/input/managed_policies_everything.yaml
@@ -1,0 +1,54 @@
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.8
+      Handler: foo
+      InlineCode: bar
+      Policies:
+      # Valid AWS managed policy name (converted to ARN)
+      - AmazonS3FullAccess
+      - AmazonAPIGatewayPushToCloudWatchLogs
+      # Unknown managed policy name (pass-through)
+      - AnyNonOfficialManagedPolicy
+      # ARN (pass-through)
+      - arn:aws:iam::aws:policy/ThisIsPassedThroughAsIs
+      - arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough
+      - arn:looks:like::an/arn-also-passed-through
+      # Intrinsic (pass-through)
+      - !Sub SomethingPassThrough
+      # Policy template (added to Policies property of Role)
+      - SQSPollerPolicy:
+          QueueName: !Ref SomeQueue
+      # Dynamic references (pass-through)
+      # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
+      - '{{resolve:ssm:passedthrough:2}}'
+      - '{{resolve:ssm-secure:PassedThrough:10}}'
+      # Inline statement (added to Policies property of Role)
+      - {Statement: {Some: Statement}}
+
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: s3://foo/bar
+      Policies:
+      # Valid AWS managed policy name (converted to ARN)
+      - AmazonS3FullAccess
+      - AmazonAPIGatewayPushToCloudWatchLogs
+      # Unknown managed policy name (pass-through)
+      - AnyNonOfficialManagedPolicy
+      # ARN (pass-through)
+      - arn:aws:iam::aws:policy/ThisIsPassedThroughAsIs
+      - arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough
+      - arn:looks:like::an/arn-also-passed-through
+      # Intrinsic (pass-through)
+      - !Sub SomethingPassThrough
+      # Policy template (added to Policies property of Role)
+      - SQSPollerPolicy:
+          QueueName: !Ref SomeQueue
+      # Dynamic references (pass-through)
+      # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
+      - '{{resolve:ssm:passedthrough:2}}'
+      - '{{resolve:ssm-secure:PassedThrough:10}}'
+      # Inline statement (added to Policies property of Role)
+      - {Statement: {Some: Statement}}

--- a/tests/translator/input/managed_policies_everything.yaml
+++ b/tests/translator/input/managed_policies_everything.yaml
@@ -17,6 +17,7 @@ Resources:
       - arn:looks:like::an/arn-also-passed-through
       # Intrinsic (pass-through)
       - !Sub SomethingPassThrough
+      - !If [SomeCondition, !Ref NewSecurityGroup, !Ref ExistingSecurityGroup]
       # Policy template (added to Policies property of Role)
       - SQSPollerPolicy:
           QueueName: !Ref SomeQueue
@@ -43,6 +44,7 @@ Resources:
       - arn:looks:like::an/arn-also-passed-through
       # Intrinsic (pass-through)
       - !Sub SomethingPassThrough
+      - !If [SomeCondition, !Ref NewSecurityGroup, !Ref ExistingSecurityGroup]
       # Policy template (added to Policies property of Role)
       - SQSPollerPolicy:
           QueueName: !Ref SomeQueue

--- a/tests/translator/output/aws-cn/managed_policies_everything.json
+++ b/tests/translator/output/aws-cn/managed_policies_everything.json
@@ -60,7 +60,7 @@
           "arn:aws-cn:iam::aws:policy/AmazonS3FullAccess",
           "arn:aws-cn:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
           "AnyNonOfficialManagedPolicy",
-          "arn:aws-cn:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws:iam::aws:policy/ThisIsPassedThroughAsIs",
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {
@@ -180,7 +180,7 @@
           "arn:aws-cn:iam::aws:policy/AmazonS3FullAccess",
           "arn:aws-cn:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
           "AnyNonOfficialManagedPolicy",
-          "arn:aws-cn:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws:iam::aws:policy/ThisIsPassedThroughAsIs",
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {

--- a/tests/translator/output/aws-cn/managed_policies_everything.json
+++ b/tests/translator/output/aws-cn/managed_policies_everything.json
@@ -1,4 +1,19 @@
 {
+  "Conditions": {
+    "SomeCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "SomeParameter"
+        },
+        true
+      ]
+    }
+  },
+  "Parameters": {
+    "SomeParameter": {
+      "Type": "String"
+    }
+  },
   "Resources": {
     "MyFunction": {
       "Properties": {
@@ -49,21 +64,20 @@
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {
-            "Fn::Sub": "SomethingPassThrough"
+            "Fn::Sub": "${MyQueue}WhateverPassThrough"
           },
           {
             "Fn::If": [
               "SomeCondition",
               {
-                "Ref": "NewSecurityGroup"
+                "Ref": "MyManagedPolicy"
               },
               {
-                "Ref": "ExistingSecurityGroup"
+                "Ref": "MyManagedPolicy"
               }
             ]
           },
-          "{{resolve:ssm:passedthrough:2}}",
-          "{{resolve:ssm-secure:PassedThrough:10}}"
+          "{{resolve:ssm:passedthrough:2}}"
         ],
         "Policies": [
           {
@@ -84,7 +98,7 @@
                       "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": {
-                          "Ref": "SomeQueue"
+                          "Ref": "MyQueue"
                         }
                       }
                     ]
@@ -97,10 +111,12 @@
           {
             "PolicyDocument": {
               "Statement": {
-                "Some": "Statement"
+                "Action": "*",
+                "Effect": "Allow",
+                "Resource": "*"
               }
             },
-            "PolicyName": "MyFunctionRolePolicy11"
+            "PolicyName": "MyFunctionRolePolicy10"
           }
         ],
         "Tags": [
@@ -111,6 +127,15 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "MyManagedPolicy": {
+      "Properties": {
+        "PolicyDocument": {}
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "MyQueue": {
+      "Type": "AWS::SQS::Queue"
     },
     "MyStateMachine": {
       "Properties": {
@@ -159,21 +184,20 @@
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {
-            "Fn::Sub": "SomethingPassThrough"
+            "Fn::Sub": "${MyQueue}WhateverPassThrough"
           },
           {
             "Fn::If": [
               "SomeCondition",
               {
-                "Ref": "NewSecurityGroup"
+                "Ref": "MyManagedPolicy"
               },
               {
-                "Ref": "ExistingSecurityGroup"
+                "Ref": "MyManagedPolicy"
               }
             ]
           },
-          "{{resolve:ssm:passedthrough:2}}",
-          "{{resolve:ssm-secure:PassedThrough:10}}"
+          "{{resolve:ssm:passedthrough:2}}"
         ],
         "Policies": [
           {
@@ -194,7 +218,7 @@
                       "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": {
-                          "Ref": "SomeQueue"
+                          "Ref": "MyQueue"
                         }
                       }
                     ]
@@ -207,10 +231,12 @@
           {
             "PolicyDocument": {
               "Statement": {
-                "Some": "Statement"
+                "Action": "*",
+                "Effect": "Allow",
+                "Resource": "*"
               }
             },
-            "PolicyName": "MyStateMachineRolePolicy11"
+            "PolicyName": "MyStateMachineRolePolicy10"
           }
         ],
         "Tags": [

--- a/tests/translator/output/aws-cn/managed_policies_everything.json
+++ b/tests/translator/output/aws-cn/managed_policies_everything.json
@@ -1,0 +1,204 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "bar"
+        },
+        "Handler": "foo",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/AmazonS3FullAccess",
+          "arn:aws-cn:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          "AnyNonOfficialManagedPolicy",
+          "arn:aws-cn:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
+          "arn:looks:like::an/arn-also-passed-through",
+          {
+            "Fn::Sub": "SomethingPassThrough"
+          },
+          "{{resolve:ssm:passedthrough:2}}",
+          "{{resolve:ssm-secure:PassedThrough:10}}"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
+                    "sqs:ReceiveMessage"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
+                      {
+                        "queueName": {
+                          "Ref": "SomeQueue"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyFunctionRolePolicy7"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Some": "Statement"
+              }
+            },
+            "PolicyName": "MyFunctionRolePolicy10"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "foo",
+          "Key": "bar"
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/AmazonS3FullAccess",
+          "arn:aws-cn:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          "AnyNonOfficialManagedPolicy",
+          "arn:aws-cn:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
+          "arn:looks:like::an/arn-also-passed-through",
+          {
+            "Fn::Sub": "SomethingPassThrough"
+          },
+          "{{resolve:ssm:passedthrough:2}}",
+          "{{resolve:ssm-secure:PassedThrough:10}}"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
+                    "sqs:ReceiveMessage"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
+                      {
+                        "queueName": {
+                          "Ref": "SomeQueue"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineRolePolicy7"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Some": "Statement"
+              }
+            },
+            "PolicyName": "MyStateMachineRolePolicy10"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/managed_policies_everything.json
+++ b/tests/translator/output/aws-cn/managed_policies_everything.json
@@ -51,6 +51,17 @@
           {
             "Fn::Sub": "SomethingPassThrough"
           },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "Ref": "NewSecurityGroup"
+              },
+              {
+                "Ref": "ExistingSecurityGroup"
+              }
+            ]
+          },
           "{{resolve:ssm:passedthrough:2}}",
           "{{resolve:ssm-secure:PassedThrough:10}}"
         ],
@@ -81,7 +92,7 @@
                 }
               ]
             },
-            "PolicyName": "MyFunctionRolePolicy7"
+            "PolicyName": "MyFunctionRolePolicy8"
           },
           {
             "PolicyDocument": {
@@ -89,7 +100,7 @@
                 "Some": "Statement"
               }
             },
-            "PolicyName": "MyFunctionRolePolicy10"
+            "PolicyName": "MyFunctionRolePolicy11"
           }
         ],
         "Tags": [
@@ -150,6 +161,17 @@
           {
             "Fn::Sub": "SomethingPassThrough"
           },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "Ref": "NewSecurityGroup"
+              },
+              {
+                "Ref": "ExistingSecurityGroup"
+              }
+            ]
+          },
           "{{resolve:ssm:passedthrough:2}}",
           "{{resolve:ssm-secure:PassedThrough:10}}"
         ],
@@ -180,7 +202,7 @@
                 }
               ]
             },
-            "PolicyName": "MyStateMachineRolePolicy7"
+            "PolicyName": "MyStateMachineRolePolicy8"
           },
           {
             "PolicyDocument": {
@@ -188,7 +210,7 @@
                 "Some": "Statement"
               }
             },
-            "PolicyName": "MyStateMachineRolePolicy10"
+            "PolicyName": "MyStateMachineRolePolicy11"
           }
         ],
         "Tags": [

--- a/tests/translator/output/aws-us-gov/managed_policies_everything.json
+++ b/tests/translator/output/aws-us-gov/managed_policies_everything.json
@@ -1,4 +1,19 @@
 {
+  "Conditions": {
+    "SomeCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "SomeParameter"
+        },
+        true
+      ]
+    }
+  },
+  "Parameters": {
+    "SomeParameter": {
+      "Type": "String"
+    }
+  },
   "Resources": {
     "MyFunction": {
       "Properties": {
@@ -49,21 +64,20 @@
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {
-            "Fn::Sub": "SomethingPassThrough"
+            "Fn::Sub": "${MyQueue}WhateverPassThrough"
           },
           {
             "Fn::If": [
               "SomeCondition",
               {
-                "Ref": "NewSecurityGroup"
+                "Ref": "MyManagedPolicy"
               },
               {
-                "Ref": "ExistingSecurityGroup"
+                "Ref": "MyManagedPolicy"
               }
             ]
           },
-          "{{resolve:ssm:passedthrough:2}}",
-          "{{resolve:ssm-secure:PassedThrough:10}}"
+          "{{resolve:ssm:passedthrough:2}}"
         ],
         "Policies": [
           {
@@ -84,7 +98,7 @@
                       "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": {
-                          "Ref": "SomeQueue"
+                          "Ref": "MyQueue"
                         }
                       }
                     ]
@@ -97,10 +111,12 @@
           {
             "PolicyDocument": {
               "Statement": {
-                "Some": "Statement"
+                "Action": "*",
+                "Effect": "Allow",
+                "Resource": "*"
               }
             },
-            "PolicyName": "MyFunctionRolePolicy11"
+            "PolicyName": "MyFunctionRolePolicy10"
           }
         ],
         "Tags": [
@@ -111,6 +127,15 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "MyManagedPolicy": {
+      "Properties": {
+        "PolicyDocument": {}
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "MyQueue": {
+      "Type": "AWS::SQS::Queue"
     },
     "MyStateMachine": {
       "Properties": {
@@ -159,21 +184,20 @@
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {
-            "Fn::Sub": "SomethingPassThrough"
+            "Fn::Sub": "${MyQueue}WhateverPassThrough"
           },
           {
             "Fn::If": [
               "SomeCondition",
               {
-                "Ref": "NewSecurityGroup"
+                "Ref": "MyManagedPolicy"
               },
               {
-                "Ref": "ExistingSecurityGroup"
+                "Ref": "MyManagedPolicy"
               }
             ]
           },
-          "{{resolve:ssm:passedthrough:2}}",
-          "{{resolve:ssm-secure:PassedThrough:10}}"
+          "{{resolve:ssm:passedthrough:2}}"
         ],
         "Policies": [
           {
@@ -194,7 +218,7 @@
                       "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": {
-                          "Ref": "SomeQueue"
+                          "Ref": "MyQueue"
                         }
                       }
                     ]
@@ -207,10 +231,12 @@
           {
             "PolicyDocument": {
               "Statement": {
-                "Some": "Statement"
+                "Action": "*",
+                "Effect": "Allow",
+                "Resource": "*"
               }
             },
-            "PolicyName": "MyStateMachineRolePolicy11"
+            "PolicyName": "MyStateMachineRolePolicy10"
           }
         ],
         "Tags": [

--- a/tests/translator/output/aws-us-gov/managed_policies_everything.json
+++ b/tests/translator/output/aws-us-gov/managed_policies_everything.json
@@ -57,10 +57,10 @@
         },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-us-gov:iam::aws:policy/AmazonS3FullAccess",
-          "arn:aws-us-gov:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          "AmazonS3FullAccess",
+          "AmazonAPIGatewayPushToCloudWatchLogs",
           "AnyNonOfficialManagedPolicy",
-          "arn:aws-us-gov:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws:iam::aws:policy/ThisIsPassedThroughAsIs",
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {
@@ -177,10 +177,10 @@
           "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/AmazonS3FullAccess",
-          "arn:aws-us-gov:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          "AmazonS3FullAccess",
+          "AmazonAPIGatewayPushToCloudWatchLogs",
           "AnyNonOfficialManagedPolicy",
-          "arn:aws-us-gov:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws:iam::aws:policy/ThisIsPassedThroughAsIs",
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {

--- a/tests/translator/output/aws-us-gov/managed_policies_everything.json
+++ b/tests/translator/output/aws-us-gov/managed_policies_everything.json
@@ -1,0 +1,204 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "bar"
+        },
+        "Handler": "foo",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/AmazonS3FullAccess",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          "AnyNonOfficialManagedPolicy",
+          "arn:aws-us-gov:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
+          "arn:looks:like::an/arn-also-passed-through",
+          {
+            "Fn::Sub": "SomethingPassThrough"
+          },
+          "{{resolve:ssm:passedthrough:2}}",
+          "{{resolve:ssm-secure:PassedThrough:10}}"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
+                    "sqs:ReceiveMessage"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
+                      {
+                        "queueName": {
+                          "Ref": "SomeQueue"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyFunctionRolePolicy7"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Some": "Statement"
+              }
+            },
+            "PolicyName": "MyFunctionRolePolicy10"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "foo",
+          "Key": "bar"
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/AmazonS3FullAccess",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          "AnyNonOfficialManagedPolicy",
+          "arn:aws-us-gov:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
+          "arn:looks:like::an/arn-also-passed-through",
+          {
+            "Fn::Sub": "SomethingPassThrough"
+          },
+          "{{resolve:ssm:passedthrough:2}}",
+          "{{resolve:ssm-secure:PassedThrough:10}}"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
+                    "sqs:ReceiveMessage"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
+                      {
+                        "queueName": {
+                          "Ref": "SomeQueue"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineRolePolicy7"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Some": "Statement"
+              }
+            },
+            "PolicyName": "MyStateMachineRolePolicy10"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/managed_policies_everything.json
+++ b/tests/translator/output/aws-us-gov/managed_policies_everything.json
@@ -51,6 +51,17 @@
           {
             "Fn::Sub": "SomethingPassThrough"
           },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "Ref": "NewSecurityGroup"
+              },
+              {
+                "Ref": "ExistingSecurityGroup"
+              }
+            ]
+          },
           "{{resolve:ssm:passedthrough:2}}",
           "{{resolve:ssm-secure:PassedThrough:10}}"
         ],
@@ -81,7 +92,7 @@
                 }
               ]
             },
-            "PolicyName": "MyFunctionRolePolicy7"
+            "PolicyName": "MyFunctionRolePolicy8"
           },
           {
             "PolicyDocument": {
@@ -89,7 +100,7 @@
                 "Some": "Statement"
               }
             },
-            "PolicyName": "MyFunctionRolePolicy10"
+            "PolicyName": "MyFunctionRolePolicy11"
           }
         ],
         "Tags": [
@@ -150,6 +161,17 @@
           {
             "Fn::Sub": "SomethingPassThrough"
           },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "Ref": "NewSecurityGroup"
+              },
+              {
+                "Ref": "ExistingSecurityGroup"
+              }
+            ]
+          },
           "{{resolve:ssm:passedthrough:2}}",
           "{{resolve:ssm-secure:PassedThrough:10}}"
         ],
@@ -180,7 +202,7 @@
                 }
               ]
             },
-            "PolicyName": "MyStateMachineRolePolicy7"
+            "PolicyName": "MyStateMachineRolePolicy8"
           },
           {
             "PolicyDocument": {
@@ -188,7 +210,7 @@
                 "Some": "Statement"
               }
             },
-            "PolicyName": "MyStateMachineRolePolicy10"
+            "PolicyName": "MyStateMachineRolePolicy11"
           }
         ],
         "Tags": [

--- a/tests/translator/output/managed_policies_everything.json
+++ b/tests/translator/output/managed_policies_everything.json
@@ -1,4 +1,19 @@
 {
+  "Conditions": {
+    "SomeCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "SomeParameter"
+        },
+        true
+      ]
+    }
+  },
+  "Parameters": {
+    "SomeParameter": {
+      "Type": "String"
+    }
+  },
   "Resources": {
     "MyFunction": {
       "Properties": {
@@ -49,21 +64,20 @@
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {
-            "Fn::Sub": "SomethingPassThrough"
+            "Fn::Sub": "${MyQueue}WhateverPassThrough"
           },
           {
             "Fn::If": [
               "SomeCondition",
               {
-                "Ref": "NewSecurityGroup"
+                "Ref": "MyManagedPolicy"
               },
               {
-                "Ref": "ExistingSecurityGroup"
+                "Ref": "MyManagedPolicy"
               }
             ]
           },
-          "{{resolve:ssm:passedthrough:2}}",
-          "{{resolve:ssm-secure:PassedThrough:10}}"
+          "{{resolve:ssm:passedthrough:2}}"
         ],
         "Policies": [
           {
@@ -84,7 +98,7 @@
                       "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": {
-                          "Ref": "SomeQueue"
+                          "Ref": "MyQueue"
                         }
                       }
                     ]
@@ -97,10 +111,12 @@
           {
             "PolicyDocument": {
               "Statement": {
-                "Some": "Statement"
+                "Action": "*",
+                "Effect": "Allow",
+                "Resource": "*"
               }
             },
-            "PolicyName": "MyFunctionRolePolicy11"
+            "PolicyName": "MyFunctionRolePolicy10"
           }
         ],
         "Tags": [
@@ -111,6 +127,15 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "MyManagedPolicy": {
+      "Properties": {
+        "PolicyDocument": {}
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "MyQueue": {
+      "Type": "AWS::SQS::Queue"
     },
     "MyStateMachine": {
       "Properties": {
@@ -159,21 +184,20 @@
           "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
           "arn:looks:like::an/arn-also-passed-through",
           {
-            "Fn::Sub": "SomethingPassThrough"
+            "Fn::Sub": "${MyQueue}WhateverPassThrough"
           },
           {
             "Fn::If": [
               "SomeCondition",
               {
-                "Ref": "NewSecurityGroup"
+                "Ref": "MyManagedPolicy"
               },
               {
-                "Ref": "ExistingSecurityGroup"
+                "Ref": "MyManagedPolicy"
               }
             ]
           },
-          "{{resolve:ssm:passedthrough:2}}",
-          "{{resolve:ssm-secure:PassedThrough:10}}"
+          "{{resolve:ssm:passedthrough:2}}"
         ],
         "Policies": [
           {
@@ -194,7 +218,7 @@
                       "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": {
-                          "Ref": "SomeQueue"
+                          "Ref": "MyQueue"
                         }
                       }
                     ]
@@ -207,10 +231,12 @@
           {
             "PolicyDocument": {
               "Statement": {
-                "Some": "Statement"
+                "Action": "*",
+                "Effect": "Allow",
+                "Resource": "*"
               }
             },
-            "PolicyName": "MyStateMachineRolePolicy11"
+            "PolicyName": "MyStateMachineRolePolicy10"
           }
         ],
         "Tags": [

--- a/tests/translator/output/managed_policies_everything.json
+++ b/tests/translator/output/managed_policies_everything.json
@@ -1,0 +1,204 @@
+{
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "bar"
+        },
+        "Handler": "foo",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.8",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+          "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          "AnyNonOfficialManagedPolicy",
+          "arn:aws:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
+          "arn:looks:like::an/arn-also-passed-through",
+          {
+            "Fn::Sub": "SomethingPassThrough"
+          },
+          "{{resolve:ssm:passedthrough:2}}",
+          "{{resolve:ssm-secure:PassedThrough:10}}"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
+                    "sqs:ReceiveMessage"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
+                      {
+                        "queueName": {
+                          "Ref": "SomeQueue"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyFunctionRolePolicy7"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Some": "Statement"
+              }
+            },
+            "PolicyName": "MyFunctionRolePolicy10"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "foo",
+          "Key": "bar"
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+          "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          "AnyNonOfficialManagedPolicy",
+          "arn:aws:iam::aws:policy/ThisIsPassedThroughAsIs",
+          "arn:aws-cn:iam::aws:policy/ThisIsAlsoPassedThrough",
+          "arn:looks:like::an/arn-also-passed-through",
+          {
+            "Fn::Sub": "SomethingPassThrough"
+          },
+          "{{resolve:ssm:passedthrough:2}}",
+          "{{resolve:ssm-secure:PassedThrough:10}}"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
+                    "sqs:ReceiveMessage"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
+                      {
+                        "queueName": {
+                          "Ref": "SomeQueue"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineRolePolicy7"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": {
+                "Some": "Statement"
+              }
+            },
+            "PolicyName": "MyStateMachineRolePolicy10"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/managed_policies_everything.json
+++ b/tests/translator/output/managed_policies_everything.json
@@ -51,6 +51,17 @@
           {
             "Fn::Sub": "SomethingPassThrough"
           },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "Ref": "NewSecurityGroup"
+              },
+              {
+                "Ref": "ExistingSecurityGroup"
+              }
+            ]
+          },
           "{{resolve:ssm:passedthrough:2}}",
           "{{resolve:ssm-secure:PassedThrough:10}}"
         ],
@@ -81,7 +92,7 @@
                 }
               ]
             },
-            "PolicyName": "MyFunctionRolePolicy7"
+            "PolicyName": "MyFunctionRolePolicy8"
           },
           {
             "PolicyDocument": {
@@ -89,7 +100,7 @@
                 "Some": "Statement"
               }
             },
-            "PolicyName": "MyFunctionRolePolicy10"
+            "PolicyName": "MyFunctionRolePolicy11"
           }
         ],
         "Tags": [
@@ -150,6 +161,17 @@
           {
             "Fn::Sub": "SomethingPassThrough"
           },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "Ref": "NewSecurityGroup"
+              },
+              {
+                "Ref": "ExistingSecurityGroup"
+              }
+            ]
+          },
           "{{resolve:ssm:passedthrough:2}}",
           "{{resolve:ssm-secure:PassedThrough:10}}"
         ],
@@ -180,7 +202,7 @@
                 }
               ]
             },
-            "PolicyName": "MyStateMachineRolePolicy7"
+            "PolicyName": "MyStateMachineRolePolicy8"
           },
           {
             "PolicyDocument": {
@@ -188,7 +210,7 @@
                 "Some": "Statement"
               }
             },
-            "PolicyName": "MyStateMachineRolePolicy10"
+            "PolicyName": "MyStateMachineRolePolicy11"
           }
         ],
         "Tags": [


### PR DESCRIPTION
### Issue #, if available

https://github.com/aws/serverless-application-model/issues/3152

### Description of changes

Adding some tests to ensure we have better coverage of allowed values in `Policies`.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
