### PR TITLE
chore: update valid appsync function runtime in tests

### DIFF
--- a/tests/translator/input/graphqlapi_function_by_id.yaml
+++ b/tests/translator/input/graphqlapi_function_by_id.yaml
@@ -22,5 +22,5 @@ Resources:
       DataSourceName: some-cool-datasource
       Name: MyFunction
       Runtime:
-        Name: some-runtime
+        Name: APPSYNC_JS
         RuntimeVersion: 1.2.3

--- a/tests/translator/input/graphqlapi_multiple_none_datasource_functions.yaml
+++ b/tests/translator/input/graphqlapi_multiple_none_datasource_functions.yaml
@@ -15,23 +15,23 @@ Resources:
           CodeUri: my-code-uri
           DataSource: NONE
           Runtime:
-            Name: some-runtime
+            Name: APPSYNC_JS
             Version: 1.2.3
         AnotherFunction:
           CodeUri: my-code-uri
           DataSource: None
           Runtime:
-            Name: some-runtime
+            Name: APPSYNC_JS
             Version: 1.2.3
         SimilarFunction:
           CodeUri: my-code-uri
           DataSource: none
           Runtime:
-            Name: some-runtime
+            Name: APPSYNC_JS
             Version: 1.2.3
         GoodFunction:
           CodeUri: my-code-uri
           DataSource: nOnE
           Runtime:
-            Name: some-runtime
+            Name: APPSYNC_JS
             Version: 1.2.3

--- a/tests/translator/input/graphqlapi_resolver_function_with_lambda_datasource.yaml
+++ b/tests/translator/input/graphqlapi_resolver_function_with_lambda_datasource.yaml
@@ -50,7 +50,7 @@ Resources:
       Functions:
         MyFunction:
           Runtime:
-            Name: some-runtime
+            Name: APPSYNC_JS
             Version: 1.2.3
           InlineCode: this is my epic code
           DataSource: MyDataSource

--- a/tests/translator/output/aws-cn/graphqlapi_function_by_id.json
+++ b/tests/translator/output/aws-cn/graphqlapi_function_by_id.json
@@ -12,7 +12,7 @@
         "DataSourceName": "some-cool-datasource",
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },

--- a/tests/translator/output/aws-cn/graphqlapi_multiple_none_datasource_functions.json
+++ b/tests/translator/output/aws-cn/graphqlapi_multiple_none_datasource_functions.json
@@ -39,7 +39,7 @@
         },
         "Name": "AnotherFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -88,7 +88,7 @@
         },
         "Name": "GoodFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -111,7 +111,7 @@
         },
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -159,7 +159,7 @@
         },
         "Name": "SimilarFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },

--- a/tests/translator/output/aws-cn/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/aws-cn/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -173,7 +173,7 @@
         "MaxBatchSize": 10,
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },

--- a/tests/translator/output/aws-us-gov/graphqlapi_function_by_id.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_function_by_id.json
@@ -12,7 +12,7 @@
         "DataSourceName": "some-cool-datasource",
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },

--- a/tests/translator/output/aws-us-gov/graphqlapi_multiple_none_datasource_functions.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_multiple_none_datasource_functions.json
@@ -39,7 +39,7 @@
         },
         "Name": "AnotherFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -88,7 +88,7 @@
         },
         "Name": "GoodFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -111,7 +111,7 @@
         },
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -159,7 +159,7 @@
         },
         "Name": "SimilarFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },

--- a/tests/translator/output/aws-us-gov/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -173,7 +173,7 @@
         "MaxBatchSize": 10,
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },

--- a/tests/translator/output/graphqlapi_function_by_id.json
+++ b/tests/translator/output/graphqlapi_function_by_id.json
@@ -12,7 +12,7 @@
         "DataSourceName": "some-cool-datasource",
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },

--- a/tests/translator/output/graphqlapi_multiple_none_datasource_functions.json
+++ b/tests/translator/output/graphqlapi_multiple_none_datasource_functions.json
@@ -39,7 +39,7 @@
         },
         "Name": "AnotherFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -88,7 +88,7 @@
         },
         "Name": "GoodFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -111,7 +111,7 @@
         },
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },
@@ -159,7 +159,7 @@
         },
         "Name": "SimilarFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },

--- a/tests/translator/output/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -173,7 +173,7 @@
         "MaxBatchSize": 10,
         "Name": "MyFunction",
         "Runtime": {
-          "Name": "some-runtime",
+          "Name": "APPSYNC_JS",
           "RuntimeVersion": "1.2.3"
         }
       },


### PR DESCRIPTION
### Issue #, if available
None
### Description of changes
Update appsync function related tests with valid runtime value `APPSYNC_JS` as the cfn-lint failed

### Description of how you validated changes
by running `make pr`

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
