### PR TITLE
chore: fix graphql transform test template

### DIFF
--- a/tests/translator/input/graphqlapi_cognito_default_auth.yaml
+++ b/tests/translator/input/graphqlapi_cognito_default_auth.yaml
@@ -16,7 +16,7 @@ Resources:
           AppIdClientRegex: myregex
           AwsRegion: na-east-1
           # This default action will exist post transform since this is our default authentication.
-          DefaultAction: something
+          DefaultAction: ALLOW
           UserPoolId: myid
       Tags:
         key1: value1

--- a/tests/translator/output/aws-cn/graphqlapi_cognito_default_auth.json
+++ b/tests/translator/output/aws-cn/graphqlapi_cognito_default_auth.json
@@ -30,7 +30,7 @@
         "UserPoolConfig": {
           "AppIdClientRegex": "myregex",
           "AwsRegion": "na-east-1",
-          "DefaultAction": "something",
+          "DefaultAction": "ALLOW",
           "UserPoolId": "myid"
         },
         "XrayEnabled": true

--- a/tests/translator/output/aws-us-gov/graphqlapi_cognito_default_auth.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_cognito_default_auth.json
@@ -30,7 +30,7 @@
         "UserPoolConfig": {
           "AppIdClientRegex": "myregex",
           "AwsRegion": "na-east-1",
-          "DefaultAction": "something",
+          "DefaultAction": "ALLOW",
           "UserPoolId": "myid"
         },
         "XrayEnabled": true

--- a/tests/translator/output/graphqlapi_cognito_default_auth.json
+++ b/tests/translator/output/graphqlapi_cognito_default_auth.json
@@ -30,7 +30,7 @@
         "UserPoolConfig": {
           "AppIdClientRegex": "myregex",
           "AwsRegion": "na-east-1",
-          "DefaultAction": "something",
+          "DefaultAction": "ALLOW",
           "UserPoolId": "myid"
         },
         "XrayEnabled": true


### PR DESCRIPTION
### Issue #, if available
`make pr` failed because `something` is not a valid value when using the latest cfn-lint

### Description of changes
update the transform test 

### Description of how you validated changes

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
