### PR TITLE
chore: make statemachine cw events test nonblocking

### DIFF
--- a/integration/combination/test_state_machine_with_schedule.py
+++ b/integration/combination/test_state_machine_with_schedule.py
@@ -3,7 +3,7 @@ from unittest.case import skipIf
 from parameterized import parameterized
 
 from integration.config.service_names import STATE_MACHINE_CWE_CWS
-from integration.helpers.base_test import BaseTest
+from integration.helpers.base_test import BaseTest, nonblocking
 from integration.helpers.common_api import get_policy_statements
 from integration.helpers.resource import current_region_does_not_support
 
@@ -12,6 +12,7 @@ from integration.helpers.resource import current_region_does_not_support
     current_region_does_not_support([STATE_MACHINE_CWE_CWS]),
     "StateMachine CweCws is not supported in this testing region",
 )
+@nonblocking
 class TestStateMachineWithSchedule(BaseTest):
     @parameterized.expand(
         [

--- a/tests/translator/input/state_machine_with_schedule_cloudwatch_event.yaml
+++ b/tests/translator/input/state_machine_with_schedule_cloudwatch_event.yaml
@@ -1,0 +1,46 @@
+Resources:
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Definition:
+        Comment: A Hello World example of the Amazon States Language using Pass states
+        StartAt: Hello
+        States:
+          Hello:
+            Type: Pass
+            Result: Hello
+            Next: World
+          World:
+            Type: Pass
+            Result: World
+            End: true
+      Policies:
+      - Version: '2012-10-17'
+        Statement:
+        - Effect: Deny
+          Action: '*'
+          Resource: '*'
+
+      Events:
+        CWSchedule:
+          Type: Schedule
+          Properties:
+            Schedule: rate(1 minute)
+            Description: test schedule
+            Enabled: false
+
+Outputs:
+  MyStateMachineArn:
+    Description: ARN of the State Machine
+    Value:
+      Ref: MyStateMachine
+  MyScheduleName:
+    Description: Name of the Schedule rule created
+    Value:
+      Ref: MyStateMachineCWSchedule
+  MyEventRole:
+    Description: ARN of the role created for the Schedule rule
+    Value:
+      Ref: MyStateMachineCWScheduleRole
+Metadata:
+  SamTransformTest: true

--- a/tests/translator/input/state_machine_with_schedule_cloudwatch_event_target_id.yaml
+++ b/tests/translator/input/state_machine_with_schedule_cloudwatch_event_target_id.yaml
@@ -1,0 +1,48 @@
+Resources:
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Definition:
+        Comment: A Hello World example of the Amazon States Language using Pass states
+        StartAt: Hello
+        States:
+          Hello:
+            Type: Pass
+            Result: Hello
+            Next: World
+          World:
+            Type: Pass
+            Result: World
+            End: true
+      Policies:
+      - Version: '2012-10-17'
+        Statement:
+        - Effect: Deny
+          Action: '*'
+          Resource: '*'
+
+      Events:
+        CWSchedule:
+          Type: Schedule
+          Properties:
+            Schedule: rate(1 minute)
+            Description: test schedule
+            Enabled: false
+            Target:
+              Id: ThisMyTargetID
+
+Outputs:
+  MyStateMachineArn:
+    Description: ARN of the State Machine
+    Value:
+      Ref: MyStateMachine
+  MyScheduleName:
+    Description: Name of the Schedule rule created
+    Value:
+      Ref: MyStateMachineCWSchedule
+  MyEventRole:
+    Description: ARN of the role created for the Schedule rule
+    Value:
+      Ref: MyStateMachineCWScheduleRole
+Metadata:
+  SamTransformTest: true

--- a/tests/translator/output/aws-cn/state_machine_with_schedule_cloudwatch_event.json
+++ b/tests/translator/output/aws-cn/state_machine_with_schedule_cloudwatch_event.json
@@ -1,0 +1,169 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Outputs": {
+    "MyEventRole": {
+      "Description": "ARN of the role created for the Schedule rule",
+      "Value": {
+        "Ref": "MyStateMachineCWScheduleRole"
+      }
+    },
+    "MyScheduleName": {
+      "Description": "Name of the Schedule rule created",
+      "Value": {
+        "Ref": "MyStateMachineCWSchedule"
+      }
+    },
+    "MyStateMachineArn": {
+      "Description": "ARN of the State Machine",
+      "Value": {
+        "Ref": "MyStateMachine"
+      }
+    }
+  },
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/state_machine_with_schedule_cloudwatch_event_target_id.json
+++ b/tests/translator/output/aws-cn/state_machine_with_schedule_cloudwatch_event_target_id.json
@@ -1,0 +1,169 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Outputs": {
+    "MyEventRole": {
+      "Description": "ARN of the role created for the Schedule rule",
+      "Value": {
+        "Ref": "MyStateMachineCWScheduleRole"
+      }
+    },
+    "MyScheduleName": {
+      "Description": "Name of the Schedule rule created",
+      "Value": {
+        "Ref": "MyStateMachineCWSchedule"
+      }
+    },
+    "MyStateMachineArn": {
+      "Description": "ARN of the State Machine",
+      "Value": {
+        "Ref": "MyStateMachine"
+      }
+    }
+  },
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "ThisMyTargetID",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/state_machine_with_schedule_cloudwatch_event.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_schedule_cloudwatch_event.json
@@ -1,0 +1,169 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Outputs": {
+    "MyEventRole": {
+      "Description": "ARN of the role created for the Schedule rule",
+      "Value": {
+        "Ref": "MyStateMachineCWScheduleRole"
+      }
+    },
+    "MyScheduleName": {
+      "Description": "Name of the Schedule rule created",
+      "Value": {
+        "Ref": "MyStateMachineCWSchedule"
+      }
+    },
+    "MyStateMachineArn": {
+      "Description": "ARN of the State Machine",
+      "Value": {
+        "Ref": "MyStateMachine"
+      }
+    }
+  },
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/state_machine_with_schedule_cloudwatch_event_target_id.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_schedule_cloudwatch_event_target_id.json
@@ -1,0 +1,169 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Outputs": {
+    "MyEventRole": {
+      "Description": "ARN of the role created for the Schedule rule",
+      "Value": {
+        "Ref": "MyStateMachineCWScheduleRole"
+      }
+    },
+    "MyScheduleName": {
+      "Description": "Name of the Schedule rule created",
+      "Value": {
+        "Ref": "MyStateMachineCWSchedule"
+      }
+    },
+    "MyStateMachineArn": {
+      "Description": "ARN of the State Machine",
+      "Value": {
+        "Ref": "MyStateMachine"
+      }
+    }
+  },
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "ThisMyTargetID",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/state_machine_with_schedule_cloudwatch_event.json
+++ b/tests/translator/output/state_machine_with_schedule_cloudwatch_event.json
@@ -1,0 +1,169 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Outputs": {
+    "MyEventRole": {
+      "Description": "ARN of the role created for the Schedule rule",
+      "Value": {
+        "Ref": "MyStateMachineCWScheduleRole"
+      }
+    },
+    "MyScheduleName": {
+      "Description": "Name of the Schedule rule created",
+      "Value": {
+        "Ref": "MyStateMachineCWSchedule"
+      }
+    },
+    "MyStateMachineArn": {
+      "Description": "ARN of the State Machine",
+      "Value": {
+        "Ref": "MyStateMachine"
+      }
+    }
+  },
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/state_machine_with_schedule_cloudwatch_event_target_id.json
+++ b/tests/translator/output/state_machine_with_schedule_cloudwatch_event_target_id.json
@@ -1,0 +1,169 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Outputs": {
+    "MyEventRole": {
+      "Description": "ARN of the role created for the Schedule rule",
+      "Value": {
+        "Ref": "MyStateMachineCWScheduleRole"
+      }
+    },
+    "MyScheduleName": {
+      "Description": "Name of the Schedule rule created",
+      "Value": {
+        "Ref": "MyStateMachineCWSchedule"
+      }
+    },
+    "MyStateMachineArn": {
+      "Description": "ARN of the State Machine",
+      "Value": {
+        "Ref": "MyStateMachine"
+      }
+    }
+  },
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "ThisMyTargetID",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes

These tests blocked the pipeline; added equivalent transform tests and marking as non-blocking since we've already tested it.

The integration tests only check that the right resources are made and that the properties are transformed as expected. This can be verified through the transform tests. 

https://github.com/aws/serverless-application-model/blob/b02c0a43f71f2759389307f8c77802ca12831443/integration/combination/test_state_machine_with_schedule.py#L33-L61



### Description of how you validated changes

Ensured new transform tests are same as the integration ones and that the output is expected. 

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
