### PR TITLE
allow intrinsics for some less important fields

### DIFF
--- a/samtranslator/internal/schema_source/aws_serverless_graphqlapi.py
+++ b/samtranslator/internal/schema_source/aws_serverless_graphqlapi.py
@@ -57,13 +57,13 @@ class ApiKey(BaseModel):
 class Logging(BaseModel):
     CloudWatchLogsRoleArn: Optional[PassThroughProp]
     ExcludeVerboseContent: Optional[PassThroughProp]
-    FieldLogLevel: Optional[str]
+    FieldLogLevel: Optional[PassThroughProp]
 
 
 class DeltaSync(BaseModel):
-    BaseTableTTL: str
-    DeltaSyncTableName: str
-    DeltaSyncTableTTL: str
+    BaseTableTTL: PassThroughProp
+    DeltaSyncTableName: PassThroughProp
+    DeltaSyncTableTTL: PassThroughProp
 
 
 class DynamoDBDataSource(BaseModel):
@@ -71,7 +71,7 @@ class DynamoDBDataSource(BaseModel):
     ServiceRoleArn: Optional[PassThroughProp]
     TableArn: Optional[PassThroughProp]
     Permissions: Optional[PermissionsType]
-    Name: Optional[str]
+    Name: Optional[PassThroughProp]
     Description: Optional[PassThroughProp]
     Region: Optional[PassThroughProp]
     DeltaSync: Optional[DeltaSync]
@@ -82,7 +82,7 @@ class DynamoDBDataSource(BaseModel):
 class LambdaDataSource(BaseModel):
     FunctionArn: PassThroughProp
     ServiceRoleArn: Optional[PassThroughProp]
-    Name: Optional[str]
+    Name: Optional[PassThroughProp]
     Description: Optional[PassThroughProp]
 
 
@@ -153,7 +153,7 @@ class Cache(BaseModel):
 class Properties(BaseModel):
     Auth: Auth
     Tags: Optional[DictStrAny]
-    Name: Optional[str]
+    Name: Optional[PassThroughProp]
     XrayEnabled: Optional[bool]
     SchemaInline: Optional[PassThroughProp]
     SchemaUri: Optional[PassThroughProp]

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -2193,7 +2193,7 @@ class SamGraphQLApi(SamResourceMacro):
 
     resource_type = "AWS::Serverless::GraphQLApi"
     property_types = {
-        "Name": Property(False, IS_STR),
+        "Name": PassThroughProperty(False),
         "Tags": Property(False, IS_DICT),
         "XrayEnabled": PassThroughProperty(False),
         "Auth": Property(True, IS_DICT),
@@ -2211,7 +2211,7 @@ class SamGraphQLApi(SamResourceMacro):
     Auth: List[Dict[str, Any]]
     Tags: Optional[Dict[str, Any]]
     XrayEnabled: Optional[PassThrough]
-    Name: Optional[str]
+    Name: Optional[PassThrough]
     SchemaInline: Optional[str]
     SchemaUri: Optional[str]
     Logging: Optional[Union[Dict[str, Any], bool]]
@@ -2290,7 +2290,7 @@ class SamGraphQLApi(SamResourceMacro):
     ) -> Tuple[GraphQLApi, Optional[IAMRole], List[SamConnector]]:
         api = GraphQLApi(logical_id=self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)
 
-        api.Name = model.Name or self.logical_id
+        api.Name = passthrough_value(model.Name) or self.logical_id
         api.XrayEnabled = model.XrayEnabled
 
         lambda_auth_arns = self._parse_and_set_auth_properties(api, model.Auth)
@@ -2465,7 +2465,7 @@ class SamGraphQLApi(SamResourceMacro):
         if model.Logging.ExcludeVerboseContent:
             log_config["ExcludeVerboseContent"] = cast(PassThrough, model.Logging.ExcludeVerboseContent)
 
-        log_config["FieldLogLevel"] = model.Logging.FieldLogLevel or "ALL"
+        log_config["FieldLogLevel"] = passthrough_value(model.Logging.FieldLogLevel) or "ALL"
         log_config["CloudWatchLogsRoleArn"] = cast(PassThrough, model.Logging.CloudWatchLogsRoleArn)
 
         if log_config["CloudWatchLogsRoleArn"]:
@@ -2598,7 +2598,7 @@ class SamGraphQLApi(SamResourceMacro):
             )
 
             # Datasource "Name" property must be unique from all other datasources.
