### PR TITLE
[chore] switch to `timezone.utc` instead of `utcnow()` since the last one is deprecated in Python 12

### DIFF
--- a/integration/helpers/deployer/deployer.py
+++ b/integration/helpers/deployer/deployer.py
@@ -29,7 +29,7 @@ import logging
 import sys
 import time
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 
 import botocore
 
@@ -140,7 +140,7 @@ class Deployer:
             "ChangeSetType": changeset_type,
             "Parameters": parameter_values,
             "Capabilities": capabilities,
-            "Description": f"Created by SAM CLI at {datetime.utcnow().isoformat()} UTC",
+            "Description": f"Created by SAM CLI at {datetime.now(timezone.utc).isoformat()} UTC",
             "Tags": tags,
         }
 

--- a/integration/helpers/deployer/utils/time_util.py
+++ b/integration/helpers/deployer/utils/time_util.py
@@ -122,7 +122,7 @@ def parse_date(date_string):
         # will use current local time as the base for subtraction, but falsely assume it is a UTC time. Therefore
         # the time that dateparser returns will be a `datetime` object that did not have any timezone information.
         # So be explicit to set the time to UTC.
-        "RELATIVE_BASE": datetime.datetime.utcnow()
+        "RELATIVE_BASE": datetime.datetime.now(datetime.timezone.utc)
     }
 
     return dateparser.parse(date_string, settings=parser_settings)


### PR DESCRIPTION
### Issue #, if available
finishing what was started in https://github.com/aws/serverless-application-model/pull/3538
changing it in integ tests too

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
