### PR TITLE
fix: move the normalized open api version to feature flag normalized_open_api_version

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1293,6 +1293,7 @@ class SamApi(SamResourceMacro):
         shared_api_usage_plan = kwargs.get("shared_api_usage_plan")
         template_conditions = kwargs.get("conditions")
         route53_record_set_groups = kwargs.get("route53_record_set_groups", {})
+        feature_toggle = kwargs.get("feature_toggle")
 
         api_generator = ApiGenerator(
             self.logical_id,
@@ -1329,6 +1330,7 @@ class SamApi(SamResourceMacro):
             mode=self.Mode,
             api_key_source_type=self.ApiKeySourceType,
             always_deploy=self.AlwaysDeploy,
+            feature_toggle=feature_toggle,
         )
 
         generated_resources = api_generator.to_cloudformation(redeploy_restapi_parameters, route53_record_set_groups)

--- a/tests/feature_toggle/input/feature_toggle_config.json
+++ b/tests/feature_toggle/input/feature_toggle_config.json
@@ -46,5 +46,22 @@
         "enabled": false
       }
     }
+  },
+  "normalized_open_api_version": {
+    "beta": {
+      "default": {
+        "enabled": false
+      }
+    },
+    "gamma": {
+      "default": {
+        "enabled": false
+      }
+    },
+    "prod": {
+      "default": {
+        "enabled": false
+      }
+    }
   }
 }

--- a/tests/feature_toggle/input/feature_toggle_config.json
+++ b/tests/feature_toggle/input/feature_toggle_config.json
@@ -46,22 +46,5 @@
         "enabled": false
       }
     }
-  },
-  "normalized_open_api_version": {
-    "beta": {
-      "default": {
-        "enabled": false
-      }
-    },
-    "gamma": {
-      "default": {
-        "enabled": false
-      }
-    },
-    "prod": {
-      "default": {
-        "enabled": false
-      }
-    }
   }
 }

--- a/tests/translator/input/feature_toggle_api_open_api_version_override.yaml
+++ b/tests/translator/input/feature_toggle_api_open_api_version_override.yaml
@@ -1,0 +1,166 @@
+Transform:
+- AWS::Serverless-2016-10-31
+Resources:
+  ApiGatewayCognitoExecutionRole4F7CB5C8:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service: apigateway.amazonaws.com
+        Version: '2012-10-17'
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - Action: lambda:Invoke*
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+              - LambdaFunction7804BD21
+              - Arn
+          Version: '2012-10-17'
+        PolicyName: apigInvokeLambda
+  LambdaFunctionServiceRoleD6E423C9:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+      - Fn::Join:
+        - ''
+        - - 'arn:'
+          - Ref: AWS::Partition
+          - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  LambdaFunctionServiceRoleDefaultPolicyF01A7EDC:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+        - Action: sns:Publish
+          Effect: Allow
+          Resource: '*'
+        Version: '2012-10-17'
+      PolicyName: LambdaFunctionServiceRoleDefaultPolicyF01A7EDC
+      Roles:
+      - Ref: LambdaFunctionServiceRoleD6E423C9
+  LambdaFunction7804BD21:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          exports.handler = async (event, context, callback) => {
+            const auth = event.queryStringParameters.authorization
+            const policyDocument = {
+              Version: '2012-10-17',
+              Statement: [{
+                Action: 'execute-api:Invoke',
+                Effect: auth && auth.toLowerCase() === 'allow' ? 'Allow' : 'Deny',
+                Resource: event.methodArn
+              }]
+            }
+            
+            return {
+              principalId: 'user',
+              context: {},
+              policyDocument
+            }
+          }
+      Role:
+        Fn::GetAtt:
+        - LambdaFunctionServiceRoleD6E423C9
+        - Arn
+      Handler: index.handler
+      Runtime: nodejs16.x
+  MyCognitoUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: MyCognitoUserPool
+  ApiGatewayCognitoService15108F0B:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      Auth:
+        AddDefaultAuthorizerToCorsPreflight: false
+        Authorizers:
+          CognitoAuthorizer:
+            UserPoolArn:
+              Fn::GetAtt: MyCognitoUserPool.Arn
+        DefaultAuthorizer: CognitoAuthorizer
+      DefinitionBody:
+        openapi: 3.0.2
+        info:
+          title: RxtHofApprovalServiceLambdaCognito
+          version: '2018-05-10'
+        paths:
+          /reviews:
+            post:
+              operationId: CreateReview
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/CreateReviewRequestContent'
+                required: true
+              responses:
+                '200':
+                  description: CreateReview 200 response
+                  headers:
+                    Access-Control-Allow-Origin:
+                      schema:
+                        type: string
+                    Access-Control-Expose-Headers:
+                      schema:
+                        type: string
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/CreateReviewResponseContent'
+              x-amazon-apigateway-integration:
+                type: aws_proxy
+                httpMethod: POST
+                uri:
+                  Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaFunction7804BD21.Arn}/invocations
+                credentials:
+                  Fn::Sub: ${ApiGatewayCognitoExecutionRole4F7CB5C8.Arn}
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseParameters:
+                      method.response.header.Access-Control-Allow-Origin: "'*'"
+                      method.response.header.Access-Control-Expose-Headers: "'Content-Length,Content-Type,X-Amzn-Errortype,X-Amzn-Requestid'"
+        components:
+          schemas:
+            CreateReviewRequestContent:
+              type: object
+              properties:
+                reviewId:
+                  type: string
+            CreateReviewResponseContent:
+              type: object
+              properties:
+                reviewId:
+                  type: string
+          securitySchemes:
+            aws.auth.sigv4:
+              type: apiKey
+              description: AWS Signature Version 4 authentication
+              name: Authorization
+              in: header
+              x-amazon-apigateway-authtype: awsSigv4
+        security:
+        - aws.auth.sigv4: []
+        x-amazon-apigateway-gateway-responses:
+          DEFAULT_5XX:
+            responseTemplates:
+              application/json: '{"message":$context.error.messageString}'
+            responseParameters:
+              gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+      OpenApiVersion: '2.0'
+      TracingEnabled: true

