### PR TITLE
Use datetime.now(utc) in MetricDatum

### DIFF
--- a/samtranslator/metrics/metrics.py
+++ b/samtranslator/metrics/metrics.py
@@ -1,9 +1,10 @@
 """
 Helper classes to publish metrics
 """
+
 import logging
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, TypedDict, Union
 
 from samtranslator.internal.deprecation_control import deprecated
@@ -114,7 +115,7 @@ class MetricDatum:
         self.value = value
         self.unit = unit
         self.dimensions = dimensions if dimensions else []
-        self.timestamp = timestamp if timestamp else datetime.utcnow()
+        self.timestamp = timestamp if timestamp else datetime.now(timezone.utc)
 
     def get_metric_data(self) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
datetime.utcnow() is deprecated as of Python 3.12, and its use will raise a DeprecationWarning. Since warnings are treated as errors, this results in test failures under Python 3.12. Switch to using datetime.now() with a timezone.utc parameter.

### Issue #, if available

None

### Description of changes

As above

### Description of how you validated changes

I've run the full test suite against Python 3.9, 3.10, 3.11 and 3.12 and verified no errors.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
