### PR TITLE
fix: Remove validation of SNS Event FilterPolicy

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -485,7 +485,7 @@ class SNS(PushEventSource):
     property_types = {
         "Topic": PropertyType(True, IS_STR),
         "Region": PropertyType(False, IS_STR),
-        "FilterPolicy": PropertyType(False, dict_of(IS_STR, list_of(one_of(IS_STR, IS_DICT)))),
+        "FilterPolicy": PassThroughProperty(False),
         "FilterPolicyScope": PassThroughProperty(False),
         "SqsSubscription": PropertyType(False, one_of(IS_BOOL, IS_DICT)),
         "RedrivePolicy": PropertyType(False, IS_DICT),

--- a/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
+++ b/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
@@ -5,7 +5,6 @@ Resources:
       CodeUri: s3://sam-demo-bucket/hello.zip
       Handler: hello.handler
       Runtime: python2.7
-
       Events:
         NotificationTopic:
           Type: SNS
@@ -25,4 +24,7 @@ Resources:
               - numeric:
                 - '>='
                 - 100
+              before:
+                owner:
+                - '0x0'
             FilterPolicyScope: MessageAttributes

--- a/tests/translator/output/aws-cn/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_sns_event_source_all_parameters.json
@@ -32,6 +32,11 @@
           ]
         },
         "FilterPolicy": {
+          "before": {
+            "owner": [
+              "0x0"
+            ]
+          },
           "customer_interests": [
             "rugby",
             "football",

--- a/tests/translator/output/aws-us-gov/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_sns_event_source_all_parameters.json
@@ -32,6 +32,11 @@
           ]
         },
         "FilterPolicy": {
+          "before": {
+            "owner": [
+              "0x0"
+            ]
+          },
           "customer_interests": [
             "rugby",
             "football",

--- a/tests/translator/output/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/function_with_sns_event_source_all_parameters.json
@@ -32,6 +32,11 @@
           ]
         },
         "FilterPolicy": {
+          "before": {
+            "owner": [
+              "0x0"
+            ]
+          },
           "customer_interests": [
             "rugby",
             "football",


### PR DESCRIPTION
### Issue #, if available
https://github.com/aws/serverless-application-model/issues/3214

### Description of changes
Remove the validation of SNS Event `FilterPolicy` because it's a pass-through prop.

### Description of how you validated changes
Make `FilterPolicy` nested json in transform test and test passes.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
