### PR TITLE
chore: Update Runtime to Python3.11

### DIFF
--- a/integration/resources/templates/combination/all_policy_templates.yaml
+++ b/integration/resources/templates/combination/all_policy_templates.yaml
@@ -8,7 +8,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       Policies:
 
       - SQSPollerPolicy:
@@ -123,7 +123,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       Policies:
 
       - SESEmailTemplateCrudPolicy: {}
@@ -187,7 +187,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       Policies:
       - ElasticMapReduceModifyInstanceFleetPolicy:
           ClusterId: name

--- a/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
@@ -12,7 +12,7 @@ Resources:
       InlineCode: |
         print("hello")
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       Events:
         API3:
           Type: Api

--- a/integration/resources/templates/combination/connector_function_to_location_place_index.yaml
+++ b/integration/resources/templates/combination/connector_function_to_location_place_index.yaml
@@ -9,7 +9,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: index.handler
       InlineCode: |
         import boto3

--- a/integration/resources/templates/combination/depends_on.yaml
+++ b/integration/resources/templates/combination/depends_on.yaml
@@ -12,7 +12,7 @@ Resources:
       Role:
         Fn::GetAtt: LambdaRole.Arn
       Handler: lambda_function.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.11
       Timeout: 15
       CodeUri: ${codeuri}
 

--- a/integration/resources/templates/combination/function_with_custom_code_deploy.yaml
+++ b/integration/resources/templates/combination/function_with_custom_code_deploy.yaml
@@ -10,7 +10,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
 
       AutoPublishAlias: Live
 

--- a/integration/resources/templates/combination/function_with_deployment_basic.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_basic.yaml
@@ -5,7 +5,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
 
       AutoPublishAlias: Live
 

--- a/integration/resources/templates/combination/function_with_deployment_default_role_managed_policy.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_default_role_managed_policy.yaml
@@ -4,7 +4,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       AutoPublishAlias: Live
       DeploymentPreference:
         Type: Canary10Percent5Minutes

--- a/integration/resources/templates/combination/function_with_deployment_globals.yaml
+++ b/integration/resources/templates/combination/function_with_deployment_globals.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       AutoPublishAlias: Live
 
   DeploymentRole:

--- a/integration/resources/templates/combination/function_with_http_api.yaml
+++ b/integration/resources/templates/combination/function_with_http_api.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       InlineCode: |
         def handler(event, context):
             return {'body': 'Hello World!', 'statusCode': 200}

--- a/integration/resources/templates/combination/function_with_http_api_default_path.yaml
+++ b/integration/resources/templates/combination/function_with_http_api_default_path.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       InlineCode: |
         def handler(event, context):
             return {'body': 'Hello World!', 'statusCode': 200}

--- a/integration/resources/templates/combination/function_with_implicit_http_api.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_http_api.yaml
@@ -4,7 +4,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       InlineCode: |
         def handler(event, context):
             return {'body': 'Hello World!', 'statusCode': 200}

--- a/integration/resources/templates/combination/function_with_policy_templates.yaml
+++ b/integration/resources/templates/combination/function_with_policy_templates.yaml
@@ -14,7 +14,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       Policies:
       - SQSPollerPolicy:
           QueueName:

--- a/integration/resources/templates/combination/function_with_resource_refs.yaml
+++ b/integration/resources/templates/combination/function_with_resource_refs.yaml
@@ -10,14 +10,14 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       AutoPublishAlias: Live
 
   MyOtherFunction:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ${codeuri}
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: hello.handler
       Environment:
         Variables:

--- a/integration/resources/templates/combination/http_api_with_auth.yaml
+++ b/integration/resources/templates/combination/http_api_with_auth.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       InlineCode: |
         def handler(event, context):
             return {'body': 'Hello World!', 'statusCode': 200}

--- a/integration/resources/templates/combination/http_api_with_auth_updated.yaml
+++ b/integration/resources/templates/combination/http_api_with_auth_updated.yaml
@@ -3,7 +3,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       InlineCode: |
         def handler(event, context):
             return {'body': 'Hello World!', 'statusCode': 200}

