### PR TITLE
fix: add cfn-lint ignore rules for new format validation checks

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -120,3 +120,8 @@ ignore_checks:
   - W2001 # Parameter not used
   - E3006 # Resource type check; we have some Foo Bar resources
   - W3037 # Ignore cfn-lint check for non existing IAM permissions
+  - E1041 # Ref/GetAtt format mismatch; test fixtures use refs that resolve correctly at deploy time
+  - E1156 # Invalid IAM Role ARN format; test fixtures use placeholder values
+  - E1157 # Invalid KMS Key ARN format; test fixtures use placeholder values
+  - E1159 # Invalid ACM Certificate ARN format; test fixtures use placeholder values
+  - W1031 # Fn::Sub resolved value format mismatch; test fixtures use simplified ARN patterns


### PR DESCRIPTION
## Summary

cfn-lint v1.49.0 ([aws-cloudformation/cfn-lint#4442](https://github.com/aws-cloudformation/cfn-lint/pull/4442)) expanded format keyword coverage, adding validation for several new AWS resource property formats. This causes 97 new lint errors on test fixture files that use placeholder/fake ARN values.

### New rules added to `.cfnlintrc.yaml` ignore list

| Rule | Description |
|------|-------------|
| E1041 | Ref/GetAtt format mismatch — test fixtures use refs that resolve correctly at deploy time |
| E1156 | Invalid IAM Role ARN format — test fixtures use placeholder values like `some-arn` |
| E1157 | Invalid KMS Key ARN format — test fixtures use placeholder values like `thisIsaKey` |
| E1159 | Invalid ACM Certificate ARN format — test fixtures use placeholder values like `arn::cert::abc` |
| W1031 | Fn::Sub resolved value format mismatch — test fixtures use simplified ARN patterns |

### Context

These errors are not caused by any code change — they are triggered by the upstream cfn-lint release. The `develop` branch will also fail once CI re-runs with cfn-lint >= 1.49.0. This also unblocks #3913.

The test fixture files under `tests/translator/output/` intentionally use simplified placeholder values for ARNs, which is consistent with how other checks (E3001, E3006, W3037) are already suppressed in `.cfnlintrc.yaml`.

### Testing

Verified locally that `cfn-lint 1.49.1 --format parseable` produces 0 errors with this change.