### PR TITLE
fix:RuntimeManagementConfig

### DIFF
--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -70,7 +70,6 @@ class LambdaVersion(Resource):
         "CodeSha256": GeneratedProperty(),
         "Description": GeneratedProperty(),
         "FunctionName": GeneratedProperty(),
-        "RuntimeManagementConfig": GeneratedProperty(),
     }
 
     runtime_attrs = {

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -934,8 +934,6 @@ class SamFunction(SamResourceMacro):
         lambda_version = LambdaVersion(logical_id=logical_id, attributes=attributes)
         lambda_version.FunctionName = function.get_runtime_attr("name")
         lambda_version.Description = self.VersionDescription
-        # Copy the same runtime policy for the version and the function
-        lambda_version.RuntimeManagementConfig = function.RuntimeManagementConfig
 
         return lambda_version
 

--- a/tests/translator/output/aws-cn/function_with_runtime_config.json
+++ b/tests/translator/output/aws-cn/function_with_runtime_config.json
@@ -229,9 +229,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "FunctionWithRuntimeManagementConfigAndAlias"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "Auto"
         }
       },
       "Type": "AWS::Lambda::Version"

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -2,7 +2,9 @@
   "Resources": {
     "FunctionWithOverrides": {
       "Properties": {
-        "Architectures": ["x86_64"],
+        "Architectures": [
+          "x86_64"
+        ],
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
@@ -29,7 +31,10 @@
         "MemorySize": 512,
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::GetAtt": ["FunctionWithOverridesRole", "Arn"]
+          "Fn::GetAtt": [
+            "FunctionWithOverridesRole",
+            "Arn"
+          ]
         },
         "Runtime": "nodejs12.x",
         "RuntimeManagementConfig": {
@@ -57,8 +62,13 @@
           "Mode": "PassThrough"
         },
         "VpcConfig": {
-          "SecurityGroupIds": ["sg-edcd9784", "sg-123"],
-          "SubnetIds": ["sub-id-2"]
+          "SecurityGroupIds": [
+            "sg-edcd9784",
+            "sg-123"
+          ],
+          "SubnetIds": [
+            "sub-id-2"
+          ]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -69,7 +79,10 @@
           "Ref": "FunctionWithOverrides"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": ["FunctionWithOverridesVersion096ed3b52b", "Version"]
+          "Fn::GetAtt": [
+            "FunctionWithOverridesVersion096ed3b52b",
+            "Version"
+          ]
         },
         "Name": "prod"
       },
@@ -80,10 +93,14 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": ["sts:AssumeRole"],
+              "Action": [
+                "sts:AssumeRole"
+              ],
               "Effect": "Allow",
               "Principal": {
-                "Service": ["lambda.amazonaws.com"]
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ],
@@ -123,7 +140,9 @@
     },
     "MinimalFunction": {
       "Properties": {
-        "Architectures": ["x86_64"],
+        "Architectures": [
+          "x86_64"
+        ],
         "Code": {
           "S3Bucket": "global-bucket",
           "S3Key": "global.zip"
@@ -146,7 +165,10 @@
         "MemorySize": 1024,
         "ReservedConcurrentExecutions": 50,
         "Role": {
-          "Fn::GetAtt": ["MinimalFunctionRole", "Arn"]
+          "Fn::GetAtt": [
+            "MinimalFunctionRole",
+            "Arn"
+          ]
         },
         "Runtime": "python2.7",
         "RuntimeManagementConfig": {
@@ -170,8 +192,12 @@
           "Mode": "Active"
         },
         "VpcConfig": {
-          "SecurityGroupIds": ["sg-edcd9784"],
-          "SubnetIds": ["sub-id-2"]
+          "SecurityGroupIds": [
+            "sg-edcd9784"
+          ],
+          "SubnetIds": [
+            "sub-id-2"
+          ]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -182,7 +208,10 @@
           "Ref": "MinimalFunction"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": ["MinimalFunctionVersione7c6f56e4d", "Version"]
+          "Fn::GetAtt": [
+            "MinimalFunctionVersione7c6f56e4d",
+            "Version"
+          ]
         },
         "Name": "live"
       },
@@ -193,10 +222,14 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": ["sts:AssumeRole"],
+              "Action": [
+                "sts:AssumeRole"
+              ],
               "Effect": "Allow",
               "Principal": {
-                "Service": ["lambda.amazonaws.com"]
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ],

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -2,9 +2,7 @@
   "Resources": {
     "FunctionWithOverrides": {
       "Properties": {
-        "Architectures": [
-          "x86_64"
-        ],
+        "Architectures": ["x86_64"],
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
@@ -31,10 +29,7 @@
         "MemorySize": 512,
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::GetAtt": [
-            "FunctionWithOverridesRole",
-            "Arn"
-          ]
+          "Fn::GetAtt": ["FunctionWithOverridesRole", "Arn"]
         },
         "Runtime": "nodejs12.x",
         "RuntimeManagementConfig": {
@@ -62,13 +57,8 @@
           "Mode": "PassThrough"
         },
         "VpcConfig": {
-          "SecurityGroupIds": [
-            "sg-edcd9784",
-            "sg-123"
-          ],
-          "SubnetIds": [
-            "sub-id-2"
-          ]
+          "SecurityGroupIds": ["sg-edcd9784", "sg-123"],
+          "SubnetIds": ["sub-id-2"]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -79,10 +69,7 @@
           "Ref": "FunctionWithOverrides"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": [
-            "FunctionWithOverridesVersion096ed3b52b",
-            "Version"
-          ]
+          "Fn::GetAtt": ["FunctionWithOverridesVersion096ed3b52b", "Version"]
         },
         "Name": "prod"
       },
@@ -93,14 +80,10 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Action": ["sts:AssumeRole"],
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
+                "Service": ["lambda.amazonaws.com"]
               }
             }
           ],
