### PR TITLE
fix: AttributeError: module 'pydantic.v1' has no attribute 'error_wrapper'

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -350,6 +350,10 @@ class Resource(ABC):
             with suppress(KeyError):
                 error_properties = ".".join(str(x) for x in e.errors()[0]["loc"])
             raise InvalidResourceException(self.logical_id, f"Property '{error_properties}' is invalid.") from e
+        except AttributeError as e:
+            raise InvalidResourceException(
+                self.logical_id, "Module 'pydantic.v1' has no attribute 'error_wrappers'"
+            ) from e
 
     def validate_properties(self) -> None:
         """Validates that the required properties for this Resource have been populated, and that all properties have


### PR DESCRIPTION
### Issue #3600 

### Description of changes
Added exception block to catch 'AttributeError' happening due to missing error_wrapper import in pydantic v1.10.15

This is a workaround till pydantic team solves the issue at their end:
Ticket to pydantic team https://github.com/pydantic/pydantic/issues/9625

### Description of how you validated changes

Tests ran successfully in python virtual env.


Commands used: 

```
python3 -m venv .venv
source .venv/bin/activate
make init
make test
make pr

black /Users/shikagg/sam_clone/serverless-application-model/samtranslator/model/__init__.py  -> to fix error 
1 file would be reformatted, 364 files would be left unchanged.
make: *** [format-check] Error 1

```

Result

```
Required test coverage of 95% reached. Total coverage: 95.80%

3973 passed in 83.39s (0:01:23) 
```

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
