### PR TITLE
chore: mq tests using a valid version

### DIFF
--- a/integration/resources/templates/combination/function_with_mq.yaml
+++ b/integration/resources/templates/combination/function_with_mq.yaml
@@ -111,7 +111,7 @@ Resources:
         Ref: MQBrokerName
       DeploymentMode: SINGLE_INSTANCE
       EngineType: ACTIVEMQ
-      EngineVersion: 5.15.12
+      EngineVersion: 5.17.6
       HostInstanceType: mq.t3.micro
       Logs:
         Audit: true

--- a/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
+++ b/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
@@ -84,7 +84,7 @@ Resources:
         Ref: MQBrokerName2
       DeploymentMode: SINGLE_INSTANCE
       EngineType: ACTIVEMQ
-      EngineVersion: 5.15.12
+      EngineVersion: 5.17.6
       HostInstanceType: mq.t3.micro
       Logs:
         Audit: true


### PR DESCRIPTION
### Issue #, if available

### Description of changes

mq tests were using an old version of `EngineVersion:`

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
