### PR TITLE
fix: Set to Py27Dict if components is explicitly set to None

### DIFF
--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -518,6 +518,10 @@ class OpenApiEditor(BaseEditor):
 
         if self.security_schemes:
             self._doc.setdefault("components", Py27Dict())
+            if not self._doc["components"]:
+                # explicitly set to dict to account for scenario where
+                # 'components' is explicitly set to None
+                self._doc["components"] = Py27Dict()
             self._doc["components"]["securitySchemes"] = self.security_schemes
 
         if self.info:


### PR DESCRIPTION
### Issue #, if available

### Description of changes
We had an issue where users explicitly set `components` to None and the setdefault code wouldn't set it to Py27Dict which then caused an error.

### Description of how you validated changes
All existing tests pass.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
