### PR TITLE
fix: Tags with value of False got evaluated to ""

### DIFF
--- a/samtranslator/model/tags/resource_tagging.py
+++ b/samtranslator/model/tags/resource_tagging.py
@@ -30,7 +30,7 @@ def get_tag_list(resource_tag_dict: Optional[Dict[str, Any]]) -> List[Dict[str, 
         return tag_list
 
     for tag_key, tag_value in resource_tag_dict.items():
-        tag = {_KEY: tag_key, _VALUE: tag_value if tag_value else ""}
+        tag = {_KEY: tag_key, _VALUE: tag_value if (tag_value is not None) else ""}
         tag_list.append(tag)
 
     return tag_list

--- a/tests/translator/input/simple_function_with_global_tags_false.yaml
+++ b/tests/translator/input/simple_function_with_global_tags_false.yaml
@@ -1,0 +1,28 @@
+Globals:
+  Function:
+    Tags:
+      TagKey1: TagValue1
+      TagKey2: ''
+      TagKey3: false
+      TagKey4: true
+      TagKey5: 0
+
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs18.x
+      InlineCode: |
+        exports.handler = async (event, context, callback) => {
+          return {
+            statusCode: 200,
+            body: 'Success'
+          }
+        }
+      MemorySize: 128
+      Policies:
+      - AWSLambdaRole
+      - AmazonS3ReadOnlyAccess
+Metadata:
+  SamTransformTest: true

--- a/tests/translator/input/simple_function_with_tags_false.yaml
+++ b/tests/translator/input/simple_function_with_tags_false.yaml
@@ -1,0 +1,24 @@
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs18.x
+      InlineCode: |
+        exports.handler = async (event, context, callback) => {
+          return {
+            statusCode: 200,
+            body: 'Success'
+          }
+        }
+      MemorySize: 128
+      Policies:
+      - AWSLambdaRole
+      - AmazonS3ReadOnlyAccess
+      Tags:
+        TagKey1: TagValue1
+        TagKey2: ''
+        TagKey3: false
+        TagKey4: true
+Metadata:
+  SamTransformTest: true

--- a/tests/translator/input/simple_table_with_tags_false.yaml
+++ b/tests/translator/input/simple_table_with_tags_false.yaml
@@ -1,0 +1,18 @@
+Parameters:
+  TagValueParam:
+    Type: String
+    Default: value
+
+Resources:
+  MinimalTableWithTags:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      Tags:
+        TagKey1: TagValue1
+        TagKey2: ''
+        TagKey3:
+          Ref: TagValueParam
+        TagKey4: '123'
+        TagKey5: true
+        TagKey6: false
+        TagKey7: 0

--- a/tests/translator/output/aws-cn/simple_function_with_global_tags_false.json
+++ b/tests/translator/output/aws-cn/simple_function_with_global_tags_false.json
@@ -1,0 +1,102 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Resources": {
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          },
+          {
+            "Key": "TagKey5",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaRole",
+          "arn:aws-cn:iam::aws:policy/AmazonS3ReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          },
+          {
+            "Key": "TagKey5",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/simple_function_with_tags_false.json
+++ b/tests/translator/output/aws-cn/simple_function_with_tags_false.json
@@ -1,0 +1,94 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Resources": {
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaRole",
+          "arn:aws-cn:iam::aws:policy/AmazonS3ReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/simple_table_with_tags_false.json
+++ b/tests/translator/output/aws-cn/simple_table_with_tags_false.json
@@ -1,0 +1,60 @@
+{
+  "Parameters": {
+    "TagValueParam": {
+      "Default": "value",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MinimalTableWithTags": {
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": {
+              "Ref": "TagValueParam"
+            }
+          },
+          {
+            "Key": "TagKey4",
+            "Value": "123"
+          },
+          {
+            "Key": "TagKey5",
+            "Value": true
+          },
+          {
+            "Key": "TagKey6",
+            "Value": false
+          },
+          {
+            "Key": "TagKey7",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::DynamoDB::Table"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/simple_function_with_global_tags_false.json
+++ b/tests/translator/output/aws-us-gov/simple_function_with_global_tags_false.json
@@ -1,0 +1,102 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Resources": {
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          },
+          {
+            "Key": "TagKey5",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaRole",
+          "arn:aws-us-gov:iam::aws:policy/AmazonS3ReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          },
+          {
+            "Key": "TagKey5",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/simple_function_with_tags_false.json
+++ b/tests/translator/output/aws-us-gov/simple_function_with_tags_false.json
@@ -1,0 +1,94 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Resources": {
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaRole",
+          "arn:aws-us-gov:iam::aws:policy/AmazonS3ReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/simple_table_with_tags_false.json
+++ b/tests/translator/output/aws-us-gov/simple_table_with_tags_false.json
@@ -1,0 +1,60 @@
+{
+  "Parameters": {
+    "TagValueParam": {
+      "Default": "value",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MinimalTableWithTags": {
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": {
+              "Ref": "TagValueParam"
+            }
+          },
+          {
+            "Key": "TagKey4",
+            "Value": "123"
+          },
+          {
+            "Key": "TagKey5",
+            "Value": true
+          },
+          {
+            "Key": "TagKey6",
+            "Value": false
+          },
+          {
+            "Key": "TagKey7",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::DynamoDB::Table"
+    }
+  }
+}

--- a/tests/translator/output/simple_function_with_global_tags_false.json
+++ b/tests/translator/output/simple_function_with_global_tags_false.json
@@ -1,0 +1,102 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Resources": {
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          },
+          {
+            "Key": "TagKey5",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaRole",
+          "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          },
+          {
+            "Key": "TagKey5",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/simple_function_with_tags_false.json
+++ b/tests/translator/output/simple_function_with_tags_false.json
@@ -1,0 +1,94 @@
+{
+  "Metadata": {
+    "SamTransformTest": true
+  },
+  "Resources": {
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = async (event, context, callback) => {\n  return {\n    statusCode: 200,\n    body: 'Success'\n  }\n}\n"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaRole",
+          "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          },
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": false
+          },
+          {
+            "Key": "TagKey4",
+            "Value": true
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/simple_table_with_tags_false.json
+++ b/tests/translator/output/simple_table_with_tags_false.json
@@ -1,0 +1,60 @@
+{
+  "Parameters": {
+    "TagValueParam": {
+      "Default": "value",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "MinimalTableWithTags": {
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S"
+          }
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "TagKey1",
+            "Value": "TagValue1"
+          },
+          {
+            "Key": "TagKey2",
+            "Value": ""
+          },
+          {
+            "Key": "TagKey3",
+            "Value": {
+              "Ref": "TagValueParam"
+            }
+          },
+          {
+            "Key": "TagKey4",
+            "Value": "123"
+          },
+          {
+            "Key": "TagKey5",
+            "Value": true
+          },
+          {
+            "Key": "TagKey6",
+            "Value": false
+          },
+          {
+            "Key": "TagKey7",
+            "Value": 0
+          }
+        ]
+      },
+      "Type": "AWS::DynamoDB::Table"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available
https://github.com/aws/serverless-application-model/issues/3426
### Description of changes
When the value of a tag was False it would be set to the default "" value as the if statement evaluated the value rather than checking if it was None.

### Description of how you validated changes
Tested by transforming template and looking at tags

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
