### PR TITLE
chore: Update Lambda node runtime envs in integ tests

### DIFF
--- a/integration/resources/templates/combination/api_with_authorizer_apikey.yaml
+++ b/integration/resources/templates/combination/api_with_authorizer_apikey.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {
@@ -45,7 +45,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           console.log(event);

--- a/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
@@ -31,7 +31,7 @@ Resources:
       InlineCode: |
         print("hello")
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         API3:
           Type: Api
@@ -50,7 +50,7 @@ Resources:
       InlineCode: |
         print("hello")
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         MyApiWithAwsIamAuth:
           Type: Api

--- a/integration/resources/templates/combination/api_with_authorizers_max.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_max.yaml
@@ -43,7 +43,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {
@@ -101,7 +101,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           const token = event.type === 'TOKEN' ? event.authorizationToken : event.queryStringParameters.authorization

--- a/integration/resources/templates/combination/api_with_authorizers_max_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_max_openapi.yaml
@@ -46,7 +46,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {
@@ -114,7 +114,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           const token = event.type === 'TOKEN' ? event.authorizationToken : event.queryStringParameters.authorization

--- a/integration/resources/templates/combination/api_with_authorizers_min.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_min.yaml
@@ -23,7 +23,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {
@@ -80,7 +80,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           const token = event.type === 'TOKEN' ? event.authorizationToken : event.queryStringParameters.authorization

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
@@ -51,7 +51,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket:
           Ref: Bucket

--- a/integration/resources/templates/combination/api_with_cors.yaml
+++ b/integration/resources/templates/combination/api_with_cors.yaml
@@ -22,7 +22,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/api_with_cors_and_apikey.yaml
+++ b/integration/resources/templates/combination/api_with_cors_and_apikey.yaml
@@ -22,7 +22,7 @@ Resources:
             body: JSON.stringify({ message: "Hello, SAM!" }),
           }
         }
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
 
   ApiGatewayLambdaRole:
     Type: AWS::IAM::Role

--- a/integration/resources/templates/combination/api_with_cors_only_headers.yaml
+++ b/integration/resources/templates/combination/api_with_cors_only_headers.yaml
@@ -24,7 +24,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/api_with_cors_only_max_age.yaml
+++ b/integration/resources/templates/combination/api_with_cors_only_max_age.yaml
@@ -24,7 +24,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/api_with_cors_only_methods.yaml
+++ b/integration/resources/templates/combination/api_with_cors_only_methods.yaml
@@ -24,7 +24,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/api_with_cors_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_cors_openapi.yaml
@@ -22,7 +22,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/api_with_cors_shorthand.yaml
+++ b/integration/resources/templates/combination/api_with_cors_shorthand.yaml
@@ -23,7 +23,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/api_with_custom_domains_edge.yaml
+++ b/integration/resources/templates/combination/api_with_custom_domains_edge.yaml
@@ -19,7 +19,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         Fetch:
           Type: Api

--- a/integration/resources/templates/combination/api_with_custom_domains_regional.yaml
+++ b/integration/resources/templates/combination/api_with_custom_domains_regional.yaml
@@ -38,7 +38,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/integration/resources/templates/combination/api_with_custom_domains_regional_ownership_verification.yaml
+++ b/integration/resources/templates/combination/api_with_custom_domains_regional_ownership_verification.yaml
@@ -42,7 +42,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/integration/resources/templates/combination/api_with_disable_execute_api_endpoint.yaml
+++ b/integration/resources/templates/combination/api_with_disable_execute_api_endpoint.yaml
@@ -24,7 +24,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         Iam:
           Type: Api

--- a/integration/resources/templates/combination/api_with_disable_execute_api_endpoint_openapi_3.yaml
+++ b/integration/resources/templates/combination/api_with_disable_execute_api_endpoint_openapi_3.yaml
@@ -25,7 +25,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         Iam:
           Type: Api

--- a/integration/resources/templates/combination/api_with_fail_on_warnings.yaml
+++ b/integration/resources/templates/combination/api_with_fail_on_warnings.yaml
@@ -23,7 +23,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         Iam:
           Type: Api

--- a/integration/resources/templates/combination/api_with_gateway_responses.yaml
+++ b/integration/resources/templates/combination/api_with_gateway_responses.yaml
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/integration/resources/templates/combination/api_with_propagate_tags.yaml
+++ b/integration/resources/templates/combination/api_with_propagate_tags.yaml
@@ -17,7 +17,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/integration/resources/templates/combination/api_with_request_models.yaml
+++ b/integration/resources/templates/combination/api_with_request_models.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/integration/resources/templates/combination/api_with_request_models_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_request_models_openapi.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/integration/resources/templates/combination/api_with_request_parameters_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_request_parameters_openapi.yaml
@@ -29,7 +29,7 @@ Resources:
             });
         }
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         GetHtml:
           Type: Api

