### PR TITLE
fix: Fix Propagate Tags when Tags is defined in Globals

### DIFF
--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -109,10 +109,11 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
         implicit_api_resource = template.get(self.IMPLICIT_API_LOGICAL_ID)
         globals_var = template.get_globals().get(SamResourceType(resource.type).name, {})
         should_propagate_tags = resource.properties.get("PropagateTags") or globals_var.get("PropagateTags")
+        tags_properties = resource.properties.get("Tags") or globals_var.get("Tags")
 
-        if implicit_api_resource and resource.properties.get("Tags") and should_propagate_tags:
+        if implicit_api_resource and tags_properties and should_propagate_tags:
             # This makes an assumption that the SAM resource has 'Tags' property and is a dictionary.
-            implicit_api_resource.properties.setdefault("Tags", {}).update(resource.properties["Tags"])
+            implicit_api_resource.properties.setdefault("Tags", {}).update(tags_properties)
             implicit_api_resource.properties["PropagateTags"] = True
 
     @cw_timer(prefix="Plugin-ImplicitApi")

--- a/tests/plugins/api/test_implicit_api_plugin.py
+++ b/tests/plugins/api/test_implicit_api_plugin.py
@@ -369,6 +369,7 @@ class TestImplicitRestApiPlugin_process_api_events(TestCase):
         api_events = {"Api1": {"Type": "Api", "Properties": {"Path": "/", "Methid": "POST"}}}
 
         template = Mock()
+        template.get_globals.return_value = {}
         function_events_mock = Mock()
         function = SamResource({"Type": SamResourceType.Function.value, "Properties": {"Events": function_events_mock}})
         function_events_mock.update = Mock()
@@ -380,6 +381,7 @@ class TestImplicitRestApiPlugin_process_api_events(TestCase):
         api_events = {"Api1": {"Type": "Api", "Properties": {"Path": "/", "Method": ["POST"]}}}
 
         template = Mock()
+        template.get_globals.return_value = {}
         function_events_mock = Mock()
         function = SamResource({"Type": SamResourceType.Function.value, "Properties": {"Events": function_events_mock}})
         function_events_mock.update = Mock()
@@ -411,6 +413,7 @@ class TestImplicitRestApiPlugin_process_api_events(TestCase):
         api_events = {"Api1": {"Type": "Api", "Properties": {"Path": ["/"], "Method": "POST"}}}
 
         template = Mock()
+        template.get_globals.return_value = {}
         function_events_mock = Mock()
         function = SamResource({"Type": SamResourceType.Function.value, "Properties": {"Events": function_events_mock}})
         function_events_mock.update = Mock()

--- a/tests/translator/input/function_with_globals_tags_and_propagate_tags.yaml
+++ b/tests/translator/input/function_with_globals_tags_and_propagate_tags.yaml
@@ -1,0 +1,26 @@
+Globals:
+  Function:
+    Tags:
+      test: 'yes'
+
+Resources:
+  ApiFunction: # Adds a GET api endpoint at "/" to the ApiGatewayApi via an Api event
+    Type: AWS::Serverless::Function
+    Properties:
+      PropagateTags: true
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+            RequestParameters:
+            - method.request.header.Authorization
+            - method.request.querystring.keyword:
+                Required: true
+                Caching: false
+      Runtime: python3.7
+      Handler: index.handler
+      InlineCode: |-
+        def handler(event, context):
+            return {'body': 'Hello World!', 'statusCode': 200}

--- a/tests/translator/output/aws-cn/function_with_globals_tags_and_propagate_tags.json
+++ b/tests/translator/output/aws-cn/function_with_globals_tags_and_propagate_tags.json
@@ -1,0 +1,161 @@
+{
+  "Resources": {
+    "ApiFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "ApiFunctionApiEventPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "ApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "ApiFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "parameters": [
+                  {
+                    "in": "header",
+                    "name": "Authorization",
+                    "required": false,
+                    "type": "string"
+                  },
+                  {
+                    "in": "query",
+                    "name": "keyword",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeployment4036e5c19a": {
+      "Properties": {
+        "Description": "RestApi deployment id: 4036e5c19a6892f11f6cc916e1588a5723066abf",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment4036e5c19a"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod",
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/function_with_globals_tags_and_propagate_tags.json
+++ b/tests/translator/output/aws-us-gov/function_with_globals_tags_and_propagate_tags.json
@@ -1,0 +1,161 @@
+{
+  "Resources": {
+    "ApiFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "ApiFunctionApiEventPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "ApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "ApiFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "parameters": [
+                  {
+                    "in": "header",
+                    "name": "Authorization",
+                    "required": false,
+                    "type": "string"
+                  },
+                  {
+                    "in": "query",
+                    "name": "keyword",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        },
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeployment06c7f65191": {
+      "Properties": {
+        "Description": "RestApi deployment id: 06c7f651916afb666c61d5700ef27473645d640a",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment06c7f65191"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod",
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/function_with_globals_tags_and_propagate_tags.json
+++ b/tests/translator/output/function_with_globals_tags_and_propagate_tags.json
@@ -1,0 +1,153 @@
+{
+  "Resources": {
+    "ApiFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "def handler(event, context):\n    return {'body': 'Hello World!', 'statusCode': 200}"
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "ApiFunctionApiEventPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "ApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "ApiFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/": {
+              "get": {
+                "parameters": [
+                  {
+                    "in": "header",
+                    "name": "Authorization",
+                    "required": false,
+                    "type": "string"
+                  },
+                  {
+                    "in": "query",
+                    "name": "keyword",
+                    "required": true,
+                    "type": "string"
+                  }
+                ],
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeployment31234ee817": {
+      "Properties": {
+        "Description": "RestApi deployment id: 31234ee81799985ee7023c8ab26c9ec8092f7422",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment31234ee817"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod",
+        "Tags": [
+          {
+            "Key": "test",
+            "Value": "yes"
+          }
+        ]
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Propagate Tags doesn't work property when tags is defined in globals section. 

### Description of how you validated changes
Added new tests and existing tests pass.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
