### PR TITLE
fix: add `Enables` to MSK model. Use this property for MSK events in integ tests

### DIFF
--- a/integration/combination/test_function_with_msk.py
+++ b/integration/combination/test_function_with_msk.py
@@ -25,12 +25,12 @@ class TestFunctionWithMsk(BaseTest):
         parameters.append(self.generate_parameter("MskClusterName", cluster_name))
         self._common_validations_for_MSK("combination/function_with_msk", parameters)
 
-    # def test_function_with_msk_trigger_using_manage_policy(self):
-    #     companion_stack_outputs = self.companion_stack_outputs
-    #     parameters = self.get_parameters(companion_stack_outputs)
-    #     cluster_name = "MskCluster2-" + generate_suffix()
-    #     parameters.append(self.generate_parameter("MskClusterName2", cluster_name))
-    #     self._common_validations_for_MSK("combination/function_with_msk_using_managed_policy", parameters)
+    def test_function_with_msk_trigger_using_manage_policy(self):
+        companion_stack_outputs = self.companion_stack_outputs
+        parameters = self.get_parameters(companion_stack_outputs)
+        cluster_name = "MskCluster2-" + generate_suffix()
+        parameters.append(self.generate_parameter("MskClusterName2", cluster_name))
+        self._common_validations_for_MSK("combination/function_with_msk_using_managed_policy", parameters)
 
     def test_function_with_msk_trigger_and_s3_onfailure_events_destinations(self):
         companion_stack_outputs = self.companion_stack_outputs
@@ -41,14 +41,14 @@ class TestFunctionWithMsk(BaseTest):
             "combination/function_with_msk_trigger_and_s3_onfailure_events_destinations", parameters
         )
 
-    # def test_function_with_msk_trigger_and_confluent_schema_registry(self):
-    #     companion_stack_outputs = self.companion_stack_outputs
-    #     parameters = self.get_parameters(companion_stack_outputs)
-    #     cluster_name = "MskCluster4-" + generate_suffix()
-    #     parameters.append(self.generate_parameter("MskClusterName4", cluster_name))
-    #     self._common_validations_for_MSK(
-    #         "combination/function_with_msk_trigger_and_confluent_schema_registry", parameters
-    #     )
+    def test_function_with_msk_trigger_and_confluent_schema_registry(self):
+        companion_stack_outputs = self.companion_stack_outputs
+        parameters = self.get_parameters(companion_stack_outputs)
+        cluster_name = "MskCluster4-" + generate_suffix()
+        parameters.append(self.generate_parameter("MskClusterName4", cluster_name))
+        self._common_validations_for_MSK(
+            "combination/function_with_msk_trigger_and_confluent_schema_registry", parameters
+        )
 
     def _common_validations_for_MSK(self, file_name, parameters):
         self.create_and_verify_stack(file_name, parameters)

--- a/integration/combination/test_function_with_msk.py
+++ b/integration/combination/test_function_with_msk.py
@@ -25,12 +25,12 @@ class TestFunctionWithMsk(BaseTest):
         parameters.append(self.generate_parameter("MskClusterName", cluster_name))
         self._common_validations_for_MSK("combination/function_with_msk", parameters)
 
-    def test_function_with_msk_trigger_using_manage_policy(self):
-        companion_stack_outputs = self.companion_stack_outputs
-        parameters = self.get_parameters(companion_stack_outputs)
-        cluster_name = "MskCluster2-" + generate_suffix()
-        parameters.append(self.generate_parameter("MskClusterName2", cluster_name))
-        self._common_validations_for_MSK("combination/function_with_msk_using_managed_policy", parameters)
+    # def test_function_with_msk_trigger_using_manage_policy(self):
+    #     companion_stack_outputs = self.companion_stack_outputs
+    #     parameters = self.get_parameters(companion_stack_outputs)
+    #     cluster_name = "MskCluster2-" + generate_suffix()
+    #     parameters.append(self.generate_parameter("MskClusterName2", cluster_name))
+    #     self._common_validations_for_MSK("combination/function_with_msk_using_managed_policy", parameters)
 
     def test_function_with_msk_trigger_and_s3_onfailure_events_destinations(self):
         companion_stack_outputs = self.companion_stack_outputs
@@ -41,14 +41,14 @@ class TestFunctionWithMsk(BaseTest):
             "combination/function_with_msk_trigger_and_s3_onfailure_events_destinations", parameters
         )
 
-    def test_function_with_msk_trigger_and_confluent_schema_registry(self):
-        companion_stack_outputs = self.companion_stack_outputs
-        parameters = self.get_parameters(companion_stack_outputs)
-        cluster_name = "MskCluster4-" + generate_suffix()
-        parameters.append(self.generate_parameter("MskClusterName4", cluster_name))
-        self._common_validations_for_MSK(
-            "combination/function_with_msk_trigger_and_confluent_schema_registry", parameters
-        )
+    # def test_function_with_msk_trigger_and_confluent_schema_registry(self):
+    #     companion_stack_outputs = self.companion_stack_outputs
+    #     parameters = self.get_parameters(companion_stack_outputs)
+    #     cluster_name = "MskCluster4-" + generate_suffix()
+    #     parameters.append(self.generate_parameter("MskClusterName4", cluster_name))
+    #     self._common_validations_for_MSK(
+    #         "combination/function_with_msk_trigger_and_confluent_schema_registry", parameters
+    #     )
 
     def _common_validations_for_MSK(self, file_name, parameters):
         self.create_and_verify_stack(file_name, parameters)

