### PR TITLE
update conditions in tests to fix lint failures

### DIFF
--- a/tests/translator/input/basic_application.yaml
+++ b/tests/translator/input/basic_application.yaml
@@ -1,8 +1,8 @@
 Conditions:
   TestCondition:
     Fn::Equals:
-    - true
-    - false
+    - !Ref AWS::AccountId
+    - myAccountId
 Resources:
   BasicApplication:
     Type: AWS::Serverless::Application

--- a/tests/translator/input/definition_body_intrinsics_support.yaml
+++ b/tests/translator/input/definition_body_intrinsics_support.yaml
@@ -13,8 +13,8 @@ Description: >
 Conditions:
   FalseCondition:
     Fn::Equals:
-    - true
-    - false
+    - !Ref AWS::AccountId
+    - myAccountId
 
 Resources:
   # Rest Api with DefinitionBody under If intrinsic, SwaggerEditor not used

--- a/tests/translator/input/function_with_deployment_preference_alarms_intrinsic_if.yaml
+++ b/tests/translator/input/function_with_deployment_preference_alarms_intrinsic_if.yaml
@@ -1,8 +1,8 @@
 Conditions:
   MyCondition:
     Fn::Equals:
-    - true
-    - false
+    - !Ref AWS::AccountId
+    - myAccountId
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/s3_with_condition.yaml
+++ b/tests/translator/input/s3_with_condition.yaml
@@ -1,8 +1,8 @@
 Conditions:
   MyCondition:
     Fn::Equals:
-    - true
-    - false
+    - !Ref AWS::AccountId
+    - myAccountId
 Resources:
   ThumbnailFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/sns_intrinsics.yaml
+++ b/tests/translator/input/sns_intrinsics.yaml
@@ -6,8 +6,8 @@ Parameters:
 Conditions:
   MyCondition:
     Fn::Equals:
-    - true
-    - false
+    - !Ref AWS::AccountId
+    - myAccountId
 
 Resources:
   SaveNotificationFunction:

--- a/tests/translator/output/aws-cn/basic_application.json
+++ b/tests/translator/output/aws-cn/basic_application.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "TestCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-cn/definition_body_intrinsics_support.json
+++ b/tests/translator/output/aws-cn/definition_body_intrinsics_support.json
@@ -3,8 +3,10 @@
   "Conditions": {
     "FalseCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_alarms_intrinsic_if.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_alarms_intrinsic_if.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-cn/s3_with_condition.json
+++ b/tests/translator/output/aws-cn/s3_with_condition.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-cn/sns_intrinsics.json
+++ b/tests/translator/output/aws-cn/sns_intrinsics.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-us-gov/basic_application.json
+++ b/tests/translator/output/aws-us-gov/basic_application.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "TestCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-us-gov/definition_body_intrinsics_support.json
+++ b/tests/translator/output/aws-us-gov/definition_body_intrinsics_support.json
@@ -3,8 +3,10 @@
   "Conditions": {
     "FalseCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_alarms_intrinsic_if.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_alarms_intrinsic_if.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-us-gov/s3_with_condition.json
+++ b/tests/translator/output/aws-us-gov/s3_with_condition.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/aws-us-gov/sns_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/sns_intrinsics.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/basic_application.json
+++ b/tests/translator/output/basic_application.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "TestCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/definition_body_intrinsics_support.json
+++ b/tests/translator/output/definition_body_intrinsics_support.json
@@ -3,8 +3,10 @@
   "Conditions": {
     "FalseCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/function_with_deployment_preference_alarms_intrinsic_if.json
+++ b/tests/translator/output/function_with_deployment_preference_alarms_intrinsic_if.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/s3_with_condition.json
+++ b/tests/translator/output/s3_with_condition.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },

--- a/tests/translator/output/sns_intrinsics.json
+++ b/tests/translator/output/sns_intrinsics.json
@@ -2,8 +2,10 @@
   "Conditions": {
     "MyCondition": {
       "Fn::Equals": [
-        true,
-        false
+        {
+          "Ref": "AWS::AccountId"
+        },
+        "myAccountId"
       ]
     }
   },


### PR DESCRIPTION
### Issue #, if available

### Description of changes
Due to a recent update to the cfn_lint, Conditions in some tests files are violating [W8003 cfn_lint rule](https://github.com/aws-cloudformation/cfn-lint/blob/bba21dc4d593989f38fd3477de7233a4bb2833d2/src/cfnlint/rules/conditions/EqualsIsUseful.py#L14), making the linter fail. This PR updates the Condition section of those tests files to make the linter succeed.

### Description of how you validated changes
make pr

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
