### PR TITLE
fix: change endpoint configuration for state machine integ test

### DIFF
--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -567,9 +567,9 @@ class BaseTest(TestCase):
             )
         return response
 
-    def verify_post_request(self, url: str, body_obj, expected_status_code: int):
+    def verify_post_request(self, url: str, body_obj, expected_status_code: int, headers=None):
         """Return response to POST request and verify matches expected status code."""
-        response = self.do_post_request(url, body_obj)
+        response = self.do_post_request_with_logging(url, body_obj, headers)
         if response.status_code != expected_status_code:
             raise StatusCodeError(
                 f"Request to {url} failed with status: {response.status_code}, expected status: {expected_status_code}"
@@ -650,12 +650,13 @@ class BaseTest(TestCase):
             )
         return response
 
-    def do_post_request(self, url: str, body_obj):
+    def do_post_request_with_logging(self, url: str, body_obj, headers=None):
         """Perform a POST request with dict body body_obj."""
-        response = requests.post(url, json=body_obj)
+        response = requests.post(url, json=body_obj, headers=headers) if headers else requests.post(url, json=body_obj)
+        amazon_headers = RequestUtils(response).get_amazon_headers()
         if self.internal:
             REQUEST_LOGGER.info(
                 "POST request made to " + url,
-                extra={"test": self.testcase, "status": response.status_code},
+                extra={"test": self.testcase, "status": response.status_code, "headers": amazon_headers},
             )
         return response

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -650,9 +650,9 @@ class BaseTest(TestCase):
             )
         return response
 
-    def do_post_request_with_logging(self, url: str, body_obj, headers=None):
+    def do_post_request_with_logging(self, url: str, body_obj, requestHeaders=None):
         """Perform a POST request with dict body body_obj."""