--- a/integration/resources/templates/combination/http_api_with_fail_on_warnings_and_default_stage_name.yaml
+++ b/integration/resources/templates/combination/http_api_with_fail_on_warnings_and_default_stage_name.yaml
@@ -16,7 +16,7 @@ Resources:
       InlineCode: |
         def handler(event, context):
           print("Hello, world!")
-      Runtime: python3.8
+      Runtime: python3.11
       Architectures:
       - x86_64
       Events:

--- a/integration/resources/templates/combination/state_machine_with_policy_templates.yaml
+++ b/integration/resources/templates/combination/state_machine_with_policy_templates.yaml
@@ -24,7 +24,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
 
   MyQueue:
     Type: AWS::SQS::Queue

--- a/integration/resources/templates/single/basic_api_with_mode.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       AutoPublishAlias: live
       InlineCode: |
         import json

--- a/integration/resources/templates/single/basic_api_with_mode_update.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode_update.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
       AutoPublishAlias: live
       InlineCode: |
         def handler(event, context):

--- a/integration/resources/templates/single/function_with_deployment_preference_alarms_intrinsic_if.yaml
+++ b/integration/resources/templates/single/function_with_deployment_preference_alarms_intrinsic_if.yaml
@@ -9,7 +9,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       AutoPublishAlias: live
       DeploymentPreference:
         Type: Linear10PercentEvery3Minutes

--- a/integration/resources/templates/single/function_with_role_path.yaml
+++ b/integration/resources/templates/single/function_with_role_path.yaml
@@ -4,7 +4,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       RolePath: /foo/bar/
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/single/state_machine_with_api.yaml
+++ b/integration/resources/templates/single/state_machine_with_api.yaml
@@ -14,7 +14,7 @@ Resources:
             print(event)
             return "do nothing"
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
   Post:
     Type: AWS::Serverless::StateMachine
     Properties:

--- a/tests/translator/input/api_http_with_default_iam_authorizer.yaml
+++ b/tests/translator/input/api_http_with_default_iam_authorizer.yaml
@@ -4,7 +4,7 @@ Resources:
     Properties:
       CodeUri: s3://bucket/key
       Handler: app.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.11
       Role:
         Fn::GetAtt:
         - HelloWorldFunctionRole

--- a/tests/translator/input/api_merge_definitions_with_any_method.yaml
+++ b/tests/translator/input/api_merge_definitions_with_any_method.yaml
@@ -15,7 +15,7 @@ Resources:
     Properties:
       CodeUri: s3://bucket/key
       Handler: code/handler
-      Runtime: python3.8
+      Runtime: python3.11
       Events:
         AllEvent:
           Type: Api

--- a/tests/translator/input/api_with_merge_definitions_null_paths.yaml
+++ b/tests/translator/input/api_with_merge_definitions_null_paths.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: s3://bucket/key
       Handler: code/handler
-      Runtime: python3.8
+      Runtime: python3.11
       Events:
         AllEvent:
           Type: Api

--- a/tests/translator/input/cognito_user_pool_with_new_property_and_cognito_event.yaml
+++ b/tests/translator/input/cognito_user_pool_with_new_property_and_cognito_event.yaml
@@ -8,7 +8,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.8
+      Runtime: python3.11
       InlineCode: foo
       Handler: bar
       Events:

--- a/tests/translator/input/error_state_machine_with_api_intrinsics.yaml
+++ b/tests/translator/input/error_state_machine_with_api_intrinsics.yaml
@@ -12,7 +12,7 @@ Resources:
             print(event)
             return "do nothing"
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
   Post:
     Type: AWS::Serverless::StateMachine
     Properties:

--- a/tests/translator/input/function_with_cw_event.yaml
+++ b/tests/translator/input/function_with_cw_event.yaml
@@ -3,7 +3,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: foo
       InlineCode: bar
       Events:

--- a/tests/translator/input/function_with_ignore_globals.yaml
+++ b/tests/translator/input/function_with_ignore_globals.yaml
@@ -1,6 +1,6 @@
 Globals:
   Function:
-    Runtime: python3.8
+    Runtime: python3.11
     Handler: index.lambda_handler
     MemorySize: 128
 

