### PR TITLE
feat: fully support Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -26,7 +26,7 @@ Environment setup
 -----------------
 ### 1. Install Python versions
 
-Our officially supported Python versions are 3.10, 3.11, 3.12, 3.13
+Our officially supported Python versions are 3.10, 3.11, 3.12, 3.13, 3.14
 Our CI/CD pipeline is setup to run unit tests against Python 3 versions. Make sure you test it before sending a Pull Request.
 See [Unit testing with multiple Python versions](#unit-testing-with-multiple-python-versions).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target_version = ['py310', 'py311', 'py312', 'py313']
+target_version = ['py310', 'py311', 'py312', 'py313', 'py314']
 exclude = '''
 
 (

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,4 +3,4 @@ jsonschema<5,>=4.23
 typing_extensions>=4.4
 
 # resource validation & schema generation
-pydantic~=2.12.5
+pydantic~=2.13.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,4 +3,4 @@ jsonschema<5,>=4.23
 typing_extensions>=4.4
 
 # resource validation & schema generation
-pydantic~=2.13.2
+pydantic~=2.13.3

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -2,10 +2,8 @@
 
 import copy
 import re
-import sys
 from collections.abc import Callable
 from contextlib import suppress
-from types import ModuleType
 from typing import Any, Literal, Union, cast
 
 import samtranslator.model.eventsources
@@ -37,19 +35,11 @@ from samtranslator.internal.model.appsync import (
     SyncConfigType,
     UserPoolConfigType,
 )
-
-# Pydantic 1 doesn't support Python 3.14 so these imports will fail until we migrate to v2
-try:
-    from samtranslator.internal.schema_source import (
-        aws_serverless_capacity_provider,
-        aws_serverless_function,
-        aws_serverless_graphqlapi,
-    )
-except RuntimeError:  # Pydantic fails when initializing the model classes with a RuntimeError in 3.14
-    aws_serverless_capacity_provider = cast(ModuleType, None)
-    aws_serverless_function = cast(ModuleType, None)
-    aws_serverless_graphqlapi = cast(ModuleType, None)
-
+from samtranslator.internal.schema_source import (
+    aws_serverless_capacity_provider,
+    aws_serverless_function,
+    aws_serverless_graphqlapi,
+)
 from samtranslator.internal.schema_source.common import PermissionsType, SamIntrinsicable
 from samtranslator.internal.types import GetManagedPolicyMap
 from samtranslator.internal.utils.utils import passthrough_value, remove_none_values
@@ -156,14 +146,6 @@ from .s3_utils.uri_parser import construct_image_code_object, construct_s3_locat
 from .tags.resource_tagging import get_tag_list
 
 _CONDITION_CHAR_LIMIT = 255
-
-
-# Utility function to throw an error when using functionality that doesn't work in Python 3.14 (need migration to Pydantic v2)
-def check_python_314_compatibility(module: ModuleType | None, functionality: str) -> None:
-    if sys.version_info >= (3, 14) and module is None:
-        raise RuntimeError(
-            f"{functionality} functionalities are temporarily not supported when running SAM in Python 3.14"
-        )
 
 
 class SamFunction(SamResourceMacro):
@@ -811,7 +793,6 @@ class SamFunction(SamResourceMacro):
 
         # Validate CapacityProviderConfig using Pydantic model directly for comprehensive error collection
         try:
-            check_python_314_compatibility(aws_serverless_function, "Capacity Provider")
             validated_model = aws_serverless_function.CapacityProviderConfig.parse_obj(self.CapacityProviderConfig)
         except Exception as e:
             raise InvalidResourceException(self.logical_id, f"Invalid CapacityProviderConfig: {e!s}") from e
@@ -1574,7 +1555,6 @@ class SamCapacityProvider(SamResourceMacro):
         """
         Transform the SAM CapacityProvider resource to CloudFormation
         """
-        check_python_314_compatibility(aws_serverless_capacity_provider, "Capacity Provider")
         self.validate_before_transform(
             schema_class=aws_serverless_capacity_provider.Properties,
             collect_all_errors=True,
@@ -2792,7 +2772,6 @@ class SamGraphQLApi(SamResourceMacro):
 
     @cw_timer
     def to_cloudformation(self, **kwargs: Any) -> list[Resource]:
-        check_python_314_compatibility(aws_serverless_graphqlapi, "GraphQLApi")
         model = self.validate_properties_and_return_model(aws_serverless_graphqlapi.Properties)
 
         appsync_api, cloudwatch_role, auth_connectors = self._construct_appsync_api_resources(model)


### PR DESCRIPTION
- Update to Pydantic >= 2.13, which added support for Python 3.14 in the legacy v1 version included (that we're using)
https://pypi.org/project/pydantic/2.13.0/

- Remove previous checks that make the code fail in Python 3.14 for some functionality.

### Issue #, if available
#3831 
### Description of changes
The new version of Pydantic allows its v1 to support Python 3.14, so we can support it without having to migrate to v2 yet.
### Description of how you validated changes
- `make pr`

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
