### PR TITLE
fix: Append CodeSha256 Value to Description

### DIFF
--- a/integration/resources/templates/combination/connector_bucket_to_function_write.yaml
+++ b/integration/resources/templates/combination/connector_bucket_to_function_write.yaml
@@ -64,6 +64,8 @@ Resources:
   TriggerBucket:
     # See also https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig.html
     DependsOn: MyConnector
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref BucketName

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -297,6 +297,8 @@ class SamFunction(SamResourceMacro):
                 description = intrinsics_resolver.resolve_parameter_refs(self.Description)
                 if not description or isinstance(description, str):
                     lambda_function.Description = f"{description} {code_sha256}" if description else code_sha256
+                else:
+                    lambda_function.Description = {"Fn::Join": [" ", [description, code_sha256]]}
             lambda_version = self._construct_version(
                 lambda_function, intrinsics_resolver=intrinsics_resolver, code_sha256=code_sha256
             )

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -291,9 +291,9 @@ class SamFunction(SamResourceMacro):
                         "AutoPublishCodeSha256 must be a string",
                     )
                 # Lambda doesn't create a new version if the code in the unpublished version is the same as the
-                # previous published version. To handle scenario users only update content in 'CodeUri', CloudFormation
-                # won't be able to detect any change in lambda function in the template, which would cause deployment
-                # failure. Append to description to handle this issue
+                # previous published version. To address situations where users modify only the 'CodeUri' content, 
+                # CloudFormation might not detect any changes in the Lambda function within the template, leading 
+                # to deployment issues. To resolve this, we'll append codesha256 value to the description.
                 description = intrinsics_resolver.resolve_parameter_refs(self.Description)
                 if not description or isinstance(description, str):
                     lambda_function.Description = f"{description} {code_sha256}" if description else code_sha256

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -252,7 +252,7 @@ class SamFunction(SamResourceMacro):
             raise InvalidResourceException(self.logical_id, e.message) from e
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def] # noqa: PLR0915
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def] # noqa: PLR0912, PLR0915
         """Returns the Lambda function, role, and event resources to which this SAM Function corresponds.
 
         :param dict kwargs: already-converted resources that may need to be modified when converting this \

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -290,7 +290,7 @@ class SamFunction(SamResourceMacro):
                         self.logical_id,
                         "AutoPublishCodeSha256 must be a string",
                     )
-                # Lambda doesn't create a new version if the code in the unpublished version is the same as the 
+                # Lambda doesn't create a new version if the code in the unpublished version is the same as the
                 # previous published version. To handle scenario users only update content in 'CodeUri', CloudFormation
                 # won't be able to detect any change in lambda function in the template, which would cause deployment
                 # failure. Append to description to handle this issue

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -291,8 +291,8 @@ class SamFunction(SamResourceMacro):
                         "AutoPublishCodeSha256 must be a string",
                     )
                 # Lambda doesn't create a new version if the code in the unpublished version is the same as the
-                # previous published version. To address situations where users modify only the 'CodeUri' content, 
-                # CloudFormation might not detect any changes in the Lambda function within the template, leading 
+                # previous published version. To address situations where users modify only the 'CodeUri' content,
+                # CloudFormation might not detect any changes in the Lambda function within the template, leading
                 # to deployment issues. To resolve this, we'll append codesha256 value to the description.
                 description = intrinsics_resolver.resolve_parameter_refs(self.Description)
                 if not description or isinstance(description, str):

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -290,6 +290,13 @@ class SamFunction(SamResourceMacro):
                         self.logical_id,
                         "AutoPublishCodeSha256 must be a string",
                     )
+                # Lambda doesn't create a new version if the code in the unpublished version is the same as the 
+                # previous published version. To handle scenario users only update content in 'CodeUri', CloudFormation
+                # won't be able to detect any change in lambda function in the template, which would cause deployment
+                # failure. Append to description to handle this issue
+                description = intrinsics_resolver.resolve_parameter_refs(self.Description)
+                if not description or isinstance(description, str):
+                    lambda_function.Description = f"{description} {code_sha256}" if description else code_sha256
             lambda_version = self._construct_version(
                 lambda_function, intrinsics_resolver=intrinsics_resolver, code_sha256=code_sha256
             )

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -252,7 +252,7 @@ class SamFunction(SamResourceMacro):
             raise InvalidResourceException(self.logical_id, e.message) from e
 
     @cw_timer
-    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def]
+    def to_cloudformation(self, **kwargs):  # type: ignore[no-untyped-def] # noqa: PLR0915
         """Returns the Lambda function, role, and event resources to which this SAM Function corresponds.
 
         :param dict kwargs: already-converted resources that may need to be modified when converting this \