--- a/tests/translator/output/aws-cn/api_open_api_version_override.json
+++ b/tests/translator/output/aws-cn/api_open_api_version_override.json
@@ -60,19 +60,12 @@
               }
             },
             "securitySchemes": {
-              "CognitoAuthorizer": {
+              "aws.auth.sigv4": {
+                "description": "AWS Signature Version 4 authentication",
                 "in": "header",
                 "name": "Authorization",
                 "type": "apiKey",
-                "x-amazon-apigateway-authorizer": {
-                  "providerARNs": [
-                    {
-                      "Fn::GetAtt": "MyCognitoUserPool.Arn"
-                    }
-                  ],
-                  "type": "cognito_user_pools"
-                },
-                "x-amazon-apigateway-authtype": "cognito_user_pools"
+                "x-amazon-apigateway-authtype": "awsSigv4"
               }
             }
           },
@@ -151,6 +144,22 @@
               "aws.auth.sigv4": []
             }
           ],
+          "securityDefinitions": {
+            "CognitoAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": "MyCognitoUserPool.Arn"
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            }
+          },
           "x-amazon-apigateway-gateway-responses": {
             "DEFAULT_5XX": {
               "responseParameters": {
@@ -173,9 +182,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ApiGatewayCognitoService15108F0BDeployment2a9725c838": {
+    "ApiGatewayCognitoService15108F0BDeployment46d69ebe56": {
       "Properties": {
-        "Description": "RestApi deployment id: 2a9725c838d10c88c6c75fec8e5fe7557ff62cea",
+        "Description": "RestApi deployment id: 46d69ebe56e878706dbfbf454b9cbdf8c15a5343",
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"
         }
@@ -185,7 +194,7 @@
     "ApiGatewayCognitoService15108F0BprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayCognitoService15108F0BDeployment2a9725c838"
+          "Ref": "ApiGatewayCognitoService15108F0BDeployment46d69ebe56"
         },
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"

--- a/tests/translator/output/aws-cn/feature_toggle_api_open_api_version_override.json
+++ b/tests/translator/output/aws-cn/feature_toggle_api_open_api_version_override.json
@@ -60,12 +60,19 @@
               }
             },
             "securitySchemes": {
-              "aws.auth.sigv4": {
-                "description": "AWS Signature Version 4 authentication",
+              "CognitoAuthorizer": {
                 "in": "header",
                 "name": "Authorization",
                 "type": "apiKey",
-                "x-amazon-apigateway-authtype": "awsSigv4"
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    {
+                      "Fn::GetAtt": "MyCognitoUserPool.Arn"
+                    }
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           },
@@ -144,22 +151,6 @@
               "aws.auth.sigv4": []
             }
           ],
-          "securityDefinitions": {
-            "CognitoAuthorizer": {
-              "in": "header",
-              "name": "Authorization",
-              "type": "apiKey",
-              "x-amazon-apigateway-authorizer": {
-                "providerARNs": [
-                  {
-                    "Fn::GetAtt": "MyCognitoUserPool.Arn"
-                  }
-                ],
-                "type": "cognito_user_pools"
-              },
-              "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }
-          },
           "x-amazon-apigateway-gateway-responses": {
             "DEFAULT_5XX": {
               "responseParameters": {
@@ -170,13 +161,21 @@
               }
             }
           }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
         }
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ApiGatewayCognitoService15108F0BDeployment46d69ebe56": {
+    "ApiGatewayCognitoService15108F0BDeployment2a9725c838": {
       "Properties": {
-        "Description": "RestApi deployment id: 46d69ebe56e878706dbfbf454b9cbdf8c15a5343",
+        "Description": "RestApi deployment id: 2a9725c838d10c88c6c75fec8e5fe7557ff62cea",
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"
         }
@@ -186,7 +185,7 @@
     "ApiGatewayCognitoService15108F0BprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayCognitoService15108F0BDeployment46d69ebe56"
+          "Ref": "ApiGatewayCognitoService15108F0BDeployment2a9725c838"
         },
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"

--- a/tests/translator/output/aws-us-gov/api_open_api_version_override.json
+++ b/tests/translator/output/aws-us-gov/api_open_api_version_override.json
@@ -60,19 +60,12 @@
               }
             },
             "securitySchemes": {
-              "CognitoAuthorizer": {
+              "aws.auth.sigv4": {
+                "description": "AWS Signature Version 4 authentication",
                 "in": "header",
                 "name": "Authorization",
                 "type": "apiKey",
-                "x-amazon-apigateway-authorizer": {
-                  "providerARNs": [
-                    {
-                      "Fn::GetAtt": "MyCognitoUserPool.Arn"
-                    }
-                  ],
-                  "type": "cognito_user_pools"
-                },
-                "x-amazon-apigateway-authtype": "cognito_user_pools"
+                "x-amazon-apigateway-authtype": "awsSigv4"
               }
             }
           },