-            cfn_datasource.Name = ddb_datasource.Name or relative_id
+            cfn_datasource.Name = passthrough_value(ddb_datasource.Name) or relative_id
             cfn_datasource.Type = "AMAZON_DYNAMODB"
             cfn_datasource.ApiId = api_id
             cfn_datasource.Description = passthrough_value(ddb_datasource.Description)
@@ -2652,7 +2652,7 @@ class SamGraphQLApi(SamResourceMacro):
     def _parse_ddb_config(self, ddb_datasource: aws_serverless_graphqlapi.DynamoDBDataSource) -> DynamoDBConfigType:
         ddb_config: DynamoDBConfigType = {}
 
-        ddb_config["AwsRegion"] = cast(PassThrough, ddb_datasource.Region) or ref("AWS::Region")
+        ddb_config["AwsRegion"] = passthrough_value(ddb_datasource.Region) or ref("AWS::Region")
         ddb_config["TableName"] = passthrough_value(ddb_datasource.TableName)
 
         if ddb_datasource.UseCallerCredentials:
@@ -2713,7 +2713,7 @@ class SamGraphQLApi(SamResourceMacro):
                 logical_id=datasource_logical_id, depends_on=self.depends_on, attributes=self.resource_attributes
             )
 
-            cfn_datasource.Name = lambda_datasource.Name or relative_id
+            cfn_datasource.Name = passthrough_value(lambda_datasource.Name) or relative_id
             cfn_datasource.Type = "AWS_LAMBDA"
             cfn_datasource.ApiId = api_id
             cfn_datasource.Description = passthrough_value(lambda_datasource.Description)

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -558,16 +558,13 @@
       "additionalProperties": false,
       "properties": {
         "BaseTableTTL": {
-          "title": "Basetablettl",
-          "type": "string"
+          "$ref": "#/definitions/PassThroughProp"
         },
         "DeltaSyncTableName": {
-          "title": "Deltasynctablename",
-          "type": "string"
+          "$ref": "#/definitions/PassThroughProp"
         },
         "DeltaSyncTableTTL": {
-          "title": "Deltasynctablettl",
-          "type": "string"
+          "$ref": "#/definitions/PassThroughProp"
         }
       },
       "required": [
@@ -850,8 +847,7 @@
           "$ref": "#/definitions/PassThroughProp"
         },
         "Name": {
-          "title": "Name",
-          "type": "string"
+          "$ref": "#/definitions/PassThroughProp"
         },
         "Permissions": {
           "items": {
@@ -1956,8 +1952,7 @@
           "$ref": "#/definitions/PassThroughProp"
         },
         "Name": {
-          "title": "Name",
-          "type": "string"
+          "$ref": "#/definitions/PassThroughProp"
         },
         "ServiceRoleArn": {
           "$ref": "#/definitions/PassThroughProp"
@@ -2208,8 +2203,7 @@
           "$ref": "#/definitions/PassThroughProp"
         },
         "FieldLogLevel": {
-          "title": "Fieldloglevel",
-          "type": "string"
+          "$ref": "#/definitions/PassThroughProp"
         }
       },
       "title": "Logging",
