### PR TITLE
feat: allow user to provide role for schedule

### DIFF
--- a/samtranslator/internal/schema_source/aws_serverless_statemachine.py
+++ b/samtranslator/internal/schema_source/aws_serverless_statemachine.py
@@ -49,6 +49,7 @@ class ScheduleEventProperties(BaseModel):
     Schedule: Optional[PassThroughProp] = scheduleeventproperties("Schedule")
     State: Optional[PassThroughProp] = scheduleeventproperties("State")
     Target: Optional[ScheduleTarget] = scheduleeventproperties("Target")
+    Role: Optional[PassThroughProp] #TODO: add doc
 
 
 class ScheduleEvent(BaseModel):

--- a/samtranslator/internal/schema_source/aws_serverless_statemachine.py
+++ b/samtranslator/internal/schema_source/aws_serverless_statemachine.py
@@ -49,7 +49,7 @@ class ScheduleEventProperties(BaseModel):
     Schedule: Optional[PassThroughProp] = scheduleeventproperties("Schedule")
     State: Optional[PassThroughProp] = scheduleeventproperties("State")
     Target: Optional[ScheduleTarget] = scheduleeventproperties("Target")
-    Role: Optional[PassThroughProp]  # TODO: add doc
+    RoleArn: Optional[PassThroughProp]  # TODO: add doc
 
 
 class ScheduleEvent(BaseModel):

--- a/samtranslator/internal/schema_source/aws_serverless_statemachine.py
+++ b/samtranslator/internal/schema_source/aws_serverless_statemachine.py
@@ -49,7 +49,7 @@ class ScheduleEventProperties(BaseModel):
     Schedule: Optional[PassThroughProp] = scheduleeventproperties("Schedule")
     State: Optional[PassThroughProp] = scheduleeventproperties("State")
     Target: Optional[ScheduleTarget] = scheduleeventproperties("Target")
-    Role: Optional[PassThroughProp] #TODO: add doc
+    Role: Optional[PassThroughProp]  # TODO: add doc
 
 
 class ScheduleEvent(BaseModel):

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -144,7 +144,7 @@ class Schedule(EventSource):
         events_rule.Name = self.Name
         events_rule.Description = self.Description
 
-        role: Union[IAMRole, str]
+        role: Union[IAMRole, str, Dict[str, Any]]
         if self.RoleArn is None:
             role = self._construct_role(resource, permissions_boundary, prefix=None)
             resources.append(role)
@@ -166,7 +166,7 @@ class Schedule(EventSource):
     def _construct_target(
         self,
         resource: StepFunctionsStateMachine,
-        role: Union[IAMRole, str],
+        role: Union[IAMRole, str, Dict[str, Any]],
         dead_letter_queue_arn: Optional[str],
     ) -> Dict[str, Any]:
         """_summary_
@@ -195,8 +195,7 @@ class Schedule(EventSource):
             "Id": target_id,
         }
 
-        if role is not None:
-            target["RoleArn"] = role.get_runtime_attr("arn") if isinstance(role, IAMRole) else role
+        target["RoleArn"] = role.get_runtime_attr("arn") if isinstance(role, IAMRole) else role
 
         if self.Input is not None:
             target["Input"] = self.Input

--- a/samtranslator/model/stepfunctions/events.py
+++ b/samtranslator/model/stepfunctions/events.py
@@ -144,10 +144,12 @@ class Schedule(EventSource):
         events_rule.Name = self.Name
         events_rule.Description = self.Description
 
-        role = self.RoleArn
+        role: Union[IAMRole, str]
         if self.RoleArn is None:
             role = self._construct_role(resource, permissions_boundary, prefix=None)
             resources.append(role)
+        else:
+            role = self.RoleArn
 
         source_arn = events_rule.get_runtime_attr("arn")
         dlq_queue_arn = None
@@ -164,7 +166,7 @@ class Schedule(EventSource):
     def _construct_target(
         self,
         resource: StepFunctionsStateMachine,
-        role: Union[IAMRole, Optional[PassThrough]],
+        role: Union[IAMRole, str],
         dead_letter_queue_arn: Optional[str],
     ) -> Dict[str, Any]:
         """_summary_
@@ -180,7 +182,7 @@ class Schedule(EventSource):
 
         Returns
         -------
