### PR TITLE
fix: Catch network interface deletion failure

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -75,7 +75,10 @@ def _delete_unused_network_interface_by_subnet(ec2_client, subnet_id):
         network_interface_ids += [ni["NetworkInterfaceId"] for ni in page["NetworkInterfaces"]]
 
     for ni_id in network_interface_ids:
-        ec2_client.delete_network_interface(NetworkInterfaceId=ni_id)
+        try:
+            ec2_client.delete_network_interface(NetworkInterfaceId=ni_id)
+        except ClientError as e:
+            LOG.error("Unable to delete network interface %s", ni_id, exc_info=e)
         time.sleep(0.5)
 
     LOG.info("Deleted %s unused network interfaces under subnet %s", len(network_interface_ids), subnet_id)


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Catch network interface deletion failure. We should not throw an error when we failed to delete an unused network interface.

### Description of how you validated changes
N/A

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