@@ -6541,8 +6535,7 @@
           "title": "Logging"
         },
         "Name": {
-          "title": "Name",
-          "type": "string"
+          "$ref": "#/definitions/PassThroughProp"
         },
         "Resolvers": {
           "additionalProperties": {

--- a/tests/translator/input/graphqlapi_intrinsical_names.yaml
+++ b/tests/translator/input/graphqlapi_intrinsical_names.yaml
@@ -1,0 +1,57 @@
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  ApiName:
+    Type: String
+    Default: SomeApi
+  LambdaDSName:
+    Type: String
+    Default: MyLamdaDS
+  DDB1DSName:
+    Type: String
+    Default: MyDDB1DS
+  MyLoggingLevel:
+    Type: String
+    Default: ALL
+  PassItThrough:
+    Type: String
+    Default: SomeValue
+
+Resources:
+  SuperCoolAPI:
+    Type: AWS::Serverless::GraphQLApi
+    Properties:
+      Name: !Ref ApiName
+      SchemaInline: |
+        type Todo {
+          id: ID!
+          description: String!
+        }
+        type Mutation {
+          addTodo(id: ID!, description: String!): Todo!
+        }
+        type Query {
+          getTodo(id: ID!): Todo
+        }
+        schema {
+          mutation: Mutation
+          query: Query
+        }
+      Auth:
+        Type: AWS_IAM
+      Logging:
+        FieldLogLevel: !Ref MyLoggingLevel
+      DataSources:
+        Lambda:
+          MyDataSource:
+            FunctionArn: my-lambda-arn
+            ServiceRoleArn: some-role-arn
+            Name: !Ref LambdaDSName
+        DynamoDb:
+          DDB1:
+            Name: !Ref DDB1DSName
+            TableName: AwesomeTable
+            DeltaSync:
+              BaseTableTTL: !Ref PassItThrough
+              DeltaSyncTableName: !Ref PassItThrough
+              DeltaSyncTableTTL: !Ref PassItThrough

--- a/tests/translator/output/aws-cn/graphqlapi_intrinsical_names.json
+++ b/tests/translator/output/aws-cn/graphqlapi_intrinsical_names.json
@@ -1,0 +1,274 @@
+{
+  "Parameters": {
+    "ApiName": {
+      "Default": "SomeApi",
+      "Type": "String"
+    },
+    "DDB1DSName": {
+      "Default": "MyDDB1DS",
+      "Type": "String"
+    },
+    "LambdaDSName": {
+      "Default": "MyLamdaDS",
+      "Type": "String"
+    },
+    "MyLoggingLevel": {
+      "Default": "ALL",
+      "Type": "String"
+    },
+    "PassItThrough": {
+      "Default": "SomeValue",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "SuperCoolAPI": {
+      "Properties": {
+        "AuthenticationType": "AWS_IAM",
+        "LogConfig": {
+          "CloudWatchLogsRoleArn": {
+            "Fn::GetAtt": [
+              "SuperCoolAPICloudWatchRole",
+              "Arn"
+            ]
+          },
+          "FieldLogLevel": {
+            "Ref": "MyLoggingLevel"
+          }
+        },
+        "Name": {
+          "Ref": "ApiName"
+        }
+      },
+      "Type": "AWS::AppSync::GraphQLApi"
+    },
+    "SuperCoolAPICloudWatchRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "appsync.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSource": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "DynamoDBConfig": {
+          "AwsRegion": {
+            "Ref": "AWS::Region"
+          },
+          "DeltaSyncConfig": {
+            "BaseTableTTL": {
+              "Ref": "PassItThrough"
+            },
+            "DeltaSyncTableName": {
+              "Ref": "PassItThrough"
+            },
+            "DeltaSyncTableTTL": {
+              "Ref": "PassItThrough"
+            }
+          },
+          "TableName": "AwesomeTable"
+        },
+        "Name": {
+          "Ref": "DDB1DSName"
+        },
+        "ServiceRoleArn": {
+          "Fn::GetAtt": [
+            "SuperCoolAPIDDB1DynamoDBDataSourceRole",
+            "Arn"
+          ]
+        },
+        "Type": "AMAZON_DYNAMODB"
+      },
+      "Type": "AWS::AppSync::DataSource"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSourceRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "appsync.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSourceToTableConnectorPolicy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "SuperCoolAPIDDB1DynamoDBDataSourceToTableConnector": {
+            "Destination": {
+              "Type": "AWS::DynamoDB::Table"
+            },
+            "Source": {
+              "Type": "AWS::AppSync::DataSource"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchGetItem",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:PartiQLSelect"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                    {
+                      "__Region__": {
+                        "Ref": "AWS::Region"
+                      },
+                      "__TableName__": "AwesomeTable"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                          {
+                            "__Region__": {
+                              "Ref": "AWS::Region"
+                            },
+                            "__TableName__": "AwesomeTable"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PartiQLDelete",
+                "dynamodb:PartiQLInsert",
+                "dynamodb:PartiQLUpdate"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                    {
+                      "__Region__": {
+                        "Ref": "AWS::Region"
+                      },
+                      "__TableName__": "AwesomeTable"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                          {
+                            "__Region__": {
+                              "Ref": "AWS::Region"
+                            },
+                            "__TableName__": "AwesomeTable"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "SuperCoolAPIDDB1DynamoDBDataSourceRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "SuperCoolAPIMyDataSourceLambdaDataSource": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "LambdaConfig": {
+          "LambdaFunctionArn": "my-lambda-arn"
+        },
+        "Name": {
+          "Ref": "LambdaDSName"
+        },
+        "ServiceRoleArn": "some-role-arn",
+        "Type": "AWS_LAMBDA"
+      },
+      "Type": "AWS::AppSync::DataSource"
+    },
+    "SuperCoolAPISchema": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "Definition": "type Todo {\n  id: ID!\n  description: String!\n}\ntype Mutation {\n  addTodo(id: ID!, description: String!): Todo!\n}\ntype Query {\n  getTodo(id: ID!): Todo\n}\nschema {\n  mutation: Mutation\n  query: Query\n}\n"
+      },
+      "Type": "AWS::AppSync::GraphQLSchema"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/graphqlapi_intrinsical_names.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_intrinsical_names.json
@@ -1,0 +1,274 @@
+{
+  "Parameters": {
+    "ApiName": {
+      "Default": "SomeApi",
+      "Type": "String"
+    },
+    "DDB1DSName": {
+      "Default": "MyDDB1DS",
+      "Type": "String"
+    },
+    "LambdaDSName": {
+      "Default": "MyLamdaDS",
+      "Type": "String"
+    },
+    "MyLoggingLevel": {
+      "Default": "ALL",
+      "Type": "String"
+    },
+    "PassItThrough": {
+      "Default": "SomeValue",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "SuperCoolAPI": {
+      "Properties": {
+        "AuthenticationType": "AWS_IAM",
+        "LogConfig": {
+          "CloudWatchLogsRoleArn": {
+            "Fn::GetAtt": [
+              "SuperCoolAPICloudWatchRole",
+              "Arn"
+            ]
+          },
+          "FieldLogLevel": {
+            "Ref": "MyLoggingLevel"
+          }
+        },
+        "Name": {
+          "Ref": "ApiName"
+        }
+      },
+      "Type": "AWS::AppSync::GraphQLApi"
+    },
+    "SuperCoolAPICloudWatchRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "appsync.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSource": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "DynamoDBConfig": {
+          "AwsRegion": {
+            "Ref": "AWS::Region"
+          },
+          "DeltaSyncConfig": {
+            "BaseTableTTL": {
+              "Ref": "PassItThrough"
+            },
+            "DeltaSyncTableName": {
+              "Ref": "PassItThrough"
+            },
+            "DeltaSyncTableTTL": {
+              "Ref": "PassItThrough"
+            }
+          },
+          "TableName": "AwesomeTable"
+        },
+        "Name": {
+          "Ref": "DDB1DSName"
+        },
+        "ServiceRoleArn": {
+          "Fn::GetAtt": [
+            "SuperCoolAPIDDB1DynamoDBDataSourceRole",
+            "Arn"
+          ]
+        },
+        "Type": "AMAZON_DYNAMODB"
+      },
+      "Type": "AWS::AppSync::DataSource"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSourceRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "appsync.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSourceToTableConnectorPolicy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "SuperCoolAPIDDB1DynamoDBDataSourceToTableConnector": {
+            "Destination": {
+              "Type": "AWS::DynamoDB::Table"
+            },
+            "Source": {
+              "Type": "AWS::AppSync::DataSource"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchGetItem",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:PartiQLSelect"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                    {
+                      "__Region__": {
+                        "Ref": "AWS::Region"
+                      },
+                      "__TableName__": "AwesomeTable"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                          {
+                            "__Region__": {
+                              "Ref": "AWS::Region"
+                            },
+                            "__TableName__": "AwesomeTable"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PartiQLDelete",
+                "dynamodb:PartiQLInsert",
+                "dynamodb:PartiQLUpdate"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                    {
+                      "__Region__": {
+                        "Ref": "AWS::Region"
+                      },
+                      "__TableName__": "AwesomeTable"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                          {
+                            "__Region__": {
+                              "Ref": "AWS::Region"
+                            },
+                            "__TableName__": "AwesomeTable"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "SuperCoolAPIDDB1DynamoDBDataSourceRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "SuperCoolAPIMyDataSourceLambdaDataSource": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "LambdaConfig": {
+          "LambdaFunctionArn": "my-lambda-arn"
+        },
+        "Name": {
+          "Ref": "LambdaDSName"
+        },
+        "ServiceRoleArn": "some-role-arn",
+        "Type": "AWS_LAMBDA"
+      },
+      "Type": "AWS::AppSync::DataSource"
+    },
+    "SuperCoolAPISchema": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "Definition": "type Todo {\n  id: ID!\n  description: String!\n}\ntype Mutation {\n  addTodo(id: ID!, description: String!): Todo!\n}\ntype Query {\n  getTodo(id: ID!): Todo\n}\nschema {\n  mutation: Mutation\n  query: Query\n}\n"
+      },
+      "Type": "AWS::AppSync::GraphQLSchema"
+    }
+  }
+}

--- a/tests/translator/output/graphqlapi_intrinsical_names.json
+++ b/tests/translator/output/graphqlapi_intrinsical_names.json
@@ -1,0 +1,274 @@
+{
+  "Parameters": {
+    "ApiName": {
+      "Default": "SomeApi",
+      "Type": "String"
+    },
+    "DDB1DSName": {
+      "Default": "MyDDB1DS",
+      "Type": "String"
+    },
+    "LambdaDSName": {
+      "Default": "MyLamdaDS",
+      "Type": "String"
+    },
+    "MyLoggingLevel": {
+      "Default": "ALL",
+      "Type": "String"
+    },
+    "PassItThrough": {
+      "Default": "SomeValue",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "SuperCoolAPI": {
+      "Properties": {
+        "AuthenticationType": "AWS_IAM",
+        "LogConfig": {
+          "CloudWatchLogsRoleArn": {
+            "Fn::GetAtt": [
+              "SuperCoolAPICloudWatchRole",
+              "Arn"
+            ]
+          },
+          "FieldLogLevel": {
+            "Ref": "MyLoggingLevel"
+          }
+        },
+        "Name": {
+          "Ref": "ApiName"
+        }
+      },
+      "Type": "AWS::AppSync::GraphQLApi"
+    },
+    "SuperCoolAPICloudWatchRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "appsync.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSource": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "DynamoDBConfig": {
+          "AwsRegion": {
+            "Ref": "AWS::Region"
+          },
+          "DeltaSyncConfig": {
+            "BaseTableTTL": {
+              "Ref": "PassItThrough"
+            },
+            "DeltaSyncTableName": {
+              "Ref": "PassItThrough"
+            },
+            "DeltaSyncTableTTL": {
+              "Ref": "PassItThrough"
+            }
+          },
+          "TableName": "AwesomeTable"
+        },
+        "Name": {
+          "Ref": "DDB1DSName"
+        },
+        "ServiceRoleArn": {
+          "Fn::GetAtt": [
+            "SuperCoolAPIDDB1DynamoDBDataSourceRole",
+            "Arn"
+          ]
+        },
+        "Type": "AMAZON_DYNAMODB"
+      },
+      "Type": "AWS::AppSync::DataSource"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSourceRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "appsync.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "SuperCoolAPIDDB1DynamoDBDataSourceToTableConnectorPolicy": {
+      "Metadata": {
+        "aws:sam:connectors": {
+          "SuperCoolAPIDDB1DynamoDBDataSourceToTableConnector": {
+            "Destination": {
+              "Type": "AWS::DynamoDB::Table"
+            },
+            "Source": {
+              "Type": "AWS::AppSync::DataSource"
+            }
+          }
+        }
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:BatchGetItem",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:PartiQLSelect"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                    {
+                      "__Region__": {
+                        "Ref": "AWS::Region"
+                      },
+                      "__TableName__": "AwesomeTable"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                          {
+                            "__Region__": {
+                              "Ref": "AWS::Region"
+                            },
+                            "__TableName__": "AwesomeTable"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PartiQLDelete",
+                "dynamodb:PartiQLInsert",
+                "dynamodb:PartiQLUpdate"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                    {
+                      "__Region__": {
+                        "Ref": "AWS::Region"
+                      },
+                      "__TableName__": "AwesomeTable"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "${DestinationArn}/index/*",
+                    {
+                      "DestinationArn": {
+                        "Fn::Sub": [
+                          "arn:${AWS::Partition}:dynamodb:${__Region__}:${AWS::AccountId}:table/${__TableName__}",
+                          {
+                            "__Region__": {
+                              "Ref": "AWS::Region"
+                            },
+                            "__TableName__": "AwesomeTable"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Roles": [
+          {
+            "Ref": "SuperCoolAPIDDB1DynamoDBDataSourceRole"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "SuperCoolAPIMyDataSourceLambdaDataSource": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "LambdaConfig": {
+          "LambdaFunctionArn": "my-lambda-arn"
+        },
+        "Name": {
+          "Ref": "LambdaDSName"
+        },
+        "ServiceRoleArn": "some-role-arn",
+        "Type": "AWS_LAMBDA"
+      },
+      "Type": "AWS::AppSync::DataSource"
+    },
+    "SuperCoolAPISchema": {
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "SuperCoolAPI",
+            "ApiId"
+          ]
+        },
+        "Definition": "type Todo {\n  id: ID!\n  description: String!\n}\ntype Mutation {\n  addTodo(id: ID!, description: String!): Todo!\n}\ntype Query {\n  getTodo(id: ID!): Todo\n}\nschema {\n  mutation: Mutation\n  query: Query\n}\n"
+      },
+      "Type": "AWS::AppSync::GraphQLSchema"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Allow to use intrinsics on a couple of Name fields, LogLevel, and DeltaSync config in DDB data source.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