-        response = requests.post(url, json=body_obj, headers=headers) if headers else requests.post(url, json=body_obj)
+        response = requests.post(url, json=body_obj, headers=requestHeaders) if requestHeaders else requests.post(url, json=body_obj)
         amazon_headers = RequestUtils(response).get_amazon_headers()
         if self.internal:
             REQUEST_LOGGER.info(

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -652,7 +652,11 @@ class BaseTest(TestCase):
 
     def do_post_request_with_logging(self, url: str, body_obj, requestHeaders=None):
         """Perform a POST request with dict body body_obj."""
-        response = requests.post(url, json=body_obj, headers=requestHeaders) if requestHeaders else requests.post(url, json=body_obj)
+        response = (
+            requests.post(url, json=body_obj, headers=requestHeaders)
+            if requestHeaders
+            else requests.post(url, json=body_obj)
+        )
         amazon_headers = RequestUtils(response).get_amazon_headers()
         if self.internal:
             REQUEST_LOGGER.info(

--- a/integration/resources/templates/single/state_machine_with_api.yaml
+++ b/integration/resources/templates/single/state_machine_with_api.yaml
@@ -4,6 +4,8 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: Prod
+      EndpointConfiguration:
+        Type: REGIONAL
   HelloWorldFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/integration/single/test_basic_api.py
+++ b/integration/single/test_basic_api.py
@@ -18,106 +18,110 @@ class TestBasicApi(BaseTest):
     Basic AWS::Serverless::Api tests
     """
 
-    def test_basic_api(self):
-        """
-        Creates an API and updates its DefinitionUri
-        """
-        self.create_and_verify_stack("single/basic_api")
-
-        first_dep_ids = self.get_stack_deployment_ids()
-        self.assertEqual(len(first_dep_ids), 1)
-
-        self.set_template_resource_property("MyApi", "DefinitionUri", self.get_s3_uri("swagger2.json"))
-        self.update_stack()
-
-        second_dep_ids = self.get_stack_deployment_ids()
-        self.assertEqual(len(second_dep_ids), 1)
-
-        self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
-
-    @skipIf(current_region_does_not_support([MODE]), "Mode is not supported in this testing region")
-    def test_basic_api_with_mode(self):
-        """
-        Creates an API and updates its DefinitionUri
-        """
-        # Create an API with get and put
-        self.create_and_verify_stack("single/basic_api_with_mode")
-
-        stack_output = self.get_stack_outputs()
-        api_endpoint = stack_output.get("ApiEndpoint")
-
-        self.verify_get_request_response(f"{api_endpoint}/get", 200)
-
-        # Removes get from the API
-        self.update_and_verify_stack(file_path="single/basic_api_with_mode_update")
-
-        # API Gateway by default returns 403 if a path do not exist
-        self.verify_get_request_response.retry_with(
-            stop=stop_after_attempt(20),
-            wait=wait_exponential(multiplier=1, min=4, max=10) + wait_random(0, 1),
-            retry=retry_if_exception_type(StatusCodeError),
-            after=after_log(LOG, logging.WARNING),
-            reraise=True,
-        )(self, f"{api_endpoint}/get", 403)
-
-        LOG.log(msg=f"retry times {self.verify_get_request_response.retry.statistics}", level=logging.WARNING)
-
-    def test_basic_api_inline_openapi(self):
-        """
-        Creates an API with and inline OpenAPI and updates its DefinitionBody basePath
-        """
-        self.create_and_verify_stack("single/basic_api_inline_openapi")
-
-        first_dep_ids = self.get_stack_deployment_ids()
-        self.assertEqual(len(first_dep_ids), 1)
-
-        body = self.get_template_resource_property("MyApi", "DefinitionBody")
-        body["basePath"] = "/newDemo"
-        self.set_template_resource_property("MyApi", "DefinitionBody", body)
-        self.update_stack()
-
-        second_dep_ids = self.get_stack_deployment_ids()
-        self.assertEqual(len(second_dep_ids), 1)
-
-        self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
-
-    def test_basic_api_inline_swagger(self):
-        """
-        Creates an API with an inline Swagger and updates its DefinitionBody basePath
-        """
-        self.create_and_verify_stack("single/basic_api_inline_swagger")
-
-        first_dep_ids = self.get_stack_deployment_ids()
-        self.assertEqual(len(first_dep_ids), 1)
-
-        body = self.get_template_resource_property("MyApi", "DefinitionBody")
-        body["basePath"] = "/newDemo"
-        self.set_template_resource_property("MyApi", "DefinitionBody", body)
-        self.update_stack()
-
-        second_dep_ids = self.get_stack_deployment_ids()
-        self.assertEqual(len(second_dep_ids), 1)
-
-        self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
-
-    def test_basic_api_with_tags(self):
-        """
-        Creates an API with tags
-        """
-        self.create_and_verify_stack("single/basic_api_with_tags")
-
-        stages = self.get_api_stack_stages()
-        self.assertEqual(len(stages), 2)
-
-        stage = next(s for s in stages if s["stageName"] == "my-new-stage-name")
-        self.assertIsNotNone(stage)
-        self.assertEqual(stage["tags"]["TagKey1"], "TagValue1")
-        self.assertEqual(stage["tags"]["TagKey2"], "")
+    # def test_basic_api(self):
+    #     """
+    #     Creates an API and updates its DefinitionUri
+    #     """
+    #     self.create_and_verify_stack("single/basic_api")
+    #
+    #     first_dep_ids = self.get_stack_deployment_ids()
+    #     self.assertEqual(len(first_dep_ids), 1)
+    #
+    #     self.set_template_resource_property("MyApi", "DefinitionUri", self.get_s3_uri("swagger2.json"))
+    #     self.update_stack()
+    #
+    #     second_dep_ids = self.get_stack_deployment_ids()
+    #     self.assertEqual(len(second_dep_ids), 1)
+    #
+    #     self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
+    #
+    # @skipIf(current_region_does_not_support([MODE]), "Mode is not supported in this testing region")
+    # def test_basic_api_with_mode(self):
+    #     """
+    #     Creates an API and updates its DefinitionUri
+    #     """
+    #     # Create an API with get and put
+    #     self.create_and_verify_stack("single/basic_api_with_mode")
+    #
+    #     stack_output = self.get_stack_outputs()
+    #     api_endpoint = stack_output.get("ApiEndpoint")
+    #
+    #     self.verify_get_request_response(f"{api_endpoint}/get", 200)
+    #
+    #     # Removes get from the API
+    #     self.update_and_verify_stack(file_path="single/basic_api_with_mode_update")
+    #
+    #     # API Gateway by default returns 403 if a path do not exist
+    #     self.verify_get_request_response.retry_with(
+    #         stop=stop_after_attempt(20),
+    #         wait=wait_exponential(multiplier=1, min=4, max=10) + wait_random(0, 1),
+    #         retry=retry_if_exception_type(StatusCodeError),
+    #         after=after_log(LOG, logging.WARNING),
+    #         reraise=True,
+    #     )(self, f"{api_endpoint}/get", 403)
+    #
+    #     LOG.log(msg=f"retry times {self.verify_get_request_response.retry.statistics}", level=logging.WARNING)
+    #
+    # def test_basic_api_inline_openapi(self):
+    #     """
+    #     Creates an API with and inline OpenAPI and updates its DefinitionBody basePath
+    #     """
+    #     self.create_and_verify_stack("single/basic_api_inline_openapi")
+    #
+    #     first_dep_ids = self.get_stack_deployment_ids()
+    #     self.assertEqual(len(first_dep_ids), 1)
+    #
+    #     body = self.get_template_resource_property("MyApi", "DefinitionBody")
+    #     body["basePath"] = "/newDemo"
+    #     self.set_template_resource_property("MyApi", "DefinitionBody", body)
+    #     self.update_stack()
+    #
+    #     second_dep_ids = self.get_stack_deployment_ids()
+    #     self.assertEqual(len(second_dep_ids), 1)
+    #
+    #     self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
+    #
+    # def test_basic_api_inline_swagger(self):
+    #     """
+    #     Creates an API with an inline Swagger and updates its DefinitionBody basePath
+    #     """
+    #     self.create_and_verify_stack("single/basic_api_inline_swagger")
+    #
+    #     first_dep_ids = self.get_stack_deployment_ids()
+    #     self.assertEqual(len(first_dep_ids), 1)
+    #
+    #     body = self.get_template_resource_property("MyApi", "DefinitionBody")
+    #     body["basePath"] = "/newDemo"
+    #     self.set_template_resource_property("MyApi", "DefinitionBody", body)
+    #     self.update_stack()
+    #
+    #     second_dep_ids = self.get_stack_deployment_ids()
+    #     self.assertEqual(len(second_dep_ids), 1)
+    #
+    #     self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
+    #
+    # def test_basic_api_with_tags(self):
+    #     """
+    #     Creates an API with tags
+    #     """
+    #     self.create_and_verify_stack("single/basic_api_with_tags")
+    #
+    #     stages = self.get_api_stack_stages()
+    #     self.assertEqual(len(stages), 2)
+    #
+    #     stage = next(s for s in stages if s["stageName"] == "my-new-stage-name")
+    #     self.assertIsNotNone(stage)
+    #     self.assertEqual(stage["tags"]["TagKey1"], "TagValue1")
+    #     self.assertEqual(stage["tags"]["TagKey2"], "")
 
     def test_state_machine_with_api_single_quotes_input(self):
         """
         Pass single quotes in input JSON to a StateMachine
         See https://github.com/aws/serverless-application-model/issues/1895
+
+        This test is known to sometimes be flaky, but we want to avoid marking it as non-blocking as this is a basic api test.
+        Instead, we chose to mitigate the test failures we set the Endpoint on API in the deployed template to REGIONAL and added logging to the api request
+        If this test continues to fail it should be marked as non-blocking
         """
         self.create_and_verify_stack("single/state_machine_with_api")
 

--- a/integration/single/test_basic_api.py
+++ b/integration/single/test_basic_api.py
@@ -120,7 +120,7 @@ class TestBasicApi(BaseTest):
         See https://github.com/aws/serverless-application-model/issues/1895
 
         This test is known to sometimes be flaky, but we want to avoid marking it as non-blocking as this is a basic api test.
-        Instead, we chose to mitigate the test failures we set the Endpoint on API in the deployed template to REGIONAL and added logging to the api request
+        Instead, we set the EndpointConfiguration to REGIONAL and added logging to the api request
         If this test continues to fail it should be marked as non-blocking
         """
         self.create_and_verify_stack("single/state_machine_with_api")

--- a/integration/single/test_basic_api.py
+++ b/integration/single/test_basic_api.py
@@ -18,101 +18,101 @@ class TestBasicApi(BaseTest):
     Basic AWS::Serverless::Api tests
     """
 
-    # def test_basic_api(self):
-    #     """
-    #     Creates an API and updates its DefinitionUri
-    #     """
-    #     self.create_and_verify_stack("single/basic_api")
-    #
-    #     first_dep_ids = self.get_stack_deployment_ids()
-    #     self.assertEqual(len(first_dep_ids), 1)
-    #
-    #     self.set_template_resource_property("MyApi", "DefinitionUri", self.get_s3_uri("swagger2.json"))
-    #     self.update_stack()
-    #
-    #     second_dep_ids = self.get_stack_deployment_ids()
-    #     self.assertEqual(len(second_dep_ids), 1)
-    #
-    #     self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
-    #
-    # @skipIf(current_region_does_not_support([MODE]), "Mode is not supported in this testing region")
-    # def test_basic_api_with_mode(self):
-    #     """
-    #     Creates an API and updates its DefinitionUri
-    #     """
-    #     # Create an API with get and put
-    #     self.create_and_verify_stack("single/basic_api_with_mode")
-    #
-    #     stack_output = self.get_stack_outputs()
-    #     api_endpoint = stack_output.get("ApiEndpoint")
-    #
-    #     self.verify_get_request_response(f"{api_endpoint}/get", 200)
-    #
-    #     # Removes get from the API
-    #     self.update_and_verify_stack(file_path="single/basic_api_with_mode_update")
-    #
-    #     # API Gateway by default returns 403 if a path do not exist
-    #     self.verify_get_request_response.retry_with(
-    #         stop=stop_after_attempt(20),
-    #         wait=wait_exponential(multiplier=1, min=4, max=10) + wait_random(0, 1),
-    #         retry=retry_if_exception_type(StatusCodeError),
-    #         after=after_log(LOG, logging.WARNING),
-    #         reraise=True,
-    #     )(self, f"{api_endpoint}/get", 403)
-    #
-    #     LOG.log(msg=f"retry times {self.verify_get_request_response.retry.statistics}", level=logging.WARNING)
-    #
-    # def test_basic_api_inline_openapi(self):
-    #     """
-    #     Creates an API with and inline OpenAPI and updates its DefinitionBody basePath
-    #     """
-    #     self.create_and_verify_stack("single/basic_api_inline_openapi")
-    #
-    #     first_dep_ids = self.get_stack_deployment_ids()
-    #     self.assertEqual(len(first_dep_ids), 1)
-    #
-    #     body = self.get_template_resource_property("MyApi", "DefinitionBody")
-    #     body["basePath"] = "/newDemo"
-    #     self.set_template_resource_property("MyApi", "DefinitionBody", body)
-    #     self.update_stack()
-    #
-    #     second_dep_ids = self.get_stack_deployment_ids()
-    #     self.assertEqual(len(second_dep_ids), 1)
-    #
-    #     self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
-    #
-    # def test_basic_api_inline_swagger(self):
-    #     """
-    #     Creates an API with an inline Swagger and updates its DefinitionBody basePath
-    #     """
-    #     self.create_and_verify_stack("single/basic_api_inline_swagger")
-    #
-    #     first_dep_ids = self.get_stack_deployment_ids()
-    #     self.assertEqual(len(first_dep_ids), 1)
-    #
-    #     body = self.get_template_resource_property("MyApi", "DefinitionBody")
-    #     body["basePath"] = "/newDemo"
-    #     self.set_template_resource_property("MyApi", "DefinitionBody", body)
-    #     self.update_stack()
-    #
-    #     second_dep_ids = self.get_stack_deployment_ids()
-    #     self.assertEqual(len(second_dep_ids), 1)
-    #
-    #     self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
-    #
-    # def test_basic_api_with_tags(self):
-    #     """
-    #     Creates an API with tags
-    #     """
-    #     self.create_and_verify_stack("single/basic_api_with_tags")
-    #
-    #     stages = self.get_api_stack_stages()
-    #     self.assertEqual(len(stages), 2)
-    #
-    #     stage = next(s for s in stages if s["stageName"] == "my-new-stage-name")
-    #     self.assertIsNotNone(stage)
-    #     self.assertEqual(stage["tags"]["TagKey1"], "TagValue1")
-    #     self.assertEqual(stage["tags"]["TagKey2"], "")
+    def test_basic_api(self):
+        """
+        Creates an API and updates its DefinitionUri
+        """
+        self.create_and_verify_stack("single/basic_api")
+
+        first_dep_ids = self.get_stack_deployment_ids()
+        self.assertEqual(len(first_dep_ids), 1)
+
+        self.set_template_resource_property("MyApi", "DefinitionUri", self.get_s3_uri("swagger2.json"))
+        self.update_stack()
+
+        second_dep_ids = self.get_stack_deployment_ids()
+        self.assertEqual(len(second_dep_ids), 1)
+
+        self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
+
+    @skipIf(current_region_does_not_support([MODE]), "Mode is not supported in this testing region")
+    def test_basic_api_with_mode(self):
+        """
+        Creates an API and updates its DefinitionUri
+        """
+        # Create an API with get and put
+        self.create_and_verify_stack("single/basic_api_with_mode")
+
+        stack_output = self.get_stack_outputs()
+        api_endpoint = stack_output.get("ApiEndpoint")
+
+        self.verify_get_request_response(f"{api_endpoint}/get", 200)
+
+        # Removes get from the API
+        self.update_and_verify_stack(file_path="single/basic_api_with_mode_update")
+
+        # API Gateway by default returns 403 if a path do not exist
+        self.verify_get_request_response.retry_with(
+            stop=stop_after_attempt(20),
+            wait=wait_exponential(multiplier=1, min=4, max=10) + wait_random(0, 1),
+            retry=retry_if_exception_type(StatusCodeError),
+            after=after_log(LOG, logging.WARNING),
+            reraise=True,
+        )(self, f"{api_endpoint}/get", 403)
+
+        LOG.log(msg=f"retry times {self.verify_get_request_response.retry.statistics}", level=logging.WARNING)
+
+    def test_basic_api_inline_openapi(self):
+        """
+        Creates an API with and inline OpenAPI and updates its DefinitionBody basePath
+        """
+        self.create_and_verify_stack("single/basic_api_inline_openapi")
+
+        first_dep_ids = self.get_stack_deployment_ids()
+        self.assertEqual(len(first_dep_ids), 1)
+
+        body = self.get_template_resource_property("MyApi", "DefinitionBody")
+        body["basePath"] = "/newDemo"
+        self.set_template_resource_property("MyApi", "DefinitionBody", body)
+        self.update_stack()
+
+        second_dep_ids = self.get_stack_deployment_ids()
+        self.assertEqual(len(second_dep_ids), 1)
+
+        self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
+
+    def test_basic_api_inline_swagger(self):
+        """
+        Creates an API with an inline Swagger and updates its DefinitionBody basePath
+        """
+        self.create_and_verify_stack("single/basic_api_inline_swagger")
+
+        first_dep_ids = self.get_stack_deployment_ids()
+        self.assertEqual(len(first_dep_ids), 1)
+
+        body = self.get_template_resource_property("MyApi", "DefinitionBody")
+        body["basePath"] = "/newDemo"
+        self.set_template_resource_property("MyApi", "DefinitionBody", body)
+        self.update_stack()
+
+        second_dep_ids = self.get_stack_deployment_ids()
+        self.assertEqual(len(second_dep_ids), 1)
+
+        self.assertEqual(len(set(first_dep_ids).intersection(second_dep_ids)), 0)
+
+    def test_basic_api_with_tags(self):
+        """
+        Creates an API with tags
+        """
+        self.create_and_verify_stack("single/basic_api_with_tags")
+
+        stages = self.get_api_stack_stages()
+        self.assertEqual(len(stages), 2)
+
+        stage = next(s for s in stages if s["stageName"] == "my-new-stage-name")
+        self.assertIsNotNone(stage)
+        self.assertEqual(stage["tags"]["TagKey1"], "TagValue1")
+        self.assertEqual(stage["tags"]["TagKey2"], "")
 
     def test_state_machine_with_api_single_quotes_input(self):
         """


### PR DESCRIPTION
### Issue #, if available

N/A

### Description of changes

We've seen this test fail in a couple of regions with the error `Request to ... failed with status: 403, expected status: 200`. This is also a known flaky test which we've seen fail before and succeed after a simple retry.

After investigation we concluded that the error is likely because the endpoint configuration is automatically set to EDGE which routes requests to a CloudFront Point of Presence. We suspect the test is calling the endpoint right after the stack is deployed but before the routing can take place. To mitigate this we set the endpoint configuration to REGIONAL for now.

### Description of how you validated changes

Ran the test locally, it deployed and everything passed as before.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
