### PR TITLE
fix: update cfn-lint versions and match tests

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -134,7 +134,6 @@ ignore_templates:
   - tests/translator/output/**/function_with_tracing.json # Obsolete DependsOn on resource
   - tests/translator/output/**/api_with_propagate_tags.json # TODO: Intentional error transform tests. Will be updated.
   - tests/translator/output/**/function_with_intrinsics_resource_attribute.json # CFN now supports intrinsics in DeletionPolicy
-  - tests/translator/output/**/embedded_connectors_hardcoded_props.json # Only checking if the embedded connectors work
   - tests/translator/output/**/function_with_snapstart.json # Snapstart intentionally not attached to a lambda version which causes lint issues
   - tests/translator/output/**/managed_policies_everything.json # intentionally contains wrong arns
 ignore_checks:

--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -134,8 +134,13 @@ ignore_templates:
   - tests/translator/output/**/function_with_tracing.json # Obsolete DependsOn on resource
   - tests/translator/output/**/api_with_propagate_tags.json # TODO: Intentional error transform tests. Will be updated.
   - tests/translator/output/**/function_with_intrinsics_resource_attribute.json # CFN now supports intrinsics in DeletionPolicy
+  - tests/translator/output/**/embedded_connectors_hardcoded_props.json # Only checking if the embedded connectors work
+  - tests/translator/output/**/function_with_snapstart.json # Snapstart intentionally not attached to a lambda version which causes lint issues
+  - tests/translator/output/**/managed_policies_everything.json # intentionally contains wrong arns
 ignore_checks:
   - E2531 # Deprecated runtime; not relevant for transform tests
+  - E2533 # Another deprecated runtime; not relevant for transform tests
   - W2531 # EOL runtime; not relevant for transform tests
   - E3001 # Invalid or unsupported Type; common in transform tests since they focus on SAM resources
   - W2001 # Parameter not used
+  - E3006 # Resource type check; we have some Foo Bar resources

--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -9,7 +9,7 @@ if [ ! -d "${VENV}" ]; then
     python3 -m venv "${VENV}"
 fi
 
-"${VENV}/bin/python" -m pip install cfn-lint==0.75.0 --upgrade --quiet
+"${VENV}/bin/python" -m pip install cfn-lint==1.12.0 --upgrade --quiet
 # update cfn schema
 "${VENV}/bin/cfn-lint" -u
 "${VENV}/bin/cfn-lint" --format parseable

--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -9,7 +9,7 @@ if [ ! -d "${VENV}" ]; then
     python3 -m venv "${VENV}"
 fi
 
-"${VENV}/bin/python" -m pip install cfn-lint==1.12.0 --upgrade --quiet
+"${VENV}/bin/python" -m pip install cfn-lint --upgrade --quiet
 # update cfn schema
 "${VENV}/bin/cfn-lint" -u
 "${VENV}/bin/cfn-lint" --format parseable

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -170,7 +170,7 @@ Resources:
           EventBusName: name
 
       - AcmGetCertificatePolicy:
-          CertificateArn: arn
+          CertificateArn: arn:aws:acm:us-west-2:987654321098:certificate/dec86919-7219-4e8d-8871-7f1609df2c7f
 
       - Route53ChangeResourceRecordSetsPolicy:
           HostedZoneId: test

--- a/tests/translator/input/connector_with_non_id_source_and_destination.yaml
+++ b/tests/translator/input/connector_with_non_id_source_and_destination.yaml
@@ -11,7 +11,7 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
       ManagedPolicyArns:
-      - arn:{AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 
   SamFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/embedded_connectors_hardcoded_props.yaml
+++ b/tests/translator/input/embedded_connectors_hardcoded_props.yaml
@@ -2,6 +2,15 @@ Transform: AWS::Serverless-2016-10-31
 Resources:
   MyFunction:
     Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: arn:aws:iam::111122223333:role/lambda-role
+      Runtime: nodejs20.x
+      Code:
+        ZipFile: |
+          exports.handler = function(event, context, callback) {
+            return callback(null, 'success');
+          }
 
   MyRule:
     Type: AWS::Events::Rule
@@ -13,6 +22,8 @@ Resources:
             Arn: !Ref MyTopic
           Permissions:
           - Write
+    Properties:
+      ScheduleExpression: rate(5 minutes)
 
   MyQueue:
     Type: AWS::SQS::Queue
@@ -42,6 +53,8 @@ Resources:
             Id: MyFunction
           Permissions:
           - Write
+    Properties:
+      Name: MyApiV1
 
   MyApiV2:
     Type: AWS::ApiGatewayV2::Api
@@ -54,6 +67,8 @@ Resources:
             Id: MyFunction
           Permissions:
           - Write
+    Properties:
+      Name: MyApiV2
 
   MySNSTopic:
     Type: AWS::SNS::Topic

--- a/tests/translator/input/function_with_alias_and_all_properties_property.yaml
+++ b/tests/translator/input/function_with_alias_and_all_properties_property.yaml
@@ -42,7 +42,7 @@ Resources:
       - x86_64
       EphemeralStorage:
         Size: 1024
-      Role: !Sub arn:${AWS::Partition}:iam::role
+      Role: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1
       KmsKeyArn: !Sub arn:${AWS::Partition}:key:key
       FileSystemConfigs:
       - Arn: !GetAtt AccessPoint.Arn
@@ -72,7 +72,7 @@ Resources:
       - x86_64
       EphemeralStorage:
         Size: 1024
-      Role: !Sub arn:${AWS::Partition}:iam::role
+      Role: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1
       KmsKeyArn: !Sub arn:${AWS::Partition}:key:key
       FileSystemConfigs:
       - Arn: !GetAtt AccessPoint.Arn

--- a/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
+++ b/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
@@ -9,7 +9,7 @@ Resources:
         NotificationTopic:
           Type: SNS
           Properties:
-            Topic: topicArn-letsAddMoreSymbols
+            Topic: arn:aws:sns:us-west-2:987654321098:key/dec86919-7219-4e8d-8871-7f1609df2c7f
             Region: region
             FilterPolicy:
               store:

--- a/tests/translator/input/graphqlapi_ddb_datasource_connector.yaml
+++ b/tests/translator/input/graphqlapi_ddb_datasource_connector.yaml
@@ -18,7 +18,7 @@ Resources:
         DynamoDb:
           MyDataSource:
             TableName: some-table
-            TableArn: big-arn
+            TableArn: arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f
           AnotherDataSource:
             TableName: cool-table
-            TableArn: table-arn
+            TableArn: arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f

--- a/tests/translator/input/graphqlapi_lambda_datasource_connector.yaml
+++ b/tests/translator/input/graphqlapi_lambda_datasource_connector.yaml
@@ -17,4 +17,4 @@ Resources:
       DataSources:
         Lambda:
           MyDataSource:
-            FunctionArn: blah
+            FunctionArn: arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1580,7 +1580,7 @@
                     "Fn::Sub": [
                       "${certificateArn}",
                       {
-                        "certificateArn": "arn"
+                        "certificateArn": "arn:aws:acm:us-west-2:987654321098:certificate/dec86919-7219-4e8d-8871-7f1609df2c7f"
                       }
                     ]
                   }

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1580,7 +1580,7 @@
                     "Fn::Sub": [
                       "${certificateArn}",
                       {
-                        "certificateArn": "arn"
+                        "certificateArn": "arn:aws:acm:us-west-2:987654321098:certificate/dec86919-7219-4e8d-8871-7f1609df2c7f"
                       }
                     ]
                   }

--- a/tests/translator/output/aws-cn/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/aws-cn/connector_with_non_id_source_and_destination.json
@@ -183,7 +183,9 @@
           ]
         },
         "ManagedPolicyArns": [
-          "arn:{AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          }
         ]
       },
       "Type": "AWS::IAM::Role"