@@ -151,6 +144,22 @@
               "aws.auth.sigv4": []
             }
           ],
+          "securityDefinitions": {
+            "CognitoAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": "MyCognitoUserPool.Arn"
+                  }
+                ],
+                "type": "cognito_user_pools"
+              },
+              "x-amazon-apigateway-authtype": "cognito_user_pools"
+            }
+          },
           "x-amazon-apigateway-gateway-responses": {
             "DEFAULT_5XX": {
               "responseParameters": {
@@ -173,9 +182,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ApiGatewayCognitoService15108F0BDeployment2a9725c838": {
+    "ApiGatewayCognitoService15108F0BDeployment46d69ebe56": {
       "Properties": {
-        "Description": "RestApi deployment id: 2a9725c838d10c88c6c75fec8e5fe7557ff62cea",
+        "Description": "RestApi deployment id: 46d69ebe56e878706dbfbf454b9cbdf8c15a5343",
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"
         }
@@ -185,7 +194,7 @@
     "ApiGatewayCognitoService15108F0BprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayCognitoService15108F0BDeployment2a9725c838"
+          "Ref": "ApiGatewayCognitoService15108F0BDeployment46d69ebe56"
         },
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"

--- a/tests/translator/output/aws-us-gov/feature_toggle_api_open_api_version_override.json
+++ b/tests/translator/output/aws-us-gov/feature_toggle_api_open_api_version_override.json
@@ -60,12 +60,19 @@
               }
             },
             "securitySchemes": {
-              "aws.auth.sigv4": {
-                "description": "AWS Signature Version 4 authentication",
+              "CognitoAuthorizer": {
                 "in": "header",
                 "name": "Authorization",
                 "type": "apiKey",
-                "x-amazon-apigateway-authtype": "awsSigv4"
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    {
+                      "Fn::GetAtt": "MyCognitoUserPool.Arn"
+                    }
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           },
@@ -144,22 +151,6 @@
               "aws.auth.sigv4": []
             }
           ],
-          "securityDefinitions": {
-            "CognitoAuthorizer": {
-              "in": "header",
-              "name": "Authorization",
-              "type": "apiKey",
-              "x-amazon-apigateway-authorizer": {
-                "providerARNs": [
-                  {
-                    "Fn::GetAtt": "MyCognitoUserPool.Arn"
-                  }
-                ],
-                "type": "cognito_user_pools"
-              },
-              "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }
-          },
           "x-amazon-apigateway-gateway-responses": {
             "DEFAULT_5XX": {
               "responseParameters": {
@@ -170,13 +161,21 @@
               }
             }
           }
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
         }
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ApiGatewayCognitoService15108F0BDeployment46d69ebe56": {
+    "ApiGatewayCognitoService15108F0BDeployment2a9725c838": {
       "Properties": {
-        "Description": "RestApi deployment id: 46d69ebe56e878706dbfbf454b9cbdf8c15a5343",
+        "Description": "RestApi deployment id: 2a9725c838d10c88c6c75fec8e5fe7557ff62cea",
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"
         }
@@ -186,7 +185,7 @@
     "ApiGatewayCognitoService15108F0BprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayCognitoService15108F0BDeployment46d69ebe56"
+          "Ref": "ApiGatewayCognitoService15108F0BDeployment2a9725c838"
         },
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"

--- a/tests/translator/output/feature_toggle_api_open_api_version_override.json
+++ b/tests/translator/output/feature_toggle_api_open_api_version_override.json
@@ -60,12 +60,19 @@
               }
             },
             "securitySchemes": {
-              "aws.auth.sigv4": {
-                "description": "AWS Signature Version 4 authentication",
+              "CognitoAuthorizer": {
                 "in": "header",
                 "name": "Authorization",
                 "type": "apiKey",
-                "x-amazon-apigateway-authtype": "awsSigv4"
+                "x-amazon-apigateway-authorizer": {
+                  "providerARNs": [
+                    {
+                      "Fn::GetAtt": "MyCognitoUserPool.Arn"
+                    }
+                  ],
+                  "type": "cognito_user_pools"
+                },
+                "x-amazon-apigateway-authtype": "cognito_user_pools"
               }
             }
           },
