### PR TITLE
chore: replace nodejs14.x with nodejs18.x

### DIFF
--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-VENV=.venv
+VENV=.venv_cfn_lint
 
 # Install to separate venv to avoid circular dependency; cfn-lint depends on samtranslator
 # See https://github.com/aws/serverless-application-model/issues/1042

--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-VENV=.venv_cfn_lint
+VENV=.venv
 
 # Install to separate venv to avoid circular dependency; cfn-lint depends on samtranslator
 # See https://github.com/aws/serverless-application-model/issues/1042

--- a/tests/translator/input/api_merge_definitions_global.yaml
+++ b/tests/translator/input/api_merge_definitions_global.yaml
@@ -31,7 +31,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/translator/input/api_merge_definitions_with_conflicting_auth.yaml
+++ b/tests/translator/input/api_merge_definitions_with_conflicting_auth.yaml
@@ -28,7 +28,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/translator/input/api_merge_definitions_with_conflicting_methods.yaml
+++ b/tests/translator/input/api_merge_definitions_with_conflicting_methods.yaml
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/translator/input/api_merge_definitions_with_conflicting_request_models.yaml
+++ b/tests/translator/input/api_merge_definitions_with_conflicting_request_models.yaml
@@ -35,7 +35,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/translator/input/api_merge_definitions_with_different_methods.yaml
+++ b/tests/translator/input/api_merge_definitions_with_different_methods.yaml
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/translator/input/api_merge_definitions_with_full_properties.yaml
+++ b/tests/translator/input/api_merge_definitions_with_full_properties.yaml
@@ -49,7 +49,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/translator/input/api_with_custom_domain_regional.yaml
+++ b/tests/translator/input/api_with_custom_domain_regional.yaml
@@ -38,7 +38,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/translator/input/api_with_custom_domains_edge.yaml
+++ b/tests/translator/input/api_with_custom_domains_edge.yaml
@@ -19,7 +19,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         Fetch:
           Type: Api

--- a/tests/translator/input/api_with_custom_domains_regional.yaml
+++ b/tests/translator/input/api_with_custom_domains_regional.yaml
@@ -38,7 +38,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/translator/input/api_with_custom_domains_regional_latency_routing.yaml
+++ b/tests/translator/input/api_with_custom_domains_regional_latency_routing.yaml
@@ -41,7 +41,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/translator/input/api_with_custom_domains_regional_latency_routing_ipv6.yaml
+++ b/tests/translator/input/api_with_custom_domains_regional_latency_routing_ipv6.yaml
@@ -42,7 +42,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/translator/input/api_with_custom_domains_regional_ownership_verification.yaml
+++ b/tests/translator/input/api_with_custom_domains_regional_ownership_verification.yaml
@@ -42,7 +42,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/translator/input/api_with_request_parameters_openapi.yaml
+++ b/tests/translator/input/api_with_request_parameters_openapi.yaml
@@ -29,7 +29,7 @@ Resources:
             });
         }
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         GetHtml:
           Type: Api

--- a/tests/translator/input/congito_userpool_with_sms_configuration.yaml
+++ b/tests/translator/input/congito_userpool_with_sms_configuration.yaml
@@ -4,7 +4,7 @@ Resources:
     Properties:
       CodeUri: s3://bucket/key
       Handler: app.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         CognitoUserPoolPreSignup:
           Type: Cognito

--- a/tests/translator/input/connector_api_to_function.yaml
+++ b/tests/translator/input/connector_api_to_function.yaml
@@ -34,7 +34,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -58,7 +58,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/translator/input/connector_api_to_multiple_function.yaml
+++ b/tests/translator/input/connector_api_to_multiple_function.yaml
@@ -7,7 +7,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -31,7 +31,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/translator/input/connector_appsync_api_to_lambda.yaml
+++ b/tests/translator/input/connector_appsync_api_to_lambda.yaml
@@ -28,5 +28,5 @@ Resources:
           }
         }
       PackageType: Zip
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler

--- a/tests/translator/input/connector_appsync_to_lambda.yaml
+++ b/tests/translator/input/connector_appsync_to_lambda.yaml
@@ -19,7 +19,7 @@ Resources:
           return "Hello World"
         }
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
 
   AppSyncApi:
     Type: AWS::AppSync::GraphQLApi

--- a/tests/translator/input/connector_bucket_to_function.yaml
+++ b/tests/translator/input/connector_bucket_to_function.yaml
@@ -2,7 +2,7 @@ Resources:
   Function:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_function_to_location.yaml
