### PR TITLE
feat: updated the cognito properties based on cloudformation properties

### DIFF
--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -11,6 +11,8 @@ class CognitoUserPool(Resource):
         "AutoVerifiedAttributes": GeneratedProperty(),
         "DeletionProtection": GeneratedProperty(),
         "DeviceConfiguration": GeneratedProperty(),
+        "EmailAuthenticationMessage": GeneratedProperty(),
+        "EmailAuthenticationSubject": GeneratedProperty(),
         "EmailConfiguration": GeneratedProperty(),
         "EmailVerificationMessage": GeneratedProperty(),
         "EmailVerificationSubject": GeneratedProperty(),
@@ -28,7 +30,10 @@ class CognitoUserPool(Resource):
         "UserPoolAddOns": GeneratedProperty(),
         "UserPoolName": GeneratedProperty(),
         "UserPoolTags": GeneratedProperty(),
+        "UserPoolTier": GeneratedProperty(),
         "VerificationMessageTemplate": GeneratedProperty(),
+        "WebAuthnRelyingPartyID": GeneratedProperty(),
+        "WebAuthnUserVerification": GeneratedProperty(),
     }
 
     runtime_attrs = {

--- a/tests/translator/input/cognito_template_with_new_properties.yaml
+++ b/tests/translator/input/cognito_template_with_new_properties.yaml
@@ -1,0 +1,11 @@
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolTier: PLUS
+      UserPoolName: MyUserPool
+      EmailAuthenticationMessage: Your verification code is {####}
+      EmailAuthenticationSubject: Your verification code
+      WebAuthnRelyingPartyID: id
+      WebAuthnUserVerification: required

--- a/tests/translator/output/aws-cn/cognito_template_with_new_properties.json
+++ b/tests/translator/output/aws-cn/cognito_template_with_new_properties.json
@@ -1,0 +1,15 @@
+{
+  "Resources": {
+    "MyUserPool": {
+      "Properties": {
+        "EmailAuthenticationMessage": "Your verification code is {####}",
+        "EmailAuthenticationSubject": "Your verification code",
+        "UserPoolName": "MyUserPool",
+        "UserPoolTier": "PLUS",
+        "WebAuthnRelyingPartyID": "id",
+        "WebAuthnUserVerification": "required"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/cognito_template_with_new_properties.json
+++ b/tests/translator/output/aws-us-gov/cognito_template_with_new_properties.json
@@ -1,0 +1,15 @@
+{
+  "Resources": {
+    "MyUserPool": {
+      "Properties": {
+        "EmailAuthenticationMessage": "Your verification code is {####}",
+        "EmailAuthenticationSubject": "Your verification code",
+        "UserPoolName": "MyUserPool",
+        "UserPoolTier": "PLUS",
+        "WebAuthnRelyingPartyID": "id",
+        "WebAuthnUserVerification": "required"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    }
+  }
+}

--- a/tests/translator/output/cognito_template_with_new_properties.json
+++ b/tests/translator/output/cognito_template_with_new_properties.json
@@ -1,0 +1,15 @@
+{
+  "Resources": {
+    "MyUserPool": {
+      "Properties": {
+        "EmailAuthenticationMessage": "Your verification code is {####}",
+        "EmailAuthenticationSubject": "Your verification code",
+        "UserPoolName": "MyUserPool",
+        "UserPoolTier": "PLUS",
+        "WebAuthnRelyingPartyID": "id",
+        "WebAuthnUserVerification": "required"
+      },
+      "Type": "AWS::Cognito::UserPool"
+    }
+  }
+}


### PR DESCRIPTION
### Issue #3726


### Description of changes

Update the CognitoUserPool property types based on the [CloudFormation syntax ](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html).

### Description of how you validated changes

The changes were validated by running the sam transformer on the template in the issue and on another template with all of the new properties. There is also a new transform test for validating this.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