--- a/tests/translator/input/function_with_alias_and_code_sha256.yaml
+++ b/tests/translator/input/function_with_alias_and_code_sha256.yaml
@@ -14,3 +14,24 @@ Resources:
       AutoPublishAlias: live
       AutoPublishCodeSha256: !Ref AutoPublishCodeSha256
       VersionDescription: sam-testing
+
+  FunctionWithIntrinsicDescription:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: hello.handler
+      Runtime: python2.7
+      AutoPublishAlias: live
+      AutoPublishCodeSha256: !Ref AutoPublishCodeSha256
+      VersionDescription: sam-testing
+      Description: !Join [':', [a, b, c]]
+  FunctionWithDescription:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: hello.handler
+      Runtime: python2.7
+      AutoPublishAlias: live
+      AutoPublishCodeSha256: !Ref AutoPublishCodeSha256
+      VersionDescription: sam-testing
+      Description: My testing description

--- a/tests/translator/output/aws-cn/function_with_alias_all_properties_and_code_sha256.json
+++ b/tests/translator/output/aws-cn/function_with_alias_all_properties_and_code_sha256.json
@@ -13,6 +13,7 @@
             "Arn"
           ]
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/aws-cn/function_with_alias_all_properties_and_code_sha256.json
+++ b/tests/translator/output/aws-cn/function_with_alias_all_properties_and_code_sha256.json
@@ -6,6 +6,7 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -13,7 +14,6 @@
             "Arn"
           ]
         },
-        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/aws-cn/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_code_sha256.json
@@ -7,6 +7,181 @@
     }
   },
   "Resources": {
+    "FunctionWithDescription": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": "My testing description 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithDescriptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "FunctionWithDescriptionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "FunctionWithDescription"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionWithDescriptionVersion6b86b273ff",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "FunctionWithDescriptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "FunctionWithDescriptionVersion6b86b273ff": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "sam-testing",
+        "FunctionName": {
+          "Ref": "FunctionWithDescription"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    },
+    "FunctionWithIntrinsicDescription": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Fn::Join": [
+                  ":",
+                  [
+                    "a",
+                    "b",
+                    "c"
+                  ]
+                ]
+              },
+              "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+            ]
+          ]
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithIntrinsicDescriptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "FunctionWithIntrinsicDescriptionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "FunctionWithIntrinsicDescription"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionWithIntrinsicDescriptionVersion6b86b273ff",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "FunctionWithIntrinsicDescriptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "FunctionWithIntrinsicDescriptionVersion6b86b273ff": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "sam-testing",
+        "FunctionName": {
+          "Ref": "FunctionWithIntrinsicDescription"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    },
     "MinimalFunction": {
       "Properties": {
         "Code": {

--- a/tests/translator/output/aws-cn/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_code_sha256.json
@@ -13,6 +13,7 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -20,7 +21,6 @@
             "Arn"
           ]
         },
-        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/aws-cn/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_code_sha256.json
@@ -20,6 +20,7 @@
             "Arn"
           ]
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/function_with_alias_all_properties_and_code_sha256.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_all_properties_and_code_sha256.json
@@ -13,6 +13,7 @@
             "Arn"
           ]
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/function_with_alias_all_properties_and_code_sha256.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_all_properties_and_code_sha256.json
@@ -6,6 +6,7 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -13,7 +14,6 @@
             "Arn"
           ]
         },
-        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_code_sha256.json
@@ -13,6 +13,7 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -20,7 +21,6 @@
             "Arn"
           ]
         },
