### PR TITLE
chore: Add GitHub Action to auto comment if customers comment on a closed issue

### DIFF
--- a/.github/workflows/close_issue_message.yml
+++ b/.github/workflows/close_issue_message.yml
@@ -1,0 +1,20 @@
+name: Closed issue message
+
+on:
+  issues:
+    types: [ closed ]
+jobs:
+  auto_comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: aws-actions/closed-issue-message@v1
+        with:
+          # These inputs are both required
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          message: |
+            ### ⚠️COMMENT VISIBILITY WARNING⚠️
+            Comments on closed issues are hard for our team to see.
+            If you need more assistance, please either tag a team member or open a new issue that references this one.
+            If you wish to keep having a conversation with other community members under this issue feel free to do so.


### PR DESCRIPTION
### Issue #, if available

### Description of changes
SAM CLI had similar github action that will auto comment if a user comments on a closed issue. Add the same one for SAM-T. 

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