--- a/integration/resources/templates/combination/function_with_msk.yaml
+++ b/integration/resources/templates/combination/function_with_msk.yaml
@@ -60,6 +60,7 @@ Resources:
         MyMskEvent:
           Type: MSK
           Properties:
+            Enabled: false
             StartingPosition: LATEST
             Stream:
               Ref: MyMskCluster

--- a/integration/resources/templates/combination/function_with_msk_trigger_and_confluent_schema_registry.yaml
+++ b/integration/resources/templates/combination/function_with_msk_trigger_and_confluent_schema_registry.yaml
@@ -60,6 +60,7 @@ Resources:
         MyMskEvent:
           Type: MSK
           Properties:
+            Enabled: false
             StartingPosition: LATEST
             Stream:
               Ref: MyMskCluster

--- a/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
+++ b/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
@@ -27,6 +27,12 @@ Resources:
               logs:CreateLogStream, logs:PutLogEvents, s3:ListBucket]
             Effect: Allow
             Resource: '*'
+          - Action: s3:PutObject
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+              - PreCreatedS3Bucket
+              - Arn
       ManagedPolicyArns:
       - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Tags:
@@ -60,6 +66,7 @@ Resources:
         MyMskEvent:
           Type: MSK
           Properties:
+            Enabled: false
             StartingPosition: LATEST
             Stream:
               Ref: MyMskCluster

--- a/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
+++ b/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
@@ -27,12 +27,11 @@ Resources:
               logs:CreateLogStream, logs:PutLogEvents, s3:ListBucket]
             Effect: Allow
             Resource: '*'
-          - Action: s3:PutObject
+          - Action: [s3:PutObject, s3:ListBucket]
             Effect: Allow
             Resource:
-              Fn::GetAtt:
-              - PreCreatedS3Bucket
-              - Arn
+              - "arn:aws:s3:::*/*"
+              - "arn:aws:s3:::*"
       ManagedPolicyArns:
       - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Tags:

--- a/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
+++ b/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
@@ -30,8 +30,8 @@ Resources:
           - Action: [s3:PutObject, s3:ListBucket]
             Effect: Allow
             Resource:
-              - "arn:aws:s3:::*/*"
-              - "arn:aws:s3:::*"
+            - arn:aws:s3:::*/*
+            - arn:aws:s3:::*
       ManagedPolicyArns:
       - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Tags:

--- a/integration/resources/templates/combination/function_with_msk_using_managed_policy.yaml
+++ b/integration/resources/templates/combination/function_with_msk_using_managed_policy.yaml
@@ -33,6 +33,7 @@ Resources:
         MyMskEvent:
           Type: MSK
           Properties:
+            Enabled: false
             StartingPosition: LATEST
             Stream:
               Ref: MyMskCluster

--- a/samtranslator/internal/schema_source/aws_serverless_function.py
+++ b/samtranslator/internal/schema_source/aws_serverless_function.py
@@ -411,6 +411,7 @@ class HttpApiEvent(BaseModel):
 
 class MSKEventProperties(BaseModel):
     ConsumerGroupId: Optional[PassThroughProp] = mskeventproperties("ConsumerGroupId")
+    Enabled: Optional[PassThroughProp]  # TODO: it doesn't show up in docs yet
     FilterCriteria: Optional[PassThroughProp] = mskeventproperties("FilterCriteria")
     KmsKeyArn: Optional[PassThroughProp]  # TODO: add documentation
     MaximumBatchingWindowInSeconds: Optional[PassThroughProp] = mskeventproperties("MaximumBatchingWindowInSeconds")

--- a/schema_source/sam.schema.json
+++ b/schema_source/sam.schema.json
@@ -2397,6 +2397,9 @@
         "DestinationConfig": {
           "$ref": "#/definitions/PassThroughProp"
         },
+        "Enabled": {
+          "$ref": "#/definitions/PassThroughProp"
+        },
         "FilterCriteria": {
           "allOf": [
             {


### PR DESCRIPTION
MSK tests are created more resources when they start polling (and the Topic we're connecting from doesn't even exist), so let's create the events with `Enabled: false`, so the polling doesn't actually start.

### Issue #, if available

Problems seen in our integration testing infrastructure.

### Description of changes

- Add `Enabled: false` to MSK templates in integration tests
- Add `Enabled` to the schema for MSK. Even though this property is supported, it wasn't part of the schema.
- Adding `s3:putObject` permissions to the test with an S3 destination for its event (`function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml`).

### Description of how you validated changes
- `pytest --no-cov integration/combination/test_function_with_msk.py -vv`

### Checklist

- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
