### PR TITLE
chore: make MSK tests non-blocking

### DIFF
--- a/integration/combination/test_function_with_msk.py
+++ b/integration/combination/test_function_with_msk.py
@@ -3,11 +3,12 @@ from unittest.case import skipIf
 import pytest
 
 from integration.config.service_names import MSK
-from integration.helpers.base_test import BaseTest
+from integration.helpers.base_test import BaseTest, nonblocking
 from integration.helpers.resource import current_region_does_not_support, generate_suffix
 
 
 @skipIf(current_region_does_not_support([MSK]), "MSK is not supported in this testing region")
+@nonblocking
 class TestFunctionWithMsk(BaseTest):
     @pytest.fixture(autouse=True)
     def companion_stack_outputs(self, get_companion_stack_outputs):

--- a/tests/translator/input/function_with_msk_2.yaml
+++ b/tests/translator/input/function_with_msk_2.yaml
@@ -1,0 +1,69 @@
+Parameters:
+  PreCreatedSubnetOne:
+    Type: String
+  PreCreatedSubnetTwo:
+    Type: String
+  MskClusterName:
+    Type: String
+
+Resources:
+  MyLambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Action: [sts:AssumeRole]
+          Effect: Allow
+          Principal:
+            Service: [lambda.amazonaws.com]
+      Policies:
+      - PolicyName: IntegrationTestExecution
+        PolicyDocument:
+          Statement:
+          - Action: [kafka:DescribeCluster, kafka:GetBootstrapBrokers, ec2:CreateNetworkInterface,
+              ec2:DescribeNetworkInterfaces, ec2:DescribeVpcs, ec2:DeleteNetworkInterface,
+              ec2:DescribeSubnets, ec2:DescribeSecurityGroups, logs:CreateLogGroup,
+              logs:CreateLogStream, logs:PutLogEvents]
+            Effect: Allow
+            Resource: '*'
+      ManagedPolicyArns: [arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]
+      Tags:
+      - {Value: SAM, Key: lambda:createdBy}
+
+  MyMskCluster:
+    Type: AWS::MSK::Cluster
+    Properties:
+      BrokerNodeGroupInfo:
+        ClientSubnets:
+        - Ref: PreCreatedSubnetOne
+        - Ref: PreCreatedSubnetTwo
+        InstanceType: kafka.t3.small
+        StorageInfo:
+          EBSStorageInfo:
+            VolumeSize: 1
+      ClusterName:
+        Ref: MskClusterName
+      KafkaVersion: 2.4.1.1
+      NumberOfBrokerNodes: 2
+
+  MyMskStreamProcessor:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: nodejs14.x
+      Handler: index.handler
+      CodeUri: s3://foo/bar
+      Role:
+        Fn::GetAtt: [MyLambdaExecutionRole, Arn]
+      Events:
+        MyMskEvent:
+          Type: MSK
+          Properties:
+            StartingPosition: LATEST
+            Stream:
+              Ref: MyMskCluster
+            Topics:
+            - MyDummyTestTopic
+
+Metadata:
+  SamTransformTest: true

--- a/tests/translator/input/function_with_msk_using_managed_policy.yaml
+++ b/tests/translator/input/function_with_msk_using_managed_policy.yaml
@@ -1,0 +1,43 @@
+Parameters:
+  PreCreatedSubnetOne:
+    Type: String
+  PreCreatedSubnetTwo:
+    Type: String
+  MskClusterName2:
+    Type: String
+
+Resources:
+  MyMskCluster:
+    Type: AWS::MSK::Cluster
+    Properties:
+      BrokerNodeGroupInfo:
+        ClientSubnets:
+        - Ref: PreCreatedSubnetOne
+        - Ref: PreCreatedSubnetTwo
+        InstanceType: kafka.t3.small
+        StorageInfo:
+          EBSStorageInfo:
+            VolumeSize: 1
+      ClusterName:
+        Ref: MskClusterName2
+      KafkaVersion: 2.4.1.1
+      NumberOfBrokerNodes: 2
+
+  MyMskStreamProcessor:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: nodejs14.x
+      Handler: index.handler
+      CodeUri: s3://foo/bar
+      Events:
+        MyMskEvent:
+          Type: MSK
+          Properties:
+            StartingPosition: LATEST
+            Stream:
+              Ref: MyMskCluster
+            Topics:
+            - MyDummyTestTopic
+
+Metadata:
+  SamTransformTest: true