--- a/integration/resources/templates/combination/api_with_resource_policies.yaml
+++ b/integration/resources/templates/combination/api_with_resource_policies.yaml
@@ -20,7 +20,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/api_with_resource_policies_aws_account.yaml
+++ b/integration/resources/templates/combination/api_with_resource_policies_aws_account.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       Events:
         Api:

--- a/integration/resources/templates/combination/connector_appsync_api_to_lambda.yaml
+++ b/integration/resources/templates/combination/connector_appsync_api_to_lambda.yaml
@@ -88,7 +88,7 @@ Resources:
           }
         }
       PackageType: Zip
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
 
   TriggerFunction:
@@ -97,7 +97,7 @@ Resources:
       Environment:
         Variables:
           GRAPHQL_URL: !GetAtt Api.GraphQLUrl
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const https = require("https");

--- a/integration/resources/templates/combination/connector_appsync_to_lambda.yaml
+++ b/integration/resources/templates/combination/connector_appsync_to_lambda.yaml
@@ -19,7 +19,7 @@ Resources:
           return "Hello World"
         }
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
 
   AppSyncApi:
     Type: AWS::AppSync::GraphQLApi
@@ -88,7 +88,7 @@ Resources:
         Variables:
           API_KEY: !GetAtt ApiKey.ApiKey
           GRAPHQL_URL: !GetAtt AppSyncApi.GraphQLUrl
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const https = require("https");

--- a/integration/resources/templates/combination/connector_appsync_to_table.yaml
+++ b/integration/resources/templates/combination/connector_appsync_to_table.yaml
@@ -120,7 +120,7 @@ Resources:
         Variables:
           API_KEY: !GetAtt ApiKey.ApiKey
           GRAPHQL_URL: !GetAtt AppSyncApi.GraphQLUrl
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const https = require("https");

--- a/integration/resources/templates/combination/connector_bucket_to_function_write.yaml
+++ b/integration/resources/templates/combination/connector_bucket_to_function_write.yaml
@@ -9,7 +9,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -42,7 +42,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_event_rule_to_eb_custom_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_eb_custom_write.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |

--- a/integration/resources/templates/combination/connector_event_rule_to_eb_default_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_eb_default_write.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |

--- a/integration/resources/templates/combination/connector_event_rule_to_lambda_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_lambda_write.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -52,7 +52,7 @@ Resources:
   Function:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_event_rule_to_lambda_write_multiple.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_lambda_write_multiple.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -54,7 +54,7 @@ Resources:
   Function:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -76,7 +76,7 @@ Resources:
   Function2:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_event_rule_to_sfn_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_sfn_write.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |

--- a/integration/resources/templates/combination/connector_event_rule_to_sns_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_sns_write.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |

--- a/integration/resources/templates/combination/connector_event_rule_to_sqs_write.yaml
+++ b/integration/resources/templates/combination/connector_event_rule_to_sqs_write.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |

--- a/integration/resources/templates/combination/connector_function_to_bucket_read.yaml
+++ b/integration/resources/templates/combination/connector_function_to_bucket_read.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_function_to_bucket_read_multiple.yaml
+++ b/integration/resources/templates/combination/connector_function_to_bucket_read_multiple.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_function_to_bucket_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_bucket_write.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_function_to_eventbus_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_eventbus_write.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_function_to_function.yaml
+++ b/integration/resources/templates/combination/connector_function_to_function.yaml
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole1.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |
@@ -53,7 +53,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole2.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_function_to_queue_read.yaml
+++ b/integration/resources/templates/combination/connector_function_to_queue_read.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_function_to_queue_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_queue_write.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_function_to_sfn_read.yaml
+++ b/integration/resources/templates/combination/connector_function_to_sfn_read.yaml
@@ -7,7 +7,7 @@ Resources:
           console.log("Hello world!")
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
 
   StateMachine:
     Type: AWS::Serverless::StateMachine
