### PR TITLE
[chore]: keep cfn schema used by cfn-lint up-to-date

### DIFF
--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -11,5 +11,5 @@ fi
 
 "${VENV}/bin/python" -m pip install cfn-lint==0.75.0 --upgrade --quiet
 # update cfn schema
-"${VENV}/bin/cfn-lint" cfn-lint -u
+"${VENV}/bin/cfn-lint" -u
 "${VENV}/bin/cfn-lint" --format parseable

--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -10,4 +10,6 @@ if [ ! -d "${VENV}" ]; then
 fi
 
 "${VENV}/bin/python" -m pip install cfn-lint==0.75.0 --upgrade --quiet
+# update cfn schema
+"${VENV}/bin/cfn-lint" cfn-lint -u
 "${VENV}/bin/cfn-lint" --format parseable

--- a/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
+++ b/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
@@ -9,7 +9,7 @@ Resources:
         NotificationTopic:
           Type: SNS
           Properties:
-            Topic: topicArn
+            Topic: topicArn-letsAddMoreSymbols
             Region: region
             FilterPolicy:
               store:

--- a/tests/translator/output/aws-cn/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_sns_event_source_all_parameters.json
@@ -62,7 +62,7 @@
         "FilterPolicyScope": "MessageAttributes",
         "Protocol": "lambda",
         "Region": "region",
-        "TopicArn": "topicArn"
+        "TopicArn": "topicArn-letsAddMoreSymbols"
       },
       "Type": "AWS::SNS::Subscription"
     },
@@ -73,7 +73,7 @@
           "Ref": "MyAwesomeFunction"
         },
         "Principal": "sns.amazonaws.com",
-        "SourceArn": "topicArn"
+        "SourceArn": "topicArn-letsAddMoreSymbols"
       },
       "Type": "AWS::Lambda::Permission"
     },

--- a/tests/translator/output/aws-us-gov/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_sns_event_source_all_parameters.json
@@ -62,7 +62,7 @@
         "FilterPolicyScope": "MessageAttributes",
         "Protocol": "lambda",
         "Region": "region",
-        "TopicArn": "topicArn"
+        "TopicArn": "topicArn-letsAddMoreSymbols"
       },
       "Type": "AWS::SNS::Subscription"
     },
@@ -73,7 +73,7 @@
           "Ref": "MyAwesomeFunction"
         },
         "Principal": "sns.amazonaws.com",
-        "SourceArn": "topicArn"
+        "SourceArn": "topicArn-letsAddMoreSymbols"
       },
       "Type": "AWS::Lambda::Permission"
     },

--- a/tests/translator/output/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/function_with_sns_event_source_all_parameters.json
@@ -62,7 +62,7 @@
         "FilterPolicyScope": "MessageAttributes",
         "Protocol": "lambda",
         "Region": "region",
-        "TopicArn": "topicArn"
+        "TopicArn": "topicArn-letsAddMoreSymbols"
       },
       "Type": "AWS::SNS::Subscription"
     },
@@ -73,7 +73,7 @@
           "Ref": "MyAwesomeFunction"
         },
         "Principal": "sns.amazonaws.com",
-        "SourceArn": "topicArn"
+        "SourceArn": "topicArn-letsAddMoreSymbols"
       },
       "Type": "AWS::Lambda::Permission"
     },


### PR DESCRIPTION
### Issue #, if available

### Description of changes
To be able to use new fields added to CFN resources, we need to keep CFN schema used by `cfn-lint` up-to-date.

We don't want to update to the latest `cfn-lint` yet because we'll have to change many ARNs and other values in the transform tests to meet `cfn-lint` requirements which are not important for the transforms tests (i.e use looking-like-legit ARNs instead of any string).

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
