### PR TITLE
fix: prevent redundant tags being added to AWS::ApiGatewayV2::Api

### DIFF
--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -25,7 +25,6 @@ class ApiGatewayV2HttpApi(Resource):
     }
 
     runtime_attrs = {"http_api_id": lambda self: ref(self.logical_id)}
-    Tags: Optional[PassThrough]
 
     def assign_tags(self, tags: Dict[str, Any]) -> None:
         """Overriding default 'assign_tags' function in Resource class
@@ -34,8 +33,8 @@ class ApiGatewayV2HttpApi(Resource):
         :param tags: Tags to be assigned to the resource
 
         """
-        if tags is not None and "Tags" in self.property_types and "Body" not in self.property_types:
-            self.Tags = tags
+        # Tags are already defined in Body so they do not need to be assigned here
+        return
 
 
 class ApiGatewayV2Stage(Resource):

--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -34,7 +34,7 @@ class ApiGatewayV2HttpApi(Resource):
         :param tags: Tags to be assigned to the resource
 
         """
-        if tags is not None and "Tags" in self.property_types:
+        if tags is not None and "Tags" in self.property_types and "Body" not in self.property_types:
             self.Tags = tags
 
 

--- a/tests/translator/input/http_api_openapi_with_propagate_tags.yaml
+++ b/tests/translator/input/http_api_openapi_with_propagate_tags.yaml
@@ -1,0 +1,33 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyHttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      DefinitionBody:
+        openapi: 3.0.1
+        info:
+          title: My API
+          version: 1.0.0
+        paths:
+          /:
+            get:
+              x-amazon-apigateway-integration:
+                type: aws_proxy
+                httpMethod: POST
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaFunction.Arn}/invocations
+              responses:
+                '200':
+                  description: OK
+      PropagateTags: true
+      Tags:
+        Project: MyProject
+
+
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: hello.handler
+      Runtime: python3.10
+      CodeUri: s3://my-bucket/my-code.zip

--- a/tests/translator/output/aws-cn/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/aws-cn/function_with_events_and_propagate_tags.json
@@ -564,11 +564,6 @@
               "x-amazon-apigateway-tag-value": "SAM"
             }
           ]
-        },
-        "Tags": {
-          "Key1": "Value1",
-          "Key2": "Value2",
-          "httpapi:createdBy": "SAM"
         }
       },
       "Type": "AWS::ApiGatewayV2::Api"

--- a/tests/translator/output/aws-cn/http_api_openapi_with_propagate_tags.json
+++ b/tests/translator/output/aws-cn/http_api_openapi_with_propagate_tags.json
@@ -1,0 +1,112 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyHttpApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": "My API",
+            "version": "1.0.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {
+            "/": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "tags": [
+            {
+              "name": "Project",
+              "x-amazon-apigateway-tag-value": "MyProject"
+            },
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Api"
+    },
+    "MyHttpApiApiGatewayDefaultStage": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "MyHttpApi"
+        },
+        "AutoDeploy": true,
+        "StageName": "$default",
+        "Tags": {
+          "Project": "MyProject",
+          "httpapi:createdBy": "SAM"
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Stage"
+    },
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "my-bucket",
+          "S3Key": "my-code.zip"
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.10",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/httpapi_with_propagate_tags.json
+++ b/tests/translator/output/aws-cn/httpapi_with_propagate_tags.json
@@ -48,12 +48,7 @@
             ]
           }
         },
-        "FailOnWarnings": true,
-        "Tags": {
-          "TagKey1": "Value1",
-          "TagKey2": "Value2",
-          "httpapi:createdBy": "SAM"
-        }
+        "FailOnWarnings": true
       },
       "Type": "AWS::ApiGatewayV2::Api"
     },

--- a/tests/translator/output/aws-us-gov/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/aws-us-gov/function_with_events_and_propagate_tags.json
@@ -564,11 +564,6 @@
               "x-amazon-apigateway-tag-value": "SAM"
             }
           ]
-        },
-        "Tags": {
-          "Key1": "Value1",
-          "Key2": "Value2",
-          "httpapi:createdBy": "SAM"
         }
       },
       "Type": "AWS::ApiGatewayV2::Api"

--- a/tests/translator/output/aws-us-gov/http_api_openapi_with_propagate_tags.json
+++ b/tests/translator/output/aws-us-gov/http_api_openapi_with_propagate_tags.json
@@ -1,0 +1,112 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyHttpApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": "My API",
+            "version": "1.0.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {
+            "/": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "tags": [
+            {
+              "name": "Project",
+              "x-amazon-apigateway-tag-value": "MyProject"
+            },
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Api"
+    },
+    "MyHttpApiApiGatewayDefaultStage": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "MyHttpApi"
+        },
+        "AutoDeploy": true,
+        "StageName": "$default",
+        "Tags": {
+          "Project": "MyProject",
+          "httpapi:createdBy": "SAM"
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Stage"
+    },
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "my-bucket",
+          "S3Key": "my-code.zip"
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.10",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/httpapi_with_propagate_tags.json
+++ b/tests/translator/output/aws-us-gov/httpapi_with_propagate_tags.json
@@ -48,12 +48,7 @@
             ]
           }
         },
-        "FailOnWarnings": true,
-        "Tags": {
-          "TagKey1": "Value1",
-          "TagKey2": "Value2",
-          "httpapi:createdBy": "SAM"
-        }
+        "FailOnWarnings": true
       },
       "Type": "AWS::ApiGatewayV2::Api"
     },

--- a/tests/translator/output/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/function_with_events_and_propagate_tags.json
@@ -564,11 +564,6 @@
               "x-amazon-apigateway-tag-value": "SAM"
             }
           ]
-        },
-        "Tags": {
-          "Key1": "Value1",
-          "Key2": "Value2",
-          "httpapi:createdBy": "SAM"
         }
       },
       "Type": "AWS::ApiGatewayV2::Api"

--- a/tests/translator/output/http_api_openapi_with_propagate_tags.json
+++ b/tests/translator/output/http_api_openapi_with_propagate_tags.json
@@ -1,0 +1,112 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyHttpApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": "My API",
+            "version": "1.0.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {
+            "/": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaFunction.Arn}/invocations"
+                  }
+                }
+              }
+            }
+          },
+          "tags": [
+            {
+              "name": "Project",
+              "x-amazon-apigateway-tag-value": "MyProject"
+            },
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Api"
+    },
+    "MyHttpApiApiGatewayDefaultStage": {
+      "Properties": {
+        "ApiId": {
+          "Ref": "MyHttpApi"
+        },
+        "AutoDeploy": true,
+        "StageName": "$default",
+        "Tags": {
+          "Project": "MyProject",
+          "httpapi:createdBy": "SAM"
+        }
+      },
+      "Type": "AWS::ApiGatewayV2::Stage"
+    },
+    "MyLambdaFunction": {
+      "Properties": {
+        "Code": {
+          "S3Bucket": "my-bucket",
+          "S3Key": "my-code.zip"
+        },
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "MyLambdaFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.10",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "MyLambdaFunctionRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}

--- a/tests/translator/output/httpapi_with_propagate_tags.json
+++ b/tests/translator/output/httpapi_with_propagate_tags.json
@@ -48,12 +48,7 @@
             ]
           }
         },
-        "FailOnWarnings": true,
-        "Tags": {
-          "TagKey1": "Value1",
-          "TagKey2": "Value2",
-          "httpapi:createdBy": "SAM"
-        }
+        "FailOnWarnings": true
       },
       "Type": "AWS::ApiGatewayV2::Api"
     },


### PR DESCRIPTION
### Issue #, if available

Currently if a user sets `PropagateTags` to True in the "AWS::Serverless::HttpApi" resource and specifies the DefinitionBody property with an OpenApi definition, they will encounter the following deploy-time error:
```
Redundant fields [tags={"TagKey":"TagValue","httpapi:createdBy":"SAM"}] provided when either Body or BodyS3Location is not empty
```

CloudFormation does not allow both the `Tags` property being set and [x-amazon-apigateway-tag-value](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-openapi-extensions-x-amazon-apigateway-tag-value.html) being set in the `Body` property.

### Description of changes
Update `assign_tags()` method for `ApiGatewayV2HttpApi` class to return (no-op). 

For context, `Tags` can only be defined when `DefinitionBody` is specified or else we raise an [error](https://github.com/aws/serverless-application-model/blob/develop/samtranslator/model/api/http_api_generator.py#L499). Also, `DefinitionBody` (OpenApi definition) will always be defined because we have a [plugin](https://github.com/aws/serverless-application-model/blob/develop/samtranslator/plugins/api/default_definition_body_plugin.py#L37) that generates a skeleton OpenApi definition before the transform if the user does not define one. Additionally `Tags` always gets [added](https://github.com/aws/serverless-application-model/blob/develop/samtranslator/model/api/http_api_generator.py#L522) to the `DefinitionBody` (see [x-amazon-apigateway-tag-value property](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-openapi-extensions-x-amazon-apigateway-tag-value.html)). 

For AWS::ApiGatewayV2::Api resource, CloudFormation does not allow `Tags` to be defined if the `Body` property is specified. SAM ensures `Body` will always be defined. Therefore no need to add `Tags` property (doing so will only cause the error specified above).

### Description of how you validated changes
Added transform tests and updated existing transform tests which would fail on deployment currently. Ran `make test` and all tests pass.

Also reproduced error and deploying the updated template succeeds without errors

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
