### PR TITLE
updated policy_template.json

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -2151,9 +2151,7 @@
           {
             "Action": [
               "sqs:ChangeMessageVisibility",
-              "sqs:ChangeMessageVisibilityBatch",
               "sqs:DeleteMessage",
-              "sqs:DeleteMessageBatch",
               "sqs:GetQueueAttributes",
               "sqs:ReceiveMessage"
             ],


### PR DESCRIPTION
Fix: Remove invalid SQS Batch actions from SQSPollerPolicy

Removed sqs:ChangeMessageVisibilityBatch and sqs:DeleteMessageBatch, which are not valid IAM actions.

These were replaced in prior lines by their valid counterparts: sqs:ChangeMessageVisibility and sqs:DeleteMessage.