### PR TITLE
fix: remove unused policies in integ test

### DIFF
--- a/integration/resources/templates/single/basic_function.yaml
+++ b/integration/resources/templates/single/basic_function.yaml
@@ -6,9 +6,6 @@ Resources:
       Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
-      Policies:
-      - AWSLambdaRole
-      - AmazonS3ReadOnlyAccess
       Environment:
         Variables:
           Name: Value

--- a/integration/resources/templates/single/basic_function_no_envvar.yaml
+++ b/integration/resources/templates/single/basic_function_no_envvar.yaml
@@ -6,8 +6,5 @@ Resources:
       Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
-      Policies:
-      - AWSLambdaRole
-      - AmazonS3ReadOnlyAccess
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/single/basic_function_openapi.yaml
+++ b/integration/resources/templates/single/basic_function_openapi.yaml
@@ -9,9 +9,6 @@ Resources:
       Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
-      Policies:
-      - AWSLambdaRole
-      - AmazonS3ReadOnlyAccess
       Environment:
         Variables:
           Name: Value

--- a/integration/resources/templates/single/basic_function_with_tags.yaml
+++ b/integration/resources/templates/single/basic_function_with_tags.yaml
@@ -6,9 +6,6 @@ Resources:
       Runtime: nodejs18.x
       CodeUri: ${codeuri}
       MemorySize: 128
-      Policies:
-      - AWSLambdaRole
-      - AmazonS3ReadOnlyAccess
       Tags:
         TagKey1: TagValue1
         TagKey2: ''


### PR DESCRIPTION
### Issue #, if available
N/A
### Description of changes
We're having some issues with deploying this template in a new region. We suspect the issue is the added the policies. Removing them here and re-deploying in the region to see if that fixes the issue

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
