### PR TITLE
chore: run schema update earlier in the day

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -3,7 +3,7 @@ name: Update schema
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 1-5" # Weekdays
+    - cron: "0 18 * * 1-5" # Weekdays
 
 jobs:
   update:


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Currently runs at 5 PM PDT; this sets it during normal hours at 11 AM PDT.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