--- a/tests/translator/output/aws-cn/function_with_msk_2.json
+++ b/tests/translator/output/aws-cn/function_with_msk_2.json
@@ -1,0 +1,138 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MskClusterName": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetTwo": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MyLambdaExecutionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "kafka:DescribeCluster",
+                    "kafka:GetBootstrapBrokers",
+                    "ec2:CreateNetworkInterface",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DescribeVpcs",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeSecurityGroups",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ]
+            },
+            "PolicyName": "IntegrationTestExecution"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyMskCluster": {
+      "Properties": {
+        "BrokerNodeGroupInfo": {
+          "ClientSubnets": [
+            {
+              "Ref": "PreCreatedSubnetOne"
+            },
+            {
+              "Ref": "PreCreatedSubnetTwo"
+            }
+          ],
+          "InstanceType": "kafka.t3.small",
+          "StorageInfo": {
+            "EBSStorageInfo": {
+              "VolumeSize": 1
+            }
+          }
+        },
+        "ClusterName": {
+          "Ref": "MskClusterName"
+        },
+        "KafkaVersion": "2.4.1.1",
+        "NumberOfBrokerNodes": 2
+      },
+      "Type": "AWS::MSK::Cluster"
+    },
+    "MyMskStreamProcessor": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "foo",
+          "S3Key": "bar"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyMskStreamProcessorMyMskEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Ref": "MyMskCluster"
+        },
+        "FunctionName": {
+          "Ref": "MyMskStreamProcessor"
+        },
+        "StartingPosition": "LATEST",
+        "Topics": [
+          "MyDummyTestTopic"
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/function_with_msk_2.json
+++ b/tests/translator/output/aws-cn/function_with_msk_2.json
@@ -33,7 +33,7 @@
           "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {

--- a/tests/translator/output/aws-cn/function_with_msk_using_managed_policy.json
+++ b/tests/translator/output/aws-cn/function_with_msk_using_managed_policy.json
@@ -1,0 +1,113 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MskClusterName2": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetTwo": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MyMskCluster": {
+      "Properties": {
+        "BrokerNodeGroupInfo": {
+          "ClientSubnets": [
+            {
+              "Ref": "PreCreatedSubnetOne"
+            },
+            {
+              "Ref": "PreCreatedSubnetTwo"
+            }
+          ],
+          "InstanceType": "kafka.t3.small",
+          "StorageInfo": {
+            "EBSStorageInfo": {
+              "VolumeSize": 1
+            }
+          }
+        },
+        "ClusterName": {
+          "Ref": "MskClusterName2"
+        },
+        "KafkaVersion": "2.4.1.1",
+        "NumberOfBrokerNodes": 2
+      },
+      "Type": "AWS::MSK::Cluster"
+    },
+    "MyMskStreamProcessor": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "foo",
+          "S3Key": "bar"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyMskStreamProcessorRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyMskStreamProcessorMyMskEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Ref": "MyMskCluster"
+        },
+        "FunctionName": {
+          "Ref": "MyMskStreamProcessor"
+        },
+        "StartingPosition": "LATEST",
+        "Topics": [
+          "MyDummyTestTopic"
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "MyMskStreamProcessorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaMSKExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/function_with_msk_2.json
+++ b/tests/translator/output/aws-us-gov/function_with_msk_2.json
@@ -33,7 +33,7 @@
           "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {

--- a/tests/translator/output/aws-us-gov/function_with_msk_2.json
+++ b/tests/translator/output/aws-us-gov/function_with_msk_2.json
@@ -1,0 +1,138 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MskClusterName": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetTwo": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MyLambdaExecutionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "kafka:DescribeCluster",
+                    "kafka:GetBootstrapBrokers",
+                    "ec2:CreateNetworkInterface",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DescribeVpcs",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeSecurityGroups",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ]
+            },
+            "PolicyName": "IntegrationTestExecution"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyMskCluster": {
+      "Properties": {
+        "BrokerNodeGroupInfo": {
+          "ClientSubnets": [
+            {
+              "Ref": "PreCreatedSubnetOne"
+            },
+            {
+              "Ref": "PreCreatedSubnetTwo"
+            }
+          ],
+          "InstanceType": "kafka.t3.small",
+          "StorageInfo": {
+            "EBSStorageInfo": {
+              "VolumeSize": 1
+            }
+          }
+        },
+        "ClusterName": {
+          "Ref": "MskClusterName"
+        },
+        "KafkaVersion": "2.4.1.1",
+        "NumberOfBrokerNodes": 2
+      },
+      "Type": "AWS::MSK::Cluster"
+    },
+    "MyMskStreamProcessor": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "foo",
+          "S3Key": "bar"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyMskStreamProcessorMyMskEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Ref": "MyMskCluster"
+        },
+        "FunctionName": {
+          "Ref": "MyMskStreamProcessor"
+        },
+        "StartingPosition": "LATEST",
+        "Topics": [
+          "MyDummyTestTopic"
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/function_with_msk_using_managed_policy.json
+++ b/tests/translator/output/aws-us-gov/function_with_msk_using_managed_policy.json
@@ -1,0 +1,113 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MskClusterName2": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetTwo": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MyMskCluster": {
+      "Properties": {
+        "BrokerNodeGroupInfo": {
+          "ClientSubnets": [
+            {
+              "Ref": "PreCreatedSubnetOne"
+            },
+            {
+              "Ref": "PreCreatedSubnetTwo"
+            }
+          ],
+          "InstanceType": "kafka.t3.small",
+          "StorageInfo": {
+            "EBSStorageInfo": {
+              "VolumeSize": 1
+            }
+          }
+        },
+        "ClusterName": {
+          "Ref": "MskClusterName2"
+        },
+        "KafkaVersion": "2.4.1.1",
+        "NumberOfBrokerNodes": 2
+      },
+      "Type": "AWS::MSK::Cluster"
+    },
+    "MyMskStreamProcessor": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "foo",
+          "S3Key": "bar"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyMskStreamProcessorRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyMskStreamProcessorMyMskEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Ref": "MyMskCluster"
+        },
+        "FunctionName": {
+          "Ref": "MyMskStreamProcessor"
+        },
+        "StartingPosition": "LATEST",
+        "Topics": [
+          "MyDummyTestTopic"
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "MyMskStreamProcessorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaMSKExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/function_with_msk_2.json
+++ b/tests/translator/output/function_with_msk_2.json
@@ -1,0 +1,138 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MskClusterName": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetTwo": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MyLambdaExecutionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "kafka:DescribeCluster",
+                    "kafka:GetBootstrapBrokers",
+                    "ec2:CreateNetworkInterface",
+                    "ec2:DescribeNetworkInterfaces",
+                    "ec2:DescribeVpcs",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeSecurityGroups",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ]
+            },
+            "PolicyName": "IntegrationTestExecution"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyMskCluster": {
+      "Properties": {
+        "BrokerNodeGroupInfo": {
+          "ClientSubnets": [
+            {
+              "Ref": "PreCreatedSubnetOne"
+            },
+            {
+              "Ref": "PreCreatedSubnetTwo"
+            }
+          ],
+          "InstanceType": "kafka.t3.small",
+          "StorageInfo": {
+            "EBSStorageInfo": {
+              "VolumeSize": 1
+            }
+          }
+        },
+        "ClusterName": {
+          "Ref": "MskClusterName"
+        },
+        "KafkaVersion": "2.4.1.1",
+        "NumberOfBrokerNodes": 2
+      },
+      "Type": "AWS::MSK::Cluster"
+    },
+    "MyMskStreamProcessor": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "foo",
+          "S3Key": "bar"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyMskStreamProcessorMyMskEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Ref": "MyMskCluster"
+        },
+        "FunctionName": {
+          "Ref": "MyMskStreamProcessor"
+        },
+        "StartingPosition": "LATEST",
+        "Topics": [
+          "MyDummyTestTopic"
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    }
+  }
+}