--- a/tests/translator/input/function_with_null_events.yaml
+++ b/tests/translator/input/function_with_null_events.yaml
@@ -4,5 +4,5 @@ Resources:
     Properties:
       CodeUri: s3://sam-demo-bucket/queues.zip
       Handler: handlers.handler
-      Runtime: python3.8
+      Runtime: python3.11
       Events:

--- a/tests/translator/input/function_with_runtime_config.yaml
+++ b/tests/translator/input/function_with_runtime_config.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       CodeUri: s3://sam-demo-bucket/hello.zip
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       RuntimeManagementConfig:
         UpdateRuntimeOn: Auto
   MinimalFunctionWithManualRuntimeManagementConfig:
@@ -20,16 +20,16 @@ Resources:
     Properties:
       CodeUri: s3://sam-demo-bucket/hello.zip
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       RuntimeManagementConfig:
         UpdateRuntimeOn: Manual
-        RuntimeVersionArn: !Sub arn:aws:lambda:${AWS::Region}::runtime:python3.8::0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505
+        RuntimeVersionArn: !Sub arn:aws:lambda:${AWS::Region}::runtime:python3.11::0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505
   FunctionWithRuntimeManagementConfigAndAlias:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: s3://sam-demo-bucket/hello.zip
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       AutoPublishAlias: live
       RuntimeManagementConfig:
         UpdateRuntimeOn: Auto
@@ -38,7 +38,7 @@ Resources:
     Properties:
       CodeUri: s3://sam-demo-bucket/hello.zip
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       RuntimeManagementConfig:
         UpdateRuntimeOn: !Ref RuntimeUpdateParam
   FunctionWithIntrinsicRuntimeVersion:
@@ -46,7 +46,7 @@ Resources:
     Properties:
       CodeUri: s3://sam-demo-bucket/hello.zip
       Handler: hello.handler
-      Runtime: python3.8
+      Runtime: python3.11
       RuntimeManagementConfig:
         UpdateRuntimeOn: !Ref RuntimeUpdateParam
         RuntimeVersionArn: !Ref RuntimeVersionParam

--- a/tests/translator/input/inline_precedence.yaml
+++ b/tests/translator/input/inline_precedence.yaml
@@ -7,4 +7,4 @@ Resources:
             pass"
       CodeUri: .
       Handler: index.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.11

--- a/tests/translator/input/managed_policies_everything.yaml
+++ b/tests/translator/input/managed_policies_everything.yaml
@@ -13,7 +13,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: foo
       InlineCode: bar
       Policies:

--- a/tests/translator/input/managed_policies_minimal.yaml
+++ b/tests/translator/input/managed_policies_minimal.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: foo
       InlineCode: bar
       Policies:

--- a/tests/translator/input/schema_validation_4.yaml
+++ b/tests/translator/input/schema_validation_4.yaml
@@ -59,7 +59,7 @@ Resources:
   OtherFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: foo
       InlineCode: bar
       Environment:

--- a/tests/translator/input/state_machine_with_api.yaml
+++ b/tests/translator/input/state_machine_with_api.yaml
@@ -12,7 +12,7 @@ Resources:
             print(event)
             return "do nothing"
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
   Post:
     Type: AWS::Serverless::StateMachine
     Properties:

--- a/tests/translator/input/state_machine_with_api_single.yaml
+++ b/tests/translator/input/state_machine_with_api_single.yaml
@@ -12,7 +12,7 @@ Resources:
             print(event)
             return "do nothing"
       Handler: index.handler
-      Runtime: python3.8
+      Runtime: python3.11
   Post:
     Type: AWS::Serverless::StateMachine
     Properties:

--- a/tests/translator/input/state_machine_with_sam_policy_templates.yaml
+++ b/tests/translator/input/state_machine_with_sam_policy_templates.yaml
@@ -14,7 +14,7 @@ Resources:
     Properties:
       CodeUri: s3://sam-demo-bucket/resolver.zip
       Handler: resolver.handler
-      Runtime: python3.8
+      Runtime: python3.11
 
   NestedWorkflow:
     Type: AWS::Serverless::StateMachine

