### PR TITLE
chore: Remove Validation on DeletionPolicy and UpdateReplacePolicy

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -131,6 +131,7 @@ ignore_templates:
   - tests/translator/output/**/function_with_mq_using_autogen_role.json  # Property "EventSourceArn" can Fn::GetAtt to a resource of types [AWS::DynamoDB::GlobalTable, AWS::DynamoDB::Table, AWS::Kinesis::Stream, AWS::Kinesis::StreamConsumer, AWS::SQS::Queue]
   - tests/translator/output/**/function_with_tracing.json # Obsolete DependsOn on resource
   - tests/translator/output/**/api_with_propagate_tags.json # TODO: Intentional error transform tests. Will be updated.
+  - tests/translator/output/**/function_with_intrinsics_resource_attribute.json # CFN now supports intrinsics in DeletionPolicy
 ignore_checks:
   - E2531 # Deprecated runtime; not relevant for transform tests
   - W2531 # EOL runtime; not relevant for transform tests

--- a/integration/combination/test_function_with_implicit_api_with_timeout.py
+++ b/integration/combination/test_function_with_implicit_api_with_timeout.py
@@ -16,6 +16,14 @@ class TestFunctionWithImplicitApiWithTimeout(BaseTest):
         rest_api_id = self.get_physical_id_by_type("AWS::ApiGateway::RestApi")
         resources = apigw_client.get_resources(restApiId=rest_api_id)["items"]
 
-        method = apigw_client.get_method(restApiId=rest_api_id, resourceId=resources[0]["id"], httpMethod="GET")
+        resource = get_resource_by_path(resources, "/hello")
+        method = apigw_client.get_method(restApiId=rest_api_id, resourceId=resource["id"], httpMethod="GET")
         method_integration = method["methodIntegration"]
         self.assertEqual(method_integration["timeoutInMillis"], expected_timeout)
+
+
+def get_resource_by_path(resources, path):
+    for resource in resources:
+        if resource["path"] == path:
+            return resource
+    return None

--- a/integration/combination/test_function_with_intrinsics_resource_attributes.py
+++ b/integration/combination/test_function_with_intrinsics_resource_attributes.py
@@ -1,0 +1,11 @@
+from integration.helpers.base_test import BaseTest
+
+
+class TestFunctionWithIntrinsicsResourceAttributes(BaseTest):
+    def test_function_with_intrinsics_resource_attributes(self):
+        # simply verify the stack is deployed successfully is enough
+        self.create_and_verify_stack("combination/function_with_intrinsics_resource_attribute")
+
+        stack_outputs = self.get_stack_outputs()
+        id_dev_stack = stack_outputs["IsDevStack"]
+        self.assertEqual(id_dev_stack, "true")

--- a/integration/resources/expected/combination/function_with_intrinsics_resource_attribute.json
+++ b/integration/resources/expected/combination/function_with_intrinsics_resource_attribute.json
@@ -1,0 +1,10 @@
+[
+  {
+    "LogicalResourceId": "MyLambdaFunction",
+    "ResourceType": "AWS::Lambda::Function"
+  },
+  {
+    "LogicalResourceId": "MyLambdaFunctionRole",
+    "ResourceType": "AWS::IAM::Role"
+  }
+]

--- a/integration/resources/templates/combination/function_with_intrinsics_resource_attribute.yaml
+++ b/integration/resources/templates/combination/function_with_intrinsics_resource_attribute.yaml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: A template to test timeout support for implicit APIs.
+
+Parameters:
+  IsDevStack: {Type: String, Default: 'true', AllowedValues: ['true', 'false']}
+Conditions:
+  IsDevStack: !Equals [!Ref IsDevStack, 'true']
+  NotIsDevStack: !Not [Condition: IsDevStack]
+
+Resources:
+  MyLambdaFunction:
+    DeletionPolicy: !If [NotIsDevStack, Retain, Delete]
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs16.x
+      MemorySize: 128
+      Timeout: 3
+      InlineCode: |
+        exports.handler = async () => 'Hello World!'
+
+Outputs:
+  IsDevStack:
+    Value: !Ref IsDevStack
+
+Metadata:
+  SamTransformTest: true

--- a/samtranslator/sdk/resource.py
+++ b/samtranslator/sdk/resource.py
@@ -43,14 +43,6 @@ class SamResource:
         if self.condition and not IS_STR(self.condition, should_raise=False):
             raise InvalidDocumentException([InvalidTemplateException("Every Condition member must be a string.")])
 
