### PR TITLE
fix:downgrade lambda runtime version to nodejs18.x in integ test

### DIFF
--- a/integration/resources/templates/combination/function_with_alias_all_properties_and_layer_version.yaml
+++ b/integration/resources/templates/combination/function_with_alias_all_properties_and_layer_version.yaml
@@ -4,7 +4,7 @@ Resources:
     Properties:
       CodeUri: ${codeuri}
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs18.x
       AutoPublishAlias: Live
       AutoPublishAliasAllProperties: true
       Layers:


### PR DESCRIPTION
### Issue #, if available
NA
### Description of changes

NodeJs 20.x lambda runtime is not fully available in all regions. Hence downgrading it to nodejs18.x in lambda integ test similar to other integ tests.

### Description of how you validated changes
Run `make pr`

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
