### PR TITLE
Fix: Raise Error When UpdateReplacePolicy is not correctly defined.

### DIFF
--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -499,7 +499,5 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
         api_dict_deletion = self.api_deletion_policies.setdefault(api_id, set())
         api_dict_deletion.add(deletion_policy)
 
-        api_dict_update_replace = self.api_update_replace_policies.setdefault(api_id, set())
-        if update_replace_policy not in ["Retain", "Snapshot", "Delete", None]:
-            raise ValueError("UpdateReplacePolicy must be equal to Retain, Snapshot, Delete, or must be None.")
-        api_dict_update_replace.add(update_replace_policy)
+        api_dict_update_replace = self.api_update_replace_policies.setdefault(api_id, list())
+        api_dict_update_replace.append(update_replace_policy)

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -501,5 +501,5 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
 
         api_dict_update_replace = self.api_update_replace_policies.setdefault(api_id, set())
         if update_replace_policy not in ["Retain", "Snapshot", "Delete", None]:
-            raise ValueError("UpdateReplacePolicy must be equal to Retain, Snapshot, or Delete, or must be None.")
+            raise ValueError("UpdateReplacePolicy must be equal to Retain, Snapshot, Delete, or must be None.")
         api_dict_update_replace.add(update_replace_policy)

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -500,4 +500,6 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
         api_dict_deletion.add(deletion_policy)
 
         api_dict_update_replace = self.api_update_replace_policies.setdefault(api_id, set())
+        if update_replace_policy not in ["Retain", "Snapshot", "Delete", None]:
+            raise ValueError("UpdateReplacePolicy must be equal to Retain, Snapshot, or Delete, or must be None.")
         api_dict_update_replace.add(update_replace_policy)

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -496,8 +496,8 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
         method_conditions = api_dict_condition.setdefault(path, {})
         method_conditions[method] = condition
 
-        api_dict_deletion = self.api_deletion_policies.setdefault(api_id, set())
-        api_dict_deletion.add(deletion_policy)
+        api_dict_deletion = self.api_deletion_policies.setdefault(api_id, [])
+        api_dict_deletion.append(deletion_policy)
 
-        api_dict_update_replace = self.api_update_replace_policies.setdefault(api_id, list())
+        api_dict_update_replace = self.api_update_replace_policies.setdefault(api_id, [])
         api_dict_update_replace.append(update_replace_policy)

--- a/tests/translator/input/valid_update_replace_policy_and_deletion_policy.yaml
+++ b/tests/translator/input/valid_update_replace_policy_and_deletion_policy.yaml
@@ -1,0 +1,58 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform:
+- AWS::LanguageExtensions
+- AWS::Serverless-2016-10-31
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    UpdateReplacePolicy: Delete
+    Properties:
+      Handler: LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync
+      Runtime: dotnet6
+      CodeUri: s3://bucket/key
+      Events:
+        None:
+          Type: Api
+          Properties:
+            Method: get
+            Path: /method
+  MyFunction2:
+    Type: AWS::Serverless::Function
+    UpdateReplacePolicy: Delete
+    Properties:
+      Handler: LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync
+      Runtime: dotnet6
+      CodeUri: s3://bucket/key
+      Events:
+        Hi:
+          Type: Api
+          Properties:
+            Method: post
+            Path: /method
+  MyFunction3:
+    Type: AWS::Serverless::Function
+    DeletionPolicy: Delete
+    Properties:
+      Handler: LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync
+      Runtime: dotnet6
+      CodeUri: s3://bucket/key
+      Events:
+        All:
+          Type: Api
+          Properties:
+            Method: get
+            Path: /method2
+  MyFunction4:
+    Type: AWS::Serverless::Function
+    DeletionPolicy: Retain
+    Properties:
+      Handler: LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync
+      Runtime: dotnet6
+      CodeUri: s3://bucket/key
+      Events:
+        Bye:
+          Type: Api
+          Properties:
+            Method: post
+            Path: /method2