@@ -27,7 +27,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_function_to_sfn_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_sfn_write.yaml
@@ -7,7 +7,7 @@ Resources:
           console.log("Hello world!")
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
 
   StateMachine:
     Type: AWS::Serverless::StateMachine
@@ -27,7 +27,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_function_to_table_read.yaml
+++ b/integration/resources/templates/combination/connector_function_to_table_read.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_function_to_table_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_table_write.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_function_to_topic_write.yaml
+++ b/integration/resources/templates/combination/connector_function_to_topic_write.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_httpapi_to_function.yaml
+++ b/integration/resources/templates/combination/connector_httpapi_to_function.yaml
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole1.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |
@@ -73,7 +73,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole2.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_restapi_to_function.yaml
+++ b/integration/resources/templates/combination/connector_restapi_to_function.yaml
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole1.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |
@@ -73,7 +73,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole2.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/connector_sfn_to_function_without_policy.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_function_without_policy.yaml
@@ -16,7 +16,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         exports.handler = async (event) => {

--- a/integration/resources/templates/combination/connector_sfn_to_function_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_function_write.yaml
@@ -19,7 +19,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         exports.handler = async (event) => {

--- a/integration/resources/templates/combination/connector_sns_to_function_write.yaml
+++ b/integration/resources/templates/combination/connector_sns_to_function_write.yaml
@@ -9,7 +9,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -43,7 +43,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_sqs_to_function.yaml
+++ b/integration/resources/templates/combination/connector_sqs_to_function.yaml
@@ -5,7 +5,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -39,7 +39,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_table_to_function_read.yaml
+++ b/integration/resources/templates/combination/connector_table_to_function_read.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 100
       InlineCode: |
@@ -43,7 +43,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/integration/resources/templates/combination/connector_topic_to_queue_write.yaml
+++ b/integration/resources/templates/combination/connector_topic_to_queue_write.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/embedded_connector.yaml
+++ b/integration/resources/templates/combination/embedded_connector.yaml
@@ -34,7 +34,7 @@ Resources:
           - Write
     Properties:
       Role: !GetAtt MyRole1.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |
@@ -60,7 +60,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole2.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/function_with_alias.yaml
+++ b/integration/resources/templates/combination/function_with_alias.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       AutoPublishAlias: Live
 Metadata:

--- a/integration/resources/templates/combination/function_with_alias_and_all_properties_property.yaml
+++ b/integration/resources/templates/combination/function_with_alias_and_all_properties_property.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       AutoPublishAlias: Live
       AutoPublishAliasAllProperties: true

--- a/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
+++ b/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
@@ -8,7 +8,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
 
       AutoPublishAlias: Live
 

--- a/integration/resources/templates/combination/function_with_alias_globals.yaml
+++ b/integration/resources/templates/combination/function_with_alias_globals.yaml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
 
       # Alias is inherited from globals here
@@ -16,7 +16,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       AutoPublishAlias: Live
 Metadata:

--- a/integration/resources/templates/combination/function_with_alias_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_alias_intrinsics.yaml
@@ -19,7 +19,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri:
         # Just trying to create a complex intrinsic function where only a part of it can be resolved
         Bucket:

--- a/integration/resources/templates/combination/function_with_all_event_types.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types.yaml
@@ -19,7 +19,7 @@ Resources:
       InlineCode: |
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImageBucket:
           Type: S3
@@ -36,7 +36,7 @@ Resources:
       InlineCode: |
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       AutoPublishAlias: Live
       Events:
         CWSchedule:

--- a/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
@@ -14,7 +14,7 @@ Resources:
       InlineCode: |
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImageBucket:
           Type: S3
@@ -31,7 +31,7 @@ Resources:
       InlineCode: |
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       AutoPublishAlias: Live
       Events:
         CWSchedule:

--- a/integration/resources/templates/combination/function_with_api.yaml
+++ b/integration/resources/templates/combination/function_with_api.yaml
@@ -11,7 +11,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_application.yaml
+++ b/integration/resources/templates/combination/function_with_application.yaml
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       Environment:
         Variables:

--- a/integration/resources/templates/combination/function_with_cloudwatch_log.yaml
+++ b/integration/resources/templates/combination/function_with_cloudwatch_log.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Events:

--- a/integration/resources/templates/combination/function_with_cwe_dlq_and_retry_policy.yaml
+++ b/integration/resources/templates/combination/function_with_cwe_dlq_and_retry_policy.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_cwe_dlq_generated.yaml
+++ b/integration/resources/templates/combination/function_with_cwe_dlq_generated.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_deployment_alarms_and_hooks.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_alarms_and_hooks.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
 
       AutoPublishAlias: Live
@@ -115,14 +115,14 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
 
   PostTrafficFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/combination/function_with_deployment_disabled.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_disabled.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
 
       AutoPublishAlias: Live

--- a/integration/resources/templates/combination/function_with_dynamodb.yaml
+++ b/integration/resources/templates/combination/function_with_dynamodb.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_file_system_config.yaml
+++ b/integration/resources/templates/combination/function_with_file_system_config.yaml
@@ -42,7 +42,7 @@ Resources:
         }
       Handler: index.handler
       MemorySize: 128
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 3
       VpcConfig:
         SecurityGroupIds:

--- a/integration/resources/templates/combination/function_with_implicit_api_and_conditions.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_api_and_conditions.yaml
@@ -52,7 +52,7 @@ Resources:
     Condition: MyCondition
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -68,7 +68,7 @@ Resources:
     Condition: Cond
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -84,7 +84,7 @@ Resources:
     Condition: Cond1
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -100,7 +100,7 @@ Resources:
     Condition: Cond2
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -116,7 +116,7 @@ Resources:
     Condition: Cond3
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -132,7 +132,7 @@ Resources:
     Condition: Cond4
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -148,7 +148,7 @@ Resources:
     Condition: Cond5
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -164,7 +164,7 @@ Resources:
     Condition: Cond6
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -180,7 +180,7 @@ Resources:
     Condition: Cond7
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -196,7 +196,7 @@ Resources:
     Condition: Cond8
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |
@@ -212,7 +212,7 @@ Resources:
     Condition: Cond9
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |

--- a/integration/resources/templates/combination/function_with_implicit_api_with_timeout.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_api_with_timeout.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |

--- a/integration/resources/templates/combination/function_with_intrinsics_resource_attribute.yaml
+++ b/integration/resources/templates/combination/function_with_intrinsics_resource_attribute.yaml
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 3
       InlineCode: |

--- a/integration/resources/templates/combination/function_with_kinesis.yaml
+++ b/integration/resources/templates/combination/function_with_kinesis.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 
@@ -25,7 +25,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_kinesis_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_kinesis_intrinsics.yaml
@@ -30,7 +30,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_layer.yaml
+++ b/integration/resources/templates/combination/function_with_layer.yaml
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       Layers:
       - Ref: MyLambdaLayer

--- a/integration/resources/templates/combination/function_with_mq.yaml
+++ b/integration/resources/templates/combination/function_with_mq.yaml
@@ -136,7 +136,7 @@ Resources:
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: ${codeuri}
       Role:

--- a/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
+++ b/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
@@ -108,7 +108,7 @@ Resources:
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: ${codeuri}
       Events:

--- a/integration/resources/templates/combination/function_with_msk.yaml
+++ b/integration/resources/templates/combination/function_with_msk.yaml
@@ -50,7 +50,7 @@ Resources:
   MyMskStreamProcessor:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: ${codeuri}
       Role:

--- a/integration/resources/templates/combination/function_with_msk_using_managed_policy.yaml
+++ b/integration/resources/templates/combination/function_with_msk_using_managed_policy.yaml
@@ -26,7 +26,7 @@ Resources:
   MyMskStreamProcessor:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: ${codeuri}
       Events:

--- a/integration/resources/templates/combination/function_with_s3.yaml
+++ b/integration/resources/templates/combination/function_with_s3.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_s3_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_s3_intrinsics.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_schedule.yaml
+++ b/integration/resources/templates/combination/function_with_schedule.yaml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Events:

--- a/integration/resources/templates/combination/function_with_schedule_dlq_and_retry_policy.yaml
+++ b/integration/resources/templates/combination/function_with_schedule_dlq_and_retry_policy.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Events:

--- a/integration/resources/templates/combination/function_with_schedule_dlq_generated.yaml
+++ b/integration/resources/templates/combination/function_with_schedule_dlq_generated.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Events:

--- a/integration/resources/templates/combination/function_with_self_managed_kafka.yaml
+++ b/integration/resources/templates/combination/function_with_self_managed_kafka.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Events:

--- a/integration/resources/templates/combination/function_with_self_managed_kafka_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_self_managed_kafka_intrinsics.yaml
@@ -12,7 +12,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Events:

--- a/integration/resources/templates/combination/function_with_signing_profile.yaml
+++ b/integration/resources/templates/combination/function_with_signing_profile.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       CodeSigningConfigArn:

--- a/integration/resources/templates/combination/function_with_sns.yaml
+++ b/integration/resources/templates/combination/function_with_sns.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_sns_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_sns_intrinsics.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/function_with_sqs.yaml
+++ b/integration/resources/templates/combination/function_with_sqs.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       Events:
         MySqsEvent:

--- a/integration/resources/templates/combination/function_with_userpool_event.yaml
+++ b/integration/resources/templates/combination/function_with_userpool_event.yaml
@@ -29,7 +29,7 @@ Resources:
         }
       Handler: index.handler
       MemorySize: 128
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Timeout: 3
       Events:
         CognitoUserPoolPreSignup:

