### PR TITLE
chore: Upgrade ruff to 0.1.*

### DIFF
--- a/integration/combination/test_function_with_cwe_dlq_generated.py
+++ b/integration/combination/test_function_with_cwe_dlq_generated.py
@@ -36,7 +36,7 @@ class TestFunctionWithCweDlqGenerated(BaseTest):
 
         # checking policy action
         actions = dlq_policy_statement["Action"]
-        action_list = actions if type(actions) == list else [actions]
+        action_list = actions if isinstance(actions, list) == list else [actions]
         self.assertEqual(len(action_list), 1, "Only one action must be in dead-letter queue policy")
         self.assertEqual(
             action_list[0], "sqs:SendMessage", "Action referenced in dead-letter queue policy must be 'sqs:SendMessage'"

--- a/integration/combination/test_function_with_policy_templates.py
+++ b/integration/combination/test_function_with_policy_templates.py
@@ -14,7 +14,7 @@ class TestFunctionWithPolicyTemplates(BaseTest):
         self.assertEqual(len(sqs_poller_policy), 1, "Only one statement must be in SQS Poller policy")
 
         sqs_policy_statement = sqs_poller_policy[0]
-        self.assertTrue(type(sqs_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(sqs_policy_statement["Resource"], list))
 
         queue_url = self.get_physical_id_by_type("AWS::SQS::Queue")
         parts = queue_url.split("/")
@@ -32,7 +32,7 @@ class TestFunctionWithPolicyTemplates(BaseTest):
         self.assertEqual(len(lambda_invoke_policy), 1, "One policies statements should be present")
 
         lambda_policy_statement = lambda_invoke_policy[0]
-        self.assertTrue(type(lambda_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(lambda_policy_statement["Resource"], list))
 
         #  NOTE: The resource ARN has "*" suffix to allow for any Lambda function version as well
         expected_function_suffix = "function:somename*"

--- a/integration/combination/test_state_machine_with_api.py
+++ b/integration/combination/test_state_machine_with_api.py
@@ -75,7 +75,7 @@ class TestStateMachineWithApi(BaseTest):
 
         start_execution_policy_statement = start_execution_policy[0]
 
-        self.assertTrue(type(start_execution_policy_statement["Action"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Action"], list))
         policy_action = start_execution_policy_statement["Action"]
         self.assertEqual(
             policy_action,
@@ -83,7 +83,7 @@ class TestStateMachineWithApi(BaseTest):
             "Action referenced in event role policy must be 'states:StartExecution'",
         )
 
-        self.assertTrue(type(start_execution_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Resource"], list))
         referenced_state_machine_arn = start_execution_policy_statement["Resource"]
         self.assertEqual(
             referenced_state_machine_arn,

--- a/integration/combination/test_state_machine_with_cwe.py
+++ b/integration/combination/test_state_machine_with_cwe.py
@@ -34,7 +34,7 @@ class TestStateMachineWithCwe(BaseTest):
 
         start_execution_policy_statement = start_execution_policy[0]
 
-        self.assertTrue(type(start_execution_policy_statement["Action"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Action"], list))
         policy_action = start_execution_policy_statement["Action"]
         self.assertEqual(
             policy_action,
@@ -42,7 +42,7 @@ class TestStateMachineWithCwe(BaseTest):
             "Action referenced in event role policy must be 'states:StartExecution'",
         )
 
-        self.assertTrue(type(start_execution_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Resource"], list))
         referenced_state_machine_arn = start_execution_policy_statement["Resource"]
         self.assertEqual(
             referenced_state_machine_arn,

--- a/integration/combination/test_state_machine_with_cwe_dlq_generated.py
+++ b/integration/combination/test_state_machine_with_cwe_dlq_generated.py
@@ -37,7 +37,7 @@ class TestStateMachineWithCweDlqGenerated(BaseTest):
 
         start_execution_policy_statement = start_execution_policy[0]
 
-        self.assertTrue(type(start_execution_policy_statement["Action"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Action"], list))
         policy_action = start_execution_policy_statement["Action"]
         self.assertEqual(
             policy_action,
@@ -45,7 +45,7 @@ class TestStateMachineWithCweDlqGenerated(BaseTest):
             "Action referenced in event role policy must be 'states:StartExecution'",
         )
 
-        self.assertTrue(type(start_execution_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Resource"], list))
         referenced_state_machine_arn = start_execution_policy_statement["Resource"]
         self.assertEqual(
             referenced_state_machine_arn,

--- a/integration/combination/test_state_machine_with_policy_templates.py
+++ b/integration/combination/test_state_machine_with_policy_templates.py
@@ -22,7 +22,7 @@ class TestStateMachineWithPolicyTemplates(BaseTest):
         self.assertEqual(len(sqs_poller_policy), 1, "Only one statement must be in SQS Poller policy")
 
         sqs_policy_statement = sqs_poller_policy[0]
-        self.assertTrue(type(sqs_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(sqs_policy_statement["Resource"], list))
 
         queue_url = self.get_physical_id_by_type("AWS::SQS::Queue")
         parts = queue_url.split("/")
@@ -40,7 +40,7 @@ class TestStateMachineWithPolicyTemplates(BaseTest):
         self.assertEqual(len(lambda_invoke_policy), 1, "One policies statements should be present")
 
         lambda_policy_statement = lambda_invoke_policy[0]
-        self.assertTrue(type(lambda_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(lambda_policy_statement["Resource"], list))
 
         function_name = self.get_physical_id_by_type("AWS::Lambda::Function")
         #  NOTE: The resource ARN has "*" suffix to allow for any Lambda function version as well

--- a/integration/combination/test_state_machine_with_schedule.py
+++ b/integration/combination/test_state_machine_with_schedule.py
@@ -45,7 +45,7 @@ class TestStateMachineWithSchedule(BaseTest):
 
         start_execution_policy_statement = start_execution_policy[0]
 
-        self.assertTrue(type(start_execution_policy_statement["Action"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Action"], list))
         policy_action = start_execution_policy_statement["Action"]
         self.assertEqual(
             policy_action,
@@ -53,7 +53,7 @@ class TestStateMachineWithSchedule(BaseTest):
             "Action referenced in event role policy must be 'states:StartExecution'",
         )
 
-        self.assertTrue(type(start_execution_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Resource"], list))
         referenced_state_machine_arn = start_execution_policy_statement["Resource"]
         self.assertEqual(
             referenced_state_machine_arn,

--- a/integration/combination/test_state_machine_with_schedule_dlq_and_retry_policy.py
+++ b/integration/combination/test_state_machine_with_schedule_dlq_and_retry_policy.py
@@ -46,7 +46,7 @@ class TestStateMachineWithScheduleDlqAndRetryPolicy(BaseTest):
 
         start_execution_policy_statement = start_execution_policy[0]
 
-        self.assertTrue(type(start_execution_policy_statement["Action"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Action"], list))
         policy_action = start_execution_policy_statement["Action"]
         self.assertEqual(
             policy_action,
@@ -54,7 +54,7 @@ class TestStateMachineWithScheduleDlqAndRetryPolicy(BaseTest):
             "Action referenced in event role policy must be 'states:StartExecution'",
         )
 
-        self.assertTrue(type(start_execution_policy_statement["Resource"]) != list)
+        self.assertFalse(isinstance(start_execution_policy_statement["Resource"], list))
         referenced_state_machine_arn = start_execution_policy_statement["Resource"]
         self.assertEqual(
             referenced_state_machine_arn,

--- a/integration/helpers/resource.py
+++ b/integration/helpers/resource.py
@@ -206,8 +206,7 @@ def _resource_using_s3_events(resource: Dict[str, Any]) -> bool:
 def _get_all_event_sources(template_dict: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
     resources = template_dict.get("Resources", {}).values()
     for resource in resources:
-        for event in resource.get("Properties", {}).get("Events", {}).values():
-            yield event
+        yield from resource.get("Properties", {}).get("Events", {}).values()
 
 
 def _event_using_sns_filter_policy_scope(event: Dict[str, Any]) -> bool:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ pytest-xdist>=2.5,<4
 pytest-env>=0.6,<1
 pytest-rerunfailures>=9.1,<12
 pyyaml~=6.0
-ruff==0.0.284  # loose the requirement once it is more stable
+ruff~=0.1.0
 
 # Test requirements
 pytest>=6.2,<8


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Ruff has entered 0.1.* and according to their [version policy](https://docs.astral.sh/ruff/versioning/):

> Ruff uses a custom versioning scheme that uses the minor version number for breaking changes and the patch version number for bug fixes. Ruff does not yet have a stable API; once Ruff's API is stable, the major version number and semantic versioning will be used.

### Description of how you validated changes

`make pr`

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