--- a/tests/translator/output/aws-cn/embedded_connectors_hardcoded_props.json
+++ b/tests/translator/output/aws-cn/embedded_connectors_hardcoded_props.json
@@ -1,6 +1,9 @@
 {
   "Resources": {
     "MyApiV1": {
+      "Properties": {
+        "Name": "MyApiV1"
+      },
       "Type": "AWS::ApiGateway::RestApi"
     },
     "MyApiV1ApiV1ToLambdaWriteLambdaPermission": {
@@ -40,6 +43,9 @@
       "Type": "AWS::Lambda::Permission"
     },
     "MyApiV2": {
+      "Properties": {
+        "Name": "MyApiV2"
+      },
       "Type": "AWS::ApiGatewayV2::Api"
     },
     "MyApiV2ApiV2ToLambdaWriteLambdaPermission": {
@@ -79,6 +85,14 @@
       "Type": "AWS::Lambda::Permission"
     },
     "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = function(event, context, callback) {\n  return callback(null, 'success');\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": "arn:aws:iam::111122223333:role/lambda-role",
+        "Runtime": "nodejs20.x"
+      },
       "Type": "AWS::Lambda::Function"
     },
     "MyQueue": {
@@ -88,6 +102,9 @@
       "Type": "AWS::SQS::Queue"
     },
     "MyRule": {
+      "Properties": {
+        "ScheduleExpression": "rate(5 minutes)"
+      },
       "Type": "AWS::Events::Rule"
     },
     "MyRuleRuleToTopicTopicPolicy": {

--- a/tests/translator/output/aws-cn/function_with_alias_and_all_properties_property.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_all_properties_property.json
@@ -46,7 +46,7 @@
         "PackageType": "Zip",
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::Sub": "arn:${AWS::Partition}:iam::role"
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1"
         },
         "Runtime": "python2.7",
         "Tags": [
@@ -74,7 +74,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "HashChangeFunctionVersion17ca83d2bf",
+            "HashChangeFunctionVersiona1a9d4d1e4",
             "Version"
           ]
         },
@@ -82,7 +82,7 @@
       },
       "Type": "AWS::Lambda::Alias"
     },
-    "HashChangeFunctionVersion17ca83d2bf": {
+    "HashChangeFunctionVersiona1a9d4d1e4": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "Description": "sam-testing",
@@ -127,7 +127,7 @@
         "PackageType": "Zip",
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::Sub": "arn:${AWS::Partition}:iam::role"
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1"
         },
         "Runtime": "python2.7",
         "Tags": [

--- a/tests/translator/output/aws-cn/function_with_snapstart.json
+++ b/tests/translator/output/aws-cn/function_with_snapstart.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -155,7 +155,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": {
             "Ref": "SnapStartParam"
@@ -169,21 +169,6 @@
         ]
       },
       "Type": "AWS::Lambda::Function"
-    },
-    "SnapStartParameterFunctionAliaslive": {
-      "Properties": {
-        "FunctionName": {
-          "Ref": "SnapStartParameterFunction"
-        },
-        "FunctionVersion": {
-          "Fn::GetAtt": [
-            "SnapStartParameterFunctionVersione3921e07ea",
-            "Version"
-          ]
-        },
-        "Name": "live"
-      },
-      "Type": "AWS::Lambda::Alias"
     },
     "SnapStartParameterFunctionRole": {
       "Properties": {
@@ -214,15 +199,6 @@
         ]
       },
       "Type": "AWS::IAM::Role"
-    },
-    "SnapStartParameterFunctionVersione3921e07ea": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "SnapStartParameterFunction"
-        }
-      },
-      "Type": "AWS::Lambda::Version"
     }
   }
 }

--- a/tests/translator/output/aws-cn/function_with_snapstart.json
+++ b/tests/translator/output/aws-cn/function_with_snapstart.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -155,7 +155,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": {
             "Ref": "SnapStartParam"
@@ -169,6 +169,21 @@
         ]
       },
       "Type": "AWS::Lambda::Function"
+    },
+    "SnapStartParameterFunctionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "SnapStartParameterFunction"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "SnapStartParameterFunctionVersione3921e07ea",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
     },
     "SnapStartParameterFunctionRole": {
       "Properties": {
@@ -199,6 +214,15 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "SnapStartParameterFunctionVersione3921e07ea": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "SnapStartParameterFunction"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
     }
   }
 }

