### PR TITLE
fix: Add setup and teardown markers to make companion stack

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,8 @@ addopts = --cov samtranslator --cov-report term-missing --cov-fail-under 95 --re
 testpaths = tests
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    setup: setup companion stack
+    teardown: teardown companion stack
 log_cli = 1
 log_cli_level = INFO
 filterwarnings =


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Errors occurred when running `make prepare-companion-stack` (required for running integration tests): 
`pytest.PytestUnknownMarkWarning: Unknown pytest.mark.setup`
`pytest.PytestUnknownMarkWarning: Unknown pytest.mark.teardown`

Adding `setup` and `teardown` markers to `pytest.ini` file resolved the above errors.

### Description of how you validated changes

Ran `make prepare-companion-stack` command and some integration tests successfully.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
