### PR TITLE
feat: Add TimeoutInMillis Property to API Event Source

### DIFF
--- a/integration/combination/test_function_with_implicit_api_with_timeout.py
+++ b/integration/combination/test_function_with_implicit_api_with_timeout.py
@@ -9,3 +9,13 @@ from integration.helpers.resource import current_region_does_not_support
 class TestFunctionWithImplicitApiWithTimeout(BaseTest):
     def test_function_with_implicit_api_with_timeout(self):
         self.create_and_verify_stack("combination/function_with_implicit_api_with_timeout")
+
+        # verify that TimeoutInMillis is set to expected value in the integration
+        expected_timeout = 5000
+        apigw_client = self.client_provider.api_client
+        rest_api_id = self.get_physical_id_by_type("AWS::ApiGateway::RestApi")
+        resources = apigw_client.get_resources(restApiId=rest_api_id)["items"]
+
+        method = apigw_client.get_method(restApiId=rest_api_id, resourceId=resources[0]["id"], httpMethod="GET")
+        method_integration = method["methodIntegration"]
+        self.assertEqual(method_integration["timeoutInMillis"], expected_timeout)

--- a/integration/combination/test_function_with_implicit_api_with_timeout.py
+++ b/integration/combination/test_function_with_implicit_api_with_timeout.py
@@ -1,0 +1,11 @@
+from unittest.case import skipIf
+
+from integration.config.service_names import REST_API
+from integration.helpers.base_test import BaseTest
+from integration.helpers.resource import current_region_does_not_support
+
+
+@skipIf(current_region_does_not_support([REST_API]), "REST API is not supported in this testing region")
+class TestFunctionWithImplicitApiWithTimeout(BaseTest):
+    def test_function_with_implicit_api_with_timeout(self):
+        self.create_and_verify_stack("combination/function_with_implicit_api_with_timeout")

--- a/integration/resources/expected/combination/function_with_implicit_api_with_timeout.json
+++ b/integration/resources/expected/combination/function_with_implicit_api_with_timeout.json
@@ -1,0 +1,38 @@
+[
+  {
+    "LogicalResourceId": "MyLambdaFunctionApiEventPermissionProd",
+    "ResourceType": "AWS::Lambda::Permission"
+  },
+  {
+    "LogicalResourceId": "MyLambdaFunctionRole",
+    "ResourceType": "AWS::IAM::Role"
+  },
+  {
+    "LogicalResourceId": "MyLambdaFunction",
+    "ResourceType": "AWS::Lambda::Function"
+  },
+  {
+    "LogicalResourceId": "MyOtherLambdaFunctionApiEventPermissionProd",
+    "ResourceType": "AWS::Lambda::Permission"
+  },
+  {
+    "LogicalResourceId": "MyOtherLambdaFunctionRole",
+    "ResourceType": "AWS::IAM::Role"
+  },
+  {
+    "LogicalResourceId": "MyOtherLambdaFunction",
+    "ResourceType": "AWS::Lambda::Function"
+  },
+  {
+    "LogicalResourceId": "ServerlessRestApiDeployment",
+    "ResourceType": "AWS::ApiGateway::Deployment"
+  },
+  {
+    "LogicalResourceId": "ServerlessRestApiProdStage",
+    "ResourceType": "AWS::ApiGateway::Stage"
+  },
+  {
+    "LogicalResourceId": "ServerlessRestApi",
+    "ResourceType": "AWS::ApiGateway::RestApi"
+  }
+]

--- a/integration/resources/expected/combination/function_with_implicit_api_with_timeout.json
+++ b/integration/resources/expected/combination/function_with_implicit_api_with_timeout.json
@@ -12,18 +12,6 @@
     "ResourceType": "AWS::Lambda::Function"
   },
   {
-    "LogicalResourceId": "MyOtherLambdaFunctionApiEventPermissionProd",
-    "ResourceType": "AWS::Lambda::Permission"
-  },
-  {
-    "LogicalResourceId": "MyOtherLambdaFunctionRole",
-    "ResourceType": "AWS::IAM::Role"
-  },
-  {
-    "LogicalResourceId": "MyOtherLambdaFunction",
-    "ResourceType": "AWS::Lambda::Function"
-  },
-  {
     "LogicalResourceId": "ServerlessRestApiDeployment",
     "ResourceType": "AWS::ApiGateway::Deployment"
   },