+++ b/tests/translator/input/connector_function_to_location.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_function_to_multiple_s3.yaml
+++ b/tests/translator/input/connector_function_to_multiple_s3.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_function_to_s3.yaml
+++ b/tests/translator/input/connector_function_to_s3.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_function_to_sqs.yaml
+++ b/tests/translator/input/connector_function_to_sqs.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |
@@ -30,7 +30,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_function_to_table.yaml
+++ b/tests/translator/input/connector_function_to_table.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |
@@ -32,7 +32,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_mix_destination.yaml
+++ b/tests/translator/input/connector_mix_destination.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -54,7 +54,7 @@ Resources:
   Function:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_sfn_to_function.yaml
+++ b/tests/translator/input/connector_sfn_to_function.yaml
@@ -19,7 +19,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_sfn_to_function_without_policy.yaml
+++ b/tests/translator/input/connector_sfn_to_function_without_policy.yaml
@@ -16,7 +16,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         exports.handler = async (event) => {

--- a/tests/translator/input/connector_sns_to_function.yaml
+++ b/tests/translator/input/connector_sns_to_function.yaml
@@ -18,7 +18,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/translator/input/connector_sqs_to_function.yaml
+++ b/tests/translator/input/connector_sqs_to_function.yaml
@@ -5,7 +5,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -39,7 +39,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_sqs_to_multiple_function.yaml
+++ b/tests/translator/input/connector_sqs_to_multiple_function.yaml
@@ -5,7 +5,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -26,7 +26,7 @@ Resources:
   InvokedFunction2:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_table_to_function.yaml
+++ b/tests/translator/input/connector_table_to_function.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/translator/input/connector_table_to_function_read.yaml
+++ b/tests/translator/input/connector_table_to_function_read.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -36,7 +36,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/connector_with_non_id_source_and_destination.yaml
+++ b/tests/translator/input/connector_with_non_id_source_and_destination.yaml
@@ -16,7 +16,7 @@ Resources:
   SamFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Role: !GetAtt MyRole.Arn
       InlineCode: |

--- a/tests/translator/input/embedded_connector_function_to_multi_dest.yaml
+++ b/tests/translator/input/embedded_connector_function_to_multi_dest.yaml
@@ -11,7 +11,7 @@ Resources:
           - Read
           - Write
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/embedded_connectors_api_to_function.yaml
+++ b/tests/translator/input/embedded_connectors_api_to_function.yaml
@@ -49,7 +49,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -73,7 +73,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |-

--- a/tests/translator/input/embedded_connectors_function_to.yaml
+++ b/tests/translator/input/embedded_connectors_function_to.yaml
@@ -45,7 +45,7 @@ Resources:
           - Read
           - Write
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -79,7 +79,7 @@ Resources:
           - Write
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/translator/input/embedded_connectors_sfn_to.yaml
+++ b/tests/translator/input/embedded_connectors_sfn_to.yaml
@@ -47,7 +47,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/embedded_connectors_sns_to.yaml
+++ b/tests/translator/input/embedded_connectors_sns_to.yaml
@@ -21,7 +21,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: " const AWS = require('aws-sdk'); exports.handler = async (event)\
         \ => { console.log(JSON.stringify(event)); };"

--- a/tests/translator/input/embedded_connectors_table_to_function.yaml
+++ b/tests/translator/input/embedded_connectors_table_to_function.yaml
@@ -2,7 +2,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         exports.handler = async (event) => {
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/translator/input/error_api_merge_definitions_with_definitionuri.yaml
+++ b/tests/translator/input/error_api_merge_definitions_with_definitionuri.yaml
@@ -29,7 +29,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/translator/input/error_s3_lambda_configuration_invalid_type.yaml
+++ b/tests/translator/input/error_s3_lambda_configuration_invalid_type.yaml
@@ -4,7 +4,7 @@ Resources:
     Properties:
       CodeUri: s3://bucket/key
       Handler: app.lambdaHandler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Architectures:
       - x86_64
       Events:
@@ -28,7 +28,7 @@ Resources:
     Properties:
       CodeUri: s3://bucket/key
       Handler: app.lambdaHandler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Architectures:
       - x86_64
       Events:

--- a/tests/translator/input/error_schema_validation_wrong_property.yaml
+++ b/tests/translator/input/error_schema_validation_wrong_property.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/error_schema_validation_wrong_type.yaml
+++ b/tests/translator/input/error_schema_validation_wrong_type.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/translator/input/event_bridge_rule_super_long_id.yaml
+++ b/tests/translator/input/event_bridge_rule_super_long_id.yaml
@@ -5,7 +5,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/translator/input/function_with_events_and_propagate_tags.yaml
+++ b/tests/translator/input/function_with_events_and_propagate_tags.yaml
@@ -43,7 +43,7 @@ Resources:
       InlineCode: |
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       DeploymentPreference:
         Type: AllAtOnce
         Role:

--- a/tests/translator/input/function_with_mq.yaml
+++ b/tests/translator/input/function_with_mq.yaml
@@ -137,7 +137,7 @@ Resources:
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: s3://bucket/key
       Role:

--- a/tests/translator/input/function_with_mq_using_autogen_role.yaml
+++ b/tests/translator/input/function_with_mq_using_autogen_role.yaml
@@ -108,7 +108,7 @@ Resources:
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: s3://bucket/key
       Events:

--- a/tests/translator/input/function_with_msk_2.yaml
+++ b/tests/translator/input/function_with_msk_2.yaml
@@ -50,7 +50,7 @@ Resources:
   MyMskStreamProcessor:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: s3://foo/bar
       Role:

--- a/tests/translator/input/function_with_msk_using_managed_policy.yaml
+++ b/tests/translator/input/function_with_msk_using_managed_policy.yaml
@@ -26,7 +26,7 @@ Resources:
   MyMskStreamProcessor:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: s3://foo/bar
       Events:

--- a/tests/translator/input/function_with_propagate_tags_and_no_tags.yaml
+++ b/tests/translator/input/function_with_propagate_tags_and_no_tags.yaml
@@ -5,7 +5,7 @@ Resources:
       InlineCode: |
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       # PropagateTags: True
       AutoPublishAlias: Live
       Events:

--- a/tests/translator/input/function_with_tracing.yaml
+++ b/tests/translator/input/function_with_tracing.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
             return {
@@ -32,7 +32,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
             return {
@@ -50,7 +50,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
             return {
@@ -68,7 +68,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
             return {
@@ -86,7 +86,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
             return {
@@ -104,7 +104,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
             return {
@@ -122,7 +122,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
             return {
@@ -140,7 +140,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
             return {
@@ -158,7 +158,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       MemorySize: 128
       InlineCode: |
         exports.handler = async (event, context, callback) => {

--- a/tests/translator/input/graphqlapi_multiple_auth.yaml
+++ b/tests/translator/input/graphqlapi_multiple_auth.yaml
@@ -48,7 +48,7 @@ Resources:
           }
         }
       PackageType: Zip
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
 
   Authorizer2:
@@ -62,5 +62,5 @@ Resources:
           }
         }
       PackageType: Zip
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler

--- a/tests/translator/input/http_api_with_custom_domains_regional.yaml
+++ b/tests/translator/input/http_api_with_custom_domains_regional.yaml
@@ -38,7 +38,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: HttpApi

--- a/tests/translator/input/http_api_with_custom_domains_regional_latency_routing.yaml
+++ b/tests/translator/input/http_api_with_custom_domains_regional_latency_routing.yaml
@@ -41,7 +41,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/translator/input/http_api_with_custom_domains_regional_latency_routing_ipv6.yaml
+++ b/tests/translator/input/http_api_with_custom_domains_regional_latency_routing_ipv6.yaml
@@ -42,7 +42,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/translator/input/http_api_with_custom_domains_regional_ownership_verification.yaml
+++ b/tests/translator/input/http_api_with_custom_domains_regional_ownership_verification.yaml
@@ -42,7 +42,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: HttpApi

--- a/tests/translator/input/http_api_with_default_stage_name_and_fail_on_warnings.yaml
+++ b/tests/translator/input/http_api_with_default_stage_name_and_fail_on_warnings.yaml
@@ -9,7 +9,7 @@ Resources:
     Properties:
       InlineCode: foo
       Handler: bar
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         AppHandler:
           Type: HttpApi

--- a/tests/translator/input/schema_validation_1.yaml
+++ b/tests/translator/input/schema_validation_1.yaml
@@ -59,7 +59,7 @@ Resources:
       - ResourceName: Function
       CodeUri: s3://src/Function
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       MemorySize: 3008
       Timeout: 30
       Tracing: Active

--- a/tests/translator/input/schema_validation_5.yaml
+++ b/tests/translator/input/schema_validation_5.yaml
@@ -33,6 +33,6 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: foo
       InlineCode: bar

--- a/tests/translator/input/state_machine_with_schedule_target_id.yaml
+++ b/tests/translator/input/state_machine_with_schedule_target_id.yaml
@@ -7,7 +7,7 @@ Resources:
           console.log("Hello world!")
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
 
   StateMachineIdWith30Characters:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/output/api_merge_definitions_global.json
+++ b/tests/translator/output/api_merge_definitions_global.json
@@ -113,7 +113,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_merge_definitions_with_conflicting_auth.json
+++ b/tests/translator/output/api_merge_definitions_with_conflicting_auth.json
@@ -113,7 +113,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_merge_definitions_with_conflicting_methods.json
+++ b/tests/translator/output/api_merge_definitions_with_conflicting_methods.json
@@ -90,7 +90,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_merge_definitions_with_conflicting_request_models.json
+++ b/tests/translator/output/api_merge_definitions_with_conflicting_request_models.json
@@ -119,7 +119,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_merge_definitions_with_different_methods.json
+++ b/tests/translator/output/api_merge_definitions_with_different_methods.json
@@ -99,7 +99,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_merge_definitions_with_full_properties.json
+++ b/tests/translator/output/api_merge_definitions_with_full_properties.json
@@ -117,7 +117,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_with_custom_domain_regional.json
+++ b/tests/translator/output/api_with_custom_domain_regional.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_with_custom_domains_edge.json
+++ b/tests/translator/output/api_with_custom_domains_edge.json
@@ -106,7 +106,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_with_custom_domains_regional.json
+++ b/tests/translator/output/api_with_custom_domains_regional.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_with_custom_domains_regional_latency_routing.json
+++ b/tests/translator/output/api_with_custom_domains_regional_latency_routing.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_with_custom_domains_regional_latency_routing_ipv6.json
+++ b/tests/translator/output/api_with_custom_domains_regional_latency_routing_ipv6.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_with_custom_domains_regional_ownership_verification.json
+++ b/tests/translator/output/api_with_custom_domains_regional_ownership_verification.json
@@ -52,7 +52,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_with_request_parameters_openapi.json
+++ b/tests/translator/output/api_with_request_parameters_openapi.json
@@ -15,7 +15,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_merge_definitions_global.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_global.json
@@ -121,7 +121,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_merge_definitions_with_conflicting_auth.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_with_conflicting_auth.json
@@ -121,7 +121,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_merge_definitions_with_conflicting_methods.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_with_conflicting_methods.json
@@ -98,7 +98,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_merge_definitions_with_conflicting_request_models.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_with_conflicting_request_models.json
@@ -127,7 +127,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_merge_definitions_with_different_methods.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_with_different_methods.json
@@ -107,7 +107,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_merge_definitions_with_full_properties.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_with_full_properties.json
@@ -125,7 +125,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_with_custom_domain_regional.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_regional.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_with_custom_domains_edge.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domains_edge.json
@@ -114,7 +114,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_with_custom_domains_regional.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domains_regional.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_with_custom_domains_regional_latency_routing.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domains_regional_latency_routing.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_with_custom_domains_regional_latency_routing_ipv6.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domains_regional_latency_routing_ipv6.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_with_custom_domains_regional_ownership_verification.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domains_regional_ownership_verification.json
@@ -52,7 +52,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_with_request_parameters_openapi.json
+++ b/tests/translator/output/aws-cn/api_with_request_parameters_openapi.json
@@ -15,7 +15,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/congito_userpool_with_sms_configuration.json
+++ b/tests/translator/output/aws-cn/congito_userpool_with_sms_configuration.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_api_to_function.json
+++ b/tests/translator/output/aws-cn/connector_api_to_function.json
@@ -189,7 +189,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -305,7 +305,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_api_to_multiple_function.json
+++ b/tests/translator/output/aws-cn/connector_api_to_multiple_function.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -166,7 +166,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_appsync_api_to_lambda.json
+++ b/tests/translator/output/aws-cn/connector_appsync_api_to_lambda.json
@@ -28,7 +28,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_appsync_to_lambda.json
+++ b/tests/translator/output/aws-cn/connector_appsync_to_lambda.json
@@ -132,7 +132,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_bucket_to_function.json
+++ b/tests/translator/output/aws-cn/connector_bucket_to_function.json
@@ -34,7 +34,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_function_to_location.json
+++ b/tests/translator/output/aws-cn/connector_function_to_location.json
@@ -99,7 +99,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_function_to_multiple_s3.json
+++ b/tests/translator/output/aws-cn/connector_function_to_multiple_s3.json
@@ -216,7 +216,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_function_to_s3.json
+++ b/tests/translator/output/aws-cn/connector_function_to_s3.json
@@ -114,7 +114,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_function_to_sqs.json
+++ b/tests/translator/output/aws-cn/connector_function_to_sqs.json
@@ -164,7 +164,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -202,7 +202,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_function_to_table.json
+++ b/tests/translator/output/aws-cn/connector_function_to_table.json
@@ -288,7 +288,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -330,7 +330,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_mix_destination.json
+++ b/tests/translator/output/aws-cn/connector_mix_destination.json
@@ -57,7 +57,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -228,7 +228,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_samfunction_to_table.json
+++ b/tests/translator/output/aws-cn/connector_samfunction_to_table.json
@@ -66,7 +66,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_sfn_to_function.json
+++ b/tests/translator/output/aws-cn/connector_sfn_to_function.json
@@ -54,7 +54,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_sfn_to_function_without_policy.json
+++ b/tests/translator/output/aws-cn/connector_sfn_to_function_without_policy.json
@@ -57,7 +57,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_sns_to_function.json
+++ b/tests/translator/output/aws-cn/connector_sns_to_function.json
@@ -47,7 +47,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },

--- a/tests/translator/output/aws-cn/connector_sqs_to_function.json
+++ b/tests/translator/output/aws-cn/connector_sqs_to_function.json
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -186,7 +186,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_sqs_to_multiple_function.json
+++ b/tests/translator/output/aws-cn/connector_sqs_to_multiple_function.json
@@ -131,7 +131,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -160,7 +160,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_table_to_function.json
+++ b/tests/translator/output/aws-cn/connector_table_to_function.json
@@ -70,7 +70,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },

--- a/tests/translator/output/aws-cn/connector_table_to_function_read.json
+++ b/tests/translator/output/aws-cn/connector_table_to_function_read.json
@@ -153,7 +153,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -264,7 +264,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/aws-cn/connector_with_non_id_source_and_destination.json
@@ -240,7 +240,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/embedded_connector_function_to_multi_dest.json
+++ b/tests/translator/output/aws-cn/embedded_connector_function_to_multi_dest.json
@@ -18,7 +18,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/embedded_connectors_api_to_function.json
+++ b/tests/translator/output/aws-cn/embedded_connectors_api_to_function.json
@@ -81,7 +81,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -224,7 +224,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/embedded_connectors_function_to.json
+++ b/tests/translator/output/aws-cn/embedded_connectors_function_to.json
@@ -22,7 +22,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -286,7 +286,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/embedded_connectors_sfn_to.json
+++ b/tests/translator/output/aws-cn/embedded_connectors_sfn_to.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/embedded_connectors_sns_to.json
+++ b/tests/translator/output/aws-cn/embedded_connectors_sns_to.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/embedded_connectors_table_to_function.json
+++ b/tests/translator/output/aws-cn/embedded_connectors_table_to_function.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -51,7 +51,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/event_bridge_rule_super_long_id.json
+++ b/tests/translator/output/aws-cn/event_bridge_rule_super_long_id.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/aws-cn/function_with_events_and_propagate_tags.json
@@ -98,7 +98,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "Key1",

--- a/tests/translator/output/aws-cn/function_with_mq.json
+++ b/tests/translator/output/aws-cn/function_with_mq.json
@@ -168,7 +168,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_mq_using_autogen_role.json
+++ b/tests/translator/output/aws-cn/function_with_mq_using_autogen_role.json
@@ -103,7 +103,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_msk_2.json
+++ b/tests/translator/output/aws-cn/function_with_msk_2.json
@@ -109,7 +109,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_msk_using_managed_policy.json
+++ b/tests/translator/output/aws-cn/function_with_msk_using_managed_policy.json
@@ -53,7 +53,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_propagate_tags_and_no_tags.json
+++ b/tests/translator/output/aws-cn/function_with_propagate_tags_and_no_tags.json
@@ -36,7 +36,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_tracing.json
+++ b/tests/translator/output/aws-cn/function_with_tracing.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -88,7 +88,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -147,7 +147,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -202,7 +202,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -257,7 +257,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -312,7 +312,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -371,7 +371,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -432,7 +432,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -491,7 +491,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/graphqlapi_multiple_auth.json
+++ b/tests/translator/output/aws-cn/graphqlapi_multiple_auth.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -66,7 +66,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/http_api_with_custom_domains_regional.json
+++ b/tests/translator/output/aws-cn/http_api_with_custom_domains_regional.json
@@ -140,7 +140,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/http_api_with_custom_domains_regional_latency_routing.json
+++ b/tests/translator/output/aws-cn/http_api_with_custom_domains_regional_latency_routing.json
@@ -26,7 +26,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/http_api_with_custom_domains_regional_latency_routing_ipv6.json
+++ b/tests/translator/output/aws-cn/http_api_with_custom_domains_regional_latency_routing_ipv6.json
@@ -26,7 +26,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/http_api_with_custom_domains_regional_ownership_verification.json
+++ b/tests/translator/output/aws-cn/http_api_with_custom_domains_regional_ownership_verification.json
@@ -146,7 +146,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/http_api_with_default_stage_name_and_fail_on_warnings.json
+++ b/tests/translator/output/aws-cn/http_api_with_default_stage_name_and_fail_on_warnings.json
@@ -62,7 +62,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/schema_validation_1.json
+++ b/tests/translator/output/aws-cn/schema_validation_1.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/schema_validation_5.json
+++ b/tests/translator/output/aws-cn/schema_validation_5.json
@@ -49,7 +49,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/state_machine_with_schedule_target_id.json
+++ b/tests/translator/output/aws-cn/state_machine_with_schedule_target_id.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_global.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_global.json
@@ -121,7 +121,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_with_conflicting_auth.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_with_conflicting_auth.json
@@ -121,7 +121,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_with_conflicting_methods.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_with_conflicting_methods.json
@@ -98,7 +98,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_with_conflicting_request_models.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_with_conflicting_request_models.json
@@ -127,7 +127,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_with_different_methods.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_with_different_methods.json
@@ -107,7 +107,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_with_full_properties.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_with_full_properties.json
@@ -125,7 +125,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_regional.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_regional.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_with_custom_domains_edge.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domains_edge.json
@@ -114,7 +114,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_with_custom_domains_regional.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domains_regional.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_with_custom_domains_regional_latency_routing.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domains_regional_latency_routing.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_with_custom_domains_regional_latency_routing_ipv6.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domains_regional_latency_routing_ipv6.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_with_custom_domains_regional_ownership_verification.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domains_regional_ownership_verification.json
@@ -52,7 +52,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_with_request_parameters_openapi.json
+++ b/tests/translator/output/aws-us-gov/api_with_request_parameters_openapi.json
@@ -15,7 +15,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/congito_userpool_with_sms_configuration.json
+++ b/tests/translator/output/aws-us-gov/congito_userpool_with_sms_configuration.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_api_to_function.json
+++ b/tests/translator/output/aws-us-gov/connector_api_to_function.json
@@ -189,7 +189,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -305,7 +305,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_api_to_multiple_function.json
+++ b/tests/translator/output/aws-us-gov/connector_api_to_multiple_function.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -166,7 +166,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_appsync_api_to_lambda.json
+++ b/tests/translator/output/aws-us-gov/connector_appsync_api_to_lambda.json
@@ -28,7 +28,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_appsync_to_lambda.json
+++ b/tests/translator/output/aws-us-gov/connector_appsync_to_lambda.json
@@ -132,7 +132,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_bucket_to_function.json
+++ b/tests/translator/output/aws-us-gov/connector_bucket_to_function.json
@@ -34,7 +34,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_function_to_location.json
+++ b/tests/translator/output/aws-us-gov/connector_function_to_location.json
@@ -99,7 +99,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_function_to_multiple_s3.json
+++ b/tests/translator/output/aws-us-gov/connector_function_to_multiple_s3.json
@@ -216,7 +216,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_function_to_s3.json
+++ b/tests/translator/output/aws-us-gov/connector_function_to_s3.json
@@ -114,7 +114,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_function_to_sqs.json
+++ b/tests/translator/output/aws-us-gov/connector_function_to_sqs.json
@@ -164,7 +164,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -202,7 +202,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_function_to_table.json
+++ b/tests/translator/output/aws-us-gov/connector_function_to_table.json
@@ -288,7 +288,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -330,7 +330,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_mix_destination.json
+++ b/tests/translator/output/aws-us-gov/connector_mix_destination.json
@@ -57,7 +57,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -228,7 +228,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_samfunction_to_table.json
+++ b/tests/translator/output/aws-us-gov/connector_samfunction_to_table.json
@@ -66,7 +66,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_sfn_to_function.json
+++ b/tests/translator/output/aws-us-gov/connector_sfn_to_function.json
@@ -54,7 +54,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_sfn_to_function_without_policy.json
+++ b/tests/translator/output/aws-us-gov/connector_sfn_to_function_without_policy.json
@@ -57,7 +57,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_sns_to_function.json
+++ b/tests/translator/output/aws-us-gov/connector_sns_to_function.json
@@ -47,7 +47,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },

--- a/tests/translator/output/aws-us-gov/connector_sqs_to_function.json
+++ b/tests/translator/output/aws-us-gov/connector_sqs_to_function.json
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -186,7 +186,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_sqs_to_multiple_function.json
+++ b/tests/translator/output/aws-us-gov/connector_sqs_to_multiple_function.json
@@ -131,7 +131,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -160,7 +160,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_table_to_function.json
+++ b/tests/translator/output/aws-us-gov/connector_table_to_function.json
@@ -70,7 +70,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },

--- a/tests/translator/output/aws-us-gov/connector_table_to_function_read.json
+++ b/tests/translator/output/aws-us-gov/connector_table_to_function_read.json
@@ -153,7 +153,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -264,7 +264,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/aws-us-gov/connector_with_non_id_source_and_destination.json
@@ -240,7 +240,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/embedded_connector_function_to_multi_dest.json
+++ b/tests/translator/output/aws-us-gov/embedded_connector_function_to_multi_dest.json
@@ -18,7 +18,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/embedded_connectors_api_to_function.json
+++ b/tests/translator/output/aws-us-gov/embedded_connectors_api_to_function.json
@@ -81,7 +81,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -224,7 +224,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/embedded_connectors_function_to.json
+++ b/tests/translator/output/aws-us-gov/embedded_connectors_function_to.json
@@ -22,7 +22,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -286,7 +286,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/embedded_connectors_sfn_to.json
+++ b/tests/translator/output/aws-us-gov/embedded_connectors_sfn_to.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/embedded_connectors_sns_to.json
+++ b/tests/translator/output/aws-us-gov/embedded_connectors_sns_to.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/embedded_connectors_table_to_function.json
+++ b/tests/translator/output/aws-us-gov/embedded_connectors_table_to_function.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -51,7 +51,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/event_bridge_rule_super_long_id.json
+++ b/tests/translator/output/aws-us-gov/event_bridge_rule_super_long_id.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/aws-us-gov/function_with_events_and_propagate_tags.json
@@ -98,7 +98,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "Key1",

--- a/tests/translator/output/aws-us-gov/function_with_mq.json
+++ b/tests/translator/output/aws-us-gov/function_with_mq.json
@@ -168,7 +168,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_mq_using_autogen_role.json
+++ b/tests/translator/output/aws-us-gov/function_with_mq_using_autogen_role.json
@@ -103,7 +103,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_msk_2.json
+++ b/tests/translator/output/aws-us-gov/function_with_msk_2.json
@@ -109,7 +109,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_msk_using_managed_policy.json
+++ b/tests/translator/output/aws-us-gov/function_with_msk_using_managed_policy.json
@@ -53,7 +53,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_propagate_tags_and_no_tags.json
+++ b/tests/translator/output/aws-us-gov/function_with_propagate_tags_and_no_tags.json
@@ -36,7 +36,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_tracing.json
+++ b/tests/translator/output/aws-us-gov/function_with_tracing.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -88,7 +88,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -147,7 +147,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -202,7 +202,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -257,7 +257,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -312,7 +312,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -371,7 +371,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -432,7 +432,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -491,7 +491,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/graphqlapi_multiple_auth.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_multiple_auth.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -66,7 +66,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/http_api_with_custom_domains_regional.json
+++ b/tests/translator/output/aws-us-gov/http_api_with_custom_domains_regional.json
@@ -140,7 +140,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/http_api_with_custom_domains_regional_latency_routing.json
+++ b/tests/translator/output/aws-us-gov/http_api_with_custom_domains_regional_latency_routing.json
@@ -26,7 +26,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/http_api_with_custom_domains_regional_latency_routing_ipv6.json
+++ b/tests/translator/output/aws-us-gov/http_api_with_custom_domains_regional_latency_routing_ipv6.json
@@ -26,7 +26,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/http_api_with_custom_domains_regional_ownership_verification.json
+++ b/tests/translator/output/aws-us-gov/http_api_with_custom_domains_regional_ownership_verification.json
@@ -146,7 +146,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/http_api_with_default_stage_name_and_fail_on_warnings.json
+++ b/tests/translator/output/aws-us-gov/http_api_with_default_stage_name_and_fail_on_warnings.json
@@ -62,7 +62,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/schema_validation_1.json
+++ b/tests/translator/output/aws-us-gov/schema_validation_1.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/schema_validation_5.json
+++ b/tests/translator/output/aws-us-gov/schema_validation_5.json
@@ -49,7 +49,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/state_machine_with_schedule_target_id.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_schedule_target_id.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/congito_userpool_with_sms_configuration.json
+++ b/tests/translator/output/congito_userpool_with_sms_configuration.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_api_to_function.json
+++ b/tests/translator/output/connector_api_to_function.json
@@ -189,7 +189,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -297,7 +297,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_api_to_multiple_function.json
+++ b/tests/translator/output/connector_api_to_multiple_function.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -158,7 +158,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_appsync_api_to_lambda.json
+++ b/tests/translator/output/connector_appsync_api_to_lambda.json
@@ -28,7 +28,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_appsync_to_lambda.json
+++ b/tests/translator/output/connector_appsync_to_lambda.json
@@ -132,7 +132,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_bucket_to_function.json
+++ b/tests/translator/output/connector_bucket_to_function.json
@@ -34,7 +34,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_function_to_location.json
+++ b/tests/translator/output/connector_function_to_location.json
@@ -99,7 +99,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_function_to_multiple_s3.json
+++ b/tests/translator/output/connector_function_to_multiple_s3.json
@@ -216,7 +216,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_function_to_s3.json
+++ b/tests/translator/output/connector_function_to_s3.json
@@ -114,7 +114,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_function_to_sqs.json
+++ b/tests/translator/output/connector_function_to_sqs.json
@@ -164,7 +164,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -202,7 +202,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_function_to_table.json
+++ b/tests/translator/output/connector_function_to_table.json
@@ -288,7 +288,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -330,7 +330,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_mix_destination.json
+++ b/tests/translator/output/connector_mix_destination.json
@@ -57,7 +57,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -228,7 +228,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_samfunction_to_table.json
+++ b/tests/translator/output/connector_samfunction_to_table.json
@@ -66,7 +66,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_sfn_to_function.json
+++ b/tests/translator/output/connector_sfn_to_function.json
@@ -54,7 +54,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_sfn_to_function_without_policy.json
+++ b/tests/translator/output/connector_sfn_to_function_without_policy.json
@@ -57,7 +57,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_sns_to_function.json
+++ b/tests/translator/output/connector_sns_to_function.json
@@ -47,7 +47,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },

--- a/tests/translator/output/connector_sqs_to_function.json
+++ b/tests/translator/output/connector_sqs_to_function.json
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -186,7 +186,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_sqs_to_multiple_function.json
+++ b/tests/translator/output/connector_sqs_to_multiple_function.json
@@ -131,7 +131,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -160,7 +160,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_table_to_function.json
+++ b/tests/translator/output/connector_table_to_function.json
@@ -70,7 +70,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },

--- a/tests/translator/output/connector_table_to_function_read.json
+++ b/tests/translator/output/connector_table_to_function_read.json
@@ -153,7 +153,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -264,7 +264,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/connector_with_non_id_source_and_destination.json
@@ -232,7 +232,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/embedded_connector_function_to_multi_dest.json
+++ b/tests/translator/output/embedded_connector_function_to_multi_dest.json
@@ -18,7 +18,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/embedded_connectors_api_to_function.json
+++ b/tests/translator/output/embedded_connectors_api_to_function.json
@@ -81,7 +81,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -224,7 +224,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/embedded_connectors_function_to.json
+++ b/tests/translator/output/embedded_connectors_function_to.json
@@ -22,7 +22,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -286,7 +286,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/embedded_connectors_sfn_to.json
+++ b/tests/translator/output/embedded_connectors_sfn_to.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/embedded_connectors_sns_to.json
+++ b/tests/translator/output/embedded_connectors_sns_to.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/embedded_connectors_table_to_function.json
+++ b/tests/translator/output/embedded_connectors_table_to_function.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x"
+        "Runtime": "nodejs18.x"
       },
       "Type": "AWS::Lambda::Function"
     },