@@ -134,18 +117,13 @@
       "Properties": {
         "FunctionName": {
           "Ref": "FunctionWithOverrides"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "FunctionChange"
         }
       },
       "Type": "AWS::Lambda::Version"
     },
     "MinimalFunction": {
       "Properties": {
-        "Architectures": [
-          "x86_64"
-        ],
+        "Architectures": ["x86_64"],
         "Code": {
           "S3Bucket": "global-bucket",
           "S3Key": "global.zip"
@@ -168,10 +146,7 @@
         "MemorySize": 1024,
         "ReservedConcurrentExecutions": 50,
         "Role": {
-          "Fn::GetAtt": [
-            "MinimalFunctionRole",
-            "Arn"
-          ]
+          "Fn::GetAtt": ["MinimalFunctionRole", "Arn"]
         },
         "Runtime": "python2.7",
         "RuntimeManagementConfig": {
@@ -195,12 +170,8 @@
           "Mode": "Active"
         },
         "VpcConfig": {
-          "SecurityGroupIds": [
-            "sg-edcd9784"
-          ],
-          "SubnetIds": [
-            "sub-id-2"
-          ]
+          "SecurityGroupIds": ["sg-edcd9784"],
+          "SubnetIds": ["sub-id-2"]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -211,10 +182,7 @@
           "Ref": "MinimalFunction"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": [
-            "MinimalFunctionVersione7c6f56e4d",
-            "Version"
-          ]
+          "Fn::GetAtt": ["MinimalFunctionVersione7c6f56e4d", "Version"]
         },
         "Name": "live"
       },
@@ -225,14 +193,10 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Action": ["sts:AssumeRole"],
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
+                "Service": ["lambda.amazonaws.com"]
               }
             }
           ],
@@ -262,9 +226,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "MinimalFunction"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "Auto"
         }
       },
       "Type": "AWS::Lambda::Version"

