### PR TITLE
Fix(Intrinsic Resolver): should ignore CFN placeholder in parameter

### DIFF
--- a/samtranslator/intrinsics/actions.py
+++ b/samtranslator/intrinsics/actions.py
@@ -5,6 +5,29 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from samtranslator.model.exceptions import InvalidDocumentException, InvalidTemplateException
 
 
+def _get_parameter_value(parameters: Dict[str, Any], param_name: str, default: Any = None) -> Any:
+    """
+    Get parameter value from parameters dict, but return None if it's a CloudFormation internal placeholder.
+
+    CloudFormation internal placeholders are passed during changeset creation with --include-nested-stacks
+    when there are cross-references between nested stacks that don't exist yet.
+    These placeholders should not be resolved by SAM.
+
+    :param parameters: Dictionary of parameter values
+    :param param_name: Name of the parameter to retrieve
+    :param default: Default value to return if parameter not found or is a placeholder
+    :return: Parameter value, or default if not found or is a CloudFormation placeholder
+    """
+    value = parameters.get(param_name, default)
+
+    # Check if the value is a CloudFormation internal placeholder
+    # E.g. {{IntrinsicFunction:api-xx/MyStack.Outputs.API/Fn::GetAtt}}
+    if isinstance(value, str) and value.startswith("{{IntrinsicFunction:"):
+        return default
+
+    return value
+
+
 class Action(ABC):
     """
     Base class for intrinsic function actions. Each intrinsic function must subclass this,
@@ -103,9 +126,12 @@ class RefAction(Action):
         if not isinstance(param_name, str):
             return input_dict
 
-        if param_name in parameters:
-            return parameters[param_name]
-        return input_dict
+        # Use the wrapper function to get parameter value
+        # It returns None if the parameter is a CloudFormation internal placeholder
+
+        # If param_value is None, either the parameter doesn't exist or it's a placeholder
+        # Return the original input unchanged
+        return _get_parameter_value(parameters, param_name, input_dict)
 
     def resolve_resource_refs(
         self, input_dict: Optional[Any], supported_resource_refs: Dict[str, Any]
@@ -193,7 +219,9 @@ class SubAction(Action):
             :param prop_name: => logicalId.property
             :return: Either the value it resolves to. If not the original reference
             """
-            return parameters.get(prop_name, full_ref)
+            # Use the wrapper function to get parameter value
+            # It returns None if the parameter is a CloudFormation internal placeholder
+            return _get_parameter_value(parameters, prop_name, full_ref)
 
         return self._handle_sub_action(input_dict, do_replacement)
 


### PR DESCRIPTION
## Description

This PR fixes an issue where CloudFormation internal placeholders were being incorrectly resolved during SAM transformation, causing changeset creation failures when using the `--include-nested-stacks` flag.

## Problem

When creating changesets with `--include-nested-stacks`, CloudFormation passes internal placeholders for cross-references between nested stacks that don't exist yet. These placeholders follow the format:
```
{{IntrinsicFunction:stack-name/Resource.Outputs.Property/Fn::GetAtt}}
```

Previously, SAM was resolving these placeholders as regular parameter values, which caused them to be wrapped in arrays for list-type fields. This resulted in CloudFormation validation errors:
```
Usage of {{IntrinsicFunction:debugging-cloudformation-issues/Cognito.Outputs.UserPoolArn/Fn::GetAtt}} is not allowed
```

## Solution

1. **Added a wrapper function `_get_parameter_value()`** that checks if a parameter value is a CloudFormation internal placeholder
   - Returns `None` (or a default value) if the parameter value starts with `{{IntrinsicFunction:`
   - Returns the actual value for normal parameters

2. **Updated intrinsic functions to use the wrapper**:
   - `RefAction.resolve_parameter_refs()`: Returns the original `{"Ref": "ParamName"}` unchanged for placeholders
   - `SubAction.resolve_parameter_refs()`: Keeps the original `${ParamName}` reference in Sub strings for placeholders

3. **Added comprehensive test coverage** in `tests/intrinsics/test_resolver.py` to verify:
   - CloudFormation placeholders are not resolved
   - Normal parameters continue to work correctly
   - Placeholders in nested structures and lists are handled properly
   - Both Ref and Fn::Sub handle placeholders correctly

## Impact

### Before
```yaml
# SAM would resolve this:
UserPoolArn: !Ref UserPoolArn
# Where UserPoolArn parameter = "{{IntrinsicFunction:stack/Cognito.Outputs.UserPoolArn/Fn::GetAtt}}"

# Into this (causing errors):
UserPoolArn: 
  - "{{IntrinsicFunction:stack/Cognito.Outputs.UserPoolArn/Fn::GetAtt}}"
```

### After
```yaml
# Now it remains as:
UserPoolArn: !Ref UserPoolArn
# The intrinsic function is preserved, allowing CloudFormation to handle it properly
```

## Testing

- Added test cases for CloudFormation placeholder handling in both `Ref` and `Fn::Sub` intrinsic functions
- All existing tests pass, ensuring no regression in normal parameter resolution
- Verified with the reproduction case from the issue report

## Related Issues

Fixes the issue where `sam package` followed by `aws cloudformation create-change-set --include-nested-stacks` would fail with "Usage of {{IntrinsicFunction:...}} is not allowed" error.

## Checklist

- [x] Code changes are covered by tests
- [x] No breaking changes to existing functionality
- [x] Tests pass locally
- [x] Documentation updated (inline comments explain the placeholder handling)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
