### PR TITLE
doc: Replace EOL nodejs16.x from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         exports.handler = async (event) => {
@@ -56,7 +56,7 @@ Resources:
           }
       Handler: index.handler
       Role: !GetAtt MyFunctionRole.Arn
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Tags:
         - Key: lambda:createdBy
           Value: SAM


### PR DESCRIPTION
node 16 is EOL in Sep 2023:
https://nodejs.org/en/blog/announcements/nodejs16-eol

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