@@ -144,22 +151,6 @@
               "aws.auth.sigv4": []
             }
           ],
-          "securityDefinitions": {
-            "CognitoAuthorizer": {
-              "in": "header",
-              "name": "Authorization",
-              "type": "apiKey",
-              "x-amazon-apigateway-authorizer": {
-                "providerARNs": [
-                  {
-                    "Fn::GetAtt": "MyCognitoUserPool.Arn"
-                  }
-                ],
-                "type": "cognito_user_pools"
-              },
-              "x-amazon-apigateway-authtype": "cognito_user_pools"
-            }
-          },
           "x-amazon-apigateway-gateway-responses": {
             "DEFAULT_5XX": {
               "responseParameters": {
@@ -174,9 +165,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ApiGatewayCognitoService15108F0BDeployment46d69ebe56": {
+    "ApiGatewayCognitoService15108F0BDeployment2a9725c838": {
       "Properties": {
-        "Description": "RestApi deployment id: 46d69ebe56e878706dbfbf454b9cbdf8c15a5343",
+        "Description": "RestApi deployment id: 2a9725c838d10c88c6c75fec8e5fe7557ff62cea",
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"
         }
@@ -186,7 +177,7 @@
     "ApiGatewayCognitoService15108F0BprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayCognitoService15108F0BDeployment46d69ebe56"
+          "Ref": "ApiGatewayCognitoService15108F0BDeployment2a9725c838"
         },
         "RestApiId": {
           "Ref": "ApiGatewayCognitoService15108F0B"

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -34,9 +34,12 @@ DO_NOT_SORT = ["Layers"]
 BASE_PATH = os.path.dirname(__file__)
 INPUT_FOLDER = os.path.join(BASE_PATH, "input")
 SUCCESS_FILES_NAMES_FOR_TESTING = [
-    os.path.splitext(f)[0] for f in os.listdir(INPUT_FOLDER) if not (f.startswith(("error_", "translate_")))
+    os.path.splitext(f)[0]
+    for f in os.listdir(INPUT_FOLDER)
+    if not (f.startswith(("error_", "translate_"))) and not (f.startswith("feature_toggle_"))
 ]
 ERROR_FILES_NAMES_FOR_TESTING = [os.path.splitext(f)[0] for f in os.listdir(INPUT_FOLDER) if f.startswith("error_")]
+FEATURE_TOGGLE_TESTING = [os.path.splitext(f)[0] for f in os.listdir(INPUT_FOLDER) if f.startswith("feature_toggle_")]
 OUTPUT_FOLDER = os.path.join(BASE_PATH, "output")
 
 
@@ -154,7 +157,7 @@ class AbstractTestTranslator(TestCase):
         expected_filepath = os.path.join(OUTPUT_FOLDER, partition_folder, testcase + ".json")
         return json.load(open(expected_filepath))
 
-    def _compare_transform(self, manifest, expected, partition, region):
+    def _compare_transform(self, manifest, expected, partition, region, enable_feature_toggle=False):
         with patch("boto3.session.Session.region_name", region):
             parameter_values = get_template_parameter_values()
             mock_policy_loader = MagicMock()
@@ -173,7 +176,12 @@ class AbstractTestTranslator(TestCase):
                     "AWSXRayDaemonWriteAccess"
                 ] = f"arn:{partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
 
-            output_fragment = transform(manifest, parameter_values, mock_policy_loader)
+            if enable_feature_toggle:
+                mock_feature_toggle = MagicMock()
+                mock_feature_toggle.is_enabled.return_value = True
+                output_fragment = transform(manifest, parameter_values, mock_policy_loader, mock_feature_toggle)
+            else:
+                output_fragment = transform(manifest, parameter_values, mock_policy_loader)
 
         print(json.dumps(output_fragment, indent=2))
 
@@ -276,6 +284,31 @@ class TestTranslatorEndToEnd(AbstractTestTranslator):
         expected = self._read_expected_output(testcase, partition)
 
         self._compare_transform(manifest, expected, partition, region)
+
+    @parameterized.expand(
+        itertools.product(
+            FEATURE_TOGGLE_TESTING,
+            [
+                ("aws", "ap-southeast-1"),
+                ("aws-cn", "cn-north-1"),
+                ("aws-us-gov", "us-gov-west-1"),
+            ],  # Run all the above tests against each of the list of partitions to test against
+        )
+    )
+    @patch(
+        "samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call",
+        mock_sar_service_call,
+    )
+    @patch("samtranslator.translator.arn_generator._get_region_from_session")
+    def test_transform_feature_toggle(self, testcase, partition_with_region, mock_get_region_from_session):
+        partition = partition_with_region[0]
+        region = partition_with_region[1]
+        mock_get_region_from_session.return_value = region
+
+        manifest = self._read_input(testcase)
+        expected = self._read_expected_output(testcase, partition)
+
+        self._compare_transform(manifest, expected, partition, region, True)
 
     @parameterized.expand(
         itertools.product(


### PR DESCRIPTION
### Issue #, if available
Use the feature flag to ship the previous fix https://github.com/aws/serverless-application-model/pull/3551

### Description of changes
If the feature is enable, use the previous fix.
If the feature is disable, do not change anything.

### Description of how you validated changes
Running tests when the feature flag is on/off and verify the authorizer is added/not added.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