-            _description_
+            The Target property
         """
         target_id = (
             self.Target["Id"]
@@ -194,7 +196,7 @@ class Schedule(EventSource):
         }
 
         if role is not None:
-            target["RoleArn"] = role if isinstance(role, str) else role.get_runtime_attr("arn")
+            target["RoleArn"] = role.get_runtime_attr("arn") if isinstance(role, IAMRole) else role
 
         if self.Input is not None:
             target["Input"] = self.Input

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -3013,6 +3013,9 @@
           "markdownDescription": "A `RetryPolicy` object that includes information about the retry policy settings\\. For more information, see [Event retry policy and using dead\\-letter queues](https://docs.aws.amazon.com/eventbridge/latest/userguide/rule-dlq.html) in the *Amazon EventBridge User Guide*\\.  \n*Type*: [RetryPolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-target.html#cfn-events-rule-target-retrypolicy)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`RetryPolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-target.html#cfn-events-rule-target-retrypolicy) property of the `AWS::Events::Rule` `Target` data type\\.",
           "title": "RetryPolicy"
         },
+        "Role": {
+          "$ref": "#/definitions/PassThroughProp"
+        },
         "Schedule": {
           "allOf": [
             {

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -3013,7 +3013,7 @@
           "markdownDescription": "A `RetryPolicy` object that includes information about the retry policy settings\\. For more information, see [Event retry policy and using dead\\-letter queues](https://docs.aws.amazon.com/eventbridge/latest/userguide/rule-dlq.html) in the *Amazon EventBridge User Guide*\\.  \n*Type*: [RetryPolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-target.html#cfn-events-rule-target-retrypolicy)  \n*Required*: No  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`RetryPolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-target.html#cfn-events-rule-target-retrypolicy) property of the `AWS::Events::Rule` `Target` data type\\.",
           "title": "RetryPolicy"
         },
-        "Role": {
+        "RoleArn": {
           "$ref": "#/definitions/PassThroughProp"
         },
         "Schedule": {

--- a/tests/model/stepfunctions/test_schedule_event.py
+++ b/tests/model/stepfunctions/test_schedule_event.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 from parameterized import parameterized
 from samtranslator.model.exceptions import InvalidEventException
-from samtranslator.model.intrinsics import fnSub
 from samtranslator.model.stepfunctions.events import Schedule
 
 
@@ -155,13 +154,11 @@ class ScheduleEventSource(TestCase):
             self.schedule_event_source.to_cloudformation(resource=self.state_machine)
 
     def test_to_cloudformation_with_role_arn_provided(self):
-        role = "ScheduleRole"
-        self.schedule_event_source.Role = role
+        role = "not a real arn"
+        self.schedule_event_source.RoleArn = role
         resources = self.schedule_event_source.to_cloudformation(resource=self.state_machine)
         event_rule = resources[0]
-        self.assertEqual(
-            event_rule.Targets[0]["RoleArn"], fnSub("arn:aws:iam::${AWS::AccountId}:role/${Role}", {"Role": role})
-        )
+        self.assertEqual(event_rule.Targets[0]["RoleArn"], "not a real arn")
 
     @parameterized.expand(
         [

--- a/tests/model/stepfunctions/test_schedule_event.py
+++ b/tests/model/stepfunctions/test_schedule_event.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 from parameterized import parameterized
 from samtranslator.model.exceptions import InvalidEventException
+from samtranslator.model.intrinsics import fnSub
 from samtranslator.model.stepfunctions.events import Schedule
 
 
@@ -153,6 +154,13 @@ class ScheduleEventSource(TestCase):
         with self.assertRaises(InvalidEventException):
             self.schedule_event_source.to_cloudformation(resource=self.state_machine)
 
+    def test_to_cloudformation_with_role_arn_provided(self):
+        role = "ScheduleRole"
+        self.schedule_event_source.Role = role
+        resources = self.schedule_event_source.to_cloudformation(resource=self.state_machine)
+        event_rule = resources[0]
+        self.assertEqual(event_rule.Targets[0]["RoleArn"], fnSub("arn:aws:iam::${AWS::AccountId}:role/${Role}", {"Role": role}))
+        
     @parameterized.expand(
         [
             (True, "Enabled"),

--- a/tests/model/stepfunctions/test_schedule_event.py
+++ b/tests/model/stepfunctions/test_schedule_event.py
@@ -159,8 +159,10 @@ class ScheduleEventSource(TestCase):
         self.schedule_event_source.Role = role
         resources = self.schedule_event_source.to_cloudformation(resource=self.state_machine)
         event_rule = resources[0]
-        self.assertEqual(event_rule.Targets[0]["RoleArn"], fnSub("arn:aws:iam::${AWS::AccountId}:role/${Role}", {"Role": role}))
-        
+        self.assertEqual(
+            event_rule.Targets[0]["RoleArn"], fnSub("arn:aws:iam::${AWS::AccountId}:role/${Role}", {"Role": role})
+        )
+
     @parameterized.expand(
         [
             (True, "Enabled"),

--- a/tests/translator/input/state_machine_with_schedule_role.yaml
+++ b/tests/translator/input/state_machine_with_schedule_role.yaml
@@ -1,0 +1,32 @@
+Resources:
+
+  MyStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Definition:
+        Comment: A Hello World example of the Amazon States Language using Pass states
+        StartAt: Hello
+        States:
+          Hello:
+            Type: Pass
+            Result: Hello
+            Next: World
+          World:
+            Type: Pass
+            Result: World
+            End: true
+      Policies:
+      - Version: '2012-10-17'
+        Statement:
+        - Effect: Deny
+          Action: '*'
+          Resource: '*'
+
+      Events:
+        CWSchedule:
+          Type: Schedule
+          Properties:
+            Schedule: rate(1 minute)
+            Description: test schedule
+            Enabled: false
+            Role: with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9

--- a/tests/translator/input/state_machine_with_schedule_role.yaml
+++ b/tests/translator/input/state_machine_with_schedule_role.yaml
@@ -2,26 +2,9 @@ Resources:
 
   MyStateMachine:
     Type: AWS::Serverless::StateMachine
-    Properties:
-      Definition:
-        Comment: A Hello World example of the Amazon States Language using Pass states
-        StartAt: Hello
-        States:
-          Hello:
-            Type: Pass
-            Result: Hello
-            Next: World
-          World:
-            Type: Pass
-            Result: World
-            End: true
-      Policies:
-      - Version: '2012-10-17'
-        Statement:
-        - Effect: Deny
-          Action: '*'
-          Resource: '*'
 
+    Properties:
+      DefinitionUri: s3://sam-demo-bucket/my_state_machine.asl.json
       Events:
         CWSchedule:
           Type: Schedule
@@ -29,4 +12,4 @@ Resources:
             Schedule: rate(1 minute)
             Description: test schedule
             Enabled: false
-            Role: with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9
+            RoleArn: FakeArn

--- a/tests/translator/input/state_machine_with_schedule_role.yaml
+++ b/tests/translator/input/state_machine_with_schedule_role.yaml
@@ -12,4 +12,10 @@ Resources:
             Schedule: rate(1 minute)
             Description: test schedule
             Enabled: false
-            RoleArn: FakeArn
+            RoleArn: arn:${AWS::Partition}:iam::role/yoyo
+        CWScheduleCreateRole:
+          Type: Schedule
+          Properties:
+            Schedule: rate(1 minute)
+            Description: test schedule
+            Enabled: false

--- a/tests/translator/input/state_machine_with_schedule_role.yaml
+++ b/tests/translator/input/state_machine_with_schedule_role.yaml
@@ -12,7 +12,7 @@ Resources:
             Schedule: rate(1 minute)
             Description: test schedule
             Enabled: false
-            RoleArn: arn:${AWS::Partition}:iam::role/yoyo
+            RoleArn: arn:0000000000:iam::role/yoyo
         CWScheduleCreateRole:
           Type: Schedule
           Properties:

--- a/tests/translator/output/aws-cn/state_machine_with_schedule_role.json
+++ b/tests/translator/output/aws-cn/state_machine_with_schedule_role.json
@@ -32,11 +32,70 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": "FakeArn"
+            "RoleArn": "arn:${AWS::Partition}:iam::role/yoyo"
           }
         ]
       },
       "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleCreateRole": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleCreateRoleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleCreateRoleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleCreateRoleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleCreateRoleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
     },
     "MyStateMachineRole": {
       "Properties": {

--- a/tests/translator/output/aws-cn/state_machine_with_schedule_role.json
+++ b/tests/translator/output/aws-cn/state_machine_with_schedule_role.json
@@ -1,0 +1,111 @@
+{
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::Sub": [
+                "arn:aws:iam::${AWS::AccountId}:role/${Role}",
+                {
+                  "Role": "with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/state_machine_with_schedule_role.json
+++ b/tests/translator/output/aws-cn/state_machine_with_schedule_role.json
@@ -32,7 +32,7 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": "arn:${AWS::Partition}:iam::role/yoyo"
+            "RoleArn": "arn:0000000000:iam::role/yoyo"
           }
         ]
       },

--- a/tests/translator/output/aws-cn/state_machine_with_schedule_role.json
+++ b/tests/translator/output/aws-cn/state_machine_with_schedule_role.json
@@ -2,28 +2,9 @@
   "Resources": {
     "MyStateMachine": {
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Result\": \"World\",",
-              "            \"Type\": \"Pass\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my_state_machine.asl.json"
         },
         "RoleArn": {
           "Fn::GetAtt": [
@@ -51,14 +32,7 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": {
-              "Fn::Sub": [
-                "arn:aws:iam::${AWS::AccountId}:role/${Role}",
-                {
-                  "Role": "with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9"
-                }
-              ]
-            }
+            "RoleArn": "FakeArn"
           }
         ]
       },
@@ -83,21 +57,6 @@
           "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [],
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": "*",
-                  "Effect": "Deny",
-                  "Resource": "*"
-                }
-              ],
-              "Version": "2012-10-17"
-            },
-            "PolicyName": "MyStateMachineRolePolicy0"
-          }
-        ],
         "Tags": [
           {
             "Key": "stateMachine:createdBy",

--- a/tests/translator/output/aws-us-gov/state_machine_with_schedule_role.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_schedule_role.json
@@ -32,11 +32,70 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": "FakeArn"
+            "RoleArn": "arn:${AWS::Partition}:iam::role/yoyo"
           }
         ]
       },
       "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleCreateRole": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleCreateRoleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleCreateRoleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleCreateRoleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleCreateRoleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
     },
     "MyStateMachineRole": {
       "Properties": {

--- a/tests/translator/output/aws-us-gov/state_machine_with_schedule_role.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_schedule_role.json
@@ -1,0 +1,111 @@
+{
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::Sub": [
+                "arn:aws:iam::${AWS::AccountId}:role/${Role}",
+                {
+                  "Role": "with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/state_machine_with_schedule_role.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_schedule_role.json
@@ -32,7 +32,7 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": "arn:${AWS::Partition}:iam::role/yoyo"
+            "RoleArn": "arn:0000000000:iam::role/yoyo"
           }
         ]
       },

--- a/tests/translator/output/aws-us-gov/state_machine_with_schedule_role.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_schedule_role.json
@@ -2,28 +2,9 @@
   "Resources": {
     "MyStateMachine": {
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Result\": \"World\",",
-              "            \"Type\": \"Pass\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my_state_machine.asl.json"
         },
         "RoleArn": {
           "Fn::GetAtt": [
@@ -51,14 +32,7 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": {
-              "Fn::Sub": [
-                "arn:aws:iam::${AWS::AccountId}:role/${Role}",
-                {
-                  "Role": "with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9"
-                }
-              ]
-            }
+            "RoleArn": "FakeArn"
           }
         ]
       },
@@ -83,21 +57,6 @@
           "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [],
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": "*",
-                  "Effect": "Deny",
-                  "Resource": "*"
-                }
-              ],
-              "Version": "2012-10-17"
-            },
-            "PolicyName": "MyStateMachineRolePolicy0"
-          }
-        ],
         "Tags": [
           {
             "Key": "stateMachine:createdBy",

--- a/tests/translator/output/state_machine_with_schedule_role.json
+++ b/tests/translator/output/state_machine_with_schedule_role.json
@@ -32,11 +32,70 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": "FakeArn"
+            "RoleArn": "arn:${AWS::Partition}:iam::role/yoyo"
           }
         ]
       },
       "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleCreateRole": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleCreateRoleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "MyStateMachineCWScheduleCreateRoleRole",
+                "Arn"
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineCWScheduleCreateRoleRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "states:StartExecution",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Ref": "MyStateMachine"
+                  }
+                }
+              ]
+            },
+            "PolicyName": "MyStateMachineCWScheduleCreateRoleRoleStartExecutionPolicy"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
     },
     "MyStateMachineRole": {
       "Properties": {

--- a/tests/translator/output/state_machine_with_schedule_role.json
+++ b/tests/translator/output/state_machine_with_schedule_role.json
@@ -1,0 +1,111 @@
+{
+  "Resources": {
+    "MyStateMachine": {
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "\n",
+            [
+              "{",
+              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
+              "    \"StartAt\": \"Hello\",",
+              "    \"States\": {",
+              "        \"Hello\": {",
+              "            \"Next\": \"World\",",
+              "            \"Result\": \"Hello\",",
+              "            \"Type\": \"Pass\"",
+              "        },",
+              "        \"World\": {",
+              "            \"End\": true,",
+              "            \"Result\": \"World\",",
+              "            \"Type\": \"Pass\"",
+              "        }",
+              "    }",
+              "}"
+            ]
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "MyStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::StepFunctions::StateMachine"
+    },
+    "MyStateMachineCWSchedule": {
+      "Properties": {
+        "Description": "test schedule",
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "MyStateMachine"
+            },
+            "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
+            "RoleArn": {
+              "Fn::Sub": [
+                "arn:aws:iam::${AWS::AccountId}:role/${Role}",
+                {
+                  "Role": "with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "MyStateMachineRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "*",
+                  "Effect": "Deny",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "MyStateMachineRolePolicy0"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/state_machine_with_schedule_role.json
+++ b/tests/translator/output/state_machine_with_schedule_role.json
@@ -32,7 +32,7 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": "arn:${AWS::Partition}:iam::role/yoyo"
+            "RoleArn": "arn:0000000000:iam::role/yoyo"
           }
         ]
       },

--- a/tests/translator/output/state_machine_with_schedule_role.json
+++ b/tests/translator/output/state_machine_with_schedule_role.json
@@ -2,28 +2,9 @@
   "Resources": {
     "MyStateMachine": {
       "Properties": {
-        "DefinitionString": {
-          "Fn::Join": [
-            "\n",
-            [
-              "{",
-              "    \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",",
-              "    \"StartAt\": \"Hello\",",
-              "    \"States\": {",
-              "        \"Hello\": {",
-              "            \"Next\": \"World\",",
-              "            \"Result\": \"Hello\",",
-              "            \"Type\": \"Pass\"",
-              "        },",
-              "        \"World\": {",
-              "            \"End\": true,",
-              "            \"Result\": \"World\",",
-              "            \"Type\": \"Pass\"",
-              "        }",
-              "    }",
-              "}"
-            ]
-          ]
+        "DefinitionS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "my_state_machine.asl.json"
         },
         "RoleArn": {
           "Fn::GetAtt": [
@@ -51,14 +32,7 @@
               "Ref": "MyStateMachine"
             },
             "Id": "MyStateMachineCWScheduleStepFunctionsTarget",
-            "RoleArn": {
-              "Fn::Sub": [
-                "arn:aws:iam::${AWS::AccountId}:role/${Role}",
-                {
-                  "Role": "with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9"
-                }
-              ]
-            }
+            "RoleArn": "FakeArn"
           }
         ]
       },
@@ -83,21 +57,6 @@
           "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [],
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": "*",
-                  "Effect": "Deny",
-                  "Resource": "*"
-                }
-              ],
-              "Version": "2012-10-17"
-            },
-            "PolicyName": "MyStateMachineRolePolicy0"
-          }
-        ],
         "Tags": [
           {
             "Key": "stateMachine:createdBy",


### PR DESCRIPTION
### Issue #, if available
feature request discussion [#3290](https://github.com/aws/serverless-application-model/discussions/3290
)
### Description of changes
Add new Role property to Schedule for user to pass in their own role to be used with the generated event rule
 Example 
```Resources:

  MyStateMachine:
    Type: AWS::Serverless::StateMachine
    Properties:
      Definition:
        Comment: A Hello World example of the Amazon States Language using Pass states
        StartAt: Hello
        States:
          Hello:
            Type: Pass
            Result: Hello
            Next: World
          World:
            Type: Pass
            Result: World
            End: true
      Policies:
      - Version: '2012-10-17'
        Statement:
        - Effect: Deny
          Action: '*'
          Resource: '*'

      Events:
        CWSchedule:
          Type: Schedule
          Properties:
            Schedule: rate(1 minute)
            Description: test schedule
            Enabled: false
            Role: with-role-MyStateMachineCWScheduleRole-RI4SGRI1ORL9
```
### Description of how you validated changes
Validated with tests and tansformed a template with the new Role property and succesfully deployed and had it execute the state machine 
### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
