### PR TITLE
Adding InputTransformer Property

### DIFF
--- a/samtranslator/internal/schema_source/aws_serverless_statemachine.py
+++ b/samtranslator/internal/schema_source/aws_serverless_statemachine.py
@@ -119,6 +119,7 @@ class EventBridgeRuleEventProperties(BaseModel):
     RetryPolicy: Optional[PassThroughProp] = eventbridgeruleeventproperties("RetryPolicy")
     Target: Optional[EventBridgeRuleTarget] = eventbridgeruleeventproperties("Target")
     RuleName: Optional[PassThroughProp] = eventbridgeruleeventproperties("RuleName")
+    InputTransformer: Optional[PassThroughProp] # TODO: add docs
 
 
 class EventBridgeRuleEvent(BaseModel):

--- a/samtranslator/internal/schema_source/aws_serverless_statemachine.py
+++ b/samtranslator/internal/schema_source/aws_serverless_statemachine.py
@@ -119,7 +119,7 @@ class EventBridgeRuleEventProperties(BaseModel):
     RetryPolicy: Optional[PassThroughProp] = eventbridgeruleeventproperties("RetryPolicy")
     Target: Optional[EventBridgeRuleTarget] = eventbridgeruleeventproperties("Target")
     RuleName: Optional[PassThroughProp] = eventbridgeruleeventproperties("RuleName")
-    InputTransformer: Optional[PassThroughProp] # TODO: add docs
+    InputTransformer: Optional[PassThroughProp]  # TODO: add docs
 
 
 class EventBridgeRuleEvent(BaseModel):

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -193,6 +193,7 @@ class CloudWatchEvent(EventSource):
         "RetryPolicy": PropertyType(False, IS_DICT),
         "State": PropertyType(False, IS_STR),
         "Target": Property(False, IS_DICT),
+        "InputTransformer": PropertyType(False, IS_DICT),
     }
 
     EventBusName: Optional[PassThrough]
@@ -204,6 +205,7 @@ class CloudWatchEvent(EventSource):
     RetryPolicy: Optional[PassThrough]
     State: Optional[PassThrough]
     Target: Optional[PassThrough]
+    InputTransformer: Optional[PassThrough]
 
     @cw_timer(prefix=SFN_EVETSOURCE_METRIC_PREFIX)
     def to_cloudformation(self, resource, **kwargs):  # type: ignore[no-untyped-def]
@@ -272,6 +274,9 @@ class CloudWatchEvent(EventSource):
 
         if self.RetryPolicy is not None:
             target["RetryPolicy"] = self.RetryPolicy
+
+        if self.InputTransformer is not None:
+            target["InputTransformer"] = self.InputTransformer
 
         return target
 

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -7660,6 +7660,9 @@
           "markdownDescription": "When you don't want to pass the entire matched event to the target, use the `InputPath` property to describe which part of the event to pass\\.  \n*Type*: String  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`InputPath`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-target.html#cfn-events-rule-target-inputpath) property of an `AWS::Events::Rule Target` resource\\.",
           "title": "InputPath"
         },
