### PR TITLE
Allow AWS::NoValue to omit Role property in if - FeatureRequest#3728

### DIFF
--- a/tests/intrinsics/test_actions.py
+++ b/tests/intrinsics/test_actions.py
@@ -111,6 +111,11 @@ class TestRefCanResolveParameterRefs(TestCase):
         ref = RefAction()
         self.assertEqual(expected, ref.resolve_parameter_refs(input, parameters))
 
+    def test_resolve_ref_value(self):
+        self.ref = RefAction()
+        input_aws_no_value = {"Ref": "AWS::NoValue"}
+        self.assertEqual(None, self.ref.resolve_ref_value(input_aws_no_value))
+
     def test_must_ignore_invalid_value(self):
         parameters = {"key": "value"}
         input = {"Ref": ["invalid value"]}


### PR DESCRIPTION
### 3728 #, if available

### Allow AWS::NoValue to omit Role property in Fn::If

### I have validated the changes with unit tests and hand testing with `bin/sam-translate.py`. The change resolved my need in https://github.com/aws/serverless-application-model/issues/3728.

### Checklist

- [X] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [X] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [X] Using correct values
    - [X] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