--- a/tests/translator/output/aws-cn/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_sns_event_source_all_parameters.json
@@ -62,7 +62,7 @@
         "FilterPolicyScope": "MessageAttributes",
         "Protocol": "lambda",
         "Region": "region",
-        "TopicArn": "topicArn-letsAddMoreSymbols"
+        "TopicArn": "arn:aws:sns:us-west-2:987654321098:key/dec86919-7219-4e8d-8871-7f1609df2c7f"
       },
       "Type": "AWS::SNS::Subscription"
     },
@@ -73,7 +73,7 @@
           "Ref": "MyAwesomeFunction"
         },
         "Principal": "sns.amazonaws.com",
-        "SourceArn": "topicArn-letsAddMoreSymbols"
+        "SourceArn": "arn:aws:sns:us-west-2:987654321098:key/dec86919-7219-4e8d-8871-7f1609df2c7f"
       },
       "Type": "AWS::Lambda::Permission"
     },

--- a/tests/translator/output/aws-cn/graphqlapi_ddb_datasource_connector.json
+++ b/tests/translator/output/aws-cn/graphqlapi_ddb_datasource_connector.json
@@ -104,12 +104,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "table-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "table-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -127,12 +127,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "table-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "table-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -248,12 +248,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "big-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "big-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -271,12 +271,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "big-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "big-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }

--- a/tests/translator/output/aws-cn/graphqlapi_lambda_datasource_connector.json
+++ b/tests/translator/output/aws-cn/graphqlapi_lambda_datasource_connector.json
@@ -66,7 +66,7 @@
           ]
         },
         "LambdaConfig": {
-          "LambdaFunctionArn": "blah"
+          "LambdaFunctionArn": "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f"
         },
         "Name": "MyDataSource",
         "ServiceRoleArn": {
@@ -123,12 +123,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "blah",
+                "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}:*",
                     {
-                      "DestinationArn": "blah"
+                      "DestinationArn": "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1580,7 +1580,7 @@
                     "Fn::Sub": [
                       "${certificateArn}",
                       {
-                        "certificateArn": "arn"
+                        "certificateArn": "arn:aws:acm:us-west-2:987654321098:certificate/dec86919-7219-4e8d-8871-7f1609df2c7f"
                       }
                     ]
                   }

--- a/tests/translator/output/aws-us-gov/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/aws-us-gov/connector_with_non_id_source_and_destination.json
@@ -183,7 +183,9 @@
           ]
         },
         "ManagedPolicyArns": [
-          "arn:{AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          }
         ]
       },
       "Type": "AWS::IAM::Role"

--- a/tests/translator/output/aws-us-gov/embedded_connectors_hardcoded_props.json
+++ b/tests/translator/output/aws-us-gov/embedded_connectors_hardcoded_props.json
@@ -1,6 +1,9 @@
 {
   "Resources": {
     "MyApiV1": {
+      "Properties": {
+        "Name": "MyApiV1"
+      },
       "Type": "AWS::ApiGateway::RestApi"
     },
     "MyApiV1ApiV1ToLambdaWriteLambdaPermission": {
@@ -40,6 +43,9 @@
       "Type": "AWS::Lambda::Permission"
     },
     "MyApiV2": {
+      "Properties": {
+        "Name": "MyApiV2"
+      },
       "Type": "AWS::ApiGatewayV2::Api"
     },
     "MyApiV2ApiV2ToLambdaWriteLambdaPermission": {
@@ -79,6 +85,14 @@
       "Type": "AWS::Lambda::Permission"
     },
     "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = function(event, context, callback) {\n  return callback(null, 'success');\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": "arn:aws:iam::111122223333:role/lambda-role",
+        "Runtime": "nodejs20.x"
+      },
       "Type": "AWS::Lambda::Function"
     },
     "MyQueue": {
@@ -88,6 +102,9 @@
       "Type": "AWS::SQS::Queue"
     },
     "MyRule": {
+      "Properties": {
+        "ScheduleExpression": "rate(5 minutes)"
+      },
       "Type": "AWS::Events::Rule"
     },
     "MyRuleRuleToTopicTopicPolicy": {

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_all_properties_property.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_all_properties_property.json
@@ -46,7 +46,7 @@
         "PackageType": "Zip",
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::Sub": "arn:${AWS::Partition}:iam::role"
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1"
         },
         "Runtime": "python2.7",
         "Tags": [
@@ -74,7 +74,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "HashChangeFunctionVersion17ca83d2bf",
+            "HashChangeFunctionVersiona1a9d4d1e4",
             "Version"
           ]
         },