--- a/integration/resources/templates/combination/graphqlapi_lambda_resolver.yaml
+++ b/integration/resources/templates/combination/graphqlapi_lambda_resolver.yaml
@@ -4,7 +4,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Role: !GetAtt LambdaFunctionRole.Arn
       Code:
         ZipFile: |

--- a/integration/resources/templates/combination/http_api_with_auth.yaml
+++ b/integration/resources/templates/combination/http_api_with_auth.yaml
@@ -40,7 +40,7 @@ Resources:
       InlineCode: |
         print("hello")
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:

--- a/integration/resources/templates/combination/http_api_with_auth_updated.yaml
+++ b/integration/resources/templates/combination/http_api_with_auth_updated.yaml
@@ -25,7 +25,7 @@ Resources:
       InlineCode: |
         print("hello")
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
 
   MyApi:
     Type: AWS::Serverless::HttpApi

--- a/integration/resources/templates/combination/http_api_with_cors.yaml
+++ b/integration/resources/templates/combination/http_api_with_cors.yaml
@@ -23,7 +23,7 @@ Resources:
           }
         }
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImplicitApi:
           Type: HttpApi

--- a/integration/resources/templates/combination/http_api_with_custom_domains_regional.yaml
+++ b/integration/resources/templates/combination/http_api_with_custom_domains_regional.yaml
@@ -38,7 +38,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: HttpApi

