### PR TITLE
chore: Fix hardcoded endpoint domain in test template

### DIFF
--- a/integration/resources/templates/single/basic_api_with_mode.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode.yaml
@@ -31,6 +31,6 @@ Resources:
 
 Outputs:
   ApiEndpoint:
-    Value: !Sub "https://${MyApi}.execute-api.${AWS::Region}.amazonaws.com/MyNewStageName"
+    Value: !Sub "https://${MyApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/MyNewStageName"
 Metadata:
   SamTransformTest: true


### PR DESCRIPTION
### Issue #, if available

None

### Description of changes

Hardcoded domain does not work in all regions. It caused test failures

### Description of how you validated changes

Same as https://github.com/aws/serverless-application-model/blob/develop/integration/resources/templates/single/state_machine_with_api.yaml#L41

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [n/a] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
