### PR TITLE
fix: LayerVersion cannot be the target of DependsOn due to being hashed during transformation

### DIFF
--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -238,6 +238,7 @@ class Translator:
             del template["Transform"]
 
         if len(self.document_errors) == 0:
+            template = traverse_template_depends_on(template, changed_logical_ids)
             template = intrinsics_resolver.resolve_sam_resource_id_refs(template, changed_logical_ids)
             return intrinsics_resolver.resolve_sam_resource_refs(template, supported_resource_refs)
         raise InvalidDocumentException(self.document_errors)
@@ -396,6 +397,81 @@ class Translator:
             del properties["SourceReference"]
 
         return SamConnector.from_dict(full_connector_logical_id, connector)
+
+
+def traverse_template_depends_on(input_value: Dict[str, Any], resolution_data: Dict[str, str]) -> Dict[str, Any]:
+    """
+    Driver method that performs the actual traversal of input and calls _resolve_depends_on when
+    needed to perform the resolution.
+    :param input_value: Any primitive type  (dict, array, string etc) whose value might contain an intrinsic function
+    :param resolution_data: Data that will help with resolution i.e. old and new logical ids after transformation
+    :return: Modified `input` with DependsOn resolved
+    """
+    if len(resolution_data) == 0:
+        return input_value
+
+        #
+        # Traversal Algorithm:
+        #
+        # Imagine the input dictionary/list as a tree. We are doing a Pre-Order tree traversal here where we first
+        # process the root node before going to its children. Dict and Lists are the only two iterable nodes.
+        # Everything else is a leaf node. More description can be found on line 126 in _traverse in resolver.py
+        #
+
+    _resolve_depends_on(input_value, resolution_data)
+    if isinstance(input_value, dict):
+        traverse_dict(input_value, resolution_data)
+    return input_value
+
+
+def _resolve_depends_on(input_dict: Dict[str, Any], resolution_data: dict[str, str]) -> Dict[str, Any]:
+    """
+    Resolve DependsOn when logical ids get changed when transforming (ex: AWS::Serverless::LayerVersion)
+
+    :param input_dict: Chunk of the template that is attempting to be resolved
+    :param resolution_data: Dictionary of the original and changed logical ids
+    :return: Modified dictionary with values resolved
+    """
+    # Checks if input dict is resolvable
+    if input_dict is None or not canHandle(input_dict=input_dict):
+        return input_dict
+    # Checks if DependsOn is valid
+    if not (isinstance(input_dict["DependsOn"], (list, str))):
+        return input_dict
+    # Check if DependsOn matches the original value of a changed_logical_id key
+    for old_logical_id, changed_logical_id in resolution_data.items():
+        # Done like this as there is no other way to know if this is a DependsOn vs some value named the
+        # same as the old logical id. (ex LayerName is commonly the old_logical_id)
+        if isinstance(input_dict["DependsOn"], list):
+            for index, value in enumerate(input_dict["DependsOn"]):
+                if value == old_logical_id:
+                    input_dict["DependsOn"][index] = changed_logical_id
+        elif input_dict["DependsOn"] == old_logical_id:
+            input_dict["DependsOn"] = changed_logical_id
+    return input_dict
+
+
+def traverse_dict(input_dict: Dict[str, Any], resolution_data: Dict[str, str]) -> Dict[str, Any]:
+    """
+    Traverse a dictionary to resolve intrinsic functions on every value
+
+    :param input_dict: Input dictionary to traverse
+    :param resolution_data: Data needed to resolve DependsOn
+    :return: Modified dictionary with values resolved
+    """
+    for key, value in input_dict.items():
+        input_dict[key] = traverse_template_depends_on(value, resolution_data)
+    return input_dict
+
+
+def canHandle(input_dict: Dict[str, Any]) -> bool:
+    """
+    Checks if the input dictionary is of length one and contains "DependsOn"
+
+    :param input_dict: the Dictionary that is attempting to be resolved
+    :return boolean value of validation attempt
+    """
+    return isinstance(input_dict, dict) and "DependsOn" in input_dict
 
 
 def prepare_plugins(plugins: Optional[List[BasePlugin]], parameters: Optional[Dict[str, Any]] = None) -> SamPlugins:

--- a/tests/translator/input/layer_version_depends_on.yaml
+++ b/tests/translator/input/layer_version_depends_on.yaml
@@ -1,0 +1,26 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  Layer1:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      ContentUri:
+        Bucket: test
+        Key: test.zip
+
+  Layer2:
+    Type: AWS::Serverless::LayerVersion
+    DependsOn: Layer1
+    Properties:
+      ContentUri:
+        Bucket: test
+        Key: test.zip
+
+  Layer3:
+    Type: AWS::Serverless::LayerVersion
+    DependsOn:
+    - Layer1
+    - Layer2
+    Properties:
+      ContentUri:
+        Bucket: test
+        Key: test.zip

--- a/tests/translator/output/aws-cn/layer_version_depends_on.json
+++ b/tests/translator/output/aws-cn/layer_version_depends_on.json
@@ -1,0 +1,42 @@
+{
+  "Resources": {
+    "Layer1d45b36fd2d": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer1"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "Layer25093239808": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": "Layer1d45b36fd2d",
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer2"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "Layer34d7f81220c": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "Layer1d45b36fd2d",
+        "Layer25093239808"
+      ],
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer3"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/layer_version_depends_on.json
+++ b/tests/translator/output/aws-us-gov/layer_version_depends_on.json
@@ -1,0 +1,42 @@
+{
+  "Resources": {
+    "Layer1d45b36fd2d": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer1"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "Layer25093239808": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": "Layer1d45b36fd2d",
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer2"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "Layer34d7f81220c": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "Layer1d45b36fd2d",
+        "Layer25093239808"
+      ],
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer3"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    }
+  }
+}

--- a/tests/translator/output/layer_version_depends_on.json
+++ b/tests/translator/output/layer_version_depends_on.json
@@ -1,0 +1,42 @@
+{
+  "Resources": {
+    "Layer1d45b36fd2d": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer1"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "Layer25093239808": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": "Layer1d45b36fd2d",
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer2"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "Layer34d7f81220c": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "Layer1d45b36fd2d",
+        "Layer25093239808"
+      ],
+      "Properties": {
+        "Content": {
+          "S3Bucket": "test",
+          "S3Key": "test.zip"
+        },
+        "LayerName": "Layer3"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Changed it so that DependsOn will resolve to the hashed logical id of a target that has a logical id that changed during transformation.

### Description of how you validated changes
Added a transform test

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
