### PR TITLE
Fix GitHub Action Issues in Python 3.10 and 3.11

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,3 +20,5 @@ filterwarnings =
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
     # Pytest warnings
     ignore::pytest.PytestUnraisableExceptionWarning
+    # https://github.com/urllib3/urllib3/blob/main/src/urllib3/poolmanager.py#L313
+    ignore::DeprecationWarning:urllib3.*:

--- a/tests/plugins/application/test_serverless_app_plugin.py
+++ b/tests/plugins/application/test_serverless_app_plugin.py
@@ -1,9 +1,7 @@
-import sys
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
 import boto3
-import pytest
 from botocore.exceptions import ClientError
 from samtranslator.model.exceptions import InvalidResourceException
 from samtranslator.plugins.application.serverless_app_plugin import ServerlessAppPlugin
@@ -53,7 +51,6 @@ def mock_get_region(self, service_name, region_name):
     return "us-east-1"
 
 
-@pytest.mark.skipif(sys.version_info > (3, 10), reason="Test fails for python versions >3.10")
 class TestServerlessAppPlugin_init(TestCase):
     def setUp(self):
         client = boto3.client("serverlessrepo", region_name="us-east-1")
@@ -118,7 +115,6 @@ class TestServerlessAppPlugin_sar_client_creator(TestCase):
         self.client_mock.assert_not_called()
 
 
-@pytest.mark.skipif(sys.version_info > (3, 10), reason="Test fails for python versions >3.10")
 class TestServerlessAppPlugin_on_before_transform_template_translate(TestCase):
     def setUp(self):
         client = boto3.client("serverlessrepo", region_name="us-east-1")


### PR DESCRIPTION
### Issue #, if available

### Description of changes
We used `-W` flag to turn warnings into errors. We need to ignore the deprecation warnings.

### Description of how you validated changes
All tests pass.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
