### PR TITLE
fix: add retry for statemachine integ test

### DIFF
--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -567,6 +567,13 @@ class BaseTest(TestCase):
             )
         return response
 
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_exponential(multiplier=1, min=16, max=64) + wait_random(0, 1),
+        retry=retry_if_exception_type(StatusCodeError),
+        after=after_log(LOG, logging.WARNING),
+        reraise=True,
+    )
     def verify_post_request(self, url: str, body_obj, expected_status_code: int, headers=None):
         """Return response to POST request and verify matches expected status code."""
         response = self.do_post_request_with_logging(url, body_obj, headers)

--- a/integration/single/test_basic_api.py
+++ b/integration/single/test_basic_api.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from unittest.case import skipIf
 
 from tenacity import after_log, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_random
@@ -129,7 +130,13 @@ class TestBasicApi(BaseTest):
         api_endpoint = stack_output.get("ApiEndpoint")
 
         input_json = {"f'oo": {"hello": "'wor'l'd'''"}}
+
+        # This will be the wait time before triggering the APIGW request
+        time.sleep(10)
+
         response = self.verify_post_request(api_endpoint, input_json, 200)
+
+        LOG.log(msg=f"retry times {self.verify_get_request_response.retry.statistics}", level=logging.WARNING)
 
         execution_arn = response.json()["executionArn"]
         execution = self.client_provider.sfn_client.describe_execution(executionArn=execution_arn)


### PR DESCRIPTION
### Issue #, if available
N/A

### Description of changes
`test_state_machine_with_api_single_quotes_input` integ test is failing sometimes with status code 403 from APIGW. This test seems flaky test. However, We are adding retry mechanism to this test which can make this test pass.

Error:
```
Request to .... failed with status: 403, expected status: 200
```

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
