### PR TITLE
chore: encrypt SNS and Kinesis resources in integration test templates

### DIFF
--- a/integration/resources/templates/combination/connector_sfn_to_sns_write.yaml
+++ b/integration/resources/templates/combination/connector_sfn_to_sns_write.yaml
@@ -19,6 +19,8 @@ Resources:
 
   MyTopic:
     Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: alias/aws/sns
 
   MyConnector:
     Type: AWS::Serverless::Connector

--- a/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
+++ b/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
@@ -91,6 +91,9 @@ Resources:
     Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: alias/aws/kinesis
 
   # What an irony the I can't use AWS::Serverless::SimpleTable here because it doesn't support streams specification
   MyTable:

--- a/integration/resources/templates/combination/function_with_all_event_types.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types.yaml
@@ -132,6 +132,9 @@ Resources:
     Condition: MyCondition
     Properties:
       ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: alias/aws/kinesis
 
   MyDynamoDB:
     UpdateReplacePolicy: Delete

--- a/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
@@ -113,6 +113,9 @@ Resources:
     Condition: MyCondition
     Properties:
       ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: alias/aws/kinesis
 
   MyDynamoDB:
     Type: AWS::DynamoDB::Table

--- a/integration/resources/templates/combination/function_with_kinesis.yaml
+++ b/integration/resources/templates/combination/function_with_kinesis.yaml
@@ -48,5 +48,8 @@ Resources:
     Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: alias/aws/kinesis
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/combination/function_with_kinesis_intrinsics.yaml
+++ b/integration/resources/templates/combination/function_with_kinesis_intrinsics.yaml
@@ -80,5 +80,8 @@ Resources:
     Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: alias/aws/kinesis
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/single/basic_function_with_sns_dlq.yaml
+++ b/integration/resources/templates/single/basic_function_with_sns_dlq.yaml
@@ -12,5 +12,7 @@ Resources:
 
   MyTopic:
     Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: alias/aws/sns
 Metadata:
   SamTransformTest: true


### PR DESCRIPTION
### Issue #, if available

N/A

### Description of changes

Enable encryption using `KmsMasterKeyId` for SNS topic and `StreamEncryption` for Kinesis stream resources in integration test templates to follow best security practices.

### Description of how you validated changes

Ran updated integration tests successfully.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
