### PR TITLE
fix: Add intrinsic support for AWS::Serverless::Api BasePath property

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -554,12 +554,13 @@ class ApiGenerator:
             basepath_mapping = self._create_basepath_mapping(api_domain_name, rest_api, None, None)
             basepath_resource_list.extend([basepath_mapping])
         else:
+            if not is_intrinsic(basepaths[0]):
+                sam_expect(basepaths, self.logical_id, "Domain.BasePath").to_be_a_list_of(ExpectedType.STRING)
             for basepath in basepaths:
                 if is_intrinsic(basepath):
                     mapping_basepath = basepath
                     logical_id = self.logical_id + "BasePathMapping"
                 else:
-                    sam_expect(basepaths, self.logical_id, "Domain.BasePath").to_be_a_list_of(ExpectedType.STRING)
                     # Remove possible leading and trailing '/' because a base path may only
                     # contain letters, numbers, and one of "$-_.+!*'()"
                     path = "".join(e for e in basepath if e.isalnum())

--- a/tests/translator/input/api_with_basic_custom_domain_intrinsics.yaml
+++ b/tests/translator/input/api_with_basic_custom_domain_intrinsics.yaml
@@ -58,7 +58,7 @@ Resources:
         DomainName: !Sub 'example-${AWS::Region}.com'
         CertificateArn: !Ref MyDomainCert
         EndpointConfiguration: !Ref EndpointConf
-        BasePath: [/get, /fetch]
+        BasePath: !Sub '${AWS::Region}-api'
         MutualTlsAuthentication:
           TruststoreUri: !Ref MyMTLSUri
           TruststoreVersion: !Ref MyMTLSVersion