--- a/tests/translator/output/aws-us-gov/function_with_runtime_config.json
+++ b/tests/translator/output/aws-us-gov/function_with_runtime_config.json
@@ -229,9 +229,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "FunctionWithRuntimeManagementConfigAndAlias"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "Auto"
         }
       },
       "Type": "AWS::Lambda::Version"

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -2,7 +2,9 @@
   "Resources": {
     "FunctionWithOverrides": {
       "Properties": {
-        "Architectures": ["x86_64"],
+        "Architectures": [
+          "x86_64"
+        ],
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
@@ -29,7 +31,10 @@
         "MemorySize": 512,
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::GetAtt": ["FunctionWithOverridesRole", "Arn"]
+          "Fn::GetAtt": [
+            "FunctionWithOverridesRole",
+            "Arn"
+          ]
         },
         "Runtime": "nodejs12.x",
         "RuntimeManagementConfig": {
@@ -57,8 +62,13 @@
           "Mode": "PassThrough"
         },
         "VpcConfig": {
-          "SecurityGroupIds": ["sg-edcd9784", "sg-123"],
-          "SubnetIds": ["sub-id-2"]
+          "SecurityGroupIds": [
+            "sg-edcd9784",
+            "sg-123"
+          ],
+          "SubnetIds": [
+            "sub-id-2"
+          ]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -69,7 +79,10 @@
           "Ref": "FunctionWithOverrides"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": ["FunctionWithOverridesVersion096ed3b52b", "Version"]
+          "Fn::GetAtt": [
+            "FunctionWithOverridesVersion096ed3b52b",
+            "Version"
+          ]
         },
         "Name": "prod"
       },
@@ -80,10 +93,14 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": ["sts:AssumeRole"],
+              "Action": [
+                "sts:AssumeRole"
+              ],
               "Effect": "Allow",
               "Principal": {
-                "Service": ["lambda.amazonaws.com"]
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ],
@@ -123,7 +140,9 @@
     },
     "MinimalFunction": {
       "Properties": {
-        "Architectures": ["x86_64"],
+        "Architectures": [
+          "x86_64"
+        ],
         "Code": {
           "S3Bucket": "global-bucket",
           "S3Key": "global.zip"
@@ -146,7 +165,10 @@
         "MemorySize": 1024,
         "ReservedConcurrentExecutions": 50,
         "Role": {
-          "Fn::GetAtt": ["MinimalFunctionRole", "Arn"]
+          "Fn::GetAtt": [
+            "MinimalFunctionRole",
+            "Arn"
+          ]
         },
         "Runtime": "python2.7",
         "RuntimeManagementConfig": {
@@ -170,8 +192,12 @@
           "Mode": "Active"
         },
         "VpcConfig": {
-          "SecurityGroupIds": ["sg-edcd9784"],
-          "SubnetIds": ["sub-id-2"]
+          "SecurityGroupIds": [
+            "sg-edcd9784"
+          ],
+          "SubnetIds": [
+            "sub-id-2"
+          ]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -182,7 +208,10 @@
           "Ref": "MinimalFunction"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": ["MinimalFunctionVersione7c6f56e4d", "Version"]
+          "Fn::GetAtt": [
+            "MinimalFunctionVersione7c6f56e4d",
+            "Version"
+          ]
         },
         "Name": "live"
       },
@@ -193,10 +222,14 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": ["sts:AssumeRole"],
+              "Action": [
+                "sts:AssumeRole"
+              ],
               "Effect": "Allow",
               "Principal": {
-                "Service": ["lambda.amazonaws.com"]
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ],

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -2,9 +2,7 @@
   "Resources": {
     "FunctionWithOverrides": {
       "Properties": {
-        "Architectures": [
-          "x86_64"
-        ],
+        "Architectures": ["x86_64"],
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
@@ -31,10 +29,7 @@
         "MemorySize": 512,
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::GetAtt": [
-            "FunctionWithOverridesRole",
-            "Arn"
-          ]
+          "Fn::GetAtt": ["FunctionWithOverridesRole", "Arn"]
         },
         "Runtime": "nodejs12.x",
         "RuntimeManagementConfig": {
@@ -62,13 +57,8 @@
           "Mode": "PassThrough"
         },
         "VpcConfig": {
-          "SecurityGroupIds": [
-            "sg-edcd9784",
-            "sg-123"
-          ],
-          "SubnetIds": [
-            "sub-id-2"
-          ]
+          "SecurityGroupIds": ["sg-edcd9784", "sg-123"],
+          "SubnetIds": ["sub-id-2"]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -79,10 +69,7 @@
           "Ref": "FunctionWithOverrides"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": [
-            "FunctionWithOverridesVersion096ed3b52b",
-            "Version"
-          ]
+          "Fn::GetAtt": ["FunctionWithOverridesVersion096ed3b52b", "Version"]
         },
         "Name": "prod"
       },
@@ -93,14 +80,10 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Action": ["sts:AssumeRole"],
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
+                "Service": ["lambda.amazonaws.com"]
               }
             }
           ],