@@ -82,7 +82,7 @@
       },
       "Type": "AWS::Lambda::Alias"
     },
-    "HashChangeFunctionVersion17ca83d2bf": {
+    "HashChangeFunctionVersiona1a9d4d1e4": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "Description": "sam-testing",
@@ -127,7 +127,7 @@
         "PackageType": "Zip",
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::Sub": "arn:${AWS::Partition}:iam::role"
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1"
         },
         "Runtime": "python2.7",
         "Tags": [

--- a/tests/translator/output/aws-us-gov/function_with_snapstart.json
+++ b/tests/translator/output/aws-us-gov/function_with_snapstart.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -155,7 +155,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": {
             "Ref": "SnapStartParam"
@@ -169,21 +169,6 @@
         ]
       },
       "Type": "AWS::Lambda::Function"
-    },
-    "SnapStartParameterFunctionAliaslive": {
-      "Properties": {
-        "FunctionName": {
-          "Ref": "SnapStartParameterFunction"
-        },
-        "FunctionVersion": {
-          "Fn::GetAtt": [
-            "SnapStartParameterFunctionVersione3921e07ea",
-            "Version"
-          ]
-        },
-        "Name": "live"
-      },
-      "Type": "AWS::Lambda::Alias"
     },
     "SnapStartParameterFunctionRole": {
       "Properties": {
@@ -214,15 +199,6 @@
         ]
       },
       "Type": "AWS::IAM::Role"
-    },
-    "SnapStartParameterFunctionVersione3921e07ea": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "SnapStartParameterFunction"
-        }
-      },
-      "Type": "AWS::Lambda::Version"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/function_with_snapstart.json
+++ b/tests/translator/output/aws-us-gov/function_with_snapstart.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -155,7 +155,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": {
             "Ref": "SnapStartParam"
@@ -169,6 +169,21 @@
         ]
       },
       "Type": "AWS::Lambda::Function"
+    },
+    "SnapStartParameterFunctionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "SnapStartParameterFunction"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "SnapStartParameterFunctionVersione3921e07ea",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
     },
     "SnapStartParameterFunctionRole": {
       "Properties": {
@@ -199,6 +214,15 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "SnapStartParameterFunctionVersione3921e07ea": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "SnapStartParameterFunction"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_sns_event_source_all_parameters.json
@@ -62,7 +62,7 @@
         "FilterPolicyScope": "MessageAttributes",
         "Protocol": "lambda",
         "Region": "region",
-        "TopicArn": "topicArn-letsAddMoreSymbols"
+        "TopicArn": "arn:aws:sns:us-west-2:987654321098:key/dec86919-7219-4e8d-8871-7f1609df2c7f"
       },
       "Type": "AWS::SNS::Subscription"
     },
@@ -73,7 +73,7 @@
           "Ref": "MyAwesomeFunction"
         },
         "Principal": "sns.amazonaws.com",
-        "SourceArn": "topicArn-letsAddMoreSymbols"
+        "SourceArn": "arn:aws:sns:us-west-2:987654321098:key/dec86919-7219-4e8d-8871-7f1609df2c7f"
       },
       "Type": "AWS::Lambda::Permission"
     },

--- a/tests/translator/output/aws-us-gov/graphqlapi_ddb_datasource_connector.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_ddb_datasource_connector.json
@@ -104,12 +104,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "table-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "table-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -127,12 +127,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "table-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "table-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -248,12 +248,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "big-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "big-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -271,12 +271,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "big-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "big-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }

