### PR TITLE
Revert "fix: AttributeError: module 'pydantic.v1' has no attribute 'error_wrapper'"

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -350,10 +350,6 @@ class Resource(ABC):
             with suppress(KeyError):
                 error_properties = ".".join(str(x) for x in e.errors()[0]["loc"])
             raise InvalidResourceException(self.logical_id, f"Property '{error_properties}' is invalid.") from e
-        except AttributeError as e:
-            raise InvalidResourceException(
-                self.logical_id, "Module 'pydantic.v1' has no attribute 'error_wrappers'"
-            ) from e
 
     def validate_properties(self) -> None:
         """Validates that the required properties for this Resource have been populated, and that all properties have


### PR DESCRIPTION
Reverts aws/serverless-application-model#3611 since the pydantic issue persists with this PR.