--- a/tests/translator/output/api_http_with_default_iam_authorizer.json
+++ b/tests/translator/output/api_http_with_default_iam_authorizer.json
@@ -16,7 +16,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_merge_definitions_with_any_method.json
+++ b/tests/translator/output/api_merge_definitions_with_any_method.json
@@ -46,7 +46,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/api_with_merge_definitions_null_paths.json
+++ b/tests/translator/output/api_with_merge_definitions_null_paths.json
@@ -47,7 +47,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_http_with_default_iam_authorizer.json
+++ b/tests/translator/output/aws-cn/api_http_with_default_iam_authorizer.json
@@ -16,7 +16,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_merge_definitions_with_any_method.json
+++ b/tests/translator/output/aws-cn/api_merge_definitions_with_any_method.json
@@ -54,7 +54,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/api_with_merge_definitions_null_paths.json
+++ b/tests/translator/output/aws-cn/api_with_merge_definitions_null_paths.json
@@ -55,7 +55,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/cognito_user_pool_with_new_property_and_cognito_event.json
+++ b/tests/translator/output/aws-cn/cognito_user_pool_with_new_property_and_cognito_event.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_cw_event.json
+++ b/tests/translator/output/aws-cn/function_with_cw_event.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_ignore_globals.json
+++ b/tests/translator/output/aws-cn/function_with_ignore_globals.json
@@ -125,7 +125,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_null_events.json
+++ b/tests/translator/output/aws-cn/function_with_null_events.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/function_with_runtime_config.json
+++ b/tests/translator/output/aws-cn/function_with_runtime_config.json
@@ -21,7 +21,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "RuntimeVersionArn": {
             "Ref": "RuntimeVersionParam"
@@ -82,7 +82,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": {
             "Ref": "RuntimeUpdateParam"
@@ -140,7 +140,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": "Auto"
         },
@@ -166,7 +166,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": "Auto"
         },
@@ -276,10 +276,10 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "RuntimeVersionArn": {
-            "Fn::Sub": "arn:aws:lambda:${AWS::Region}::runtime:python3.8::0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505"
+            "Fn::Sub": "arn:aws:lambda:${AWS::Region}::runtime:python3.11::0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505"
           },
           "UpdateRuntimeOn": "Manual"
         },

--- a/tests/translator/output/aws-cn/inline_precedence.json
+++ b/tests/translator/output/aws-cn/inline_precedence.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/managed_policies_everything.json
+++ b/tests/translator/output/aws-cn/managed_policies_everything.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/managed_policies_minimal.json
+++ b/tests/translator/output/aws-cn/managed_policies_minimal.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/schema_validation_4.json
+++ b/tests/translator/output/aws-cn/schema_validation_4.json
@@ -119,7 +119,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/state_machine_with_api.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/state_machine_with_api_single.json
+++ b/tests/translator/output/aws-cn/state_machine_with_api_single.json
@@ -22,7 +22,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-cn/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/aws-cn/state_machine_with_sam_policy_templates.json
@@ -394,7 +394,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_http_with_default_iam_authorizer.json
+++ b/tests/translator/output/aws-us-gov/api_http_with_default_iam_authorizer.json
@@ -16,7 +16,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_merge_definitions_with_any_method.json
+++ b/tests/translator/output/aws-us-gov/api_merge_definitions_with_any_method.json
@@ -54,7 +54,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/api_with_merge_definitions_null_paths.json
+++ b/tests/translator/output/aws-us-gov/api_with_merge_definitions_null_paths.json
@@ -55,7 +55,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/cognito_user_pool_with_new_property_and_cognito_event.json
+++ b/tests/translator/output/aws-us-gov/cognito_user_pool_with_new_property_and_cognito_event.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_cw_event.json
+++ b/tests/translator/output/aws-us-gov/function_with_cw_event.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_ignore_globals.json
+++ b/tests/translator/output/aws-us-gov/function_with_ignore_globals.json
@@ -125,7 +125,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_null_events.json
+++ b/tests/translator/output/aws-us-gov/function_with_null_events.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/function_with_runtime_config.json
+++ b/tests/translator/output/aws-us-gov/function_with_runtime_config.json
@@ -21,7 +21,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "RuntimeVersionArn": {
             "Ref": "RuntimeVersionParam"
@@ -82,7 +82,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": {
             "Ref": "RuntimeUpdateParam"
@@ -140,7 +140,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": "Auto"
         },
