### PR TITLE
fix(dep): compat.py should import right pydantic class for pydantic >= 1.10.17

### DIFF
--- a/samtranslator/compat.py
+++ b/samtranslator/compat.py
@@ -1,6 +1,6 @@
 try:
     from pydantic import v1 as pydantic
-    # Starting Pydantic v1.10.17, pydantic import v1 will success, 
+    # Starting Pydantic v1.10.17, pydantic import v1 will success,
     # adding the following line to make Pydantic v1 should fall back to v1 import correctly.
     pydantic.error_wrappers
 except ImportError:
@@ -10,5 +10,5 @@ except ImportError:
 except AttributeError:
     # Pydantic v1.10.17+
     import pydantic  # type: ignore
-    
+
 __all__ = ["pydantic"]

--- a/samtranslator/compat.py
+++ b/samtranslator/compat.py
@@ -1,8 +1,9 @@
 try:
     from pydantic import v1 as pydantic
+
     # Starting Pydantic v1.10.17, pydantic import v1 will success,
     # adding the following line to make Pydantic v1 should fall back to v1 import correctly.
-    pydantic.error_wrappers
+    pydantic.error_wrappers.ValidationError  # noqa
 except ImportError:
     # Unfortunately mypy cannot handle this try/expect pattern, and "type: ignore"
     # is the simplest work-around. See: https://github.com/python/mypy/issues/1153

--- a/samtranslator/compat.py
+++ b/samtranslator/compat.py
@@ -1,8 +1,14 @@
 try:
     from pydantic import v1 as pydantic
+    # Starting Pydantic v1.10.17, pydantic import v1 will success, 
+    # adding the following line to make Pydantic v1 should fall back to v1 import correctly.
+    pydantic.error_wrappers
 except ImportError:
     # Unfortunately mypy cannot handle this try/expect pattern, and "type: ignore"
     # is the simplest work-around. See: https://github.com/python/mypy/issues/1153
     import pydantic  # type: ignore
-
+except AttributeError:
+    # Pydantic v1.10.17+
+    import pydantic  # type: ignore
+    
 __all__ = ["pydantic"]


### PR DESCRIPTION
### Issue #, if available
#3617
https://github.com/pydantic/pydantic/issues/9742
### Description of changes
Update compat.py to make sure pydantic v1 should call `import pydantic` correctly
starting from pydantic 1.10.17, `from pydantic import v1 as pydantic` will not fail anymore, adding additional check to make sure pydantic v1 will run `import pydantic` correctly`
### Description of how you validated changes
`make test` with pydantic 1.10.17-1.10.21
### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
