### PR TITLE
test: Fix MQ integ tests

### DIFF
--- a/integration/resources/templates/combination/function_with_mq.yaml
+++ b/integration/resources/templates/combination/function_with_mq.yaml
@@ -112,13 +112,13 @@ Resources:
         Ref: MQBrokerName
       DeploymentMode: SINGLE_INSTANCE
       EngineType: ACTIVEMQ
-      EngineVersion: 5.17.6
+      EngineVersion: 5.18
       HostInstanceType: mq.t3.micro
       Logs:
         Audit: true
         General: true
       PubliclyAccessible: true
-      AutoMinorVersionUpgrade: false
+      AutoMinorVersionUpgrade: true
       SecurityGroups:
       - Ref: MQSecurityGroup
       SubnetIds:

--- a/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
+++ b/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
@@ -84,13 +84,13 @@ Resources:
         Ref: MQBrokerName2
       DeploymentMode: SINGLE_INSTANCE
       EngineType: ACTIVEMQ
-      EngineVersion: 5.17.6
+      EngineVersion: 5.18
       HostInstanceType: mq.t3.micro
       Logs:
         Audit: true
         General: true
       PubliclyAccessible: true
-      AutoMinorVersionUpgrade: false
+      AutoMinorVersionUpgrade: true
       SecurityGroups:
       - Ref: MQSecurityGroup
       SubnetIds:


### PR DESCRIPTION
### Issue #, if available

Integration tests were failing because of an old version of ActiveMQ being used. In theory 5.17 is still supported for [two more weeks](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/activemq-version-management.html#activemq-version-management-calendar), but it's still something we have to change anyway.

### Description of changes

This required to change the variable `AutoMinorVersionUpgrade` that has to be true for this version of ActiveMQ

### Description of how you validated changes

I ran integ tests (They were failing before, they succeeded afterwards)

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
