### PR TITLE
chore: Fix KeyError when accessing PolicyDocument

### DIFF
--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -233,7 +233,7 @@ class PullEventSource(ResourceMacro, metaclass=ABCMeta):
             if role.Policies and destination_config_policy not in role.Policies:
                 policy_document = destination_config_policy.get("PolicyDocument")
                 # do not add the policy if the same policy document is already present
-                if policy_document not in [d["PolicyDocument"] for d in role.Policies]:
+                if policy_document not in [d.get("PolicyDocument", {}) for d in role.Policies]:
                     role.Policies.append(destination_config_policy)
 
     def _validate_filter_criteria(self) -> None:

--- a/tests/translator/input/function_with_event_dest_basic.yaml
+++ b/tests/translator/input/function_with_event_dest_basic.yaml
@@ -39,14 +39,14 @@ Resources:
       Runtime: nodejs12.x
       MemorySize: 1024
       Policies:
-        - Fn::If:
-          - SomeCondition
-          - Version: '2012-10-17'
-            Statement:
-            - Effect: Deny
-              Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-              Resource: arn:aws:logs:*:*:*
-          - Ref: AWS::NoValue
+      - Fn::If:
+        - SomeCondition
+        - Version: '2012-10-17'
+          Statement:
+          - Effect: Deny
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+        - Ref: AWS::NoValue

--- a/tests/translator/input/function_with_event_dest_basic.yaml
+++ b/tests/translator/input/function_with_event_dest_basic.yaml
@@ -38,3 +38,15 @@ Resources:
       Handler: index.handler
       Runtime: nodejs12.x
       MemorySize: 1024
+      Policies:
+        - Fn::If:
+          - SomeCondition
+          - Version: '2012-10-17'
+            Statement:
+            - Effect: Deny
+              Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              Resource: arn:aws:logs:*:*:*
+          - Ref: AWS::NoValue

--- a/tests/translator/output/aws-cn/function_with_event_dest_basic.json
+++ b/tests/translator/output/aws-cn/function_with_event_dest_basic.json
@@ -125,6 +125,31 @@
               ]
             },
             "PolicyName": "MyTestFunctionEventInvokeConfigOnFailureSNSPolicy"
+          },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "PolicyName": "MyTestFunctionRolePolicy0",
+                "PolicyDocument": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Deny",
+                      "Action": [
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                      ],
+                      "Resource": "arn:aws:logs:*:*:*"
+                    }
+                  ]
+                }
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
           }
         ],
         "Tags": [

--- a/tests/translator/output/aws-cn/function_with_event_dest_basic.json
+++ b/tests/translator/output/aws-cn/function_with_event_dest_basic.json
@@ -130,21 +130,21 @@
             "Fn::If": [
               "SomeCondition",
               {
-                "PolicyName": "MyTestFunctionRolePolicy0",
                 "PolicyDocument": {
-                  "Version": "2012-10-17",
                   "Statement": [
                     {
-                      "Effect": "Deny",
                       "Action": [
                         "logs:CreateLogGroup",
                         "logs:CreateLogStream",
                         "logs:PutLogEvents"
                       ],
+                      "Effect": "Deny",
                       "Resource": "arn:aws:logs:*:*:*"
                     }
-                  ]
-                }
+                  ],
+                  "Version": "2012-10-17"
+                },
+                "PolicyName": "MyTestFunctionRolePolicy0"
               },
               {
                 "Ref": "AWS::NoValue"

--- a/tests/translator/output/aws-us-gov/function_with_event_dest_basic.json
+++ b/tests/translator/output/aws-us-gov/function_with_event_dest_basic.json
@@ -125,6 +125,31 @@
               ]
             },
             "PolicyName": "MyTestFunctionEventInvokeConfigOnFailureSNSPolicy"
+          },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "PolicyName": "MyTestFunctionRolePolicy0",
+                "PolicyDocument": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Deny",
+                      "Action": [
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                      ],
+                      "Resource": "arn:aws:logs:*:*:*"
+                    }
+                  ]
+                }
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
           }
         ],
         "Tags": [

--- a/tests/translator/output/aws-us-gov/function_with_event_dest_basic.json
+++ b/tests/translator/output/aws-us-gov/function_with_event_dest_basic.json
@@ -130,21 +130,21 @@
             "Fn::If": [
               "SomeCondition",
               {
-                "PolicyName": "MyTestFunctionRolePolicy0",
                 "PolicyDocument": {
-                  "Version": "2012-10-17",
                   "Statement": [
                     {
-                      "Effect": "Deny",
                       "Action": [
                         "logs:CreateLogGroup",
                         "logs:CreateLogStream",
                         "logs:PutLogEvents"
                       ],
+                      "Effect": "Deny",
                       "Resource": "arn:aws:logs:*:*:*"
                     }
-                  ]
-                }
+                  ],
+                  "Version": "2012-10-17"
+                },
+                "PolicyName": "MyTestFunctionRolePolicy0"
               },
               {
                 "Ref": "AWS::NoValue"

--- a/tests/translator/output/function_with_event_dest_basic.json
+++ b/tests/translator/output/function_with_event_dest_basic.json
@@ -125,6 +125,31 @@
               ]
             },
             "PolicyName": "MyTestFunctionEventInvokeConfigOnFailureSNSPolicy"
+          },
+          {
+            "Fn::If": [
+              "SomeCondition",
+              {
+                "PolicyName": "MyTestFunctionRolePolicy0",
+                "PolicyDocument": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Deny",
+                      "Action": [
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                      ],
+                      "Resource": "arn:aws:logs:*:*:*"
+                    }
+                  ]
+                }
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
           }
         ],
         "Tags": [

--- a/tests/translator/output/function_with_event_dest_basic.json
+++ b/tests/translator/output/function_with_event_dest_basic.json
@@ -130,21 +130,21 @@
             "Fn::If": [
               "SomeCondition",
               {
-                "PolicyName": "MyTestFunctionRolePolicy0",
                 "PolicyDocument": {
-                  "Version": "2012-10-17",
                   "Statement": [
                     {
-                      "Effect": "Deny",
                       "Action": [
                         "logs:CreateLogGroup",
                         "logs:CreateLogStream",
                         "logs:PutLogEvents"
                       ],
+                      "Effect": "Deny",
                       "Resource": "arn:aws:logs:*:*:*"
                     }
-                  ]
-                }
+                  ],
+                  "Version": "2012-10-17"
+                },
+                "PolicyName": "MyTestFunctionRolePolicy0"
               },
               {
                 "Ref": "AWS::NoValue"


### PR DESCRIPTION
If an intrinsic is within the Function.Policies Property, the `d["PolicyDocument"]` will fail because the valid policy is backed within the `FN:If`. Instead, we access `PolicyDocument` through a `.get()` call, which allows us to handle the intrinsic case.

### Issue #, if available
None

### Description of changes
See above

### Description of how you validated changes
Wrote a test to validate the template is transformable.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