@@ -166,7 +166,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": "Auto"
         },
@@ -276,10 +276,10 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "RuntimeVersionArn": {
-            "Fn::Sub": "arn:aws:lambda:${AWS::Region}::runtime:python3.8::0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505"
+            "Fn::Sub": "arn:aws:lambda:${AWS::Region}::runtime:python3.11::0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505"
           },
           "UpdateRuntimeOn": "Manual"
         },

--- a/tests/translator/output/aws-us-gov/inline_precedence.json
+++ b/tests/translator/output/aws-us-gov/inline_precedence.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/managed_policies_everything.json
+++ b/tests/translator/output/aws-us-gov/managed_policies_everything.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/managed_policies_minimal.json
+++ b/tests/translator/output/aws-us-gov/managed_policies_minimal.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/schema_validation_4.json
+++ b/tests/translator/output/aws-us-gov/schema_validation_4.json
@@ -119,7 +119,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/state_machine_with_api.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/state_machine_with_api_single.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_api_single.json
@@ -22,7 +22,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/aws-us-gov/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/state_machine_with_sam_policy_templates.json
@@ -394,7 +394,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/cognito_user_pool_with_new_property_and_cognito_event.json
+++ b/tests/translator/output/cognito_user_pool_with_new_property_and_cognito_event.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_cw_event.json
+++ b/tests/translator/output/function_with_cw_event.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_ignore_globals.json
+++ b/tests/translator/output/function_with_ignore_globals.json
@@ -125,7 +125,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_null_events.json
+++ b/tests/translator/output/function_with_null_events.json
@@ -13,7 +13,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/function_with_runtime_config.json
+++ b/tests/translator/output/function_with_runtime_config.json
@@ -21,7 +21,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "RuntimeVersionArn": {
             "Ref": "RuntimeVersionParam"
@@ -82,7 +82,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": {
             "Ref": "RuntimeUpdateParam"
@@ -140,7 +140,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": "Auto"
         },
@@ -166,7 +166,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "UpdateRuntimeOn": "Auto"
         },
@@ -276,10 +276,10 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "RuntimeManagementConfig": {
           "RuntimeVersionArn": {
-            "Fn::Sub": "arn:aws:lambda:${AWS::Region}::runtime:python3.8::0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505"
+            "Fn::Sub": "arn:aws:lambda:${AWS::Region}::runtime:python3.11::0af1966588ced06e3143ae720245c9b7aeaae213c6921c12c742a166679cc505"
           },
           "UpdateRuntimeOn": "Manual"
         },

--- a/tests/translator/output/inline_precedence.json
+++ b/tests/translator/output/inline_precedence.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/managed_policies_everything.json
+++ b/tests/translator/output/managed_policies_everything.json
@@ -27,7 +27,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/managed_policies_minimal.json
+++ b/tests/translator/output/managed_policies_minimal.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/schema_validation_4.json
+++ b/tests/translator/output/schema_validation_4.json
@@ -119,7 +119,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/state_machine_with_api.json
+++ b/tests/translator/output/state_machine_with_api.json
@@ -12,7 +12,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/state_machine_with_api_single.json
+++ b/tests/translator/output/state_machine_with_api_single.json
@@ -22,7 +22,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/output/state_machine_with_sam_policy_templates.json
+++ b/tests/translator/output/state_machine_with_sam_policy_templates.json
@@ -394,7 +394,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.11",
         "Tags": [
           {
             "Key": "lambda:createdBy",

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -781,7 +781,7 @@ class TestTemplateValidation(TestCase):
             "MyFunction": {
                 "Type": "AWS::Serverless::Function",
                 "Properties": {
-                    "Runtime": "python3.8",
+                    "Runtime": "python3.11",
                     "Handler": "foo",
                     "InlineCode": "bar",
                     "Policies": [


### PR DESCRIPTION
### Issue #, if available
None

### Description of changes
Updates to latest Python Runtime

### Description of how you validated changes
Used find and replace. Grepped for `python3.8` throughout package to make sure I got all instances.

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
