### PR TITLE
feat: Correctly support custom domain in private apis

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -13,6 +13,7 @@ from samtranslator.model.apigateway import (
     ApiGatewayBasePathMappingV2,
     ApiGatewayDeployment,
     ApiGatewayDomainName,
+    ApiGatewayDomainNameAccessAssociation,
     ApiGatewayDomainNameV2,
     ApiGatewayResponse,
     ApiGatewayRestApi,
@@ -86,6 +87,7 @@ class ApiDomainResponseV2:
     domain: Optional[ApiGatewayDomainNameV2]
     apigw_basepath_mapping_list: Optional[List[ApiGatewayBasePathMappingV2]]
     recordset_group: Any
+    domain_access_association: Any
 
 
 class SharedApiUsagePlan:
@@ -218,6 +220,7 @@ class ApiGenerator:
         api_key_source_type: Optional[Intrinsicable[str]] = None,
         always_deploy: Optional[bool] = False,
         feature_toggle: Optional[FeatureToggle] = None,
+        policy: Optional[Dict[str, Any] | Intrinsicable[str]] = None,
     ):
         """Constructs an API Generator class that generates API Gateway resources
 
@@ -275,6 +278,7 @@ class ApiGenerator:
         self.api_key_source_type = api_key_source_type
         self.always_deploy = always_deploy
         self.feature_toggle = feature_toggle
+        self.policy = policy
 
     def _construct_rest_api(self) -> ApiGatewayRestApi:
         """Constructs and returns the ApiGateway RestApi.
@@ -327,6 +331,9 @@ class ApiGenerator:
 
         if self.api_key_source_type:
             rest_api.ApiKeySourceType = self.api_key_source_type
+
+        if self.policy:
+            rest_api.Policy = self.policy
 
         return rest_api
 
