### PR TITLE
fix: exclude breaking pydantic version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,4 +3,5 @@ jsonschema<5,>=3.2  # TODO: evaluate risk of removing jsonschema 3.x support
 typing_extensions>=4.4 # 3.8 doesn't have Required, TypeGuard and ParamSpec
 
 # resource validation & schema generation
-pydantic>=1.8,<3
+# 1.10.15 and 1.10.17 included breaking change from pydantic, more info: https://github.com/aws/serverless-application-model/issues/3617
+pydantic>=1.8,<3,!=1.10.15,!=1.10.17


### PR DESCRIPTION
### Issue #, if available
#3617

### Description of changes

Pydantic versions 1.10.15 and 1.10.17 introduced breaking changes. Exclude those versions from being installed.

### Description of how you validated changes

Ran `make init` with `pydantic>=1.8,!=1.10.15,!=1.10.17,<2` (to insure pydantic V1 got installed). `pydantic 1.10.16` was installed

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
