### PR TITLE
chore: add missing partition to edge config support

### DIFF
--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -18,7 +18,14 @@ class RegionConfiguration:
         :return: True, if API Gateway does not support Edge configuration
         """
 
-        return ArnGenerator.get_partition_name() not in ["aws-us-gov", "aws-iso", "aws-iso-b", "aws-cn", "aws-iso-e", "aws-iso-f"]
+        return ArnGenerator.get_partition_name() not in [
+            "aws-us-gov",
+            "aws-iso",
+            "aws-iso-b",
+            "aws-cn",
+            "aws-iso-e",
+            "aws-iso-f",
+        ]
 
     @classmethod
     def is_service_supported(cls, service, region=None):  # type: ignore[no-untyped-def]

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -18,7 +18,7 @@ class RegionConfiguration:
         :return: True, if API Gateway does not support Edge configuration
         """
         partition = ArnGenerator.get_partition_name()
-        if partition.startswith('aws-iso') or partition in ["aws-us-gov", "aws-cn"]:
+        if partition.startswith("aws-iso") or partition in ["aws-us-gov", "aws-cn"]:
             return False
         return True
 

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -18,7 +18,7 @@ class RegionConfiguration:
         :return: True, if API Gateway does not support Edge configuration
         """
 
-        return ArnGenerator.get_partition_name() not in ["aws-us-gov", "aws-iso", "aws-iso-b", "aws-cn", "aws-iso-e"]
+        return ArnGenerator.get_partition_name() not in ["aws-us-gov", "aws-iso", "aws-iso-b", "aws-cn", "aws-iso-e", "aws-iso-f"]
 
     @classmethod
     def is_service_supported(cls, service, region=None):  # type: ignore[no-untyped-def]

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -17,15 +17,10 @@ class RegionConfiguration:
 
         :return: True, if API Gateway does not support Edge configuration
         """
-
-        return ArnGenerator.get_partition_name() not in [
-            "aws-us-gov",
-            "aws-iso",
-            "aws-iso-b",
-            "aws-cn",
-            "aws-iso-e",
-            "aws-iso-f",
-        ]
+        partition = ArnGenerator.get_partition_name()
+        if partition.startswith('aws-iso') or partition in ["aws-us-gov", "aws-cn"]:
+            return False
+        return True
 
     @classmethod
     def is_service_supported(cls, service, region=None):  # type: ignore[no-untyped-def]

--- a/tests/unit/test_region_configuration.py
+++ b/tests/unit/test_region_configuration.py
@@ -20,16 +20,7 @@ class TestRegionConfiguration(TestCase):
 
             self.assertTrue(RegionConfiguration.is_apigw_edge_configuration_supported())
 
-    @parameterized.expand(
-        [
-            ["aws-cn"],
-            ["aws-us-gov"],
-            ["aws-iso"],
-            ["aws-iso-b"],
-            ["aws-iso-e"],
-            ["aws-iso-f"]
-        ]
-    )
+    @parameterized.expand([["aws-cn"], ["aws-us-gov"], ["aws-iso"], ["aws-iso-b"], ["aws-iso-e"], ["aws-iso-f"]])
     def test_when_apigw_edge_configuration_is_not_supported(self, partition):
         with patch(
             "samtranslator.translator.arn_generator.ArnGenerator.get_partition_name"

--- a/tests/unit/test_region_configuration.py
+++ b/tests/unit/test_region_configuration.py
@@ -27,6 +27,7 @@ class TestRegionConfiguration(TestCase):
             ["aws-iso"],
             ["aws-iso-b"],
             ["aws-iso-e"],
+            ["aws-iso-f"]
         ]
     )
     def test_when_apigw_edge_configuration_is_not_supported(self, partition):


### PR DESCRIPTION
### Issue #, if available

### Description of changes

Missed adding the aws-iso-f partition to this static list

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