--- a/integration/resources/templates/combination/function_with_implicit_api_with_timeout.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_api_with_timeout.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: A template to test timeout support for implicit APIs.
+
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs16.x
+      MemorySize: 128
+      Timeout: 3
+      InlineCode: |
+        exports.handler = async () => ‘Hello World!'
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /sub
+            Method: get
+            TimeoutInMillis: 5000
+  MyOtherLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs16.x
+      MemorySize: 128
+      Timeout: 3
+      InlineCode: |
+        exports.handler = async () => ‘Hello World!'
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /sub
+            Method: post
+            TimeoutInMillis: 8000
+Metadata:
+  SamTransformTest: true

--- a/integration/resources/templates/combination/function_with_implicit_api_with_timeout.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_api_with_timeout.yaml
@@ -15,24 +15,9 @@ Resources:
         ApiEvent:
           Type: Api
           Properties:
-            Path: /sub
+            Path: /hello
             Method: get
             TimeoutInMillis: 5000
-  MyOtherLambdaFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: index.handler
-      Runtime: nodejs16.x
-      MemorySize: 128
-      Timeout: 3
-      InlineCode: |
-        exports.handler = async () => ‘Hello World!'
-      Events:
-        ApiEvent:
-          Type: Api
-          Properties:
-            Path: /sub
-            Method: post
-            TimeoutInMillis: 8000
+
 Metadata:
   SamTransformTest: true

--- a/samtranslator/internal/schema_source/aws_serverless_function.py
+++ b/samtranslator/internal/schema_source/aws_serverless_function.py
@@ -278,7 +278,7 @@ class ApiEventProperties(BaseModel):
     RequestModel: Optional[RequestModel] = apieventproperties("RequestModel")
     RequestParameters: Optional[RequestModelProperty] = apieventproperties("RequestParameters")
     RestApiId: Optional[Union[str, Ref]] = apieventproperties("RestApiId")
-    TimeoutInMillis: Optional[SamIntrinsicable[int]]  # TODO: add doc
+    TimeoutInMillis: Optional[PassThroughProp]  # TODO: add doc
 
 
 class ApiEvent(BaseModel):

--- a/samtranslator/internal/schema_source/aws_serverless_function.py
+++ b/samtranslator/internal/schema_source/aws_serverless_function.py
@@ -278,6 +278,7 @@ class ApiEventProperties(BaseModel):
     RequestModel: Optional[RequestModel] = apieventproperties("RequestModel")
     RequestParameters: Optional[RequestModelProperty] = apieventproperties("RequestParameters")
     RestApiId: Optional[Union[str, Ref]] = apieventproperties("RestApiId")
+    TimeoutInMillis: Optional[SamIntrinsicable[int]]  # TODO: add doc
 
 
 class ApiEvent(BaseModel):

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -832,7 +832,7 @@ class Api(PushEventSource):
                 self.Auth, api, api_id, self.relative_id, self.Method, self.Path, stage, editor, intrinsics_resolver
             )
         if self.TimeoutInMillis:
-            editor.add_timeout_to_method(self.Path, self.Method, self.TimeoutInMillis)
+            editor.add_timeout_to_method(api=api, path=self.Path, method_name=self.Method, timeout=self.TimeoutInMillis)
 
         if self.RequestModel:
             sam_expect(self.RequestModel, self.relative_id, "RequestModel", is_sam_event=True).to_be_a_map()
@@ -1402,7 +1402,9 @@ class HttpApi(PushEventSource):
         if self.Auth:
             self._add_auth_to_openapi_integration(api, api_id, editor, self.Auth)
         if self.TimeoutInMillis:
-            editor.add_timeout_to_method(path=self._path, method_name=self._method, timeout=self.TimeoutInMillis)
+            editor.add_timeout_to_method(
+                api=api, path=self._path, method_name=self._method, timeout=self.TimeoutInMillis
+            )
         path_parameters = re.findall("{(.*?)}", self._path)
         if path_parameters:
             editor.add_path_parameters_to_method(  # type: ignore[no-untyped-call]

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -832,7 +832,7 @@ class Api(PushEventSource):
                 self.Auth, api, api_id, self.relative_id, self.Method, self.Path, stage, editor, intrinsics_resolver
             )
         if self.TimeoutInMillis:
-            self.add_timeout_to_swagger(self.Path, self.Method, self.TimeoutInMillis, editor)
+            editor.add_timeout_to_method(self.Path, self.Method, self.TimeoutInMillis)
 
         if self.RequestModel:
             sam_expect(self.RequestModel, self.relative_id, "RequestModel", is_sam_event=True).to_be_a_map()
@@ -1075,20 +1075,6 @@ class Api(PushEventSource):
             editor.add_resource_policy(resource_policy=resource_policy, path=path, stage=stage)
             if resource_policy.get("CustomStatements"):
                 editor.add_custom_statements(resource_policy.get("CustomStatements"))  # type: ignore[no-untyped-call]
-
-    @staticmethod
-    def add_timeout_to_swagger(path: str, method_name: str, timeout: int, editor: SwaggerEditor) -> None:
-        """
-        Adds a timeout to this path/method.
-
-        :param path: string of path name
-        :param method_name: string of method name
-        :param timeout: int of timeout duration in milliseconds
-        :param editor: SwaggerEditor object
-
-        """
-        for method_definition in editor.iter_on_method_definitions_for_path_at_method(path, method_name):
-            method_definition[editor._X_APIGW_INTEGRATION]["timeoutInMillis"] = timeout
 
 
 class AlexaSkill(PushEventSource):
@@ -1416,7 +1402,7 @@ class HttpApi(PushEventSource):
         if self.Auth:
             self._add_auth_to_openapi_integration(api, api_id, editor, self.Auth)
         if self.TimeoutInMillis:
-            editor.add_timeout_to_method(api=api, path=self._path, method_name=self._method, timeout=self.TimeoutInMillis)  # type: ignore[no-untyped-call]
+            editor.add_timeout_to_method(path=self._path, method_name=self._method, timeout=self.TimeoutInMillis)
         path_parameters = re.findall("{(.*?)}", self._path)
         if path_parameters:
             editor.add_path_parameters_to_method(  # type: ignore[no-untyped-call]

--- a/samtranslator/open_api/base_editor.py
+++ b/samtranslator/open_api/base_editor.py
@@ -173,6 +173,18 @@ class BaseEditor:
         for path_item in self.get_conditional_contents(path_dict):
             path_item.setdefault(method, Py27Dict())
 
+    def add_timeout_to_method(self, path: str, method_name: str, timeout: int) -> None:
+        """
+        Adds a timeout to the path/method.
+
+        :param path: string of path name
+        :param method_name: string of method name
+        :param timeout: int of timeout duration in milliseconds
+
+        """
+        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
+            method_definition[self._X_APIGW_INTEGRATION]["timeoutInMillis"] = timeout
+
     @staticmethod
     def _get_authorization_scopes(
         authorizers: Union[Dict[str, ApiGatewayAuthorizer], Dict[str, ApiGatewayV2Authorizer]], default_authorizer: str

--- a/samtranslator/open_api/base_editor.py
+++ b/samtranslator/open_api/base_editor.py
@@ -173,10 +173,11 @@ class BaseEditor:
         for path_item in self.get_conditional_contents(path_dict):
             path_item.setdefault(method, Py27Dict())
 
-    def add_timeout_to_method(self, path: str, method_name: str, timeout: int) -> None:
+    def add_timeout_to_method(self, api: Dict[str, Any], path: str, method_name: str, timeout: int) -> None:
         """
         Adds a timeout to the path/method.
 
+        :param api: dict containing Api to be modified
         :param path: string of path name
         :param method_name: string of method name
         :param timeout: int of timeout duration in milliseconds

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -177,18 +177,6 @@ class OpenApiEditor(BaseEditor):
                     normalized_method_name = self._normalize_method_name(method_name)
                     yield normalized_method_name, method_definition
 
-    def add_timeout_to_method(self, api, path, method_name, timeout):  # type: ignore[no-untyped-def]
-        """
-        Adds a timeout to this path/method.
-
-        :param dict api: Reference to the related Api's properties as defined in the template.
-        :param string path: Path name
-        :param string method_name: Method name
-        :param int timeout: Timeout amount, in milliseconds
-        """
-        for method_definition in self.iter_on_method_definitions_for_path_at_method(path, method_name):
-            method_definition[self._X_APIGW_INTEGRATION]["timeoutInMillis"] = timeout
-
     def add_path_parameters_to_method(self, api, path, method_name, path_parameters):  # type: ignore[no-untyped-def]
         """
         Adds path parameters to this path + method

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -4898,15 +4898,7 @@
           "title": "RestApiId"
         },
         "TimeoutInMillis": {
-          "anyOf": [
-            {
-              "type": "object"
-            },
-            {
-              "type": "integer"
-            }
-          ],
-          "title": "Timeoutinmillis"
+          "$ref": "#/definitions/PassThroughProp"
         }
       },
       "required": [

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -4896,6 +4896,17 @@
           ],
           "markdownDescription": "Identifier of a RestApi resource, which must contain an operation with the given path and method\\. Typically, this is set to reference an [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource defined in this template\\.  \nIf you don't define this property, AWS SAM creates a default [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource using a generated `OpenApi` document\\. That resource contains a union of all paths and methods defined by `Api` events in the same template that do not specify a `RestApiId`\\.  \nThis cannot reference an [AWS::Serverless::Api](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html) resource defined in another template\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\\.",
           "title": "RestApiId"