+        "InputTransformer": {
+          "$ref": "#/definitions/PassThroughProp"
+        },
         "Pattern": {
           "allOf": [
             {

--- a/tests/translator/input/serverless_statemachine_eventbridgerule_with_input_transformer.yaml
+++ b/tests/translator/input/serverless_statemachine_eventbridgerule_with_input_transformer.yaml
@@ -1,0 +1,45 @@
+Resources:
+  StateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: !Sub ${AWS::StackName}-StateMachine
+      Definition:
+        Comment: A Hello World example of the Amazon States Language using Pass states
+        StartAt: Hello
+        States:
+          Hello:
+            Type: Pass
+            Result: Hello
+            Next: World
+          World:
+            Type: Pass
+            Result: World
+            End: true
+      Policies:
+      - Version: '2012-10-17'
+        Statement:
+        - Effect: Deny
+          Action: '*'
+          Resource: '*'
+      Events:
+        EventBridgeEvent:
+          Type: EventBridgeRule
+          Properties:
+            EventBusName: default
+            Pattern:
+              source:
+              - aws.s3
+              detail-type:
+              - Object Created
+              detail:
+                bucket:
+                  name:
+                  - abc
+                object:
+                  key:
+                  - xyz
+            InputTransformer:
+              InputPathsMap:
+                bucket: $.detail.bucket.name
+                key: $.detail.object.key
+              InputTemplate: '{"bucket": <bucket>, "key": <key>}'

--- a/tests/translator/output/aws-cn/serverless_statemachine_eventbridgerule_with_input_transformer.json
+++ b/tests/translator/output/aws-cn/serverless_statemachine_eventbridgerule_with_input_transformer.json
@@ -1,0 +1,174 @@
+{
+  "Resources": {
+    "StateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": {
+          "Fn::Sub": "${AWS::StackName}-StateMachine"
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "StateMachineEventBridgeEvent": {
+      "Properties": {
+        "EventBusName": "default",
+        "EventPattern": {
+          "detail": {
+            "bucket": {
+              "name": [
+                "abc"
+              ]
+            },
+            "object": {
+              "key": [
+                "xyz"
+              ]
+            }
+          },
+          "detail-type": [
+            "Object Created"
+          ],
+          "source": [
+            "aws.s3"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "StateMachine"
+            },
+            "Id": "StateMachineEventBridgeEventStepFunctionsTarget",
+            "InputTransformer": {
+              "InputPathsMap": {
+                "bucket": "$.detail.bucket.name",
+                "key": "$.detail.object.key"
+              },
+              "InputTemplate": "{\"bucket\": <bucket>, \"key\": <key>}"
+            },
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineEventBridgeEventRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "StateMachineEventBridgeEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "StateMachineEventBridgeEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "StateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "StateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/serverless_statemachine_eventbridgerule_with_input_transformer.json
+++ b/tests/translator/output/aws-us-gov/serverless_statemachine_eventbridgerule_with_input_transformer.json
@@ -1,0 +1,174 @@
+{
+  "Resources": {
+    "StateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": {
+          "Fn::Sub": "${AWS::StackName}-StateMachine"
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "StateMachineEventBridgeEvent": {
+      "Properties": {
+        "EventBusName": "default",
+        "EventPattern": {
+          "detail": {
+            "bucket": {
+              "name": [
+                "abc"
+              ]
+            },
+            "object": {
+              "key": [
+                "xyz"
+              ]
+            }
+          },
+          "detail-type": [
+            "Object Created"
+          ],
+          "source": [
+            "aws.s3"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "StateMachine"
+            },
+            "Id": "StateMachineEventBridgeEventStepFunctionsTarget",
+            "InputTransformer": {
+              "InputPathsMap": {
+                "bucket": "$.detail.bucket.name",
+                "key": "$.detail.object.key"
+              },
+              "InputTemplate": "{\"bucket\": <bucket>, \"key\": <key>}"
+            },
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineEventBridgeEventRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "StateMachineEventBridgeEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "StateMachineEventBridgeEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "StateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "StateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/serverless_statemachine_eventbridgerule_with_input_transformer.json
+++ b/tests/translator/output/serverless_statemachine_eventbridgerule_with_input_transformer.json
@@ -1,0 +1,174 @@
+{
+  "Resources": {
+    "StateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "StateMachineRole",
+            "Arn"
+          ]
+        },
+        "StateMachineName": {
+          "Fn::Sub": "${AWS::StackName}-StateMachine"
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "StateMachineEventBridgeEvent": {
+      "Properties": {
+        "EventBusName": "default",
+        "EventPattern": {
+          "detail": {
+            "bucket": {
+              "name": [
+                "abc"
+              ]
+            },
+            "object": {
+              "key": [
+                "xyz"
+              ]
+            }
+          },
+          "detail-type": [
+            "Object Created"
+          ],
+          "source": [
+            "aws.s3"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "StateMachine"
+            },
+            "Id": "StateMachineEventBridgeEventStepFunctionsTarget",
+            "InputTransformer": {
+              "InputPathsMap": {
+                "bucket": "$.detail.bucket.name",
+                "key": "$.detail.object.key"
+              },
+              "InputTemplate": "{\"bucket\": <bucket>, \"key\": <key>}"
+            },
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "StateMachineEventBridgeEventRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "StateMachineEventBridgeEventRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "StateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "StateMachineEventBridgeEventRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "StateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "StateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available
[3333](https://github.com/aws/serverless-application-model/issues/3333)

### Description of changes
Adding property `InputTransformer` to `AWS::Serverless::StateMachine`

### Description of how you validated changes
End to end test by deploying the transformed template.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
