### PR TITLE
fix: skip statemachine test

### DIFF
--- a/integration/single/test_basic_state_machine.py
+++ b/integration/single/test_basic_state_machine.py
@@ -34,6 +34,10 @@ class TestBasicLayerVersion(BaseTest):
         self._verify_tag_presence(tags, "TagOne", "ValueOne")
         self._verify_tag_presence(tags, "TagTwo", "ValueTwo")
 
+    @skipIf(
+        current_region_does_not_support([STATE_MACHINE_INLINE_DEFINITION]),
+        "StateMachine with inline definition is not supported in this testing region",
+    )
     def test_state_machine_with_role_path(self):
         """
         Creates a State machine with a Role Path


### PR DESCRIPTION
### Issue #, if available

### Description of changes
This test should be skipped if statemachine isn't available

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
