### PR TITLE
Safe Auth in function URL tests

### DIFF
--- a/integration/resources/templates/single/basic_function_with_function_url_config.yaml
+++ b/integration/resources/templates/single/basic_function_with_function_url_config.yaml
@@ -7,7 +7,7 @@ Resources:
       CodeUri: ${codeuri}
       MemorySize: 128
       FunctionUrlConfig:
-        AuthType: NONE
+        AuthType: AWS_IAM
         Cors:
           AllowOrigins:
           - https://foo.com

--- a/integration/resources/templates/single/basic_function_with_function_url_with_autopuplishalias.yaml
+++ b/integration/resources/templates/single/basic_function_with_function_url_with_autopuplishalias.yaml
@@ -8,7 +8,7 @@ Resources:
       MemorySize: 128
       AutoPublishAlias: live
       FunctionUrlConfig:
-        AuthType: NONE
+        AuthType: AWS_IAM
         Cors:
           AllowOrigins:
           - https://foo.com


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Using safe authoriser in function. URL integ tests. 
Motivation: if the integ test resource stack is stuck and not deleted, the function with a function url without authoriser is considered unsafe by AWS AppSec.

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