--- a/tests/translator/input/valid_update_replace_policy_and_deletion_policy.yaml
+++ b/tests/translator/input/valid_update_replace_policy_and_deletion_policy.yaml
@@ -46,6 +46,7 @@ Resources:
   MyFunction4:
     Type: AWS::Serverless::Function
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Handler: LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync
       Runtime: dotnet6

--- a/tests/translator/output/aws-cn/valid_update_replace_policy_and_deletion_policy.json
+++ b/tests/translator/output/aws-cn/valid_update_replace_policy_and_deletion_policy.json
@@ -201,7 +201,8 @@
           }
         ]
       },
-      "Type": "AWS::Lambda::Function"
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunction4ByePermissionProd": {
       "DeletionPolicy": "Retain",
@@ -223,7 +224,8 @@
           ]
         }
       },
-      "Type": "AWS::Lambda::Permission"
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunction4Role": {
       "DeletionPolicy": "Retain",
@@ -254,7 +256,8 @@
           }
         ]
       },
-      "Type": "AWS::IAM::Role"
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunctionNonePermissionProd": {
       "Properties": {
@@ -377,7 +380,7 @@
         }
       },
       "Type": "AWS::ApiGateway::RestApi",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     },
     "ServerlessRestApiDeploymentf177d7dd48": {
       "DeletionPolicy": "Retain",
@@ -389,7 +392,7 @@
         "StageName": "Stage"
       },
       "Type": "AWS::ApiGateway::Deployment",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     },
     "ServerlessRestApiProdStage": {
       "DeletionPolicy": "Retain",
@@ -403,7 +406,7 @@
         "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     }
   }
 }

--- a/tests/translator/output/aws-cn/valid_update_replace_policy_and_deletion_policy.json
+++ b/tests/translator/output/aws-cn/valid_update_replace_policy_and_deletion_policy.json
@@ -1,0 +1,409 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction2Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2HiPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction2"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/method",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2Role": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction3Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunction3AllPermissionProd": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction3"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/method2",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunction3Role": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyFunction4": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction4Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunction4ByePermissionProd": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction4"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/method2",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunction4Role": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyFunctionNonePermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/method",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApi": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/method": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              },
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction2.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/method2": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction3.Arn}/invocations"
+                  }
+                }
+              },
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction4.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApiDeploymentf177d7dd48": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "RestApi deployment id: f177d7dd480597bbebe027d565e98d1b4e36e615",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApiProdStage": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentf177d7dd48"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage",
+      "UpdateReplacePolicy": "Delete"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/valid_update_replace_policy_and_deletion_policy.json
+++ b/tests/translator/output/aws-us-gov/valid_update_replace_policy_and_deletion_policy.json
@@ -201,7 +201,8 @@
           }
         ]
       },
-      "Type": "AWS::Lambda::Function"
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunction4ByePermissionProd": {
       "DeletionPolicy": "Retain",
@@ -223,7 +224,8 @@
           ]
         }
       },
-      "Type": "AWS::Lambda::Permission"
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunction4Role": {
       "DeletionPolicy": "Retain",
@@ -254,7 +256,8 @@
           }
         ]
       },
