### PR TITLE
Security: Logical ID uniqueness check can be bypassed via substring matching

### DIFF
--- a/samtranslator/translator/verify_logical_id.py
+++ b/samtranslator/translator/verify_logical_id.py
@@ -32,5 +32,10 @@ def verify_unique_logical_id(resource: Resource, existing_resources: dict[str, A
     # new resource logicalid is in  the do_not_resolve list
     return bool(
         resource.resource_type in do_not_verify
-        and existing_resources[resource.logical_id]["Type"] in do_not_verify[resource.resource_type]
+        and existing_resources[resource.logical_id]["Type"]
+        in (
+            do_not_verify[resource.resource_type]
+            if isinstance(do_not_verify[resource.resource_type], list)
+            else [do_not_verify[resource.resource_type]]
+        )
     )


### PR DESCRIPTION
## Problem

The `verify_unique_logical_id` function uses the `in` operator to compare resource types against `do_not_verify` entries. For mappings where the value is a string (not a list), `in` performs substring checks, not strict equality. This can allow unintended type matches (e.g., crafted type strings that are substrings), potentially bypassing logical ID collision detection and causing transformed resources to overwrite or collide with existing ones.

**Severity**: `medium`
**File**: `samtranslator/translator/verify_logical_id.py`

## Solution

Use strict type comparison. Normalize `do_not_verify` values to lists and compare with equality, e.g. `allowed = do_not_verify[resource.resource_type]; allowed_types = allowed if isinstance(allowed, list) else [allowed]; return existing_type in allowed_types`.

## Changes

- `samtranslator/translator/verify_logical_id.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