@@ -51,7 +51,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/event_bridge_rule_super_long_id.json
+++ b/tests/translator/output/event_bridge_rule_super_long_id.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/function_with_events_and_propagate_tags.json
@@ -98,7 +98,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "Key1",

--- a/tests/translator/output/function_with_mq.json
+++ b/tests/translator/output/function_with_mq.json
@@ -168,7 +168,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_mq_using_autogen_role.json
+++ b/tests/translator/output/function_with_mq_using_autogen_role.json
@@ -103,7 +103,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_msk_2.json
+++ b/tests/translator/output/function_with_msk_2.json
@@ -109,7 +109,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_msk_using_managed_policy.json
+++ b/tests/translator/output/function_with_msk_using_managed_policy.json
@@ -53,7 +53,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_propagate_tags_and_no_tags.json
+++ b/tests/translator/output/function_with_propagate_tags_and_no_tags.json
@@ -36,7 +36,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_tracing.json
+++ b/tests/translator/output/function_with_tracing.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -88,7 +88,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -147,7 +147,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -202,7 +202,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -257,7 +257,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -312,7 +312,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -371,7 +371,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -432,7 +432,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -491,7 +491,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/graphqlapi_multiple_auth.json
+++ b/tests/translator/output/graphqlapi_multiple_auth.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",
@@ -66,7 +66,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/http_api_with_custom_domains_regional.json
+++ b/tests/translator/output/http_api_with_custom_domains_regional.json
@@ -140,7 +140,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/http_api_with_custom_domains_regional_latency_routing.json
+++ b/tests/translator/output/http_api_with_custom_domains_regional_latency_routing.json
@@ -26,7 +26,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/http_api_with_custom_domains_regional_latency_routing_ipv6.json
+++ b/tests/translator/output/http_api_with_custom_domains_regional_latency_routing_ipv6.json
@@ -26,7 +26,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/http_api_with_custom_domains_regional_ownership_verification.json
+++ b/tests/translator/output/http_api_with_custom_domains_regional_ownership_verification.json
@@ -146,7 +146,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/http_api_with_default_stage_name_and_fail_on_warnings.json
+++ b/tests/translator/output/http_api_with_default_stage_name_and_fail_on_warnings.json
@@ -62,7 +62,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/schema_validation_1.json
+++ b/tests/translator/output/schema_validation_1.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/schema_validation_5.json
+++ b/tests/translator/output/schema_validation_5.json
@@ -49,7 +49,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/state_machine_with_schedule_target_id.json
+++ b/tests/translator/output/state_machine_with_schedule_target_id.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -857,7 +857,7 @@ class TestTemplateValidation(TestCase):
                             "Properties": {
                                 "Handler": "foo",
                                 "InlineCode": "bar",
-                                "Runtime": "nodejs14.x",
+                                "Runtime": "nodejs18.x",
                                 "Policies": policies,
                             },
                         },


### PR DESCRIPTION
### Issue #, if available
Lambda will deprecate support for nodejs14.x so update the environment of transform test to 18.x

### Description of changes

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
