### PR TITLE
Add the property UseAliasAsEventTarget to AWS::Serverless::StateMachine and make associated events use the state machine alias as a target.

### DIFF
--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -59,10 +59,10 @@ We format our code using [Black](https://github.com/python/black) and verify the
 during PR checks. Black will be installed automatically with `make init`.
 
 After installing, you can run our formatting through our Makefile by `make format` or integrating Black directly in your favorite IDE (instructions
-can be found [here](https://black.readthedocs.io/en/stable/editor_integration.html))
+can be found [here](https://black.readthedocs.io/en/stable/integrations/editors.html))
  
 ##### (Workaround) Integrating Black directly in your favorite IDE
-Since black is installed in virtualenv, when you follow [this instruction](https://black.readthedocs.io/en/stable/editor_integration.html), `which black` might give you this
+Since black is installed in virtualenv, when you follow [this instruction](https://black.readthedocs.io/en/stable/integrations/editors.html), `which black` might give you this
 
 ```bash
 (sam38) $ where black

--- a/samtranslator/internal/schema_source/aws_serverless_statemachine.py
+++ b/samtranslator/internal/schema_source/aws_serverless_statemachine.py
@@ -174,6 +174,7 @@ class Properties(BaseModel):
     Type: Optional[PassThroughProp] = properties("Type")
     AutoPublishAlias: Optional[PassThroughProp]
     DeploymentPreference: Optional[PassThroughProp]
+    UseAliasAsEventTarget: Optional[bool]
 
 
 class Resource(ResourceAttributes):

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1778,6 +1778,7 @@ class SamStateMachine(SamResourceMacro):
         "PermissionsBoundary": PropertyType(False, IS_STR),
         "AutoPublishAlias": PassThroughProperty(False),
         "DeploymentPreference": MutatedPassThroughProperty(False),
+        "UseAliasAsEventTarget": Property(False, IS_BOOL),
     }
 
     Definition: Optional[Dict[str, Any]]
@@ -1796,6 +1797,7 @@ class SamStateMachine(SamResourceMacro):
     PermissionsBoundary: Optional[Intrinsicable[str]]
     AutoPublishAlias: Optional[PassThrough]
     DeploymentPreference: Optional[PassThrough]
+    UseAliasAsEventTarget: Optional[bool]
 
     event_resolver = ResourceTypeResolver(
         samtranslator.model.stepfunctions.events,
@@ -1834,6 +1836,7 @@ class SamStateMachine(SamResourceMacro):
             get_managed_policy_map=get_managed_policy_map,
             auto_publish_alias=self.AutoPublishAlias,
             deployment_preference=self.DeploymentPreference,
+            use_alias_as_event_target=self.UseAliasAsEventTarget,
         )
 
         generated_resources = state_machine_generator.to_cloudformation()

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -8020,6 +8020,10 @@
           ],
           "markdownDescription": "The type of the state machine\\.  \n*Valid values*: `STANDARD` or `EXPRESS`  \n*Type*: String  \n*Required*: No  \n*Default*: `STANDARD`  \n*AWS CloudFormation compatibility*: This property is passed directly to the [`StateMachineType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-statemachinetype) property of an `AWS::StepFunctions::StateMachine` resource\\.",
           "title": "Type"
+        },
+        "UseAliasAsEventTarget": {
+          "title": "Usealiasaseventtarget",
+          "type": "boolean"
         }
       },
       "title": "Properties",


### PR DESCRIPTION
### Issue #3624, if available

### Description of changes
This change add a property `UseAliasAsEventTarget` to `AWS::Serverless::StateMachine` and make associated events use the state machine alias as a target.

### Description of how you validated changes

Used the following template as input:
```yaml
Transform:
  - AWS::LanguageExtensions
  - AWS::Serverless-2016-10-31
Resources:
  ExampleFunction:
    Type: AWS::Serverless::Function
    Properties:
      AutoPublishAlias: live
      Runtime: provided.al2023
      Handler: bootstrap
      CodeUri: s3://aws-sam-cli-managed-default-samclisourcebucket-example/example-fn
      Events:
        LambdaExample:
          Type: EventBridgeRule
          Properties:
            Pattern:
              source: [ aws.tag ]
  ExampleMachine:
    Type: AWS::Serverless::StateMachine
    Properties:
      AutoPublishAlias: live
      UseAliasAsEventTarget: true
      Events:
        MachineExample:
          Type: EventBridgeRule
          Properties:
            Pattern:
              source: [aws.tag]
      DefinitionUri:
        Bucket: aws-sam-cli-managed-default-samclisourcebucket-example
        Key: example-asl
```

With the folowing variations:
- Without the property `UseAliasAsEventTarget` --> same output as before this change.
- With the property `UseAliasAsEventTarget` set to `false` --> same output as before this change.
- With the property `UseAliasAsEventTarget` set to `true` --> output template is new ussing the alias as the event target and also used in the generated permission for the action `states:StartExecution`.


### Checklist

- [X] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [X] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [X] Using correct values
    - [X] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