-        if self.deletion_policy and not IS_STR(self.deletion_policy, should_raise=False):
-            raise InvalidDocumentException([InvalidTemplateException("Every DeletionPolicy member must be a string.")])
-
-        if self.update_replace_policy and not IS_STR(self.update_replace_policy, should_raise=False):
-            raise InvalidDocumentException(
-                [InvalidTemplateException("Every UpdateReplacePolicy member must be a string.")]
-            )
-
         # TODO: should we raise exception if `self.type` is not a string?
         return isinstance(self.type, str) and SamResourceType.has_value(self.type)
 

--- a/tests/translator/input/function_with_intrinsics_resource_attribute.yaml
+++ b/tests/translator/input/function_with_intrinsics_resource_attribute.yaml
@@ -1,0 +1,18 @@
+Parameters:
+  IsDevStack: {Type: String, Default: 'true', AllowedValues: ['true', 'false']}
+Conditions:
+  IsDevStack: !Equals [!Ref IsDevStack, 'true']
+  NotIsDevStack: !Not [Condition: IsDevStack]
+
+Resources:
+  FunctionWithArchitecturesIntrinsic:
+    Type: AWS::Serverless::Function
+    UpdateReplacePolicy: !Equals [NotIsDevStack, Retain]
+    DeletionPolicy: !Equals [NotIsDevStack, Retain]
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Description: Created by SAM
+      Handler: index.handler
+      MemorySize: 1024
+      Runtime: nodejs12.x
+      Timeout: 3

--- a/tests/translator/output/aws-cn/function_with_intrinsics_resource_attribute.json
+++ b/tests/translator/output/aws-cn/function_with_intrinsics_resource_attribute.json
@@ -1,0 +1,111 @@
+{
+  "Conditions": {
+    "IsDevStack": {
+      "Fn::Equals": [
+        {
+          "Ref": "IsDevStack"
+        },
+        "true"
+      ]
+    },
+    "NotIsDevStack": {
+      "Fn::Not": [
+        {
+          "Condition": "IsDevStack"
+        }
+      ]
+    }
+  },
+  "Parameters": {
+    "IsDevStack": {
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "true",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "FunctionWithArchitecturesIntrinsic": {
+      "DeletionPolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": "Created by SAM",
+        "Handler": "index.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithArchitecturesIntrinsicRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "Timeout": 3
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      }
+    },
+    "FunctionWithArchitecturesIntrinsicRole": {
+      "DeletionPolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/function_with_intrinsics_resource_attribute.json
+++ b/tests/translator/output/aws-us-gov/function_with_intrinsics_resource_attribute.json
@@ -1,0 +1,111 @@
+{
+  "Conditions": {
+    "IsDevStack": {
+      "Fn::Equals": [
+        {
+          "Ref": "IsDevStack"
+        },
+        "true"
+      ]
+    },
+    "NotIsDevStack": {
+      "Fn::Not": [
+        {
+          "Condition": "IsDevStack"
+        }
+      ]
+    }
+  },
+  "Parameters": {
+    "IsDevStack": {
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "true",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "FunctionWithArchitecturesIntrinsic": {
+      "DeletionPolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": "Created by SAM",
+        "Handler": "index.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithArchitecturesIntrinsicRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "Timeout": 3
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      }
+    },
+    "FunctionWithArchitecturesIntrinsicRole": {
+      "DeletionPolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/function_with_intrinsics_resource_attribute.json
+++ b/tests/translator/output/function_with_intrinsics_resource_attribute.json
@@ -1,0 +1,111 @@
+{
+  "Conditions": {
+    "IsDevStack": {
+      "Fn::Equals": [
+        {
+          "Ref": "IsDevStack"
+        },
+        "true"
+      ]
+    },
+    "NotIsDevStack": {
+      "Fn::Not": [
+        {
+          "Condition": "IsDevStack"
+        }
+      ]
+    }
+  },
+  "Parameters": {
+    "IsDevStack": {
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "true",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "FunctionWithArchitecturesIntrinsic": {
+      "DeletionPolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": "Created by SAM",
+        "Handler": "index.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithArchitecturesIntrinsicRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "Timeout": 3
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      }
+    },
+    "FunctionWithArchitecturesIntrinsicRole": {
+      "DeletionPolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": {
+        "Fn::Equals": [
+          "NotIsDevStack",
+          "Retain"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes
CloudFormation now supports intrinsics in `DeletionPolicy` and `UpdateReplacePolicy`. SAM transform is enforcing a (now incorrect) validation on all DeletionPolicy fields that's preventing us from using intrinsic functions there. The transform doesn't need to process those values, it just needs to pass them through. CFN has updated their core language to permit this use case

### Description of how you validated changes
Shouldn't have impact on any existing SAM behaviour. All current tests pass

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
