### PR TITLE
Fix usage of pydantic v1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,4 @@ typing_extensions>=4.4 # 3.8 doesn't have Required, TypeGuard and ParamSpec
 
 # resource validation & schema generation
 # 1.10.15 and 1.10.17 included breaking change from pydantic, more info: https://github.com/aws/serverless-application-model/issues/3617
-pydantic>=1.8,<3,!=1.10.15,!=1.10.17
+pydantic>=1.10.18,<3

--- a/samtranslator/compat.py
+++ b/samtranslator/compat.py
@@ -3,7 +3,7 @@ try:
 
     # Starting Pydantic v1.10.17, pydantic import v1 will success,
     # adding the following line to make Pydantic v1 should fall back to v1 import correctly.
-    pydantic.error_wrappers.ValidationError  # noqa
+    pydantic.ValidationError  # noqa
 except ImportError:
     # Unfortunately mypy cannot handle this try/expect pattern, and "type: ignore"
     # is the simplest work-around. See: https://github.com/python/mypy/issues/1153

--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -345,7 +345,7 @@ class Resource(ABC):
         """
         try:
             return cls.parse_obj(self._generate_resource_dict()["Properties"])
-        except pydantic.error_wrappers.ValidationError as e:
+        except pydantic.ValidationError as e:
             error_properties: str = ""
             with suppress(KeyError):
                 error_properties = ".".join(str(x) for x in e.errors()[0]["loc"])


### PR DESCRIPTION
### Issue #, if available

https://github.com/aws/serverless-application-model/issues/3617
Supercedes: https://github.com/aws/serverless-application-model/pull/3710

### Description of changes

Importing `error_wrappers` or `ValidationError` using python's import syntax works as expected as it can also traverse directories and files. However, doing something like `from pydantic import v1 as pydantic` actually just reads `pydantic/v1/__init__.py` which just re-exports `pydantic` namespace (for 1.10.x) but it DOES NOT re-export `error_wrappers`, however it does [re-export `ValidationError` which is what we care about](https://github.com/pydantic/pydantic/blob/0cbba0f9774c470e8d8a2a62abb921b8cea4027d/pydantic/__init__.py#L40).

### Description of how you validated changes

Ran test suite with pydantic2, and able to import files with pydantic1

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

import example:
```
$ python
Python 3.11.10 (main, Sep  7 2024, 01:03:31) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pydantic
>>> pydantic.__version__
'1.10.21'
>>> pydantic.v1.error_wrappers
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pydantic' has no attribute 'v1'
>>> import pydantic.v1 as p
>>> p
<module 'pydantic.v1' from '/nix/store/fyn8cs661n9mbldsn0w3pb29pf62rprn-python3.11-pydantic-1.10.21/lib/python3.11/site-packages/pydantic/v1/__init__.py'>
>>> p.error_wrappers
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pydantic.v1' has no attribute 'error_wrappers'
>>> p.ValidationError(
... 
KeyboardInterrupt
>>> p.ValidationError
<class 'pydantic.error_wrappers.ValidationError'>
>>> from pydantic.v1 import error_wrappers
>>> error_wrappers
<module 'pydantic.v1.error_wrappers' from '/nix/store/fyn8cs661n9mbldsn0w3pb29pf62rprn-python3.11-pydantic-1.10.21/lib/python3.11/site-packages/pydantic/v1/error_wrappers.py'>
>>> error_wrappers.ValidationError
<class 'pydantic.error_wrappers.ValidationError'>
```