--- a/integration/resources/templates/combination/http_api_with_custom_domains_regional_ownership_verification.yaml
+++ b/integration/resources/templates/combination/http_api_with_custom_domains_regional_ownership_verification.yaml
@@ -42,7 +42,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: HttpApi

--- a/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_false.yaml
+++ b/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_false.yaml
@@ -11,7 +11,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: HttpApi

--- a/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_true.yaml
+++ b/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_true.yaml
@@ -11,7 +11,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: HttpApi

--- a/integration/resources/templates/combination/implicit_api_with_settings.yaml
+++ b/integration/resources/templates/combination/implicit_api_with_settings.yaml
@@ -12,7 +12,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
+++ b/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
@@ -13,7 +13,7 @@ Resources:
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       MemorySize: 128
       CodeUri:

--- a/integration/resources/templates/combination/intrinsics_serverless_api.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_api.yaml
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 
@@ -57,7 +57,7 @@ Resources:
     Condition: FalseCondition
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
 

--- a/integration/resources/templates/single/basic_function.yaml
+++ b/integration/resources/templates/single/basic_function.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Policies:

--- a/integration/resources/templates/single/basic_function_event_destinations.yaml
+++ b/integration/resources/templates/single/basic_function_event_destinations.yaml
@@ -42,7 +42,7 @@ Resources:
           }
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 1024
   MyTestFunction2:
     Type: AWS::Serverless::Function
