### PR TITLE
Add support for 'Fn::ForEach' intrinsic function

### DIFF
--- a/samtranslator/parser/parser.py
+++ b/samtranslator/parser/parser.py
@@ -9,6 +9,7 @@ from samtranslator.model.exceptions import (
 from samtranslator.plugins import LifeCycleEvents
 from samtranslator.plugins.sam_plugins import SamPlugins
 from samtranslator.public.sdk.template import SamTemplate
+from samtranslator.utils.utils import safe_dict
 from samtranslator.validator.value_validator import sam_expect
 
 LOG = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ class Parser:
         ):
             raise InvalidDocumentException([InvalidTemplateException("'Resources' section is required")])
 
-        if not all(isinstance(sam_resource, dict) for sam_resource in sam_template["Resources"].values()):
+        if not all(isinstance(sam_resource, dict) for sam_resource in safe_dict(sam_template["Resources"]).values()):
             raise InvalidDocumentException(
                 [
                     InvalidTemplateException(

--- a/samtranslator/sdk/template.py
+++ b/samtranslator/sdk/template.py
@@ -5,6 +5,7 @@ Classes representing SAM template and resources.
 from typing import Any, Dict, Iterator, Optional, Set, Tuple, Union
 
 from samtranslator.sdk.resource import SamResource
+from samtranslator.utils.utils import safe_dict
 
 
 class SamTemplate:
@@ -30,7 +31,7 @@ class SamTemplate:
         """
         if resource_types is None:
             resource_types = set()
-        for logicalId, resource_dict in self.resources.items():
+        for logicalId, resource_dict in safe_dict(self.resources).items():
             resource = SamResource(resource_dict)
             needs_filter = resource.valid()
             if resource_types:

--- a/tests/schema/test_validate_schema.py
+++ b/tests/schema/test_validate_schema.py
@@ -58,6 +58,7 @@ SKIPPED_TESTS = [
     # TODO: Support globals (e.g. somehow make all fields of a model optional only for Globals)
     "api_with_custom_base_path",
     "function_with_tracing",  # TODO: intentionally skip this tests to cover incorrect scenarios
+    "intrinsic_for_each_resource", # intrinsic forEach loop is not supported
 ]
 
 

--- a/tests/sdk/test_template.py
+++ b/tests/sdk/test_template.py
@@ -15,6 +15,8 @@ class TestSamTemplate(TestCase):
                 "Api": {"Type": "AWS::Serverless::Api"},
                 "Layer": {"Type": "AWS::Serverless::LayerVersion"},
                 "NonSam": {"Type": "AWS::Lambda::Function"},
+                "Fn::ForEach::LambdaFunctions": [ "FunctionName", ["1", "2"], { "${FunctioName}": {"Type": "AWS::Lambda::Function", "a": "b"}}],
+                "Fn::ForEach::ServerlessFunctions": ["FunctionName", ["3", "4"], {"${FunctionName}": {"Type": "AWS::Serverless::Function", "a": "b"}}],
             },
         }
 
@@ -26,6 +28,7 @@ class TestSamTemplate(TestCase):
             ("Function2", {"Type": "AWS::Serverless::Function", "a": "b", "Properties": {}}),
             ("Api", {"Type": "AWS::Serverless::Api", "Properties": {}}),
             ("Layer", {"Type": "AWS::Serverless::LayerVersion", "Properties": {}}),
+            ("ServerlessFunctions::${FunctionName}", {"Type": "AWS::Serverless::Function", "a": "b", "Properties": {}}),
         ]
 
         actual = [(id, resource.to_dict()) for id, resource in template.iterate()]
@@ -38,6 +41,7 @@ class TestSamTemplate(TestCase):
         expected = [
             ("Function1", {"Type": "AWS::Serverless::Function", "DependsOn": "SomeOtherResource", "Properties": {}}),
             ("Function2", {"Type": "AWS::Serverless::Function", "a": "b", "Properties": {}}),
+            ("ServerlessFunctions::${FunctionName}", {"Type": "AWS::Serverless::Function", "a": "b", "Properties": {}}),
         ]
 
         actual = [(id, resource.to_dict()) for id, resource in template.iterate({type})]

--- a/tests/translator/input/intrinsic_for_each_resource.yaml
+++ b/tests/translator/input/intrinsic_for_each_resource.yaml
@@ -1,0 +1,68 @@
+Mappings:
+  TemplateLinksPolicies:
+    Template1Link1:
+        template: Template1
+        principal:
+          type: "User"
+          id: "user1"
+        resource:
+          type: "Resource"
+          id: "resource1"
+    Template1Link2:
+        template: Template2
+        principal:
+          type: "User"
+          id: "user2"
+        resource:
+          type: "Resource"
+          id: "resource2"
+
+Parameters:
+  Environment:
+    Type: String
+  Project:
+    Type: String
+
+Resources:
+  PolicyStore:
+    Type: AWS::VerifiedPermissions::PolicyStore
+    Properties:
+      Description: !Sub "AVP Policy store for ${Project}-${Environment}"
+      Schema:
+        CedarJson:
+          Fn::ToJsonString:
+            Fn::Transform:
+              Name: AWS::Include
+              Parameters:
+                Location: policy-store-schema.json
+      ValidationSettings:
+        Mode: STRICT
+
+  Template1:
+    Type: AWS::VerifiedPermissions::PolicyTemplate
+    Properties:
+      PolicyStoreId: !Ref PolicyStore
+      Description: "AVP Template."
+      Statement: >
+        permit(
+            principal in ?principal,
+            action == Action::"action",
+            resource == ?resource
+          );
+
+  'Fn::ForEach::TemplateLinked':
+    - TemplateKey
+    - {"Fn::FindInMap": ["TemplateLinksPolicies"]}
+    - '${TemplateKey}':
+        Type: AWS::VerifiedPermissions::Policy
+        Properties:
+          PolicyStoreId: !Ref PolicyStore
+          Definition:
+            TemplateLinked:
+              PolicyTemplateId: {"Fn::GetAtt": [{"Fn::FindInMap": ["TemplateLinksPolicies", "${TemplateKey}", "template"]}, "PolicyTemplateId"]}
+              Principal:
+                EntityType: {"Fn::FindInMap": ["TemplateLinksPolicies", '${TemplateKey}', "principal", "type"]}
+                EntityId: {"Fn::FindInMap": ["TemplateLinksPolicies", '${TemplateKey}', "principal", "id"]}
+              Resource:
+                EntityType: {"Fn::FindInMap": ["TemplateLinksPolicies", "${TemplateKey}", "resource", "type"]}
+                EntityId: {"Fn::FindInMap": ["TemplateLinksPolicies", "${TemplateKey}", "resource", "id"]}

--- a/tests/translator/output/aws-cn/intrinsic_for_each_resource.json
+++ b/tests/translator/output/aws-cn/intrinsic_for_each_resource.json
@@ -1,0 +1,141 @@
+{
+  "Mappings": {
+    "TemplateLinksPolicies": {
+      "Template1Link1": {
+        "template": "Template1",
+        "principal": {
+          "type": "User",
+          "id": "user1"
+        },
+        "resource": {
+          "type": "Resource",
+          "id": "resource1"
+        }
+      },
+      "Template1Link2": {
+        "template": "Template2",
+        "principal": {
+          "type": "User",
+          "id": "user2"
+        },
+        "resource": {
+          "type": "Resource",
+          "id": "resource2"
+        }
+      }
+    }
+  },
+  "Parameters": {
+    "Environment": {
+      "Type": "String"
+    },
+    "Project": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "PolicyStore": {
+      "Type": "AWS::VerifiedPermissions::PolicyStore",
+      "Properties": {
+        "Description": {
+          "Fn::Sub": "AVP Policy store for ${Project}-${Environment}"
+        },
+        "Schema": {
+          "CedarJson": {
+            "Fn::ToJsonString": {
+              "Fn::Transform": {
+                "Name": "AWS::Include",
+                "Parameters": {
+                  "Location": "policy-store-schema.json"
+                }
+              }
+            }
+          }
+        },
+        "ValidationSettings": {
+          "Mode": "STRICT"
+        }
+      }
+    },
+    "Template1": {
+      "Type": "AWS::VerifiedPermissions::PolicyTemplate",
+      "Properties": {
+        "PolicyStoreId": {
+          "Ref": "PolicyStore"
+        },
+        "Description": "AVP Template.",
+        "Statement": "permit(\n    principal in ?principal,\n    action == Action::\"action\",\n    resource == ?resource\n  );\n"
+      }
+    },
+    "Fn::ForEach::TemplateLinked": [
+      "TemplateKey",
+      {
+        "Fn::FindInMap": [
+          "TemplateLinksPolicies"
+        ]
+      },
+      {
+        "${TemplateKey}": {
+          "Type": "AWS::VerifiedPermissions::Policy",
+          "Properties": {
+            "PolicyStoreId": {
+              "Ref": "PolicyStore"
+            },
+            "Definition": {
+              "TemplateLinked": {
+                "PolicyTemplateId": {
+                  "Fn::GetAtt": [
+                    {
+                      "Fn::FindInMap": [
+                        "TemplateLinksPolicies",
+                        "${TemplateKey}",
+                        "template"
+                      ]
+                    },
+                    "PolicyTemplateId"
+                  ]
+                },
+                "Principal": {
+                  "EntityType": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "principal",
+                      "type"
+                    ]
+                  },
+                  "EntityId": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "principal",
+                      "id"
+                    ]
+                  }
+                },
+                "Resource": {
+                  "EntityType": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "resource",
+                      "type"
+                    ]
+                  },
+                  "EntityId": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "resource",
+                      "id"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/translator/output/aws-us-gov/intrinsic_for_each_resource.json
+++ b/tests/translator/output/aws-us-gov/intrinsic_for_each_resource.json
@@ -1,0 +1,141 @@
+{
+  "Mappings": {
+    "TemplateLinksPolicies": {
+      "Template1Link1": {
+        "template": "Template1",
+        "principal": {
+          "type": "User",
+          "id": "user1"
+        },
+        "resource": {
+          "type": "Resource",
+          "id": "resource1"
+        }
+      },
+      "Template1Link2": {
+        "template": "Template2",
+        "principal": {
+          "type": "User",
+          "id": "user2"
+        },
+        "resource": {
+          "type": "Resource",
+          "id": "resource2"
+        }
+      }
+    }
+  },
+  "Parameters": {
+    "Environment": {
+      "Type": "String"
+    },
+    "Project": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "PolicyStore": {
+      "Type": "AWS::VerifiedPermissions::PolicyStore",
+      "Properties": {
+        "Description": {
+          "Fn::Sub": "AVP Policy store for ${Project}-${Environment}"
+        },
+        "Schema": {
+          "CedarJson": {
+            "Fn::ToJsonString": {
+              "Fn::Transform": {
+                "Name": "AWS::Include",
+                "Parameters": {
+                  "Location": "policy-store-schema.json"
+                }
+              }
+            }
+          }
+        },
+        "ValidationSettings": {
+          "Mode": "STRICT"
+        }
+      }
+    },
+    "Template1": {
+      "Type": "AWS::VerifiedPermissions::PolicyTemplate",
+      "Properties": {
+        "PolicyStoreId": {
+          "Ref": "PolicyStore"
+        },
+        "Description": "AVP Template.",
+        "Statement": "permit(\n    principal in ?principal,\n    action == Action::\"action\",\n    resource == ?resource\n  );\n"
+      }
+    },
+    "Fn::ForEach::TemplateLinked": [
+      "TemplateKey",
+      {
+        "Fn::FindInMap": [
+          "TemplateLinksPolicies"
+        ]
+      },
+      {
+        "${TemplateKey}": {
+          "Type": "AWS::VerifiedPermissions::Policy",
+          "Properties": {
+            "PolicyStoreId": {
+              "Ref": "PolicyStore"
+            },
+            "Definition": {
+              "TemplateLinked": {
+                "PolicyTemplateId": {
+                  "Fn::GetAtt": [
+                    {
+                      "Fn::FindInMap": [
+                        "TemplateLinksPolicies",
+                        "${TemplateKey}",
+                        "template"
+                      ]
+                    },
+                    "PolicyTemplateId"
+                  ]
+                },
+                "Principal": {
+                  "EntityType": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "principal",
+                      "type"
+                    ]
+                  },
+                  "EntityId": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "principal",
+                      "id"
+                    ]
+                  }
+                },
+                "Resource": {
+                  "EntityType": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "resource",
+                      "type"
+                    ]
+                  },
+                  "EntityId": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "resource",
+                      "id"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/translator/output/intrinsic_for_each_resource.json
+++ b/tests/translator/output/intrinsic_for_each_resource.json
@@ -1,0 +1,141 @@
+{
+  "Mappings": {
+    "TemplateLinksPolicies": {
+      "Template1Link1": {
+        "template": "Template1",
+        "principal": {
+          "type": "User",
+          "id": "user1"
+        },
+        "resource": {
+          "type": "Resource",
+          "id": "resource1"
+        }
+      },
+      "Template1Link2": {
+        "template": "Template2",
+        "principal": {
+          "type": "User",
+          "id": "user2"
+        },
+        "resource": {
+          "type": "Resource",
+          "id": "resource2"
+        }
+      }
+    }
+  },
+  "Parameters": {
+    "Environment": {
+      "Type": "String"
+    },
+    "Project": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "PolicyStore": {
+      "Type": "AWS::VerifiedPermissions::PolicyStore",
+      "Properties": {
+        "Description": {
+          "Fn::Sub": "AVP Policy store for ${Project}-${Environment}"
+        },
+        "Schema": {
+          "CedarJson": {
+            "Fn::ToJsonString": {
+              "Fn::Transform": {
+                "Name": "AWS::Include",
+                "Parameters": {
+                  "Location": "policy-store-schema.json"
+                }
+              }
+            }
+          }
+        },
+        "ValidationSettings": {
+          "Mode": "STRICT"
+        }
+      }
+    },
+    "Template1": {
+      "Type": "AWS::VerifiedPermissions::PolicyTemplate",
+      "Properties": {
+        "PolicyStoreId": {
+          "Ref": "PolicyStore"
+        },
+        "Description": "AVP Template.",
+        "Statement": "permit(\n    principal in ?principal,\n    action == Action::\"action\",\n    resource == ?resource\n  );\n"
+      }
+    },
+    "Fn::ForEach::TemplateLinked": [
+      "TemplateKey",
+      {
+        "Fn::FindInMap": [
+          "TemplateLinksPolicies"
+        ]
+      },
+      {
+        "${TemplateKey}": {
+          "Type": "AWS::VerifiedPermissions::Policy",
+          "Properties": {
+            "PolicyStoreId": {
+              "Ref": "PolicyStore"
+            },
+            "Definition": {
+              "TemplateLinked": {
+                "PolicyTemplateId": {
+                  "Fn::GetAtt": [
+                    {
+                      "Fn::FindInMap": [
+                        "TemplateLinksPolicies",
+                        "${TemplateKey}",
+                        "template"
+                      ]
+                    },
+                    "PolicyTemplateId"
+                  ]
+                },
+                "Principal": {
+                  "EntityType": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "principal",
+                      "type"
+                    ]
+                  },
+                  "EntityId": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "principal",
+                      "id"
+                    ]
+                  }
+                },
+                "Resource": {
+                  "EntityType": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "resource",
+                      "type"
+                    ]
+                  },
+                  "EntityId": {
+                    "Fn::FindInMap": [
+                      "TemplateLinksPolicies",
+                      "${TemplateKey}",
+                      "resource",
+                      "id"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Inspired by aws/aws-cli#8096.

### Issue #, if available aws/aws-sam-cli#5647

### Description of changes
The [Fn::ForEach](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-foreach.html) intrinsic function requires to add array entries in the `Resources` section of the SAM template. Parts of the code only expect to find object entries keyed with a string and fail with errors like `'list' object has no attribute 'get'`.

This PR brings similar changes to those merged in the `aws-cli` to the `aws-sam-cli` (replacing the array with the resource fragment provided with the `Fn::ForEach` loop definition).

### Description of how you validated changes
On top of adding more local tests I've run `sam build` and `sam validate` commands on a local environment with edited versions of `aws-sam-translator` and `aws-sam-cli` pip packages.

I've replaced calls to `resource_dict.get("Type")` or `resource_dict.get("Metadata")` with the proposed code changes in each location where the commands would fail until they passed.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
