### PR TITLE
fix: Remove ENI manual deletion

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from pathlib import Path
 
 import boto3
@@ -61,29 +60,6 @@ def clean_all_integ_buckets():
             clean_bucket(bucket.name, s3_client)
 
 
-def _delete_unused_network_interface_by_subnet(ec2_client, subnet_id):
-    """Deletes unused network interface under the provided subnet"""
-    paginator = ec2_client.get_paginator("describe_network_interfaces")
-    response_iterator = paginator.paginate(
-        Filters=[
-            {"Name": "subnet-id", "Values": [subnet_id]},
-            {"Name": "status", "Values": ["available"]},
-        ]
-    )
-    network_interface_ids = []
-    for page in response_iterator:
-        network_interface_ids += [ni["NetworkInterfaceId"] for ni in page["NetworkInterfaces"]]
-
-    for ni_id in network_interface_ids:
-        try:
-            ec2_client.delete_network_interface(NetworkInterfaceId=ni_id)
-        except ClientError as e:
-            LOG.error("Unable to delete network interface %s", ni_id, exc_info=e)
-        time.sleep(0.5)
-
-    LOG.info("Deleted %s unused network interfaces under subnet %s", len(network_interface_ids), subnet_id)
-
-
 @pytest.fixture()
 def setup_companion_stack_once(tmpdir_factory, get_prefix):
     tests_integ_dir = Path(__file__).resolve().parents[1]
@@ -94,15 +70,6 @@ def setup_companion_stack_once(tmpdir_factory, get_prefix):
     stack_name = get_prefix + COMPANION_STACK_NAME
     companion_stack = Stack(stack_name, companion_stack_tempalte_path, cfn_client, output_dir)
     companion_stack.create_or_update(_stack_exists(stack_name))
-
-    ec2_client = ClientProvider().ec2_client
-    precreated_subnet_ids = [
-        resource["PhysicalResourceId"]
-        for resource in companion_stack.stack_resources["StackResourceSummaries"]
-        if resource["LogicalResourceId"].startswith("PreCreatedSubnet")
-    ]
-    for subnet_id in precreated_subnet_ids:
-        _delete_unused_network_interface_by_subnet(ec2_client, subnet_id)
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Issue #, if available
None

### Description of changes
Removes the code that deletes ENI. This was added because MQ was not deleting the ENIs which is not happening.

### Description of how you validated changes
`make pr`

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
