### PR TITLE
fix: Allow Dynamic Reference in CodeUri Property if no / used

### DIFF
--- a/samtranslator/model/s3_utils/uri_parser.py
+++ b/samtranslator/model/s3_utils/uri_parser.py
@@ -88,10 +88,11 @@ def construct_s3_location_object(
     else:
         # SSM Pattern found here https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
         ssm_pattern = r"{{resolve:(ssm|ssm-secure|secretsmanager):[a-zA-Z0-9_.\-/]+(:\d+)?}}"
-        if search(ssm_pattern, location_uri):
+        match = search(ssm_pattern, location_uri)
+        if match and match.group(0) and "/" in match.group(0):
             raise InvalidResourceException(
                 logical_id,
-                f"Dynamic reference detected in '{property_name}'. Please "
+                f"Unsupported dynamic reference detected in '{property_name}'. Please "
                 "consider using alternative 'FunctionCode' object format.",
             )
 

--- a/tests/translator/output/error_function_with_dynamic_ref_codeuri.json
+++ b/tests/translator/output/error_function_with_dynamic_ref_codeuri.json
@@ -9,7 +9,7 @@
   "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MinimalFunction] is invalid. Dynamic reference detected in 'CodeUri'. Please consider using alternative 'FunctionCode' object format.",
   "errors": [
     {
-      "errorMessage": "Resource with id [MinimalFunction] is invalid. Dynamic reference detected in 'CodeUri'. Please consider using alternative 'FunctionCode' object format."
+      "errorMessage": "Resource with id [MinimalFunction] is invalid. Unsupported dynamic reference detected in 'CodeUri'. Please consider using alternative 'FunctionCode' object format."
     }
   ]
 }

--- a/tests/translator/output/error_function_with_dynamic_ref_codeuri.json
+++ b/tests/translator/output/error_function_with_dynamic_ref_codeuri.json
@@ -3,10 +3,10 @@
     "Invalid Serverless Application Specification document. ",
     "Number of errors found: 1. ",
     "Resource with id [MinimalFunction] is invalid. ",
-    "Dynamic reference detected in 'CodeUri'. ",
+    "Unsupported dynamic reference detected in 'CodeUri'. ",
     "Please consider using alternative 'FunctionCode' object format."
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MinimalFunction] is invalid. Dynamic reference detected in 'CodeUri'. Please consider using alternative 'FunctionCode' object format.",
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MinimalFunction] is invalid. Unsupported dynamic reference detected in 'CodeUri'. Please consider using alternative 'FunctionCode' object format.",
   "errors": [
     {
       "errorMessage": "Resource with id [MinimalFunction] is invalid. Unsupported dynamic reference detected in 'CodeUri'. Please consider using alternative 'FunctionCode' object format."


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Allow dynamic reference as long as it doesn't include `/` in it.

### Description of how you validated changes
All tests pass

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
