### PR TITLE
fix: add new partition to arn generation

### DIFF
--- a/samtranslator/metrics/method_decorator.py
+++ b/samtranslator/metrics/method_decorator.py
@@ -85,13 +85,13 @@ def _send_cw_metric(prefix, name, execution_time_ms, func, args):  # type: ignor
 @overload
 def cw_timer(
     *, name: Optional[str] = None, prefix: Optional[str] = None
-) -> Callable[[Callable[_PT, _RT]], Callable[_PT, _RT]]: ...
+) -> Callable[[Callable[_PT, _RT]], Callable[_PT, _RT]]:
+    ...
 
 
 @overload
-def cw_timer(
-    _func: Callable[_PT, _RT], name: Optional[str] = None, prefix: Optional[str] = None
-) -> Callable[_PT, _RT]: ...
+def cw_timer(_func: Callable[_PT, _RT], name: Optional[str] = None, prefix: Optional[str] = None) -> Callable[_PT, _RT]:
+    ...
 
 
 def cw_timer(

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -777,7 +777,9 @@ class HttpApiGenerator:
         self.definition_body = open_api_editor.openapi
 
     @cw_timer(prefix="Generator", name="HttpApi")
-    def to_cloudformation(self, route53_record_set_groups: Dict[str, Route53RecordSetGroup]) -> Tuple[
+    def to_cloudformation(
+        self, route53_record_set_groups: Dict[str, Route53RecordSetGroup]
+    ) -> Tuple[
         ApiGatewayV2HttpApi,
         Optional[ApiGatewayV2Stage],
         Optional[ApiGatewayV2DomainName],

--- a/samtranslator/translator/arn_generator.py
+++ b/samtranslator/translator/arn_generator.py
@@ -29,6 +29,10 @@ def _region_to_partition(region: str) -> str:
         if region_string.startswith(key):
             return value
 
+    # Using the ${AWS::Partition} placeholder so that we don't have to add new regions to the static list above
+    if "iso" in region_string:
+        return "${AWS::Partition}"
+
     return "aws"
 
 

--- a/samtranslator/translator/arn_generator.py
+++ b/samtranslator/translator/arn_generator.py
@@ -23,14 +23,11 @@ def _region_to_partition(region: str) -> str:
         "us-isob": "aws-iso-b",
         "us-gov": "aws-us-gov",
         "eu-isoe": "aws-iso-e",
+        "us-isof": "aws-iso-f",
     }
     for key, value in region_to_partition_map.items():
         if region_string.startswith(key):
             return value
-
-    # Using the ${AWS::Partition} placeholder so that we don't have to add new regions to the static list above
-    if "iso" in region_string:
-        return "${AWS::Partition}"
 
     return "aws"
 

--- a/tests/translator/test_arn_generator.py
+++ b/tests/translator/test_arn_generator.py
@@ -17,7 +17,7 @@ class TestArnGenerator(TestCase):
             ("us-isob-east-1", "aws-iso-b"),
             ("eu-isoe-west-1", "aws-iso-e"),
             ("US-EAST-1", "aws"),
-            ("us-isof-east-1", "${AWS::Partition}"),
+            ("us-isof-east-1", "aws-iso-f"),
         ]
     )
     def test_get_partition_name(self, region, expected):

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -165,13 +165,13 @@ class AbstractTestTranslator(TestCase):
                 "AWSLambdaRole": f"arn:{partition}:iam::aws:policy/service-role/AWSLambdaRole",
             }
             if partition == "aws":
-                mock_policy_loader.load.return_value["AWSXrayWriteOnlyAccess"] = (
-                    "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
-                )
+                mock_policy_loader.load.return_value[
+                    "AWSXrayWriteOnlyAccess"
+                ] = "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
             else:
-                mock_policy_loader.load.return_value["AWSXRayDaemonWriteAccess"] = (
-                    f"arn:{partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
-                )
+                mock_policy_loader.load.return_value[
+                    "AWSXRayDaemonWriteAccess"
+                ] = f"arn:{partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
 
             output_fragment = transform(manifest, parameter_values, mock_policy_loader)
 


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Added the `${AWS::Partition}` psuedo parameter before so that we didn't have to maintain a static list but there is a lot of code in SAM that relies on that static list and its causing tests in the new region to fail.

We can use `${AWS::Partition}` in the future but would require a bigger code change. To unblock us in the new region we can just add the new region's partition into the static list for now.

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
