### PR TITLE
fix: Fix availability dip in PropagateTags property

### DIFF
--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -107,7 +107,7 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
             return
 
         implicit_api_resource = template.get(self.IMPLICIT_API_LOGICAL_ID)
-        globals_var = template.get_globals().get(SamResourceType(resource.type).name, {})
+        globals_var = template.get_globals().get(SamResourceType(resource.type).name) or {}
         should_propagate_tags = resource.properties.get("PropagateTags") or globals_var.get("PropagateTags")
         tags_properties = resource.properties.get("Tags") or globals_var.get("Tags")
 


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Dip fix on `PropagateTags` property.

### Description of how you validated changes
All tests passed. 

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