+        },
+        "TimeoutInMillis": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Timeoutinmillis"
         }
       },
       "required": [

--- a/tests/translator/input/implicit_api_with_timeout.yaml
+++ b/tests/translator/input/implicit_api_with_timeout.yaml
@@ -25,17 +25,3 @@ Resources:
             Path: /getlist
             Method: get
             TimeoutInMillis: 10000
-
-  GetHtmlFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: s3://sam-demo-bucket/todo_list.zip
-      Handler: index.gethtml
-      Runtime: nodejs12.x
-      Policies: AmazonDynamoDBReadOnlyAccess
-      Events:
-        GetHtml:
-          Type: Api
-          Properties:
-            Path: /{proxy+}
-            Method: any

--- a/tests/translator/input/implicit_api_with_timeout.yaml
+++ b/tests/translator/input/implicit_api_with_timeout.yaml
@@ -1,0 +1,41 @@
+Resources:
+  RestApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/todo_list.zip
+      Handler: index.restapi
+      Runtime: nodejs12.x
+      Policies: AmazonDynamoDBFullAccess
+      Events:
+        AddItem:
+          Type: Api
+          Properties:
+            Path: /add
+            Method: post
+            TimeoutInMillis: 5000
+        CompleteItem:
+          Type: Api
+          Properties:
+            Path: /complete
+            Method: POST
+            TimeoutInMillis: 5000
+        GetList:
+          Type: Api
+          Properties:
+            Path: /getlist
+            Method: get
+            TimeoutInMillis: 10000
+
+  GetHtmlFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/todo_list.zip
+      Handler: index.gethtml
+      Runtime: nodejs12.x
+      Policies: AmazonDynamoDBReadOnlyAccess
+      Events:
+        GetHtml:
+          Type: Api
+          Properties:
+            Path: /{proxy+}
+            Method: any

--- a/tests/translator/output/aws-cn/implicit_api_with_timeout.json
+++ b/tests/translator/output/aws-cn/implicit_api_with_timeout.json
@@ -1,80 +1,5 @@
 {
   "Resources": {
-    "GetHtmlFunction": {
-      "Properties": {
-        "Code": {
-          "S3Bucket": "sam-demo-bucket",
-          "S3Key": "todo_list.zip"
-        },
-        "Handler": "index.gethtml",
-        "Role": {
-          "Fn::GetAtt": [
-            "GetHtmlFunctionRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs12.x",
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      },
-      "Type": "AWS::Lambda::Function"
-    },
-    "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Ref": "GetHtmlFunction"
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
-            {
-              "__ApiId__": {
-                "Ref": "ServerlessRestApi"
-              },
-              "__Stage__": "*"
-            }
-          ]
-        }
-      },
-      "Type": "AWS::Lambda::Permission"
-    },
-    "GetHtmlFunctionRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
-        ],
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      },
-      "Type": "AWS::IAM::Role"
-    },
     "RestApiFunction": {
       "Properties": {
         "Code": {
@@ -240,18 +165,6 @@
                   }
                 }
               }