--- a/tests/translator/output/aws-us-gov/graphqlapi_lambda_datasource_connector.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_lambda_datasource_connector.json
@@ -66,7 +66,7 @@
           ]
         },
         "LambdaConfig": {
-          "LambdaFunctionArn": "blah"
+          "LambdaFunctionArn": "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f"
         },
         "Name": "MyDataSource",
         "ServiceRoleArn": {
@@ -123,12 +123,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "blah",
+                "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}:*",
                     {
-                      "DestinationArn": "blah"
+                      "DestinationArn": "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }

--- a/tests/translator/output/connector_with_non_id_source_and_destination.json
+++ b/tests/translator/output/connector_with_non_id_source_and_destination.json
@@ -183,7 +183,9 @@
           ]
         },
         "ManagedPolicyArns": [
-          "arn:{AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          }
         ]
       },
       "Type": "AWS::IAM::Role"

--- a/tests/translator/output/embedded_connectors_hardcoded_props.json
+++ b/tests/translator/output/embedded_connectors_hardcoded_props.json
@@ -1,6 +1,9 @@
 {
   "Resources": {
     "MyApiV1": {
+      "Properties": {
+        "Name": "MyApiV1"
+      },
       "Type": "AWS::ApiGateway::RestApi"
     },
     "MyApiV1ApiV1ToLambdaWriteLambdaPermission": {
@@ -40,6 +43,9 @@
       "Type": "AWS::Lambda::Permission"
     },
     "MyApiV2": {
+      "Properties": {
+        "Name": "MyApiV2"
+      },
       "Type": "AWS::ApiGatewayV2::Api"
     },
     "MyApiV2ApiV2ToLambdaWriteLambdaPermission": {
@@ -79,6 +85,14 @@
       "Type": "AWS::Lambda::Permission"
     },
     "MyFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "exports.handler = function(event, context, callback) {\n  return callback(null, 'success');\n}\n"
+        },
+        "Handler": "index.handler",
+        "Role": "arn:aws:iam::111122223333:role/lambda-role",
+        "Runtime": "nodejs20.x"
+      },
       "Type": "AWS::Lambda::Function"
     },
     "MyQueue": {
@@ -88,6 +102,9 @@
       "Type": "AWS::SQS::Queue"
     },
     "MyRule": {
+      "Properties": {
+        "ScheduleExpression": "rate(5 minutes)"
+      },
       "Type": "AWS::Events::Rule"
     },
     "MyRuleRuleToTopicTopicPolicy": {

--- a/tests/translator/output/function_with_alias_and_all_properties_property.json
+++ b/tests/translator/output/function_with_alias_and_all_properties_property.json
@@ -46,7 +46,7 @@
         "PackageType": "Zip",
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::Sub": "arn:${AWS::Partition}:iam::role"
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1"
         },
         "Runtime": "python2.7",
         "Tags": [
@@ -74,7 +74,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "HashChangeFunctionVersion17ca83d2bf",
+            "HashChangeFunctionVersiona1a9d4d1e4",
             "Version"
           ]
         },
@@ -82,7 +82,7 @@
       },
       "Type": "AWS::Lambda::Alias"
     },
-    "HashChangeFunctionVersion17ca83d2bf": {
+    "HashChangeFunctionVersiona1a9d4d1e4": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "Description": "sam-testing",
@@ -127,7 +127,7 @@
         "PackageType": "Zip",
         "ReservedConcurrentExecutions": 100,
         "Role": {
-          "Fn::Sub": "arn:${AWS::Partition}:iam::role"
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1"
         },
         "Runtime": "python2.7",
         "Tags": [

--- a/tests/translator/output/function_with_snapstart.json
+++ b/tests/translator/output/function_with_snapstart.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -155,7 +155,7 @@
             "Arn"
           ]
         },
-        "Runtime": "java11",
+        "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": {
             "Ref": "SnapStartParam"
@@ -169,21 +169,6 @@
         ]
       },
       "Type": "AWS::Lambda::Function"
-    },
-    "SnapStartParameterFunctionAliaslive": {
-      "Properties": {
-        "FunctionName": {
-          "Ref": "SnapStartParameterFunction"
-        },
-        "FunctionVersion": {
-          "Fn::GetAtt": [
-            "SnapStartParameterFunctionVersione3921e07ea",
-            "Version"
-          ]
-        },
-        "Name": "live"
-      },
-      "Type": "AWS::Lambda::Alias"
     },
     "SnapStartParameterFunctionRole": {
       "Properties": {
@@ -214,15 +199,6 @@
         ]
       },
       "Type": "AWS::IAM::Role"
