### PR TITLE
feat: skipping test if Layers is not available

### DIFF
--- a/integration/combination/test_function_with_alias.py
+++ b/integration/combination/test_function_with_alias.py
@@ -3,7 +3,7 @@ from unittest.case import skipIf
 
 from botocore.exceptions import ClientError
 
-from integration.config.service_names import REST_API
+from integration.config.service_names import LAYERS, REST_API
 from integration.helpers.base_test import LOG, BaseTest
 from integration.helpers.common_api import get_function_versions
 from integration.helpers.resource import current_region_does_not_support
@@ -160,6 +160,7 @@ class TestFunctionWithAlias(BaseTest):
         function_policy = json.loads(function_policy_str)
         self.assertEqual(len(function_policy["Statement"]), len(permission_resources))
 
+    @skipIf(current_region_does_not_support([LAYERS]), "Layers is not supported in this testing region")
     def test_function_with_alias_and_layer_version(self):
         self.create_and_verify_stack("combination/function_with_alias_all_properties_and_layer_version")
         alias_name = "Live"


### PR DESCRIPTION
### Issue #, if available

### Description of changes
To skip the integration test for times when "Layer" functionality is not available in regions that are not GA yet. 

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
