### PR TITLE
Set runtime for resolvers which use generated code

### DIFF
--- a/integration/resources/templates/combination/graphqlapi_lambda_resolver.yaml
+++ b/integration/resources/templates/combination/graphqlapi_lambda_resolver.yaml
@@ -108,16 +108,10 @@ Resources:
       Resolvers:
         Mutation:
           addPost:
-            Runtime:
-              Name: APPSYNC_JS
-              Version: 1.0.0
             Pipeline:
             - lambdaInvoker
         Query:
           getPost:
-            Runtime:
-              Name: APPSYNC_JS
-              Version: 1.0.0
             Pipeline:
             - lambdaInvoker
 

--- a/integration/resources/templates/combination/graphqlapi_pipeline_resolver.yaml
+++ b/integration/resources/templates/combination/graphqlapi_pipeline_resolver.yaml
@@ -171,9 +171,6 @@ Resources:
       Resolvers:
         Mutation:
           addPost:
-            Runtime:
-              Name: APPSYNC_JS
-              Version: 1.0.0
             Pipeline:
             - formatPostLogItem
             - createPostLogItem
@@ -181,9 +178,6 @@ Resources:
             - createPostItem
         Query:
           getPost:
-            Runtime:
-              Name: APPSYNC_JS
-              Version: 1.0.0
             Pipeline:
             - getPostFromTable
 

--- a/samtranslator/internal/model/appsync.py
+++ b/samtranslator/internal/model/appsync.py
@@ -75,6 +75,13 @@ class AppSyncRuntimeType(TypedDict):
     RuntimeVersion: str
 
 