--- a/tests/translator/output/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/api_with_basic_custom_domain_intrinsics.json
@@ -99,10 +99,28 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment19c8cf5c63": {
+    "MyApiBasePathMapping": {
       "Condition": "C1",
       "Properties": {
-        "Description": "RestApi deployment id: 19c8cf5c63090f12c5a96f6f57162495bed446c7",
+        "BasePath": {
+          "Fn::Sub": "ap-southeast-1-api"
+        },
+        "DomainName": {
+          "Ref": "ApiGatewayDomainNamec0ed6fae34"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping"
+    },
+    "MyApiDeployment651fe13005": {
+      "Condition": "C1",
+      "Properties": {
+        "Description": "RestApi deployment id: 651fe13005fac4c7c7f2fe93b77c7ef2c6c3e746",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -113,7 +131,7 @@
       "Condition": "C1",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment19c8cf5c63"
+          "Ref": "MyApiDeployment651fe13005"
         },
         "RestApiId": {
           "Ref": "MyApi"
@@ -121,38 +139,6 @@
         "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage"
-    },
-    "MyApifetchBasePathMapping": {
-      "Condition": "C1",
-      "Properties": {
-        "BasePath": "fetch",
-        "DomainName": {
-          "Ref": "ApiGatewayDomainNamec0ed6fae34"
-        },
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
-      },
-      "Type": "AWS::ApiGateway::BasePathMapping"
-    },
-    "MyApigetBasePathMapping": {
-      "Condition": "C1",
-      "Properties": {
-        "BasePath": "get",
-        "DomainName": {
-          "Ref": "ApiGatewayDomainNamec0ed6fae34"
-        },
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
-      },
-      "Type": "AWS::ApiGateway::BasePathMapping"
     },
     "MyFunction": {
       "Condition": "C1",

--- a/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics.json
@@ -107,10 +107,28 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment4f2c19d290": {
+    "MyApiBasePathMapping": {
       "Condition": "C1",
       "Properties": {
-        "Description": "RestApi deployment id: 4f2c19d290875d88d8e30124f0953f1784e1b54d",
+        "BasePath": {
+          "Fn::Sub": "cn-north-1-api"
+        },
+        "DomainName": {
+          "Ref": "ApiGatewayDomainNamec0cd2d9dfc"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping"
+    },
+    "MyApiDeploymente1e3e9b849": {
+      "Condition": "C1",
+      "Properties": {
+        "Description": "RestApi deployment id: e1e3e9b849803f87115b2cb8fcdf5d144342aaa4",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -121,7 +139,7 @@
       "Condition": "C1",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment4f2c19d290"
+          "Ref": "MyApiDeploymente1e3e9b849"
         },
         "RestApiId": {
           "Ref": "MyApi"
@@ -129,38 +147,6 @@
         "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage"
-    },
-    "MyApifetchBasePathMapping": {
-      "Condition": "C1",
-      "Properties": {
-        "BasePath": "fetch",
-        "DomainName": {
-          "Ref": "ApiGatewayDomainNamec0cd2d9dfc"
-        },
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
-      },
-      "Type": "AWS::ApiGateway::BasePathMapping"
-    },
-    "MyApigetBasePathMapping": {
-      "Condition": "C1",
-      "Properties": {
-        "BasePath": "get",
-        "DomainName": {
-          "Ref": "ApiGatewayDomainNamec0cd2d9dfc"
-        },
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
-      },
-      "Type": "AWS::ApiGateway::BasePathMapping"
     },
     "MyFunction": {
       "Condition": "C1",

--- a/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics.json
@@ -107,10 +107,28 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment32e59613e2": {
+    "MyApiBasePathMapping": {
       "Condition": "C1",
       "Properties": {
-        "Description": "RestApi deployment id: 32e59613e2e02a1f1d264849167ea359f10342f0",
+        "BasePath": {
+          "Fn::Sub": "us-gov-west-1-api"
+        },
+        "DomainName": {
+          "Ref": "ApiGatewayDomainName9c93aac102"
+        },
+        "RestApiId": {
+          "Ref": "MyApi"
+        },
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping"
+    },
+    "MyApiDeployment9d140ab9b8": {
+      "Condition": "C1",
+      "Properties": {
+        "Description": "RestApi deployment id: 9d140ab9b8b8ee141d5cd2d4a90a374c37a10db7",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -121,7 +139,7 @@
       "Condition": "C1",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment32e59613e2"
+          "Ref": "MyApiDeployment9d140ab9b8"
         },
         "RestApiId": {
           "Ref": "MyApi"
@@ -129,38 +147,6 @@
         "StageName": "Prod"
       },
       "Type": "AWS::ApiGateway::Stage"
-    },
-    "MyApifetchBasePathMapping": {
-      "Condition": "C1",
-      "Properties": {
-        "BasePath": "fetch",
-        "DomainName": {
-          "Ref": "ApiGatewayDomainName9c93aac102"
-        },
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
-      },
-      "Type": "AWS::ApiGateway::BasePathMapping"
-    },
-    "MyApigetBasePathMapping": {
-      "Condition": "C1",
-      "Properties": {
-        "BasePath": "get",
-        "DomainName": {
-          "Ref": "ApiGatewayDomainName9c93aac102"
-        },
-        "RestApiId": {
-          "Ref": "MyApi"
-        },
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
-      },
-      "Type": "AWS::ApiGateway::BasePathMapping"
     },
     "MyFunction": {
       "Condition": "C1",


### PR DESCRIPTION
### Issue #, if available
N/a
### Description of changes
The `BasePath` attribute of `Aws::Serverless::Api` does not currently accept `!Sub` as a parameter, instead leaving it as blank or returning `None`. As an example,
```yaml
Resources:
  ApiGatewayApi:
    Type: AWS::Serverless::Api
    Properties:
      StageName: prod
      CacheClusterEnabled: true
      CacheClusterSize: '0.5'
      MethodSettings:
        - ResourcePath: /
          HttpMethod: GET
          CachingEnabled: true
          CacheTtlInSeconds: 300
      Domain:
        BasePath: !Sub ${ Service }-api
        CertificateArn: !Ref CertificateArn
        DomainName: example.myinstance.com
        Route53:
          HostedZoneId: !Ref HostedZoneId
```
Transforms to the below, without the actual BasePath being added.

```json
"ApiGatewayApiBasePathMapping": {
    "Type": "AWS::ApiGateway::BasePathMapping",
    "Properties": {
        "DomainName": {
            "Ref": "ApiGatewayDomainName619a1fb284"
        },
        "RestApiId": {
            "Ref": "ApiGatewayApi"
        },
        "Stage": {
            "Ref": "ApiGatewayApiprodStage"
        }
    }
}
```

#### After updates
With the updates to allow intrinsics for this property, the output now looks like:

```json
"Parameters": {
    "Service": {
        "Type": "String",
        "Default": "NewServ"
    }
},
...
"TestApiBasePathMapping": {
    "Type": "AWS::ApiGateway::BasePathMapping",
    "Properties": {
        "BasePath": {
            "Fn::Sub": "NewServ-api"
         },
        "DomainName": {
            "Ref": "ApiGatewayDomainName54e3d11755"
        },
        "RestApiId": {
            "Ref": "TestApi"
        },
        "Stage": {
            "Ref": "TestApiprodStage"
        }
    }
}
```


### Description of how you validated changes
Manually ran the transform with and without the updated changes and compared the templates. 

Updated the transform tests to include this new case. I didn't add any new tests because there are other locations that have `BasePath` without the intrinsics, so I figured it was fine to add this in the `api_with_basic_custom_domain_intrinsics` tests. 

Also confirmed that the added tests failed with the older transform version.

### Checklist

- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