@@ -602,7 +609,7 @@ class ApiGenerator:
         Constructs and returns the ApiGateway Domain V2 and BasepathMapping V2
         """
         if self.domain is None:
-            return ApiDomainResponseV2(None, None, None)
+            return ApiDomainResponseV2(None, None, None, None)
 
         sam_expect(self.domain, self.logical_id, "Domain").to_be_a_map()
         domain_name: PassThrough = sam_expect(
@@ -657,6 +664,14 @@ class ApiGenerator:
                 basepath_mapping.BasePath = path if normalize_basepath else basepath
                 basepath_resource_list.extend([basepath_mapping])
 
+        # Create the DomainNameAccessAssociation
+        domain_access_association = self.domain.get("AccessAssociation")
+        domain_access_association_resource = None
+        if domain_access_association is not None:
+            domain_access_association_resource = self._generate_domain_access_association(
+                domain_access_association, domain_name_arn
+            )
+
         # Create the Route53 RecordSetGroup resource
         record_set_group = None
         route53 = self.domain.get("Route53")
@@ -683,6 +698,7 @@ class ApiGenerator:
                     domain,
                     basepath_resource_list,
                     self._construct_single_record_set_group(self.domain, domain_name, route53),
+                    domain_access_association_resource,
                 )
 
             if not record_set_group:
@@ -691,7 +707,7 @@ class ApiGenerator:
 
             record_set_group.RecordSets += self._construct_record_sets_for_domain(self.domain, domain_name, route53)
 
-        return ApiDomainResponseV2(domain, basepath_resource_list, record_set_group)
+        return ApiDomainResponseV2(domain, basepath_resource_list, record_set_group, domain_access_association_resource)
 
     def _get_basepaths(self) -> Optional[List[str]]:
         if self.domain is None:
@@ -779,11 +795,14 @@ class ApiGenerator:
         if domain.get("EndpointConfiguration") == "REGIONAL":
             alias_target["HostedZoneId"] = fnGetAtt(api_domain_name, "RegionalHostedZoneId")
             alias_target["DNSName"] = fnGetAtt(api_domain_name, "RegionalDomainName")
-        else:
+        elif domain.get("EndpointConfiguration") == "EDGE":
             if route53.get("DistributionDomainName") is None:
                 route53["DistributionDomainName"] = fnGetAtt(api_domain_name, "DistributionDomainName")
             alias_target["HostedZoneId"] = "Z2FDTNDATAQYW2"
             alias_target["DNSName"] = route53.get("DistributionDomainName")
+        else:
+            alias_target["HostedZoneId"] = route53.get("VpcEndpointHostedZoneId")
+            alias_target["DNSName"] = route53.get("VpcEndpointDomainName")
         return alias_target
 
     def _create_basepath_mapping(
@@ -833,11 +852,16 @@ class ApiGenerator:
         domain: Union[Resource, None]
         basepath_mapping: Union[List[ApiGatewayBasePathMapping], List[ApiGatewayBasePathMappingV2], None]
         rest_api = self._construct_rest_api()
+        is_private_domain = isinstance(self.domain, dict) and self.domain.get("EndpointConfiguration") == "PRIVATE"
         api_domain_response = (
             self._construct_api_domain_v2(rest_api, route53_record_set_groups)
-            if isinstance(self.domain, dict) and self.domain.get("EndpointConfiguration") == "PRIVATE"
+            if is_private_domain
             else self._construct_api_domain(rest_api, route53_record_set_groups)
         )
+
+        domain_access_association = None
+        if is_private_domain:
+            domain_access_association = cast(ApiDomainResponseV2, api_domain_response).domain_access_association
 
         domain = api_domain_response.domain
         basepath_mapping = api_domain_response.apigw_basepath_mapping_list
@@ -881,6 +905,9 @@ class ApiGenerator:
                 usage_plan,
             ]
         )
+
+        if domain_access_association is not None:
+            generated_resources.append(domain_access_association)
 
         # Make a list of single resources
         generated_resources_list: List[Resource] = []
@@ -1513,3 +1540,21 @@ class ApiGenerator:
         else:
             rest_api.EndpointConfiguration = {"Types": [value]}
             rest_api.Parameters = {"endpointConfigurationTypes": value}
+
+    def _generate_domain_access_association(
+        self, domain_access_association: Dict[str, Any], domain_name_arn: Dict[str, str]
+    ) -> ApiGatewayDomainNameAccessAssociation:
+        """
+        Generate domain access association resource
+        """
+        vpcEndpointId = domain_access_association.get("VpcEndpointId")
+        logical_id = LogicalIdGenerator("DomainNameAccessAssociation", [vpcEndpointId]).gen()
+
+        domain_access_association_resource = ApiGatewayDomainNameAccessAssociation(
+            logical_id, attributes=self.passthrough_resource_attributes
+        )
+        domain_access_association_resource.DomainNameArn = domain_name_arn
+        domain_access_association_resource.AccessAssociationSourceType = "VPCE"
+        domain_access_association_resource.AccessAssociationSource = vpcEndpointId
+
+        return domain_access_association_resource

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -29,6 +29,7 @@ class ApiGatewayRestApi(Resource):
         "Mode": GeneratedProperty(),
         "ApiKeySourceType": GeneratedProperty(),
         "Tags": GeneratedProperty(),
+        "Policy": GeneratedProperty(),
     }
 
     Body: Optional[Dict[str, Any]]
@@ -44,6 +45,7 @@ class ApiGatewayRestApi(Resource):
     Mode: Optional[PassThrough]
     ApiKeySourceType: Optional[PassThrough]
     Tags: Optional[PassThrough]
+    Policy: Optional[PassThrough]
 
     runtime_attrs = {"rest_api_id": lambda self: ref(self.logical_id)}
 
@@ -305,6 +307,16 @@ class ApiGatewayApiKey(Resource):
     }
 
     runtime_attrs = {"api_key_id": lambda self: ref(self.logical_id)}
+
+
+class ApiGatewayDomainNameAccessAssociation(Resource):
+    resource_type = "AWS::ApiGateway::DomainNameAccessAssociation"
+    property_types = {
+        "AccessAssociationSource": GeneratedProperty(),
+        "AccessAssociationSourceType": GeneratedProperty(),
+        "DomainNameArn": GeneratedProperty(),
+        "Tags": GeneratedProperty(),
+    }
 
 
 class ApiGatewayAuthorizer:

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1,4 +1,4 @@
-""" SAM macro definitions """
+﻿""" SAM macro definitions """
 
 import copy
 from contextlib import suppress
@@ -1275,6 +1275,7 @@ class SamApi(SamResourceMacro):
         "DisableExecuteApiEndpoint": PropertyType(False, IS_BOOL),
         "ApiKeySourceType": PropertyType(False, IS_STR),
         "AlwaysDeploy": Property(False, IS_BOOL),
+        "Policy": PropertyType(False, one_of(IS_STR, IS_DICT)),
     }
 
     Name: Optional[Intrinsicable[str]]
@@ -1306,6 +1307,7 @@ class SamApi(SamResourceMacro):
     DisableExecuteApiEndpoint: Optional[Intrinsicable[bool]]
     ApiKeySourceType: Optional[Intrinsicable[str]]
     AlwaysDeploy: Optional[bool]
+    Policy: Optional[Dict[str, Any] | Intrinsicable[str]]
 
     referable_properties = {
         "Stage": ApiGatewayStage.resource_type,
@@ -1373,6 +1375,7 @@ class SamApi(SamResourceMacro):
             api_key_source_type=self.ApiKeySourceType,
             always_deploy=self.AlwaysDeploy,
             feature_toggle=feature_toggle,
+            policy=self.Policy,
         )
 
         generated_resources = api_generator.to_cloudformation(redeploy_restapi_parameters, route53_record_set_groups)

--- a/tests/translator/input/api_custom_domain_private_endpoint_full.yaml
+++ b/tests/translator/input/api_custom_domain_private_endpoint_full.yaml
@@ -1,0 +1,70 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Sample SAM Template for a simple serverless application
+
+Parameters:
+  DomainName:
+    Type: String
+    Default: sam.apigateway.com
+  CertificateArn:
+    Type: String
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/4ba8fce1-abcd-4717-9c34-11bfd24372ba
+  HostedZoneId:
+    Type: String
+    Default: Z012334
+  VpcEndpointId:
+    Type: String
+    Default: vpce-123123123123123
+
+
+Resources:
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      Policy:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal: '*'
+          Action: execute-api:Invoke
+          Resource: execute-api:/*
+        - Effect: Deny
+          Principal: '*'
+          Action: execute-api:Invoke
+          Resource: execute-api:/*
+          Condition:
+            StringNotEquals:
+              aws:SourceVpce: !Ref VpcEndpointId
+      OpenApiVersion: 3.0.1
+      StageName: Prod
+      EndpointConfiguration:
+        Type: PRIVATE
+        VPCEndpointIds:
+        - !Ref VpcEndpointId
+
+      Domain:
+        DomainName: !Ref DomainName
+        CertificateArn: !Ref CertificateArn
+        EndpointConfiguration: PRIVATE
+        BasePath:
+        - /get
+        Route53:
+          HostedZoneId: HostedZoneId
+          VpcEndpointDomainName: VPCEndpointDomainName
+          VpcEndpointHostedZoneId: VPCEndpointHostedZoneId
+        AccessAssociation:
+          VpcEndpointId: !Ref VpcEndpointId
+        Policy:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Principal: '*'
+            Action: execute-api:Invoke
+            Resource: execute-api:/*
+          - Effect: Deny
+            Principal: '*'
+            Action: execute-api:Invoke
+            Resource: execute-api:/*
+            Condition:
+              StringNotEquals:
+                aws:SourceVpce: !Ref VpcEndpointId

--- a/tests/translator/output/api_custom_domain_private_endpoint_full.json
+++ b/tests/translator/output/api_custom_domain_private_endpoint_full.json
@@ -1,0 +1,172 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Sample SAM Template for a simple serverless application",
+  "Parameters": {
+    "CertificateArn": {
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/4ba8fce1-abcd-4717-9c34-11bfd24372ba",
+      "Type": "String"
+    },
+    "DomainName": {
+      "Default": "sam.apigateway.com",
+      "Type": "String"
+    },
+    "HostedZoneId": {
+      "Default": "Z012334",
+      "Type": "String"
+    },
+    "VpcEndpointId": {
+      "Default": "vpce-123123123123123",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "ApiGatewayDomainNameV2f6d6317296": {
+      "Properties": {
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/4ba8fce1-abcd-4717-9c34-11bfd24372ba",
+        "DomainName": "sam.apigateway.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "PRIVATE"
+          ]
+        },
+        "Policy": {
+          "Statement": [
+            {
+              "Action": "execute-api:Invoke",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            },
+            {
+              "Action": "execute-api:Invoke",
+              "Condition": {
+                "StringNotEquals": {
+                  "aws:SourceVpce": "vpce-123123123123123"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::ApiGateway::DomainNameV2"
+    },
+    "DomainNameAccessAssociation136aec2782": {
+      "Properties": {
+        "AccessAssociationSource": "vpce-123123123123123",
+        "AccessAssociationSourceType": "VPCE",
+        "DomainNameArn": {
+          "Ref": "ApiGatewayDomainNameV2f6d6317296"
+        }
+      },
+      "Type": "AWS::ApiGateway::DomainNameAccessAssociation"
+    },
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {}
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "PRIVATE"
+          ],
+          "VpcEndpointIds": [
+            {
+              "Ref": "VpcEndpointId"
+            }
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "PRIVATE"
+        },
+        "Policy": {
+          "Statement": [
+            {
+              "Action": "execute-api:Invoke",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            },
+            {
+              "Action": "execute-api:Invoke",
+              "Condition": {
+                "StringNotEquals": {
+                  "aws:SourceVpce": {
+                    "Ref": "VpcEndpointId"
+                  }
+                }
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeployment831bb29f90": {
+      "Properties": {
+        "Description": "RestApi deployment id: 831bb29f90ba78e5cb705db850981137f44f2af6",
+        "RestApiId": {
+          "Ref": "MyApi"
+        }
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment831bb29f90"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "MyApigetBasePathMapping": {
+      "Properties": {
+        "BasePath": "get",
+        "DomainNameArn": {
+          "Ref": "ApiGatewayDomainNameV2f6d6317296"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
+      },
+      "Type": "AWS::ApiGateway::BasePathMappingV2"
+    },
+    "RecordSetGroup486a9be065": {
+      "Properties": {
+        "HostedZoneId": "HostedZoneId",
+        "RecordSets": [
+          {
+            "AliasTarget": {
+              "DNSName": "VPCEndpointDomainName",
+              "HostedZoneId": "VPCEndpointHostedZoneId"
+            },
+            "Name": "sam.apigateway.com",
+            "Type": "A"
+          }
+        ]
+      },
+      "Type": "AWS::Route53::RecordSetGroup"
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_custom_domain_private_endpoint_full.json
+++ b/tests/translator/output/aws-cn/api_custom_domain_private_endpoint_full.json
@@ -1,0 +1,172 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Sample SAM Template for a simple serverless application",
+  "Parameters": {
+    "CertificateArn": {
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/4ba8fce1-abcd-4717-9c34-11bfd24372ba",
+      "Type": "String"
+    },
+    "DomainName": {
+      "Default": "sam.apigateway.com",
+      "Type": "String"
+    },
+    "HostedZoneId": {
+      "Default": "Z012334",
+      "Type": "String"
+    },
+    "VpcEndpointId": {
+      "Default": "vpce-123123123123123",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "ApiGatewayDomainNameV2f6d6317296": {
+      "Properties": {
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/4ba8fce1-abcd-4717-9c34-11bfd24372ba",
+        "DomainName": "sam.apigateway.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "PRIVATE"
+          ]
+        },
+        "Policy": {
+          "Statement": [
+            {
+              "Action": "execute-api:Invoke",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            },
+            {
+              "Action": "execute-api:Invoke",
+              "Condition": {
+                "StringNotEquals": {
+                  "aws:SourceVpce": "vpce-123123123123123"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::ApiGateway::DomainNameV2"
+    },
+    "DomainNameAccessAssociation136aec2782": {
+      "Properties": {
+        "AccessAssociationSource": "vpce-123123123123123",
+        "AccessAssociationSourceType": "VPCE",
+        "DomainNameArn": {
+          "Ref": "ApiGatewayDomainNameV2f6d6317296"
+        }
+      },
+      "Type": "AWS::ApiGateway::DomainNameAccessAssociation"
+    },
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {}
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "PRIVATE"
+          ],
+          "VpcEndpointIds": [
+            {
+              "Ref": "VpcEndpointId"
+            }
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "PRIVATE"
+        },
+        "Policy": {
+          "Statement": [
+            {
+              "Action": "execute-api:Invoke",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            },
+            {
+              "Action": "execute-api:Invoke",
+              "Condition": {
+                "StringNotEquals": {
+                  "aws:SourceVpce": {
+                    "Ref": "VpcEndpointId"
+                  }
+                }
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeployment831bb29f90": {
+      "Properties": {
+        "Description": "RestApi deployment id: 831bb29f90ba78e5cb705db850981137f44f2af6",
+        "RestApiId": {
+          "Ref": "MyApi"
+        }
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment831bb29f90"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "MyApigetBasePathMapping": {
+      "Properties": {
+        "BasePath": "get",
+        "DomainNameArn": {
+          "Ref": "ApiGatewayDomainNameV2f6d6317296"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
+      },
+      "Type": "AWS::ApiGateway::BasePathMappingV2"
+    },
+    "RecordSetGroup486a9be065": {
+      "Properties": {
+        "HostedZoneId": "HostedZoneId",
+        "RecordSets": [
+          {
+            "AliasTarget": {
+              "DNSName": "VPCEndpointDomainName",
+              "HostedZoneId": "VPCEndpointHostedZoneId"
+            },
+            "Name": "sam.apigateway.com",
+            "Type": "A"
+          }
+        ]
+      },
+      "Type": "AWS::Route53::RecordSetGroup"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_custom_domain_private_endpoint_full.json
+++ b/tests/translator/output/aws-us-gov/api_custom_domain_private_endpoint_full.json
@@ -1,0 +1,172 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Sample SAM Template for a simple serverless application",
+  "Parameters": {
+    "CertificateArn": {
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/4ba8fce1-abcd-4717-9c34-11bfd24372ba",
+      "Type": "String"
+    },
+    "DomainName": {
+      "Default": "sam.apigateway.com",
+      "Type": "String"
+    },
+    "HostedZoneId": {
+      "Default": "Z012334",
+      "Type": "String"
+    },
+    "VpcEndpointId": {
+      "Default": "vpce-123123123123123",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "ApiGatewayDomainNameV2f6d6317296": {
+      "Properties": {
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/4ba8fce1-abcd-4717-9c34-11bfd24372ba",
+        "DomainName": "sam.apigateway.com",
+        "EndpointConfiguration": {
+          "Types": [
+            "PRIVATE"
+          ]
+        },
+        "Policy": {
+          "Statement": [
+            {
+              "Action": "execute-api:Invoke",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            },
+            {
+              "Action": "execute-api:Invoke",
+              "Condition": {
+                "StringNotEquals": {
+                  "aws:SourceVpce": "vpce-123123123123123"
+                }
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::ApiGateway::DomainNameV2"
+    },
+    "DomainNameAccessAssociation136aec2782": {
+      "Properties": {
+        "AccessAssociationSource": "vpce-123123123123123",
+        "AccessAssociationSourceType": "VPCE",
+        "DomainNameArn": {
+          "Ref": "ApiGatewayDomainNameV2f6d6317296"
+        }
+      },
+      "Type": "AWS::ApiGateway::DomainNameAccessAssociation"
+    },
+    "MyApi": {
+      "Properties": {
+        "Body": {
+          "info": {
+            "title": {
+              "Ref": "AWS::StackName"
+            },
+            "version": "1.0"
+          },
+          "openapi": "3.0.1",
+          "paths": {}
+        },
+        "EndpointConfiguration": {
+          "Types": [
+            "PRIVATE"
+          ],
+          "VpcEndpointIds": [
+            {
+              "Ref": "VpcEndpointId"
+            }
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "PRIVATE"
+        },
+        "Policy": {
+          "Statement": [
+            {
+              "Action": "execute-api:Invoke",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            },
+            {
+              "Action": "execute-api:Invoke",
+              "Condition": {
+                "StringNotEquals": {
+                  "aws:SourceVpce": {
+                    "Ref": "VpcEndpointId"
+                  }
+                }
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": "execute-api:/*"
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Type": "AWS::ApiGateway::RestApi"
+    },
+    "MyApiDeployment831bb29f90": {
+      "Properties": {
+        "Description": "RestApi deployment id: 831bb29f90ba78e5cb705db850981137f44f2af6",
+        "RestApiId": {
+          "Ref": "MyApi"
+        }
+      },
+      "Type": "AWS::ApiGateway::Deployment"
+    },
+    "MyApiProdStage": {
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment831bb29f90"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "StageName": "Prod"
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "MyApigetBasePathMapping": {
+      "Properties": {
+        "BasePath": "get",
+        "DomainNameArn": {
+          "Ref": "ApiGatewayDomainNameV2f6d6317296"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
+      },
+      "Type": "AWS::ApiGateway::BasePathMappingV2"
+    },
+    "RecordSetGroup486a9be065": {
+      "Properties": {
+        "HostedZoneId": "HostedZoneId",
+        "RecordSets": [
+          {
+            "AliasTarget": {
+              "DNSName": "VPCEndpointDomainName",
+              "HostedZoneId": "VPCEndpointHostedZoneId"
+            },
+            "Name": "sam.apigateway.com",
+            "Type": "A"
+          }
+        ]
+      },
+      "Type": "AWS::Route53::RecordSetGroup"
+    }
+  }
+}


### PR DESCRIPTION
- Add Policy to `AWS::Serverless::Api`
- Support Route53 resources correctly
- Add a new `AccessAssociation` inside `Domain`, that generates a `AWS::ApiGateway::DomainNameAccessAssociation` resource.

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
