### PR TITLE
fix integ tests

### DIFF
--- a/integration/resources/expected/single/basic_function_with_function_url_config.json
+++ b/integration/resources/expected/single/basic_function_with_function_url_config.json
@@ -10,9 +10,5 @@
   {
     "LogicalResourceId": "MyLambdaFunctionRole",
     "ResourceType": "AWS::IAM::Role"
-  },
-  {
-    "LogicalResourceId": "MyLambdaFunctionUrlPublicPermissions",
-    "ResourceType": "AWS::Lambda::Permission"
   }
 ]

--- a/integration/resources/expected/single/basic_function_with_function_url_with_autopuplishalias.json
+++ b/integration/resources/expected/single/basic_function_with_function_url_with_autopuplishalias.json
@@ -18,9 +18,5 @@
   {
     "LogicalResourceId": "MyLambdaFunctionVersion",
     "ResourceType": "AWS::Lambda::Version"
-  },
-  {
-    "LogicalResourceId": "MyLambdaFunctionUrlPublicPermissions",
-    "ResourceType": "AWS::Lambda::Permission"
   }
 ]

--- a/integration/single/test_basic_function.py
+++ b/integration/single/test_basic_function.py
@@ -126,7 +126,7 @@ class TestBasicFunction(BaseTest):
             "MaxAge": 10,
         }
 
-        self.assertEqual(function_url_config["AuthType"], "NONE")
+        self.assertEqual(function_url_config["AuthType"], "AWS_IAM")
         self.assertEqual(function_url_config["Cors"], cors_config)
         self._assert_invoke(lambda_client, function_name, qualifier, 200)
 


### PR DESCRIPTION
### Issue #, if available
Fixing tests, removing expectation on Resource policy for Function URL case.

Resource policy is optional for the AWS_IAM auth in Function URL so SAM doesn't create it as it makes sense only with cross-account access.

There are many transform tests for function URL, so the case with NONE auth is handled there.

### Description of changes

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