-        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_code_sha256.json
@@ -7,6 +7,181 @@
     }
   },
   "Resources": {
+    "FunctionWithDescription": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": "My testing description 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithDescriptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "FunctionWithDescriptionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "FunctionWithDescription"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionWithDescriptionVersion6b86b273ff",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "FunctionWithDescriptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "FunctionWithDescriptionVersion6b86b273ff": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "sam-testing",
+        "FunctionName": {
+          "Ref": "FunctionWithDescription"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    },
+    "FunctionWithIntrinsicDescription": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Fn::Join": [
+                  ":",
+                  [
+                    "a",
+                    "b",
+                    "c"
+                  ]
+                ]
+              },
+              "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+            ]
+          ]
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithIntrinsicDescriptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "FunctionWithIntrinsicDescriptionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "FunctionWithIntrinsicDescription"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionWithIntrinsicDescriptionVersion6b86b273ff",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "FunctionWithIntrinsicDescriptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "FunctionWithIntrinsicDescriptionVersion6b86b273ff": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "sam-testing",
+        "FunctionName": {
+          "Ref": "FunctionWithIntrinsicDescription"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    },
     "MinimalFunction": {
       "Properties": {
         "Code": {

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_code_sha256.json
@@ -20,6 +20,7 @@
             "Arn"
           ]
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/function_with_alias_all_properties_and_code_sha256.json
+++ b/tests/translator/output/function_with_alias_all_properties_and_code_sha256.json
@@ -14,6 +14,7 @@
           ]
         },
         "Runtime": "python2.7",
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_alias_all_properties_and_code_sha256.json
+++ b/tests/translator/output/function_with_alias_all_properties_and_code_sha256.json
@@ -6,6 +6,7 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -14,7 +15,6 @@
           ]
         },
         "Runtime": "python2.7",
-        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/function_with_alias_and_code_sha256.json
@@ -13,6 +13,7 @@
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -20,7 +21,6 @@
             "Arn"
           ]
         },
-        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {

--- a/tests/translator/output/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/function_with_alias_and_code_sha256.json
@@ -7,6 +7,181 @@
     }
   },
   "Resources": {
+    "FunctionWithDescription": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": "My testing description 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithDescriptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "FunctionWithDescriptionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "FunctionWithDescription"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionWithDescriptionVersion6b86b273ff",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "FunctionWithDescriptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "FunctionWithDescriptionVersion6b86b273ff": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "sam-testing",
+        "FunctionName": {
+          "Ref": "FunctionWithDescription"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    },
+    "FunctionWithIntrinsicDescription": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "hello.zip"
+        },
+        "Description": {
+          "Fn::Join": [
+            " ",
+            [
+              {
+                "Fn::Join": [
+                  ":",
+                  [
+                    "a",
+                    "b",
+                    "c"
+                  ]
+                ]
+              },
+              "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+            ]
+          ]
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithIntrinsicDescriptionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "FunctionWithIntrinsicDescriptionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "FunctionWithIntrinsicDescription"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionWithIntrinsicDescriptionVersion6b86b273ff",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
+    },
+    "FunctionWithIntrinsicDescriptionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "FunctionWithIntrinsicDescriptionVersion6b86b273ff": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "sam-testing",
+        "FunctionName": {
+          "Ref": "FunctionWithIntrinsicDescription"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
+    },
     "MinimalFunction": {
       "Properties": {
         "Code": {

--- a/tests/translator/output/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/function_with_alias_and_code_sha256.json
@@ -20,6 +20,7 @@
             "Arn"
           ]
         },
+        "Description": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "Runtime": "python2.7",
         "Tags": [
           {


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Append the value of CodeSha256 to end of Lambda Function description. This would cause an update to the existing users who use codesha256 but since it will always create a new lambda version, it wouldn't cause any downtime for users. 

```
When you deploy a new version of an AWS Lambda function, it does not cause downtime for the existing function. AWS Lambda is designed to allow seamless deployments without affecting the current running version
```

Additionally add `DeletionPolicy` and `UpdateReplacePolicy` to an integ test.

### Description of how you validated changes
All tests passed.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