--- a/tests/translator/output/function_with_msk_using_managed_policy.json
+++ b/tests/translator/output/function_with_msk_using_managed_policy.json
@@ -1,0 +1,113 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Parameters": {
+    "MskClusterName2": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetOne": {
+      "Type": "String"
+    },
+    "PreCreatedSubnetTwo": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MyMskCluster": {
+      "Properties": {
+        "BrokerNodeGroupInfo": {
+          "ClientSubnets": [
+            {
+              "Ref": "PreCreatedSubnetOne"
+            },
+            {
+              "Ref": "PreCreatedSubnetTwo"
+            }
+          ],
+          "InstanceType": "kafka.t3.small",
+          "StorageInfo": {
+            "EBSStorageInfo": {
+              "VolumeSize": 1
+            }
+          }
+        },
+        "ClusterName": {
+          "Ref": "MskClusterName2"
+        },
+        "KafkaVersion": "2.4.1.1",
+        "NumberOfBrokerNodes": 2
+      },
+      "Type": "AWS::MSK::Cluster"
+    },
+    "MyMskStreamProcessor": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "foo",
+          "S3Key": "bar"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyMskStreamProcessorRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyMskStreamProcessorMyMskEvent": {
+      "Properties": {
+        "EventSourceArn": {
+          "Ref": "MyMskCluster"
+        },
+        "FunctionName": {
+          "Ref": "MyMskStreamProcessor"
+        },
+        "StartingPosition": "LATEST",
+        "Topics": [
+          "MyDummyTestTopic"
+        ]
+      },
+      "Type": "AWS::Lambda::EventSourceMapping"
+    },
+    "MyMskStreamProcessorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaMSKExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Encountering flakiness every blue moon with this tests; added equivalent transform tests and marking as non-blocking since we've already tested it.

For reference, the guidelines for marking tests as `@nonblocking` are:

https://github.com/aws/serverless-application-model/blob/801c3fc2f457a8077edc717b8eb6879111031fbe/integration/helpers/base_test.py#L57-L63

In this case we do use `Parameters`. Specifically, the tests use these subnets:

https://github.com/aws/serverless-application-model/blob/801c3fc2f457a8077edc717b8eb6879111031fbe/integration/resources/templates/combination/function_with_msk.yaml#L34-L40

https://github.com/aws/serverless-application-model/blob/801c3fc2f457a8077edc717b8eb6879111031fbe/integration/combination/test_function_with_msk.py#L55-L59

Created by the companion stack:

https://github.com/aws/serverless-application-model/blob/801c3fc2f457a8077edc717b8eb6879111031fbe/integration/setup/companion-stack.yaml#L49-L56

However those parameters don't have any SAM-specific handling since they're passed straight to `AWS::MSK::Cluster`, so we can be more lax on (2).

For transform test had to replace `CodeUri` to make it work with local transform.

### Description of how you validated changes

With outdated credentials:

```
pytest integration --no-cov -k msk
```

```
==== 188 deselected, 2 xfailed, 2 warnings in 1.79s ====
```

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