@@ -134,18 +117,13 @@
       "Properties": {
         "FunctionName": {
           "Ref": "FunctionWithOverrides"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "FunctionChange"
         }
       },
       "Type": "AWS::Lambda::Version"
     },
     "MinimalFunction": {
       "Properties": {
-        "Architectures": [
-          "x86_64"
-        ],
+        "Architectures": ["x86_64"],
         "Code": {
           "S3Bucket": "global-bucket",
           "S3Key": "global.zip"
@@ -168,10 +146,7 @@
         "MemorySize": 1024,
         "ReservedConcurrentExecutions": 50,
         "Role": {
-          "Fn::GetAtt": [
-            "MinimalFunctionRole",
-            "Arn"
-          ]
+          "Fn::GetAtt": ["MinimalFunctionRole", "Arn"]
         },
         "Runtime": "python2.7",
         "RuntimeManagementConfig": {
@@ -195,12 +170,8 @@
           "Mode": "Active"
         },
         "VpcConfig": {
-          "SecurityGroupIds": [
-            "sg-edcd9784"
-          ],
-          "SubnetIds": [
-            "sub-id-2"
-          ]
+          "SecurityGroupIds": ["sg-edcd9784"],
+          "SubnetIds": ["sub-id-2"]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -211,10 +182,7 @@
           "Ref": "MinimalFunction"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": [
-            "MinimalFunctionVersione7c6f56e4d",
-            "Version"
-          ]
+          "Fn::GetAtt": ["MinimalFunctionVersione7c6f56e4d", "Version"]
         },
         "Name": "live"
       },
@@ -225,14 +193,10 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Action": ["sts:AssumeRole"],
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
+                "Service": ["lambda.amazonaws.com"]
               }
             }
           ],
@@ -262,9 +226,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "MinimalFunction"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "Auto"
         }
       },
       "Type": "AWS::Lambda::Version"

--- a/tests/translator/output/function_with_runtime_config.json
+++ b/tests/translator/output/function_with_runtime_config.json
@@ -229,9 +229,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "FunctionWithRuntimeManagementConfigAndAlias"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "Auto"
         }
       },
       "Type": "AWS::Lambda::Version"

--- a/tests/translator/output/globals_for_function.json
+++ b/tests/translator/output/globals_for_function.json
@@ -2,7 +2,9 @@
   "Resources": {
     "FunctionWithOverrides": {
       "Properties": {
-        "Architectures": ["x86_64"],
+        "Architectures": [
+          "x86_64"
+        ],
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
@@ -29,7 +31,10 @@
         "MemorySize": 512,
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::GetAtt": ["FunctionWithOverridesRole", "Arn"]
+          "Fn::GetAtt": [
+            "FunctionWithOverridesRole",
+            "Arn"
+          ]
         },
         "Runtime": "nodejs12.x",
         "RuntimeManagementConfig": {
@@ -57,8 +62,13 @@
           "Mode": "PassThrough"
         },
         "VpcConfig": {
-          "SecurityGroupIds": ["sg-edcd9784", "sg-123"],
-          "SubnetIds": ["sub-id-2"]
+          "SecurityGroupIds": [
+            "sg-edcd9784",
+            "sg-123"
+          ],
+          "SubnetIds": [
+            "sub-id-2"
+          ]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -69,7 +79,10 @@
           "Ref": "FunctionWithOverrides"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": ["FunctionWithOverridesVersion096ed3b52b", "Version"]
+          "Fn::GetAtt": [
+            "FunctionWithOverridesVersion096ed3b52b",
+            "Version"
+          ]
         },
         "Name": "prod"
       },
@@ -80,10 +93,14 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": ["sts:AssumeRole"],
+              "Action": [
+                "sts:AssumeRole"
+              ],
               "Effect": "Allow",
               "Principal": {
-                "Service": ["lambda.amazonaws.com"]
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ],
@@ -123,7 +140,9 @@
     },
     "MinimalFunction": {
       "Properties": {
-        "Architectures": ["x86_64"],
+        "Architectures": [
+          "x86_64"
+        ],
         "Code": {
           "S3Bucket": "global-bucket",
           "S3Key": "global.zip"
@@ -146,7 +165,10 @@
         "MemorySize": 1024,
         "ReservedConcurrentExecutions": 50,
         "Role": {
-          "Fn::GetAtt": ["MinimalFunctionRole", "Arn"]
+          "Fn::GetAtt": [
+            "MinimalFunctionRole",
+            "Arn"
+          ]
         },
         "Runtime": "python2.7",
         "RuntimeManagementConfig": {
@@ -170,8 +192,12 @@
           "Mode": "Active"
         },
         "VpcConfig": {
-          "SecurityGroupIds": ["sg-edcd9784"],
-          "SubnetIds": ["sub-id-2"]
+          "SecurityGroupIds": [
+            "sg-edcd9784"
+          ],
+          "SubnetIds": [
+            "sub-id-2"
+          ]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -182,7 +208,10 @@
           "Ref": "MinimalFunction"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": ["MinimalFunctionVersione7c6f56e4d", "Version"]
+          "Fn::GetAtt": [
+            "MinimalFunctionVersione7c6f56e4d",
+            "Version"
+          ]
         },
         "Name": "live"
       },
@@ -193,10 +222,14 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": ["sts:AssumeRole"],
+              "Action": [
+                "sts:AssumeRole"
+              ],
               "Effect": "Allow",
               "Principal": {
-                "Service": ["lambda.amazonaws.com"]
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ],

--- a/tests/translator/output/globals_for_function.json
+++ b/tests/translator/output/globals_for_function.json
@@ -2,9 +2,7 @@
   "Resources": {
     "FunctionWithOverrides": {
       "Properties": {
-        "Architectures": [
-          "x86_64"
-        ],
+        "Architectures": ["x86_64"],
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
@@ -31,10 +29,7 @@
         "MemorySize": 512,
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::GetAtt": [
-            "FunctionWithOverridesRole",
-            "Arn"
-          ]
+          "Fn::GetAtt": ["FunctionWithOverridesRole", "Arn"]
         },
         "Runtime": "nodejs12.x",
         "RuntimeManagementConfig": {
@@ -62,13 +57,8 @@
           "Mode": "PassThrough"
         },
         "VpcConfig": {
-          "SecurityGroupIds": [
-            "sg-edcd9784",
-            "sg-123"
-          ],
-          "SubnetIds": [
-            "sub-id-2"
-          ]
+          "SecurityGroupIds": ["sg-edcd9784", "sg-123"],
+          "SubnetIds": ["sub-id-2"]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -79,10 +69,7 @@
           "Ref": "FunctionWithOverrides"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": [
-            "FunctionWithOverridesVersion096ed3b52b",
-            "Version"
-          ]
+          "Fn::GetAtt": ["FunctionWithOverridesVersion096ed3b52b", "Version"]
         },
         "Name": "prod"
       },
@@ -93,14 +80,10 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Action": ["sts:AssumeRole"],
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
+                "Service": ["lambda.amazonaws.com"]
               }
             }
           ],
