### PR TITLE
chore: Get CFN resource properties from profiles.json for SAM Connectors

### DIFF
--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -6,8 +6,9 @@ from typing_extensions import TypeGuard
 from samtranslator.model import ResourceResolver
 from samtranslator.model.apigateway import ApiGatewayRestApi
 from samtranslator.model.apigatewayv2 import ApiGatewayV2HttpApi
+from samtranslator.model.connector_profiles.profile import replace_cfn_resource_properties
 from samtranslator.model.dynamodb import DynamoDBTable
-from samtranslator.model.intrinsics import fnGetAtt, get_logical_id_from_intrinsic, ref
+from samtranslator.model.intrinsics import get_logical_id_from_intrinsic, ref
 from samtranslator.model.lambda_ import (
     LambdaFunction,
 )
@@ -150,17 +151,21 @@ def get_resource_reference(
         raise ConnectorResourceError("'Type' is missing or not a string.")
     properties = resource.get("Properties", {})
 
-    arn = _get_resource_arn(logical_id, resource_type)
+    cfn_resource_properties = replace_cfn_resource_properties(resource_type, logical_id) or {}
 
-    role_name = _get_resource_role_name(connecting_obj.get("Id"), connecting_obj.get("Arn"), resource_type, properties)
+    arn = _get_resource_arn(cfn_resource_properties)
 
-    queue_url = _get_resource_queue_url(logical_id, resource_type)
+    role_name = _get_resource_role_name(
+        connecting_obj.get("Id"), connecting_obj.get("Arn"), cfn_resource_properties, properties
+    )
 
-    resource_id = _get_resource_id(logical_id, resource_type)
+    queue_url = _get_resource_queue_url(cfn_resource_properties)
 
-    name = _get_resource_name(logical_id, resource_type)
+    resource_id = _get_resource_id(cfn_resource_properties)
 
-    qualifier = obj.get("Qualifier") if "Qualifier" in obj else _get_resource_qualifier(resource_type)
+    name = _get_resource_name(cfn_resource_properties)
+
+    qualifier = obj.get("Qualifier") if "Qualifier" in obj else _get_resource_qualifier(cfn_resource_properties)
 
     return ConnectorResourceReference(
         logical_id=logical_id,
@@ -174,30 +179,44 @@ def get_resource_reference(
     )
 
 
+def _get_events_rule_role(
+    connecting_obj_id: Optional[str], connecting_obj_arn: Optional[Any], properties: Dict[str, Any]
+):
+    for target in properties.get("Targets", []):
+        target_arn = target.get("Arn")
+        target_logical_id = get_logical_id_from_intrinsic(target_arn)
+        if (target_logical_id and target_logical_id == connecting_obj_id) or (
+            connecting_obj_arn and target_arn == connecting_obj_arn
+        ):
+            return target.get("RoleArn")
+    return None
+
+
 def _get_resource_role_property(
-    connecting_obj_id: Optional[str], connecting_obj_arn: Optional[Any], resource_type: str, properties: Dict[str, Any]
+    connecting_obj_id: Optional[str],
+    connecting_obj_arn: Optional[Any],
+    cfn_resource_properties: Dict[str, Any],
+    properties: Dict[str, Any],
 ) -> Any:
-    if resource_type == "AWS::Lambda::Function":
-        return properties.get("Role")
-    if resource_type == "AWS::StepFunctions::StateMachine":
-        return properties.get("RoleArn")
-    if resource_type == "AWS::AppSync::DataSource":
-        return properties.get("ServiceRoleArn")
-    if resource_type == "AWS::Events::Rule":
-        for target in properties.get("Targets", []):
-            target_arn = target.get("Arn")
-            target_logical_id = get_logical_id_from_intrinsic(target_arn)
-            if (target_logical_id and target_logical_id == connecting_obj_id) or (
-                connecting_obj_arn and target_arn == connecting_obj_arn
-            ):
-                return target.get("RoleArn")
+    role_property = cfn_resource_properties.get("Inputs", {}).get("Role")
+    if not role_property:
+        return None
+
+    if isinstance(role_property, str):
+        return properties.get(role_property)
+
+    if isinstance(role_property, dict) and role_property.get("Function") == "GetEventsRuleRole":
+        return _get_events_rule_role(connecting_obj_id, connecting_obj_arn, properties)
     return None
 
 
 def _get_resource_role_name(
-    connecting_obj_id: Optional[str], connecting_obj_arn: Optional[Any], resource_type: str, properties: Dict[str, Any]
+    connecting_obj_id: Optional[str],
+    connecting_obj_arn: Optional[Any],
+    cfn_resource_properties: Dict[str, Any],
+    properties: Dict[str, Any],
 ) -> Any:
-    role = _get_resource_role_property(connecting_obj_id, connecting_obj_arn, resource_type, properties)
+    role = _get_resource_role_property(connecting_obj_id, connecting_obj_arn, cfn_resource_properties, properties)
     if not role:
         return None
 
@@ -208,39 +227,26 @@ def _get_resource_role_name(
     return ref(logical_id)
 
 
-def _get_resource_queue_url(logical_id: str, resource_type: str) -> Optional[Dict[str, Any]]:
-    if resource_type == "AWS::SQS::Queue":
-        return ref(logical_id)
-    return None
+def _get_resource_queue_url(properties) -> Optional[Dict[str, Any]]:
+    return properties.get("Outputs", {}).get("Url")
 
 
-def _get_resource_id(logical_id: str, resource_type: str) -> Optional[Dict[str, Any]]:
-    if resource_type in ["AWS::ApiGateway::RestApi", "AWS::ApiGatewayV2::Api"]:
-        return ref(logical_id)
-    if resource_type == "AWS::AppSync::GraphQLApi":
-        # unfortunately ref(AppSyncApi) == arn
-        return fnGetAtt(logical_id, "ApiId")
-    return None
+def _get_resource_id(properties) -> Optional[Dict[str, Any]]:
+    return properties.get("Outputs", {}).get("Id")
 
 
-def _get_resource_name(logical_id: str, resource_type: str) -> Optional[Dict[str, Any]]:
-    if resource_type == "AWS::StepFunctions::StateMachine":
-        return fnGetAtt(logical_id, "Name")
-    return None
+def _get_resource_name(properties: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    return properties.get("Outputs", {}).get("Name")
 
 
-def _get_resource_qualifier(resource_type: str) -> Optional[str]:
+def _get_resource_qualifier(properties: Dict[str, Any]) -> Optional[str]:
     # Qualifier is used as the execute-api ARN suffix; by default allow whole API
-    if resource_type in ["AWS::ApiGateway::RestApi", "AWS::ApiGatewayV2::Api"]:
-        return "*"
-    return None
+    return properties.get("Outputs", {}).get("Qualifier")
 
 
-def _get_resource_arn(logical_id: str, resource_type: str) -> Any:
-    if resource_type in ["AWS::SNS::Topic", "AWS::StepFunctions::StateMachine"]:
-        # according to documentation, Ref returns ARNs for these two resource types
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#aws-resource-stepfunctions-statemachine-return-values
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html#aws-resource-sns-topic-return-values
-        return ref(logical_id)
+def _get_resource_arn(properties: Dict[str, Any]) -> Any:
+    # according to documentation, Ref returns ARNs for these two resource types
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#aws-resource-stepfunctions-statemachine-return-values
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html#aws-resource-sns-topic-return-values
     # For all other supported resources, we can typically use Fn::GetAtt LogicalId.Arn to obtain ARNs
-    return fnGetAtt(logical_id, "Arn")
+    return properties.get("Outputs", {}).get("Arn")

--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -199,14 +199,14 @@ def _get_resource_role_property(
     properties: Dict[str, Any],
 ) -> Any:
     role_property = cfn_resource_properties.get("Inputs", {}).get("Role")
-    if not role_property:
-        return None
 
     if isinstance(role_property, str):
         return properties.get(role_property)
 
     if isinstance(role_property, dict) and role_property.get("Function") == "GetEventsRuleRole":
         return _get_events_rule_role(connecting_obj_id, connecting_obj_arn, properties)
+
+    return None
 
 
 def _get_resource_role_name(

--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -151,7 +151,7 @@ def get_resource_reference(
         raise ConnectorResourceError("'Type' is missing or not a string.")
     properties = resource.get("Properties", {})
 
-    cfn_resource_properties = replace_cfn_resource_properties(resource_type, logical_id) or {}
+    cfn_resource_properties = replace_cfn_resource_properties(resource_type, logical_id)
 
     arn = _get_resource_arn(cfn_resource_properties)
 
@@ -181,7 +181,7 @@ def get_resource_reference(
 
 def _get_events_rule_role(
     connecting_obj_id: Optional[str], connecting_obj_arn: Optional[Any], properties: Dict[str, Any]
-):
+) -> Optional[Any]:
     for target in properties.get("Targets", []):
         target_arn = target.get("Arn")
         target_logical_id = get_logical_id_from_intrinsic(target_arn)
@@ -207,7 +207,6 @@ def _get_resource_role_property(
 
     if isinstance(role_property, dict) and role_property.get("Function") == "GetEventsRuleRole":
         return _get_events_rule_role(connecting_obj_id, connecting_obj_arn, properties)
-    return None
 
 
 def _get_resource_role_name(
@@ -227,19 +226,19 @@ def _get_resource_role_name(
     return ref(logical_id)
 
 
-def _get_resource_queue_url(properties) -> Optional[Dict[str, Any]]:
+def _get_resource_queue_url(properties: Dict[str, Any]) -> Optional[Any]:
     return properties.get("Outputs", {}).get("Url")
 
 
-def _get_resource_id(properties) -> Optional[Dict[str, Any]]:
+def _get_resource_id(properties: Dict[str, Any]) -> Optional[Any]:
     return properties.get("Outputs", {}).get("Id")
 
 
-def _get_resource_name(properties: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _get_resource_name(properties: Dict[str, Any]) -> Optional[Any]:
     return properties.get("Outputs", {}).get("Name")
 
 
-def _get_resource_qualifier(properties: Dict[str, Any]) -> Optional[str]:
+def _get_resource_qualifier(properties: Dict[str, Any]) -> Optional[Any]:
     # Qualifier is used as the execute-api ARN suffix; by default allow whole API
     return properties.get("Outputs", {}).get("Qualifier")
 

--- a/samtranslator/model/connector/connector.py
+++ b/samtranslator/model/connector/connector.py
@@ -153,19 +153,21 @@ def get_resource_reference(
 
     cfn_resource_properties = replace_cfn_resource_properties(resource_type, logical_id)
 
-    arn = _get_resource_arn(cfn_resource_properties)
+    cfn_resource_properties_output = cfn_resource_properties.get("Outputs", {})
+
+    arn = _get_resource_arn(cfn_resource_properties_output)
 
     role_name = _get_resource_role_name(
         connecting_obj.get("Id"), connecting_obj.get("Arn"), cfn_resource_properties, properties
     )
 
-    queue_url = _get_resource_queue_url(cfn_resource_properties)
+    queue_url = _get_resource_queue_url(cfn_resource_properties_output)
 
-    resource_id = _get_resource_id(cfn_resource_properties)
+    resource_id = _get_resource_id(cfn_resource_properties_output)
 
-    name = _get_resource_name(cfn_resource_properties)
+    name = _get_resource_name(cfn_resource_properties_output)
 
-    qualifier = obj.get("Qualifier") if "Qualifier" in obj else _get_resource_qualifier(cfn_resource_properties)
+    qualifier = obj.get("Qualifier") if "Qualifier" in obj else _get_resource_qualifier(cfn_resource_properties_output)
 
     return ConnectorResourceReference(
         logical_id=logical_id,
@@ -227,20 +229,20 @@ def _get_resource_role_name(
 
 
 def _get_resource_queue_url(properties: Dict[str, Any]) -> Optional[Any]:
-    return properties.get("Outputs", {}).get("Url")
+    return properties.get("Url")
 
 
 def _get_resource_id(properties: Dict[str, Any]) -> Optional[Any]:
-    return properties.get("Outputs", {}).get("Id")
+    return properties.get("Id")
 
 
 def _get_resource_name(properties: Dict[str, Any]) -> Optional[Any]:
-    return properties.get("Outputs", {}).get("Name")
+    return properties.get("Name")
 
 
 def _get_resource_qualifier(properties: Dict[str, Any]) -> Optional[Any]:
     # Qualifier is used as the execute-api ARN suffix; by default allow whole API
-    return properties.get("Outputs", {}).get("Qualifier")
+    return properties.get("Qualifier")
 
 
 def _get_resource_arn(properties: Dict[str, Any]) -> Any:
@@ -248,4 +250,4 @@ def _get_resource_arn(properties: Dict[str, Any]) -> Any:
     # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#aws-resource-stepfunctions-statemachine-return-values
     # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html#aws-resource-sns-topic-return-values
     # For all other supported resources, we can typically use Fn::GetAtt LogicalId.Arn to obtain ARNs
-    return properties.get("Outputs", {}).get("Arn")
+    return properties.get("Arn")

--- a/samtranslator/model/connector_profiles/profile.py
+++ b/samtranslator/model/connector_profiles/profile.py
@@ -17,8 +17,8 @@ def get_profile(source_type: str, dest_type: str):  # type: ignore[no-untyped-de
     return copy.deepcopy(profile)
 
 
-def replace_cfn_resource_properties(resource_type: str, logical_id: str) -> Dict[str, Any]:
-    properties = copy.deepcopy(PROFILE["CfnResourceProperties"].get(resource_type))
+def replace_cfn_resource_properties(resource_type: str, logical_id: str) -> Any:
+    properties = copy.deepcopy(PROFILE["CfnResourceProperties"].get(resource_type, {}))
 
     return profile_replace(properties, {"logicalId": logical_id})
 

--- a/samtranslator/model/connector_profiles/profile.py
+++ b/samtranslator/model/connector_profiles/profile.py
@@ -17,6 +17,12 @@ def get_profile(source_type: str, dest_type: str):  # type: ignore[no-untyped-de
     return copy.deepcopy(profile)
 
 
+def replace_cfn_resource_properties(resource_type: str, logical_id: str) -> Dict[str, Any]:
+    properties = copy.deepcopy(PROFILE["CfnResourceProperties"].get(resource_type))
+
+    return profile_replace(properties, {"logicalId": logical_id})
+
+
 def verify_profile_variables_replaced(obj: Any) -> None:
     """
     Verifies all profile variables have been replaced; throws ValueError if not.

--- a/samtranslator/model/connector_profiles/profiles.json
+++ b/samtranslator/model/connector_profiles/profiles.json
@@ -807,5 +807,162 @@
         }
       }
     }
+  },
+  "CfnResourceProperties": {
+    "AWS::Lambda::Function": {
+      "Inputs": {
+        "Role": "Role"
+      },
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "AWS::StepFunctions::StateMachine": {
+      "Inputs": {
+        "Role": "RoleArn"
+      },
+      "Outputs": {
+        "Arn": {
+          "Ref": "%{logicalId}"
+        },
+        "Name": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Name"
+          ]
+        }
+      }
+    },
+    "AWS::AppSync::GraphQLApi": {
+      "Outputs": {
+        "Id": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "ApiId"
+          ]
+        },
+        "Arn": {
+          "Ref": "%{logicalId}"
+        }
+      }
+    },
+    "AWS::AppSync::DataSource": {
+      "Inputs": {
+        "Role": "ServiceRoleArn"
+      },
+      "Outputs": {
+        "Arn": {
+          "Ref": "%{logicalId}"
+        }
+      }
+    },
+    "AWS::Events::Rule": {
+      "Inputs": {
+        "Role": {
+          "Function": "GetEventsRuleRole"
+        }
+      },
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "AWS::SQS::Queue": {
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        },
+        "Url": {
+          "Ref": "%{logicalId}"
+        }
+      }
+    },
+    "AWS::SNS::Topic": {
+      "Outputs": {
+        "Arn": {
+          "Ref": "%{logicalId}"
+        }
+      }
+    },
+    "AWS::DynamoDB::Table": {
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "AWS::S3::Bucket": {
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "AWS::Location::PlaceIndex": {
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "AWS::ApiGatewayV2::Api": {
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        },
+        "Qualifier": "*",
+        "Id": {
+          "Ref": "%{logicalId}"
+        }
+      }
+    },
+    "AWS::ApiGateway::RestApi": {
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        },
+        "Qualifier": "*",
+        "Id": {
+          "Ref": "%{logicalId}"
+        }
+      }
+    },
+    "AWS::Events::EventBus": {
+      "Outputs": {
+        "Arn": {
+          "Fn::GetAtt": [
+            "%{logicalId}",
+            "Arn"
+          ]
+        }
+      }
+    }
   }
 }

--- a/tests/model/connector_profiles/test_profile.py
+++ b/tests/model/connector_profiles/test_profile.py
@@ -4,6 +4,7 @@ from parameterized import parameterized
 from samtranslator.model.connector_profiles.profile import (
     get_profile,
     profile_replace,
+    replace_cfn_resource_properties,
     verify_profile_variables_replaced,
 )
 
@@ -104,6 +105,15 @@ class TestProfile(TestCase):
                 "%DestinationArn",
             ],
         )
+
+    def test_replace_cfn_resource_properties(self):
+        output = replace_cfn_resource_properties("AWS::Lambda::Function", "hello-world")
+        self.assertEqual(
+            output, {"Inputs": {"Role": "Role"}, "Outputs": {"Arn": {"Fn::GetAtt": ["hello-world", "Arn"]}}}
+        )
+
+        output = replace_cfn_resource_properties("AWS::Fake::Resource", "hello-world")
+        self.assertEqual(output, None)
 
     def test_profile_replace_dict_input(self):
         input = {

--- a/tests/model/connector_profiles/test_profile.py
+++ b/tests/model/connector_profiles/test_profile.py
@@ -113,7 +113,7 @@ class TestProfile(TestCase):
         )
 
         output = replace_cfn_resource_properties("AWS::Fake::Resource", "hello-world")
-        self.assertEqual(output, None)
+        self.assertEqual(output, {})
 
     def test_profile_replace_dict_input(self):
         input = {


### PR DESCRIPTION
### Issue #, if available

### Description of changes
We want to read from profiles.json and get CFN resource properties for SAM Connectors

### Description of how you validated changes
Added new tests, all tests passed.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