-      "Type": "AWS::IAM::Role"
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunctionNonePermissionProd": {
       "Properties": {
@@ -377,7 +380,7 @@
         }
       },
       "Type": "AWS::ApiGateway::RestApi",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     },
     "ServerlessRestApiDeployment7b2714845e": {
       "DeletionPolicy": "Retain",
@@ -389,7 +392,7 @@
         "StageName": "Stage"
       },
       "Type": "AWS::ApiGateway::Deployment",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     },
     "ServerlessRestApiProdStage": {
       "DeletionPolicy": "Retain",
@@ -403,7 +406,7 @@
         "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/valid_update_replace_policy_and_deletion_policy.json
+++ b/tests/translator/output/aws-us-gov/valid_update_replace_policy_and_deletion_policy.json
@@ -1,0 +1,409 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction2Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2HiPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction2"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/method",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2Role": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction3Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunction3AllPermissionProd": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction3"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/method2",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunction3Role": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyFunction4": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction4Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunction4ByePermissionProd": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction4"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/method2",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunction4Role": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyFunctionNonePermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/method",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApi": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/method": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              },
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction2.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/method2": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction3.Arn}/invocations"
+                  }
+                }
+              },
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction4.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApiDeployment7b2714845e": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "RestApi deployment id: 7b2714845ec91c841eec02f421ced97a4bebe350",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApiProdStage": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment7b2714845e"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage",
+      "UpdateReplacePolicy": "Delete"
+    }
+  }
+}

--- a/tests/translator/output/valid_update_replace_policy_and_deletion_policy.json
+++ b/tests/translator/output/valid_update_replace_policy_and_deletion_policy.json
@@ -1,0 +1,401 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction2Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2HiPermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction2"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/method",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction2Role": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunction3": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction3Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunction3AllPermissionProd": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction3"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/method2",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunction3Role": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyFunction4": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "LambdaASP.NETCoreWebAPI2::LambdaASP.NETCoreWebAPI2.LambdaEntryPoint::FunctionHandlerAsync",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunction4Role",
+            "Arn"
+          ]
+        },
+        "Runtime": "dotnet6",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyFunction4ByePermissionProd": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction4"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/method2",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "MyFunction4Role": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "MyFunctionNonePermissionProd": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "MyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/method",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "MyFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApi": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "paths": {
+            "/method": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }
+              },
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction2.Arn}/invocations"
+                  }
+                }
+              }
+            },
+            "/method2": {
+              "get": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction3.Arn}/invocations"
+                  }
+                }
+              },
+              "post": {
+                "responses": {},
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction4.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "swagger": "2.0"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApiDeploymented02210310": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Description": "RestApi deployment id: ed022103104b41126f13a40759da23020fe2dd72",
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Stage"
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+      "UpdateReplacePolicy": "Delete"
+    },
+    "ServerlessRestApiProdStage": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymented02210310"
+        },
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage",
+      "UpdateReplacePolicy": "Delete"
+    }
+  }
+}

--- a/tests/translator/output/valid_update_replace_policy_and_deletion_policy.json
+++ b/tests/translator/output/valid_update_replace_policy_and_deletion_policy.json
@@ -201,7 +201,8 @@
           }
         ]
       },
-      "Type": "AWS::Lambda::Function"
+      "Type": "AWS::Lambda::Function",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunction4ByePermissionProd": {
       "DeletionPolicy": "Retain",
@@ -223,7 +224,8 @@
           ]
         }
       },
-      "Type": "AWS::Lambda::Permission"
+      "Type": "AWS::Lambda::Permission",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunction4Role": {
       "DeletionPolicy": "Retain",
@@ -254,7 +256,8 @@
           }
         ]
       },
-      "Type": "AWS::IAM::Role"
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain"
     },
     "MyFunctionNonePermissionProd": {
       "Properties": {
@@ -369,7 +372,7 @@
         }
       },
       "Type": "AWS::ApiGateway::RestApi",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     },
     "ServerlessRestApiDeploymented02210310": {
       "DeletionPolicy": "Retain",
@@ -381,7 +384,7 @@
         "StageName": "Stage"
       },
       "Type": "AWS::ApiGateway::Deployment",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     },
     "ServerlessRestApiProdStage": {
       "DeletionPolicy": "Retain",
@@ -395,7 +398,7 @@
         "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage",
-      "UpdateReplacePolicy": "Delete"
+      "UpdateReplacePolicy": "Retain"
     }
   }
 }


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Raises error when UpdateReplacePolicy is not Retain, Snapshot, Delete or None.

### Description of how you validated changes
Created a template to test and ran make pr.
### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
