### PR TITLE
Security: Insecure temporary file creation pattern in shared temp directory

### DIFF
--- a/integration/helpers/deployer/utils/artifact_exporter.py
+++ b/integration/helpers/deployer/utils/artifact_exporter.py
@@ -18,7 +18,6 @@ This was ported over from the sam-cli repo
 
 import os
 import tempfile
-import uuid
 from contextlib import contextmanager
 from urllib.parse import parse_qs, urlparse
 
@@ -45,11 +44,10 @@ def parse_s3_url(url, bucket_name_property="Bucket", object_key_property="Key", 
 
 @contextmanager
 def mktempfile():
-    directory = tempfile.gettempdir()
-    filename = os.path.join(directory, uuid.uuid4().hex)
+    fd, filename = tempfile.mkstemp()
 
     try:
-        with open(filename, "w+") as handle:
+        with os.fdopen(fd, "w+") as handle:
             yield handle
     finally:
         if os.path.exists(filename):


### PR DESCRIPTION
## Problem

`mktempfile` manually constructs a filename in the system temp directory and opens it with `open(..., 'w+')`. This pattern is vulnerable to race/symlink attacks in multi-user environments because creation is not done with secure exclusive flags. If this utility is used in privileged contexts, an attacker could potentially influence file targets.

**Severity**: `medium`
**File**: `integration/helpers/deployer/utils/artifact_exporter.py`

## Solution

Use `tempfile.NamedTemporaryFile` or `tempfile.mkstemp` (with restrictive permissions) to ensure atomic creation and avoid symlink/race vulnerabilities. Example: `fd, path = tempfile.mkstemp(); os.fdopen(fd, 'w+')`.

## Changes

- `integration/helpers/deployer/utils/artifact_exporter.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