+# Runtime for the default generated resolver code (see APPSYNC_PIPELINE_RESOLVER_JS_CODE above)
+APPSYNC_PIPELINE_RESOLVER_JS_RUNTIME: AppSyncRuntimeType = {
+    "Name": "APPSYNC_JS",
+    "RuntimeVersion": "1.0.0",
+}
+
+
 class LambdaConflictHandlerConfigType(TypedDict):
     LambdaConflictHandlerArn: str
 

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -14,6 +14,7 @@ from samtranslator.feature_toggle.feature_toggle import FeatureToggle
 from samtranslator.internal.intrinsics import resolve_string_parameter_in_resource
 from samtranslator.internal.model.appsync import (
     APPSYNC_PIPELINE_RESOLVER_JS_CODE,
+    APPSYNC_PIPELINE_RESOLVER_JS_RUNTIME,
     AdditionalAuthenticationProviderType,
     ApiCache,
     ApiKey,
@@ -2187,7 +2188,7 @@ class SamConnector(SamResourceMacro):
 
 
 class SamGraphQLApi(SamResourceMacro):
-    """SAM GraphQL API Macro (WIP)."""
+    """SAM GraphQL API Macro."""
 
     resource_type = "AWS::Serverless::GraphQLApi"
     property_types = {
@@ -2973,11 +2974,13 @@ class SamGraphQLApi(SamResourceMacro):
                 # to a default snippet which has basic definition of request/response functions.
                 if not cfn_resolver.Code and not cfn_resolver.CodeS3Location:
                     cfn_resolver.Code = APPSYNC_PIPELINE_RESOLVER_JS_CODE
+                    cfn_resolver.Runtime = APPSYNC_PIPELINE_RESOLVER_JS_RUNTIME
+                else:
+                    cfn_resolver.Runtime = self._parse_runtime(resolver, relative_id)
 
                 cfn_resolver.ApiId = api_id
                 cfn_resolver.FieldName = resolver.FieldName or relative_id
                 cfn_resolver.TypeName = type_name
-                cfn_resolver.Runtime = self._parse_runtime(resolver, relative_id)
 
                 if resolver.Pipeline:
                     cfn_resolver.Kind = "PIPELINE"

--- a/tests/translator/input/error_graphqlapi.yaml
+++ b/tests/translator/input/error_graphqlapi.yaml
@@ -284,37 +284,6 @@ Resources:
             Version: 1.2.3
           InlineCode: this is my epic code
 
-  ResolverBothDatasourcePropertiesDefined:
-    Type: AWS::Serverless::GraphQLApi
-    Properties:
-      Name: SomeApi
-      SchemaInline: |
-        type Mutation {
-          addTodo(id: ID!, name: String, description: String, priority: Int): Todo
-        }
-      XrayEnabled: true
-      Auth:
-        Type: AWS_IAM
-      Tags:
-        key1: value1
-        key2: value2
-      Resolvers:
-        Mutation:
-          BothDatasourcePropertiesDefined:
-            FieldName: my_field
-            Runtime:
-              Name: some-runtime
-              Version: 1.2.3
-            Pipeline:
-            - MyFunction
-      Functions:
-        MyFunction:
-          DataSource: NONE
-          Runtime:
-            Name: some-runtime
-            Version: 1.2.3
-          InlineCode: this is my epic code
-
   ResolverWithNoRuntime:
     Type: AWS::Serverless::GraphQLApi
     Properties:
@@ -333,6 +302,7 @@ Resources:
         Mutation:
           NoRuntimeForResolver:
             FieldName: my_field
+            InlineCode: overridden code must be supplied with Runtime
             Pipeline:
             - MyFunction
       Functions:

--- a/tests/translator/input/graphqlapi_resolver_function_with_lambda_datasource.yaml
+++ b/tests/translator/input/graphqlapi_resolver_function_with_lambda_datasource.yaml
@@ -26,9 +26,20 @@ Resources:
           myResolver:
             FieldName: my_field
             MaxBatchSize: 10
+            Caching:
+              Ttl: 20
+              CachingKeys:
+              - key1
+              - key2
+            Pipeline:
+            - MyFunction
+          myResolverWithCustomCode:
+            FieldName: my_field
+            InlineCode: custom code
             Runtime:
-              Name: some-runtime
+              Name: APPSYNC_JS
               Version: 1.2.3
+            MaxBatchSize: 10
             Caching:
               Ttl: 20
               CachingKeys:

--- a/tests/translator/output/aws-cn/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/aws-cn/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -86,7 +86,47 @@
           ]
         },
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0"
+        },
+        "TypeName": "Mutation"
+      },
+      "Type": "AWS::AppSync::Resolver"
+    },
+    "SuperCoolAPIMutationmyResolverWithCustomCode": {
+      "DependsOn": [
+        "SuperCoolAPISchema"
+      ],
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "CachingConfig": {
+          "CachingKeys": [
+            "key1",
+            "key2"
+          ],
+          "Ttl": 20
+        },
+        "Code": "custom code",
+        "FieldName": "my_field",
+        "Kind": "PIPELINE",
+        "MaxBatchSize": 10,
+        "PipelineConfig": {
+          "Functions": [
+            {
+              "Fn::GetAtt": [
+                "SuperCoolAPIMyFunction",
+                "FunctionId"
+              ]
+            }
+          ]
+        },
+        "Runtime": {
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         },
         "TypeName": "Mutation"

--- a/tests/translator/output/aws-us-gov/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -86,7 +86,47 @@
           ]
         },
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0"
+        },
+        "TypeName": "Mutation"
+      },
+      "Type": "AWS::AppSync::Resolver"
+    },
+    "SuperCoolAPIMutationmyResolverWithCustomCode": {
+      "DependsOn": [
+        "SuperCoolAPISchema"
+      ],
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "CachingConfig": {
+          "CachingKeys": [
+            "key1",
+            "key2"
+          ],
+          "Ttl": 20
+        },
+        "Code": "custom code",
+        "FieldName": "my_field",
+        "Kind": "PIPELINE",
+        "MaxBatchSize": 10,
+        "PipelineConfig": {
+          "Functions": [
+            {
+              "Fn::GetAtt": [
+                "SuperCoolAPIMyFunction",
+                "FunctionId"
+              ]
+            }
+          ]
+        },
+        "Runtime": {
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         },
         "TypeName": "Mutation"

--- a/tests/translator/output/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -86,7 +86,47 @@
           ]
         },
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0"
+        },
+        "TypeName": "Mutation"
+      },
+      "Type": "AWS::AppSync::Resolver"
+    },
+    "SuperCoolAPIMutationmyResolverWithCustomCode": {
+      "DependsOn": [
+        "SuperCoolAPISchema"
+      ],
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "CachingConfig": {
+          "CachingKeys": [
+            "key1",
+            "key2"
+          ],
+          "Ttl": 20
+        },
+        "Code": "custom code",
+        "FieldName": "my_field",
+        "Kind": "PIPELINE",
+        "MaxBatchSize": 10,
+        "PipelineConfig": {
+          "Functions": [
+            {
+              "Fn::GetAtt": [
+                "SuperCoolAPIMyFunction",
+                "FunctionId"
+              ]
+            }
+          ]
+        },
+        "Runtime": {
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         },
         "TypeName": "Mutation"


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Resolvers provide by default generated code to pass request to functions and receive response. There is no need to ask a customer for Runtime when default code is used because we know ourselves which Runtime should be used for the generated code.

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [x] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