@@ -74,7 +74,7 @@ Resources:
           }
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 1024
   DestinationLambda:
     Type: AWS::Serverless::Function
@@ -88,7 +88,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       MemorySize: 1024
   DestinationSQS:
     Condition: QueueCreationDisabled

--- a/integration/resources/templates/single/basic_function_no_envvar.yaml
+++ b/integration/resources/templates/single/basic_function_no_envvar.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Policies:

--- a/integration/resources/templates/single/basic_function_openapi.yaml
+++ b/integration/resources/templates/single/basic_function_openapi.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Policies:

--- a/integration/resources/templates/single/basic_function_with_arm_architecture.yaml
+++ b/integration/resources/templates/single/basic_function_with_arm_architecture.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Architectures: [arm64]

--- a/integration/resources/templates/single/basic_function_with_function_url_config.yaml
+++ b/integration/resources/templates/single/basic_function_with_function_url_config.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       FunctionUrlConfig:

--- a/integration/resources/templates/single/basic_function_with_function_url_with_autopuplishalias.yaml
+++ b/integration/resources/templates/single/basic_function_with_function_url_with_autopuplishalias.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       AutoPublishAlias: live

--- a/integration/resources/templates/single/basic_function_with_kmskeyarn.yaml
+++ b/integration/resources/templates/single/basic_function_with_kmskeyarn.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Environment:

--- a/integration/resources/templates/single/basic_function_with_sns_dlq.yaml
+++ b/integration/resources/templates/single/basic_function_with_sns_dlq.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       DeadLetterQueue:
         Type: SNS

--- a/integration/resources/templates/single/basic_function_with_sqs_dlq.yaml
+++ b/integration/resources/templates/single/basic_function_with_sqs_dlq.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       DeadLetterQueue:
         Type: SQS

--- a/integration/resources/templates/single/basic_function_with_tags.yaml
+++ b/integration/resources/templates/single/basic_function_with_tags.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Policies:

--- a/integration/resources/templates/single/basic_function_with_tracing.yaml
+++ b/integration/resources/templates/single/basic_function_with_tracing.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Policies:
@@ -26,7 +26,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Policies:

--- a/integration/resources/templates/single/basic_function_with_x86_architecture.yaml
+++ b/integration/resources/templates/single/basic_function_with_x86_architecture.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
       Architectures:

--- a/integration/resources/templates/single/basic_layer_with_compatible_architecture.yaml
+++ b/integration/resources/templates/single/basic_layer_with_compatible_architecture.yaml
@@ -1,7 +1,7 @@
 Parameters:
   Runtimes:
     Type: CommaDelimitedList
-    Default: nodejs16.x
+    Default: nodejs18.x
   LayerName:
     Type: String
     Default: MyNamedLayerVersion

--- a/integration/resources/templates/single/basic_layer_with_parameters.yaml
+++ b/integration/resources/templates/single/basic_layer_with_parameters.yaml
@@ -7,7 +7,7 @@ Parameters:
     Default: MIT-0
   Runtimes:
     Type: CommaDelimitedList
-    Default: nodejs16.x
+    Default: nodejs18.x
   LayerName:
     Type: String
     Default: MyNamedLayerVersion

--- a/integration/resources/templates/single/function_alias_with_http_api_events.yaml
+++ b/integration/resources/templates/single/function_alias_with_http_api_events.yaml
@@ -6,7 +6,7 @@ Resources:
     Properties:
       AutoPublishAlias: live
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       Events:
         FooEvent:

--- a/integration/resources/templates/single/function_with_http_api_events.yaml
+++ b/integration/resources/templates/single/function_with_http_api_events.yaml
@@ -5,7 +5,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       Events:
         FooEvent:

--- a/integration/resources/templates/single/function_with_http_api_events_and_auth.yaml
+++ b/integration/resources/templates/single/function_with_http_api_events_and_auth.yaml
@@ -11,7 +11,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       CodeUri: ${codeuri}
       Events:
         # The following events use the implicit AWS::Serverless::HttpApi called "ServerlessHttpApi".


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Node 16 is deprecating soon. Update all integ test runtime to node 18.

### Description of how you validated changes


### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
