### PR TITLE
test: delete created change sets in companion stack if empty

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -63,12 +63,12 @@ def clean_all_integ_buckets():
 @pytest.fixture()
 def setup_companion_stack_once(tmpdir_factory, get_prefix):
     tests_integ_dir = Path(__file__).resolve().parents[1]
-    template_foler = Path(tests_integ_dir, "integration", "setup")
-    companion_stack_tempalte_path = Path(template_foler, COMPANION_STACK_TEMPLATE)
+    template_folder = Path(tests_integ_dir, "integration", "setup")
+    companion_stack_template_path = Path(template_folder, COMPANION_STACK_TEMPLATE)
     cfn_client = ClientProvider().cfn_client
     output_dir = tmpdir_factory.mktemp("data")
     stack_name = get_prefix + COMPANION_STACK_NAME
-    companion_stack = Stack(stack_name, companion_stack_tempalte_path, cfn_client, output_dir)
+    companion_stack = Stack(stack_name, companion_stack_template_path, cfn_client, output_dir)
     companion_stack.create_or_update(_stack_exists(stack_name))
 
 

--- a/integration/helpers/deployer/deployer.py
+++ b/integration/helpers/deployer/deployer.py
@@ -375,7 +375,10 @@ class Deployer:
         except deploy_exceptions.ChangeEmptyError:
             try:
                 # Delete the most recent change set that failed to create because it was empty
-                changeset = sorted(self._client.list_change_sets(StackName=stack_name).get("Summaries"), key=lambda c: c["CreationTime"])[-1]
+                changeset = sorted(
+                    self._client.list_change_sets(StackName=stack_name).get("Summaries"),
+                    key=lambda c: c["CreationTime"],
+                )[-1]
                 if changeset.get("Status") == "FAILED" and changeset.get("ExecutionStatus") == "UNAVAILABLE":
                     self._client.delete_change_set(ChangeSetName=changeset["ChangeSetId"], StackName=stack_name)
             except Exception as ex:

--- a/integration/helpers/deployer/deployer.py
+++ b/integration/helpers/deployer/deployer.py
@@ -373,6 +373,13 @@ class Deployer:
             self.describe_changeset(result["Id"], stack_name)
             return result
         except deploy_exceptions.ChangeEmptyError:
+            try:
+                # Delete the most recent change set that failed to create because it was empty
+                changeset = sorted(self._client.list_change_sets(StackName=stack_name).get("Summaries"), key=lambda c: c["CreationTime"])[-1]
+                if changeset.get("Status") == "FAILED" and changeset.get("ExecutionStatus") == "UNAVAILABLE":
+                    self._client.delete_change_set(ChangeSetName=changeset["ChangeSetId"], StackName=stack_name)
+            except Exception as ex:
+                LOG.warning("Failed to clean up empty changeset", exc_info=ex)
             return {}
         except botocore.exceptions.ClientError as ex:
             raise deploy_exceptions.DeployFailedError(stack_name=stack_name, msg=str(ex))


### PR DESCRIPTION
### Issue #, if available
N/a

### Description of changes
In the integration tests, the companion stack being created is created with a change set. Often times, this change set is empty and ignored; after enough test runs, the stack hits its limit of 1000 changesets, causing create failures in the subsequent runs.

This change will now delete the created change set if it is empty.

### Description of how you validated changes
In my personal account, I ran the tests a couple time to build up a couple empty change sets. I then made the change, and continued to run `make prepare-companion-stack`, manually verifying that there were no new changesets being kept on each test run.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