@@ -134,18 +117,13 @@
       "Properties": {
         "FunctionName": {
           "Ref": "FunctionWithOverrides"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "FunctionChange"
         }
       },
       "Type": "AWS::Lambda::Version"
     },
     "MinimalFunction": {
       "Properties": {
-        "Architectures": [
-          "x86_64"
-        ],
+        "Architectures": ["x86_64"],
         "Code": {
           "S3Bucket": "global-bucket",
           "S3Key": "global.zip"
@@ -168,10 +146,7 @@
         "MemorySize": 1024,
         "ReservedConcurrentExecutions": 50,
         "Role": {
-          "Fn::GetAtt": [
-            "MinimalFunctionRole",
-            "Arn"
-          ]
+          "Fn::GetAtt": ["MinimalFunctionRole", "Arn"]
         },
         "Runtime": "python2.7",
         "RuntimeManagementConfig": {
@@ -195,12 +170,8 @@
           "Mode": "Active"
         },
         "VpcConfig": {
-          "SecurityGroupIds": [
-            "sg-edcd9784"
-          ],
-          "SubnetIds": [
-            "sub-id-2"
-          ]
+          "SecurityGroupIds": ["sg-edcd9784"],
+          "SubnetIds": ["sub-id-2"]
         }
       },
       "Type": "AWS::Lambda::Function"
@@ -211,10 +182,7 @@
           "Ref": "MinimalFunction"
         },
         "FunctionVersion": {
-          "Fn::GetAtt": [
-            "MinimalFunctionVersione7c6f56e4d",
-            "Version"
-          ]
+          "Fn::GetAtt": ["MinimalFunctionVersione7c6f56e4d", "Version"]
         },
         "Name": "live"
       },
@@ -225,14 +193,10 @@
         "AssumeRolePolicyDocument": {
           "Statement": [
             {
-              "Action": [
-                "sts:AssumeRole"
-              ],
+              "Action": ["sts:AssumeRole"],
               "Effect": "Allow",
               "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
+                "Service": ["lambda.amazonaws.com"]
               }
             }
           ],
@@ -262,9 +226,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "MinimalFunction"
-        },
-        "RuntimeManagementConfig": {
-          "UpdateRuntimeOn": "Auto"
         }
       },
       "Type": "AWS::Lambda::Version"


### PR DESCRIPTION
### Issue #, if available

### Description of changes
RuntimeManagementConfig was previous also applied to the AWS::Lambda::Version incorrectly.
### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
-  [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
