### PR TITLE
chore: Fix Managed Policy ARNs with hardcoded partition in tests

### DIFF
--- a/integration/resources/templates/combination/api_with_authorizers_max.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_max.yaml
@@ -125,8 +125,8 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaRole
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaRole
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/integration/resources/templates/combination/api_with_authorizers_max_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_max_openapi.yaml
@@ -138,8 +138,8 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaRole
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaRole
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/integration/resources/templates/combination/function_with_mq.yaml
+++ b/integration/resources/templates/combination/function_with_mq.yaml
@@ -101,7 +101,8 @@ Resources:
               secretsmanager:GetSecretValue]
             Effect: Allow
             Resource: '*'
-      ManagedPolicyArns: [arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]
+      ManagedPolicyArns:
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Tags:
       - {Value: SAM, Key: lambda:createdBy}
 

--- a/integration/resources/templates/combination/function_with_msk.yaml
+++ b/integration/resources/templates/combination/function_with_msk.yaml
@@ -27,7 +27,8 @@ Resources:
               logs:CreateLogStream, logs:PutLogEvents]
             Effect: Allow
             Resource: '*'
-      ManagedPolicyArns: [arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]
+      ManagedPolicyArns:
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Tags:
       - {Value: SAM, Key: lambda:createdBy}
 

--- a/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
+++ b/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
@@ -27,7 +27,8 @@ Resources:
               logs:CreateLogStream, logs:PutLogEvents, s3:ListBucket]
             Effect: Allow
             Resource: '*'
-      ManagedPolicyArns: [arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]
+      ManagedPolicyArns:
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Tags:
       - {Value: SAM, Key: lambda:createdBy}
 

--- a/integration/resources/templates/single/state_machine_with_api.yaml
+++ b/integration/resources/templates/single/state_machine_with_api.yaml
@@ -19,7 +19,7 @@ Resources:
     Type: AWS::Serverless::StateMachine
     Properties:
       Policies:
-      - arn:aws:iam::aws:policy/AWSLambda_FullAccess
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSLambda_FullAccess
       Definition:
         StartAt: One
         States:


### PR DESCRIPTION
### Issue #, if available

None

### Description of changes

In some of the integ test templates, for managed policies, it is using an ARN with hardcoded AWS partition. This will fail the test in some regions, hence, replacing the partition part with the `AWS::Partition` parameter. [Example](https://github.com/samson-keung/serverless-application-model/blob/725a3121fb401521168661adaf843ccfe3aee8a4/integration/resources/templates/combination/connector_function_to_bucket_read.yaml#L12) of other places where this is already done.

### Description of how you validated changes

Followed the other places in the code where this is already done

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [n/a] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