-            },
-            "/{proxy+}": {
-              "x-amazon-apigateway-any-method": {
-                "responses": {},
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
-                  }
-                }
-              }
             }
           },
           "swagger": "2.0"
@@ -267,9 +180,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeployment4a545b0298": {
+    "ServerlessRestApiDeployment98237c0ad2": {
       "Properties": {
-        "Description": "RestApi deployment id: 4a545b0298063b7d88f523dd2152bc1dc833fc39",
+        "Description": "RestApi deployment id: 98237c0ad272dd450dd85327d1810071e16dd3f6",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -280,7 +193,7 @@
     "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment4a545b0298"
+          "Ref": "ServerlessRestApiDeployment98237c0ad2"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-cn/implicit_api_with_timeout.json
+++ b/tests/translator/output/aws-cn/implicit_api_with_timeout.json
@@ -1,0 +1,293 @@
+{
+  "Resources": {
+    "GetHtmlFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "GetHtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "GetHtmlFunctionGetHtmlPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "GetHtmlFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "GetHtmlFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "RestApiFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Handler": "index.restapi",
+        "Role": {
+          "Fn::GetAtt": [
+            "RestApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "RestApiFunctionAddItemPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionCompleteItemPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionGetListPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/AmazonDynamoDBFullAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/add": {
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 5000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/complete": {
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 5000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/getlist": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 10000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/{proxy+}": {
+              "x-amazon-apigateway-any-method": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeployment4a545b0298": {
+      "Properties": {
+        "Description": "RestApi deployment id: 4a545b0298063b7d88f523dd2152bc1dc833fc39",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment4a545b0298"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/implicit_api_with_timeout.json
+++ b/tests/translator/output/aws-us-gov/implicit_api_with_timeout.json
@@ -1,80 +1,5 @@
 {
   "Resources": {
-    "GetHtmlFunction": {
-      "Properties": {
-        "Code": {
-          "S3Bucket": "sam-demo-bucket",
-          "S3Key": "todo_list.zip"
-        },
-        "Handler": "index.gethtml",
-        "Role": {
-          "Fn::GetAtt": [
-            "GetHtmlFunctionRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs12.x",
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      },
-      "Type": "AWS::Lambda::Function"
-    },
-    "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Ref": "GetHtmlFunction"
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
-            {
-              "__ApiId__": {
-                "Ref": "ServerlessRestApi"
-              },
-              "__Stage__": "*"
-            }
-          ]
-        }
-      },
-      "Type": "AWS::Lambda::Permission"
-    },
-    "GetHtmlFunctionRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
-        ],
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      },
-      "Type": "AWS::IAM::Role"
-    },
     "RestApiFunction": {
       "Properties": {
         "Code": {
@@ -240,18 +165,6 @@
                   }
                 }
               }
-            },
-            "/{proxy+}": {
-              "x-amazon-apigateway-any-method": {
-                "responses": {},
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
-                  }
-                }
-              }
             }
           },
           "swagger": "2.0"
@@ -267,9 +180,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymentb5bd53f995": {
+    "ServerlessRestApiDeployment47f4c235b9": {
       "Properties": {
-        "Description": "RestApi deployment id: b5bd53f995e4bf62fdff2d56aea55fa447457890",
+        "Description": "RestApi deployment id: 47f4c235b98a5cddea753898800525837ccda7bd",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -280,7 +193,7 @@
     "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentb5bd53f995"
+          "Ref": "ServerlessRestApiDeployment47f4c235b9"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-us-gov/implicit_api_with_timeout.json
+++ b/tests/translator/output/aws-us-gov/implicit_api_with_timeout.json
@@ -1,0 +1,293 @@
+{
+  "Resources": {
+    "GetHtmlFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "GetHtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "GetHtmlFunctionGetHtmlPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "GetHtmlFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "GetHtmlFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "RestApiFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Handler": "index.restapi",
+        "Role": {
+          "Fn::GetAtt": [
+            "RestApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "RestApiFunctionAddItemPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionCompleteItemPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionGetListPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBFullAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/add": {
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 5000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/complete": {
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 5000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/getlist": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 10000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/{proxy+}": {
+              "x-amazon-apigateway-any-method": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeploymentb5bd53f995": {
+      "Properties": {
+        "Description": "RestApi deployment id: b5bd53f995e4bf62fdff2d56aea55fa447457890",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentb5bd53f995"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/implicit_api_with_timeout.json
+++ b/tests/translator/output/implicit_api_with_timeout.json
@@ -1,0 +1,285 @@
+{
+  "Resources": {
+    "GetHtmlFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "GetHtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "GetHtmlFunctionGetHtmlPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "GetHtmlFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "GetHtmlFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "RestApiFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "todo_list.zip"
+        },
+        "Handler": "index.restapi",
+        "Role": {
+          "Fn::GetAtt": [
+            "RestApiFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "RestApiFunctionAddItemPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/add",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionCompleteItemPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/complete",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionGetListPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "RestApiFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/getlist",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "RestApiFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "ServerlessRestApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/add": {
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 5000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/complete": {
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 5000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/getlist": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 10000,
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RestApiFunction.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/{proxy+}": {
+              "x-amazon-apigateway-any-method": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "ServerlessRestApiDeploymentd981733893": {
+      "Properties": {
+        "Description": "RestApi deployment id: d9817338932b7360025fb1a512422545ff1b3425",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "ServerlessRestApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentd981733893"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    }
+  }
+}

--- a/tests/translator/output/implicit_api_with_timeout.json
+++ b/tests/translator/output/implicit_api_with_timeout.json
@@ -1,80 +1,5 @@
 {
   "Resources": {
-    "GetHtmlFunction": {
-      "Properties": {
-        "Code": {
-          "S3Bucket": "sam-demo-bucket",
-          "S3Key": "todo_list.zip"
-        },
-        "Handler": "index.gethtml",
-        "Role": {
-          "Fn::GetAtt": [
-            "GetHtmlFunctionRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs12.x",
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      },
-      "Type": "AWS::Lambda::Function"
-    },
-    "GetHtmlFunctionGetHtmlPermissionProd": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Ref": "GetHtmlFunction"
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*",
-            {
-              "__ApiId__": {
-                "Ref": "ServerlessRestApi"
-              },
-              "__Stage__": "*"
-            }
-          ]
-        }
-      },
-      "Type": "AWS::Lambda::Permission"
-    },
-    "GetHtmlFunctionRole": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"
-        ],
-        "Tags": [
-          {
-            "Key": "lambda:createdBy",
-            "Value": "SAM"
-          }
-        ]
-      },
-      "Type": "AWS::IAM::Role"
-    },
     "RestApiFunction": {
       "Properties": {
         "Code": {
@@ -240,18 +165,6 @@
                   }
                 }
               }
-            },
-            "/{proxy+}": {
-              "x-amazon-apigateway-any-method": {
-                "responses": {},
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetHtmlFunction.Arn}/invocations"
-                  }
-                }
-              }
             }
           },
           "swagger": "2.0"
@@ -259,9 +172,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymentd981733893": {
+    "ServerlessRestApiDeploymentfe95bb2253": {
       "Properties": {
-        "Description": "RestApi deployment id: d9817338932b7360025fb1a512422545ff1b3425",
+        "Description": "RestApi deployment id: fe95bb22532f0a323752e1d85d52029764403503",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -272,7 +185,7 @@
     "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentd981733893"
+          "Ref": "ServerlessRestApiDeploymentfe95bb2253"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"


### PR DESCRIPTION
### Issue #, if available

Feature request discussion: [https://github.com/aws/serverless-application-model/discussions/3287](https://github.com/aws/serverless-application-model/discussions/3287)
- Both Global level and Function level support are requested, but only Function level support is implemented in this pull request.

### Description of changes

Add TimeoutInMillis Property to API Event Source (currently only supported for HTTP API Event Source). 

Example:
```
MyFunction:
    Type: AWS::Serverless::Function
    Properties:
      Handler: src/handlers/code.handler
      Events:
        MyApiEvent:
          Type: Api  # API Event Source
          Properties:
            Path: /hello
            Method: GET
            TimeoutInMillis: 5000 # Now supported

```

### Description of how you validated changes

Validated with transform tests and integration tests. Transformed template with added TimeoutInMillis property, then deployed it successfully. Added integration test also verifies that the TimeoutInMillis property is set to the expected value from the template.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