-    },
-    "SnapStartParameterFunctionVersione3921e07ea": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "SnapStartParameterFunction"
-        }
-      },
-      "Type": "AWS::Lambda::Version"
     }
   }
 }

--- a/tests/translator/output/function_with_snapstart.json
+++ b/tests/translator/output/function_with_snapstart.json
@@ -19,7 +19,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -75,7 +75,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": "PublishedVersions"
         },
@@ -155,7 +155,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.9",
+        "Runtime": "java11",
         "SnapStart": {
           "ApplyOn": {
             "Ref": "SnapStartParam"
@@ -169,6 +169,21 @@
         ]
       },
       "Type": "AWS::Lambda::Function"
+    },
+    "SnapStartParameterFunctionAliaslive": {
+      "Properties": {
+        "FunctionName": {
+          "Ref": "SnapStartParameterFunction"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "SnapStartParameterFunctionVersione3921e07ea",
+            "Version"
+          ]
+        },
+        "Name": "live"
+      },
+      "Type": "AWS::Lambda::Alias"
     },
     "SnapStartParameterFunctionRole": {
       "Properties": {
@@ -199,6 +214,15 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "SnapStartParameterFunctionVersione3921e07ea": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "SnapStartParameterFunction"
+        }
+      },
+      "Type": "AWS::Lambda::Version"
     }
   }
 }

--- a/tests/translator/output/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/function_with_sns_event_source_all_parameters.json
@@ -62,7 +62,7 @@
         "FilterPolicyScope": "MessageAttributes",
         "Protocol": "lambda",
         "Region": "region",
-        "TopicArn": "topicArn-letsAddMoreSymbols"
+        "TopicArn": "arn:aws:sns:us-west-2:987654321098:key/dec86919-7219-4e8d-8871-7f1609df2c7f"
       },
       "Type": "AWS::SNS::Subscription"
     },
@@ -73,7 +73,7 @@
           "Ref": "MyAwesomeFunction"
         },
         "Principal": "sns.amazonaws.com",
-        "SourceArn": "topicArn-letsAddMoreSymbols"
+        "SourceArn": "arn:aws:sns:us-west-2:987654321098:key/dec86919-7219-4e8d-8871-7f1609df2c7f"
       },
       "Type": "AWS::Lambda::Permission"
     },

--- a/tests/translator/output/graphqlapi_ddb_datasource_connector.json
+++ b/tests/translator/output/graphqlapi_ddb_datasource_connector.json
@@ -104,12 +104,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "table-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "table-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -127,12 +127,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "table-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "table-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -248,12 +248,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "big-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "big-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }
@@ -271,12 +271,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "big-arn",
+                "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}/index/*",
                     {
-                      "DestinationArn": "big-arn"
+                      "DestinationArn": "arn:aws:dynamodb:us-west-2:987654321098:table/dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }

--- a/tests/translator/output/graphqlapi_lambda_datasource_connector.json
+++ b/tests/translator/output/graphqlapi_lambda_datasource_connector.json
@@ -66,7 +66,7 @@
           ]
         },
         "LambdaConfig": {
-          "LambdaFunctionArn": "blah"
+          "LambdaFunctionArn": "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f"
         },
         "Name": "MyDataSource",
         "ServiceRoleArn": {
@@ -123,12 +123,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "blah",
+                "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f",
                 {
                   "Fn::Sub": [
                     "${DestinationArn}:*",
                     {
-                      "DestinationArn": "blah"
+                      "DestinationArn": "arn:aws:lambda:us-west-2:987654321098:function:dec86919-7219-4e8d-8871-7f1609df2c7f"
                     }
                   ]
                 }


### PR DESCRIPTION
### Issue #, if available

N/A

### Description of changes

CFN lint checks are failing and out cfn lint version is outdated. Updating the cfn lint version and transform tests to match

### Description of how you validated changes

`make pr`

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [x] Using wrong values
- [n/a] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
