### PR TITLE
chore(tests): use valid ARN formats in test fixtures to comply with cfn-lint

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -120,8 +120,3 @@ ignore_checks:
   - W2001 # Parameter not used
   - E3006 # Resource type check; we have some Foo Bar resources
   - W3037 # Ignore cfn-lint check for non existing IAM permissions
-  - E1041 # Ref/GetAtt format mismatch; test fixtures use refs that resolve correctly at deploy time
-  - E1156 # Invalid IAM Role ARN format; test fixtures use placeholder values
-  - E1157 # Invalid KMS Key ARN format; test fixtures use placeholder values
-  - E1159 # Invalid ACM Certificate ARN format; test fixtures use placeholder values
-  - W1031 # Fn::Sub resolved value format mismatch; test fixtures use simplified ARN patterns

--- a/tests/translator/input/api_with_basic_custom_domain.yaml
+++ b/tests/translator/input/api_with_basic_custom_domain.yaml
@@ -5,7 +5,7 @@ Parameters:
 
   MyDomainCert:
     Type: String
-    Default: another-api-arn
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert
 
 Globals:
   Api:
@@ -59,7 +59,7 @@ Resources:
       StageName: Prod
       Domain:
         DomainName: api-example.com
-        CertificateArn: my-api-cert-arn
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert
         EndpointConfiguration: EDGE
         BasePath: [/get, /fetch]
         MutualTlsAuthentication:

--- a/tests/translator/input/api_with_basic_custom_domain_intrinsics.yaml
+++ b/tests/translator/input/api_with_basic_custom_domain_intrinsics.yaml
@@ -6,7 +6,7 @@ Conditions:
 Parameters:
   MyDomainCert:
     Type: String
-    Default: another-api-arn
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert
 
   EndpointConf:
     Type: String

--- a/tests/translator/input/api_with_basic_custom_domain_intrinsics_http.yaml
+++ b/tests/translator/input/api_with_basic_custom_domain_intrinsics_http.yaml
@@ -6,7 +6,7 @@ Conditions:
 Parameters:
   MyDomainCert:
     Type: String
-    Default: another-api-arn
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert
 
   EndpointConf:
     Type: String

--- a/tests/translator/input/api_with_custom_domain_route53.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53.yaml
@@ -4,7 +4,7 @@ Parameters:
     Default: example.com
   ACMCertificateArn:
     Type: String
-    Default: cert-arn-in-us-east-1
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/abc123
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_custom_domain_route53_hosted_zone_name.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_hosted_zone_name.yaml
@@ -4,7 +4,7 @@ Parameters:
     Default: example.com
   ACMCertificateArn:
     Type: String
-    Default: cert-arn-in-us-east-1
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/abc123
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_custom_domain_route53_hosted_zone_name_http.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_hosted_zone_name_http.yaml
@@ -4,7 +4,7 @@ Parameters:
     Default: example.com
   ACMCertificateArn:
     Type: String
-    Default: cert-arn-in-us-east-1
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/abc123
 Globals:
   HttpApi:
     Domain:

--- a/tests/translator/input/api_with_custom_domain_route53_http.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_http.yaml
@@ -4,7 +4,7 @@ Parameters:
     Default: example.com
   ACMCertificateArn:
     Type: String
-    Default: cert-arn-in-us-east-1
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/abc123
 Resources:
   MyFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_multiple.yaml
@@ -18,7 +18,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -38,7 +38,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.two.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -58,7 +58,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.three.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/input/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.yaml
@@ -22,7 +22,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: !Ref MyHostedZoneId
@@ -42,7 +42,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.two.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: !Sub "{{MyHostedZoneId}}"
@@ -62,7 +62,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.three.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: !Ref MyHostedZoneId

--- a/tests/translator/input/api_with_custom_domains_private.yaml
+++ b/tests/translator/input/api_with_custom_domains_private.yaml
@@ -6,7 +6,7 @@ Parameters:
 
   CertificateArn:
     Type: String
-    Default: another-api-arn
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert
     Description: ARN of the ACM certificate for the domain
 
   VpcEndpointId:

--- a/tests/translator/input/api_with_custom_domains_private_basePath.yaml
+++ b/tests/translator/input/api_with_custom_domains_private_basePath.yaml
@@ -6,7 +6,7 @@ Parameters:
 
   CertificateArn:
     Type: String
-    Default: another-api-arn
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert
     Description: ARN of the ACM certificate for the domain
 
   VpcEndpointId:

--- a/tests/translator/input/capacity_provider_global_with_functions.yaml
+++ b/tests/translator/input/capacity_provider_global_with_functions.yaml
@@ -48,7 +48,7 @@ Globals:
     InstanceRequirements:
       Architectures:
       - x86_64
-    KmsKeyArn: some-kms-arn
+    KmsKeyArn: arn:aws:kms:us-east-1:123456789012:key/some-kms-key
 
   Function:
     Runtime: python3.12

--- a/tests/translator/input/error_api_mtls_configuration_invalid_field.yaml
+++ b/tests/translator/input/error_api_mtls_configuration_invalid_field.yaml
@@ -6,7 +6,7 @@ Resources:
       StageName: Prod
       Domain:
         DomainName: api-example.com
-        CertificateArn: my-api-cert-arn
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert
         EndpointConfiguration: EDGE
         BasePath: [/get, /fetch]
         MutualTlsAuthentication:

--- a/tests/translator/input/error_api_mtls_configuration_invalid_type.yaml
+++ b/tests/translator/input/error_api_mtls_configuration_invalid_type.yaml
@@ -6,7 +6,7 @@ Resources:
       StageName: Prod
       Domain:
         DomainName: api-example.com
-        CertificateArn: my-api-cert-arn
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert
         EndpointConfiguration: EDGE
         BasePath: [/get, /fetch]
         MutualTlsAuthentication:

--- a/tests/translator/input/error_api_with_custom_domains_invalid.yaml
+++ b/tests/translator/input/error_api_with_custom_domains_invalid.yaml
@@ -5,7 +5,7 @@ Parameters:
 
   MyDomainCert:
     Type: String
-    Default: another-api-arn
+    Default: arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert
 
 Globals:
   Api:
@@ -58,7 +58,7 @@ Resources:
       StageName: Prod
       Domain:
         DomainName: api-example.com
-        CertificateArn: my-api-cert-arn
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert
         EndpointConfiguration: Invalid
         BasePath: [/get, /fetch]
 
@@ -85,6 +85,6 @@ Resources:
       StageName: Prod
       Domain:
         DomainName: api-example.com
-        CertificateArn: my-api-cert-arn
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert
         BasePath:
         - 3 # this should not be a number

--- a/tests/translator/input/error_api_with_custom_domains_route53_invalid.yaml
+++ b/tests/translator/input/error_api_with_custom_domains_route53_invalid.yaml
@@ -33,7 +33,7 @@ Resources:
       StageName: Prod
       Domain:
         DomainName: api-example.com
-        CertificateArn: my-api-cert-arn
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert
         EndpointConfiguration: EDGE
         BasePath: [/get, /fetch]
         Route53:

--- a/tests/translator/input/error_api_with_custom_domains_route53_invalid_type.yaml
+++ b/tests/translator/input/error_api_with_custom_domains_route53_invalid_type.yaml
@@ -27,7 +27,7 @@ Resources:
       StageName: Prod
       Domain:
         DomainName: api-example.com
-        CertificateArn: my-api-cert-arn
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert
         EndpointConfiguration: EDGE
         BasePath: [/get]
         Route53: InvalidString

--- a/tests/translator/input/error_graphqlapi.yaml
+++ b/tests/translator/input/error_graphqlapi.yaml
@@ -60,7 +60,7 @@ Resources:
         key1: value1
         key2: value2
       Logging:
-        CloudWatchLogsRoleArn: some-arn
+        CloudWatchLogsRoleArn: arn:aws:iam::123456789012:role/some-role
         FieldLogLevel: ERROR
         ExcludeVerboseContent: true
         NotSupposedToBeHere: yo
@@ -137,7 +137,7 @@ Resources:
         DynamoDb:
           InternalDataSource:
             TableName: SomeTable
-            ServiceRoleArn: SomeRoleArn
+            ServiceRoleArn: arn:aws:iam::123456789012:role/SomeRole
       Functions:
         UnknownDataSource:
           CodeUri: my-code

--- a/tests/translator/input/error_separate_route53_recordset_group.yaml
+++ b/tests/translator/input/error_separate_route53_recordset_group.yaml
@@ -31,7 +31,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -52,7 +52,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.two.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -73,7 +73,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.three.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/input/function_with_alias_and_all_properties_property.yaml
+++ b/tests/translator/input/function_with_alias_and_all_properties_property.yaml
@@ -43,7 +43,7 @@ Resources:
       EphemeralStorage:
         Size: 1024
       Role: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1
-      KmsKeyArn: !Sub arn:${AWS::Partition}:key:key
+      KmsKeyArn: !Sub arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key
       FileSystemConfigs:
       - Arn: !GetAtt AccessPoint.Arn
         LocalMountPath: /mnt/EFS
@@ -73,7 +73,7 @@ Resources:
       EphemeralStorage:
         Size: 1024
       Role: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/role1
-      KmsKeyArn: !Sub arn:${AWS::Partition}:key:key
+      KmsKeyArn: !Sub arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key
       FileSystemConfigs:
       - Arn: !GetAtt AccessPoint.Arn
         LocalMountPath: /mnt/EFS

--- a/tests/translator/input/function_with_kmskeyarn.yaml
+++ b/tests/translator/input/function_with_kmskeyarn.yaml
@@ -5,7 +5,7 @@ Resources:
       CodeUri: s3://sam-demo-bucket/hello.zip
       Handler: hello.handler
       Runtime: python2.7
-      KmsKeyArn: thisIsaKey
+      KmsKeyArn: arn:aws:kms:us-east-1:123456789012:key/this-is-a-key
 
   FunctionWithReferenceToKeyArn:
     Type: AWS::Serverless::Function
@@ -14,7 +14,9 @@ Resources:
       Handler: hello.handler
       Runtime: python2.7
       KmsKeyArn:
-        Ref: myKey
+        Fn::GetAtt:
+        - myKey
+        - Arn
 
   myKey:
     Type: AWS::KMS::Key

--- a/tests/translator/input/graphqlapi_ddb_datasource_all_properties.yaml
+++ b/tests/translator/input/graphqlapi_ddb_datasource_all_properties.yaml
@@ -18,7 +18,7 @@ Resources:
         DynamoDb:
           MyDataSource:
             TableName: some-table
-            ServiceRoleArn: some-arn
+            ServiceRoleArn: arn:aws:iam::123456789012:role/some-role
             Name: AwesomeDataSourceName
             Description: This data source is special to me
             Region: na-west-2

--- a/tests/translator/input/graphqlapi_function_datasource_property.yaml
+++ b/tests/translator/input/graphqlapi_function_datasource_property.yaml
@@ -20,7 +20,7 @@ Resources:
         DynamoDb:
           InternalDataSource:
             TableName: SomeTable
-            ServiceRoleArn: SomeRoleArn
+            ServiceRoleArn: arn:aws:iam::123456789012:role/SomeRole
       Functions:
         UseInternal:
           InlineCode: this is my epic code

--- a/tests/translator/input/graphqlapi_intrinsical_names.yaml
+++ b/tests/translator/input/graphqlapi_intrinsical_names.yaml
@@ -45,7 +45,7 @@ Resources:
         Lambda:
           MyDataSource:
             FunctionArn: my-lambda-arn
-            ServiceRoleArn: some-role-arn
+            ServiceRoleArn: arn:aws:iam::123456789012:role/some-role
             Name: !Ref LambdaDSName
         DynamoDb:
           DDB1:

--- a/tests/translator/input/graphqlapi_lambda_and_ddb_datasource.yaml
+++ b/tests/translator/input/graphqlapi_lambda_and_ddb_datasource.yaml
@@ -18,9 +18,9 @@ Resources:
         Lambda:
           MyDataSource:
             FunctionArn: blah
-            ServiceRoleArn: my-lambda-role
+            ServiceRoleArn: arn:aws:iam::123456789012:role/my-lambda-role
         DynamoDb:
           MyDataSource:
             TableName: some-table
             TableArn: big-arn
-            ServiceRoleArn: my-ddb-role
+            ServiceRoleArn: arn:aws:iam::123456789012:role/my-ddb-role

--- a/tests/translator/input/graphqlapi_logging_defined.yaml
+++ b/tests/translator/input/graphqlapi_logging_defined.yaml
@@ -14,6 +14,6 @@ Resources:
         key1: value1
         key2: value2
       Logging:
-        CloudWatchLogsRoleArn: some-arn
+        CloudWatchLogsRoleArn: arn:aws:iam::123456789012:role/some-role
         FieldLogLevel: ERROR
         ExcludeVerboseContent: true

--- a/tests/translator/input/graphqlapi_resolver_function_with_lambda_datasource.yaml
+++ b/tests/translator/input/graphqlapi_resolver_function_with_lambda_datasource.yaml
@@ -18,7 +18,7 @@ Resources:
         Lambda:
           MyDataSource:
             FunctionArn: my-lambda-arn
-            ServiceRoleArn: some-role-arn
+            ServiceRoleArn: arn:aws:iam::123456789012:role/some-role
             Name: PradsLambdaDataSource
             Description: lambda datasources are nice
       Resolvers:

--- a/tests/translator/input/http_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/http_api_with_custom_domain_route53_multiple.yaml
@@ -4,7 +4,7 @@ Resources:
     Properties:
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -14,7 +14,7 @@ Resources:
     Properties:
       Domain:
         DomainName: admin.two.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -24,7 +24,7 @@ Resources:
     Properties:
       Domain:
         DomainName: admin.three.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/input/httpapi_with_propagate_tags.yaml
+++ b/tests/translator/input/httpapi_with_propagate_tags.yaml
@@ -13,7 +13,7 @@ Resources:
       PropagateTags: true
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/input/mixed_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/mixed_api_with_custom_domain_route53_multiple.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -28,7 +28,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.two.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/input/separate_route53_recordset_group.yaml
+++ b/tests/translator/input/separate_route53_recordset_group.yaml
@@ -31,7 +31,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -52,7 +52,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.two.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -73,7 +73,7 @@ Resources:
         HttpMethod: '*'
       Domain:
         DomainName: admin.three.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/input/websocket_api_domain_globals.yaml
+++ b/tests/translator/input/websocket_api_domain_globals.yaml
@@ -2,7 +2,7 @@ Globals:
   WebSocketApi:
     Domain:
       DomainName: admin.one.amazon.com
-      CertificateArn: arn::cert::abc
+      CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
       EndpointConfiguration: REGIONAL
       Route53:
         HostedZoneId: abc123456
@@ -33,7 +33,7 @@ Resources:
     Properties:
       Domain:
         DomainName: admin.two.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/input/websocket_api_with_custom_domain_route53_multiple.yaml
+++ b/tests/translator/input/websocket_api_with_custom_domain_route53_multiple.yaml
@@ -22,7 +22,7 @@ Resources:
     Properties:
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -36,7 +36,7 @@ Resources:
     Properties:
       Domain:
         DomainName: admin.two.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456
@@ -50,7 +50,7 @@ Resources:
     Properties:
       Domain:
         DomainName: admin.three.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/input/websocket_api_with_propagate_tags.yaml
+++ b/tests/translator/input/websocket_api_with_propagate_tags.yaml
@@ -19,7 +19,7 @@ Resources:
         Format: $context.requestId
       Domain:
         DomainName: admin.one.amazon.com
-        CertificateArn: arn::cert::abc
+        CertificateArn: arn:aws:acm:us-east-1:123456789012:certificate/abc
         EndpointConfiguration: REGIONAL
         Route53:
           HostedZoneId: abc123456

--- a/tests/translator/output/api_with_basic_custom_domain.json
+++ b/tests/translator/output/api_with_basic_custom_domain.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyDomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName23cdccdf9c": {
       "Properties": {
-        "CertificateArn": "my-api-cert-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert",
         "DomainName": "api-example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -35,7 +35,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "another-api-arn"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -81,9 +81,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "MyAnotherApiDeployment48a61be119": {
+    "MyAnotherApiDeployment6a1584712a": {
       "Properties": {
-        "Description": "RestApi deployment id: 48a61be119a247807ea0ef8378e6aa16592f90fa",
+        "Description": "RestApi deployment id: 6a1584712af350e3e6b97bdb00baa3edce663457",
         "RestApiId": {
           "Ref": "MyAnotherApi"
         }
@@ -93,7 +93,7 @@
     "MyAnotherApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeployment48a61be119"
+          "Ref": "MyAnotherApiDeployment6a1584712a"
         },
         "RestApiId": {
           "Ref": "MyAnotherApi"
@@ -142,9 +142,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment347043ff9e": {
+    "MyApiDeploymentfc18b3402b": {
       "Properties": {
-        "Description": "RestApi deployment id: 347043ff9ec72c6ce10317548939c3802eb1dd55",
+        "Description": "RestApi deployment id: fc18b3402b150e523f8656b5e2fce5f954eb00f3",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -154,7 +154,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment347043ff9e"
+          "Ref": "MyApiDeploymentfc18b3402b"
         },
         "RestApiId": {
           "Ref": "MyApi"
@@ -371,9 +371,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ServerlessRestApiDeployment3c44da8ffd": {
+    "ServerlessRestApiDeployment6629dded88": {
       "Properties": {
-        "Description": "RestApi deployment id: 3c44da8ffdf3025dc792391a61590b92e8e2ff48",
+        "Description": "RestApi deployment id: 6629dded88958f90db94aac6ceea567a84c60d99",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -384,7 +384,7 @@
     "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment3c44da8ffd"
+          "Ref": "ServerlessRestApiDeployment6629dded88"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/api_with_basic_custom_domain_intrinsics.json
@@ -13,7 +13,7 @@
       "Type": "String"
     },
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyMTLSUri": {
@@ -41,7 +41,7 @@
           "TruststoreUri": "another-api-truststore-uri",
           "TruststoreVersion": "another-api-truststore-version"
         },
-        "RegionalCertificateArn": "another-api-arn",
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "SecurityPolicy": "TLS_1_2"
       },
       "Type": "AWS::ApiGateway::DomainName"
@@ -99,10 +99,10 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment19c8cf5c63": {
+    "MyApiDeploymentef17a59556": {
       "Condition": "C1",
       "Properties": {
-        "Description": "RestApi deployment id: 19c8cf5c63090f12c5a96f6f57162495bed446c7",
+        "Description": "RestApi deployment id: ef17a59556daf8c37498579c31e65d0f4f61ab3f",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -113,7 +113,7 @@
       "Condition": "C1",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment19c8cf5c63"
+          "Ref": "MyApiDeploymentef17a59556"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/api_with_basic_custom_domain_intrinsics_http.json
+++ b/tests/translator/output/api_with_basic_custom_domain_intrinsics_http.json
@@ -13,7 +13,7 @@
       "Type": "String"
     },
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyMTLSUriHTTP": {
@@ -34,7 +34,7 @@
         },
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "another-api-arn",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
             "EndpointType": "REGIONAL",
             "SecurityPolicy": "TLS_1_2"
           }

--- a/tests/translator/output/api_with_custom_domain_route53.json
+++ b/tests/translator/output/api_with_custom_domain_route53.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName0caaf24ab1": {
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
         "DomainName": "example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -50,9 +50,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeploymentf643ef7f59": {
+    "MyApiDeploymentd17d08f1ff": {
       "Properties": {
-        "Description": "RestApi deployment id: f643ef7f592a69a57638dd25e64dc12d2b4abf2d",
+        "Description": "RestApi deployment id: d17d08f1ff4d9040cb01d830caba310df8330b77",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -62,7 +62,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentf643ef7f59"
+          "Ref": "MyApiDeploymentd17d08f1ff"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName0caaf24ab1": {
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
         "DomainName": "example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -50,9 +50,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeploymenteb58d7577a": {
+    "MyApiDeployment69d4a9c956": {
       "Properties": {
-        "Description": "RestApi deployment id: eb58d7577a65af049c9c6f10c9d8b286de6b5aeb",
+        "Description": "RestApi deployment id: 69d4a9c956362df156427c3a8ad0b1983743921f",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -62,7 +62,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymenteb58d7577a"
+          "Ref": "MyApiDeployment69d4a9c956"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/api_with_custom_domain_route53_hosted_zone_name_http.json
+++ b/tests/translator/output/api_with_custom_domain_route53_hosted_zone_name_http.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -15,7 +15,7 @@
         "DomainName": "example.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "cert-arn-in-us-east-1",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/api_with_custom_domain_route53_http.json
+++ b/tests/translator/output/api_with_custom_domain_route53_http.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -15,7 +15,7 @@
         "DomainName": "example.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "cert-arn-in-us-east-1",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/api_with_custom_domain_route53_multiple.json
@@ -40,9 +40,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeploymentdd3f545183": {
+    "ApiGatewayAdminOneDeployment5f4fcb9347": {
       "Properties": {
-        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "Description": "RestApi deployment id: 5f4fcb9347315a0decaa8f0140aae89cde47f8d1",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -53,7 +53,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+          "Ref": "ApiGatewayAdminOneDeployment5f4fcb9347"
         },
         "MethodSettings": [
           {
@@ -108,9 +108,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeployment7541e97159": {
+    "ApiGatewayAdminThreeDeployment30e2eaa7d5": {
       "Properties": {
-        "Description": "RestApi deployment id: 7541e971598cffe7cafab030d3fccc687d508f59",
+        "Description": "RestApi deployment id: 30e2eaa7d590e7a85c5ce8b5eb5926ffa28afc90",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -121,7 +121,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeployment7541e97159"
+          "Ref": "ApiGatewayAdminThreeDeployment30e2eaa7d5"
         },
         "MethodSettings": [
           {
@@ -176,9 +176,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeployment61887a4eed": {
+    "ApiGatewayAdminTwoDeployment43c6a2ef1d": {
       "Properties": {
-        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "Description": "RestApi deployment id: 43c6a2ef1d8b1c11ef2beb3f5a006b57a33d8b05",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -189,7 +189,7 @@
     "ApiGatewayAdminTwoProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeployment61887a4eed"
+          "Ref": "ApiGatewayAdminTwoDeployment43c6a2ef1d"
         },
         "MethodSettings": [
           {
@@ -214,7 +214,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -226,7 +226,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -238,7 +238,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
+++ b/tests/translator/output/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
@@ -45,9 +45,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeployment066bb1ceae": {
+    "ApiGatewayAdminOneDeployment90f9e9bb3f": {
       "Properties": {
-        "Description": "RestApi deployment id: 066bb1ceaebd0cafae99258bbe7130af8b676372",
+        "Description": "RestApi deployment id: 90f9e9bb3ff69b4b71008da58841c770681ed84c",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -58,7 +58,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeployment066bb1ceae"
+          "Ref": "ApiGatewayAdminOneDeployment90f9e9bb3f"
         },
         "MethodSettings": [
           {
@@ -113,9 +113,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeployment169349c1e9": {
+    "ApiGatewayAdminThreeDeployment127733f946": {
       "Properties": {
-        "Description": "RestApi deployment id: 169349c1e96a0f130ee35f7bb9d83b042c386d6f",
+        "Description": "RestApi deployment id: 127733f94631341b13b3d91531d39f307d0b4700",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -126,7 +126,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeployment169349c1e9"
+          "Ref": "ApiGatewayAdminThreeDeployment127733f946"
         },
         "MethodSettings": [
           {
@@ -181,9 +181,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeploymentca2a75b5dd": {
+    "ApiGatewayAdminTwoDeployment19f5544fe4": {
       "Properties": {
-        "Description": "RestApi deployment id: ca2a75b5dd3713c71543e80f2b6f5aac9538ea9c",
+        "Description": "RestApi deployment id: 19f5544fe49037ecad607e6d0a584c3a252b6367",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -194,7 +194,7 @@
     "ApiGatewayAdminTwoProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeploymentca2a75b5dd"
+          "Ref": "ApiGatewayAdminTwoDeployment19f5544fe4"
         },
         "MethodSettings": [
           {
@@ -219,7 +219,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -231,7 +231,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -243,7 +243,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/api_with_custom_domains_private.json
+++ b/tests/translator/output/api_with_custom_domains_private.json
@@ -15,7 +15,7 @@
   },
   "Parameters": {
     "CertificateArn": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Description": "ARN of the ACM certificate for the domain",
       "Type": "String"
     },
@@ -33,7 +33,7 @@
   "Resources": {
     "ApiGatewayDomainNameV27c603ed871": {
       "Properties": {
-        "CertificateArn": "another-api-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "DomainName": "private.example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -116,9 +116,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMappingV2"
     },
-    "MyApiDeployment7c3b13a843": {
+    "MyApiDeployment3c30770aa3": {
       "Properties": {
-        "Description": "RestApi deployment id: 7c3b13a843cdd653d1310c6fd7881e8fe8e49da8",
+        "Description": "RestApi deployment id: 3c30770aa391b69cb92f7b4a5d5969d6f92ee5b4",
         "RestApiId": {
           "Ref": "MyApi"
         },
@@ -129,7 +129,7 @@
     "MyApiprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment7c3b13a843"
+          "Ref": "MyApiDeployment3c30770aa3"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/api_with_custom_domains_private_basePath.json
+++ b/tests/translator/output/api_with_custom_domains_private_basePath.json
@@ -15,7 +15,7 @@
   },
   "Parameters": {
     "CertificateArn": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Description": "ARN of the ACM certificate for the domain",
       "Type": "String"
     },
@@ -33,7 +33,7 @@
   "Resources": {
     "ApiGatewayDomainNameV27c603ed871": {
       "Properties": {
-        "CertificateArn": "another-api-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "DomainName": "private.example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -117,9 +117,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMappingV2"
     },
-    "MyApiDeploymente37f6c9943": {
+    "MyApiDeployment09c01d5525": {
       "Properties": {
-        "Description": "RestApi deployment id: e37f6c9943b5e1213efecf302864c9e775fcf695",
+        "Description": "RestApi deployment id: 09c01d5525be5534dba547e7bc84bad514d39efa",
         "RestApiId": {
           "Ref": "MyApi"
         },
@@ -145,7 +145,7 @@
     "MyApiprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymente37f6c9943"
+          "Ref": "MyApiDeployment09c01d5525"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-cn/api_with_basic_custom_domain.json
+++ b/tests/translator/output/aws-cn/api_with_basic_custom_domain.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyDomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName23cdccdf9c": {
       "Properties": {
-        "CertificateArn": "my-api-cert-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert",
         "DomainName": "api-example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -35,7 +35,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "another-api-arn"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -89,9 +89,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "MyAnotherApiDeployment989ae20f23": {
+    "MyAnotherApiDeployment3cfc497b28": {
       "Properties": {
-        "Description": "RestApi deployment id: 989ae20f23c53c333389afc4e570683e5665c797",
+        "Description": "RestApi deployment id: 3cfc497b28e6ce997c6b38e7e075d279472a251d",
         "RestApiId": {
           "Ref": "MyAnotherApi"
         }
@@ -101,7 +101,7 @@
     "MyAnotherApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeployment989ae20f23"
+          "Ref": "MyAnotherApiDeployment3cfc497b28"
         },
         "RestApiId": {
           "Ref": "MyAnotherApi"
@@ -158,9 +158,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment92d6d51a5e": {
+    "MyApiDeploymentba363842ba": {
       "Properties": {
-        "Description": "RestApi deployment id: 92d6d51a5e324a2836c79d3645d7e678f063037e",
+        "Description": "RestApi deployment id: ba363842ba3082ecc43b3a2192a1ddcbee7d0d3b",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -170,7 +170,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment92d6d51a5e"
+          "Ref": "MyApiDeploymentba363842ba"
         },
         "RestApiId": {
           "Ref": "MyApi"
@@ -395,9 +395,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ServerlessRestApiDeployment6aef2b756e": {
+    "ServerlessRestApiDeployment3692d3fb7e": {
       "Properties": {
-        "Description": "RestApi deployment id: 6aef2b756ee814f8722e71ca5e3f0d187e05aed5",
+        "Description": "RestApi deployment id: 3692d3fb7e66521c849d5791227bd3a08afc01f9",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -408,7 +408,7 @@
     "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment6aef2b756e"
+          "Ref": "ServerlessRestApiDeployment3692d3fb7e"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics.json
@@ -13,7 +13,7 @@
       "Type": "String"
     },
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyMTLSUri": {
@@ -41,7 +41,7 @@
           "TruststoreUri": "another-api-truststore-uri",
           "TruststoreVersion": "another-api-truststore-version"
         },
-        "RegionalCertificateArn": "another-api-arn",
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "SecurityPolicy": "TLS_1_2"
       },
       "Type": "AWS::ApiGateway::DomainName"
@@ -107,10 +107,10 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment4f2c19d290": {
+    "MyApiDeploymentcfcc371fea": {
       "Condition": "C1",
       "Properties": {
-        "Description": "RestApi deployment id: 4f2c19d290875d88d8e30124f0953f1784e1b54d",
+        "Description": "RestApi deployment id: cfcc371feadedbdfbcb28f9722fd26bb9cd74421",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -121,7 +121,7 @@
       "Condition": "C1",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment4f2c19d290"
+          "Ref": "MyApiDeploymentcfcc371fea"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics_http.json
+++ b/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics_http.json
@@ -13,7 +13,7 @@
       "Type": "String"
     },
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyMTLSUriHTTP": {
@@ -34,7 +34,7 @@
         },
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "another-api-arn",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
             "EndpointType": "REGIONAL",
             "SecurityPolicy": "TLS_1_2"
           }

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName0caaf24ab1": {
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
         "DomainName": "example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -58,9 +58,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeploymentfb330328f1": {
+    "MyApiDeployment869611ff66": {
       "Properties": {
-        "Description": "RestApi deployment id: fb330328f152e4bb4b7d68e8b976b009e0558035",
+        "Description": "RestApi deployment id: 869611ff66eac2f12f80b45836746ad857549e2c",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -70,7 +70,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentfb330328f1"
+          "Ref": "MyApiDeployment869611ff66"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName0caaf24ab1": {
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
         "DomainName": "example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -58,9 +58,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment9239fa9a13": {
+    "MyApiDeployment2d4a76c7f1": {
       "Properties": {
-        "Description": "RestApi deployment id: 9239fa9a13216200ab5bf11c04507c61842a50a7",
+        "Description": "RestApi deployment id: 2d4a76c7f1effeb714d617714430e1983675accb",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -70,7 +70,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment9239fa9a13"
+          "Ref": "MyApiDeployment2d4a76c7f1"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_hosted_zone_name_http.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_hosted_zone_name_http.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -15,7 +15,7 @@
         "DomainName": "example.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "cert-arn-in-us-east-1",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_http.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_http.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -15,7 +15,7 @@
         "DomainName": "example.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "cert-arn-in-us-east-1",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_multiple.json
@@ -40,9 +40,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeploymentdd3f545183": {
+    "ApiGatewayAdminOneDeployment5f4fcb9347": {
       "Properties": {
-        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "Description": "RestApi deployment id: 5f4fcb9347315a0decaa8f0140aae89cde47f8d1",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -53,7 +53,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+          "Ref": "ApiGatewayAdminOneDeployment5f4fcb9347"
         },
         "MethodSettings": [
           {
@@ -108,9 +108,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeployment7541e97159": {
+    "ApiGatewayAdminThreeDeployment30e2eaa7d5": {
       "Properties": {
-        "Description": "RestApi deployment id: 7541e971598cffe7cafab030d3fccc687d508f59",
+        "Description": "RestApi deployment id: 30e2eaa7d590e7a85c5ce8b5eb5926ffa28afc90",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -121,7 +121,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeployment7541e97159"
+          "Ref": "ApiGatewayAdminThreeDeployment30e2eaa7d5"
         },
         "MethodSettings": [
           {
@@ -176,9 +176,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeployment61887a4eed": {
+    "ApiGatewayAdminTwoDeployment43c6a2ef1d": {
       "Properties": {
-        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "Description": "RestApi deployment id: 43c6a2ef1d8b1c11ef2beb3f5a006b57a33d8b05",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -189,7 +189,7 @@
     "ApiGatewayAdminTwoProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeployment61887a4eed"
+          "Ref": "ApiGatewayAdminTwoDeployment43c6a2ef1d"
         },
         "MethodSettings": [
           {
@@ -214,7 +214,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -226,7 +226,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -238,7 +238,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
@@ -45,9 +45,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeployment066bb1ceae": {
+    "ApiGatewayAdminOneDeployment90f9e9bb3f": {
       "Properties": {
-        "Description": "RestApi deployment id: 066bb1ceaebd0cafae99258bbe7130af8b676372",
+        "Description": "RestApi deployment id: 90f9e9bb3ff69b4b71008da58841c770681ed84c",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -58,7 +58,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeployment066bb1ceae"
+          "Ref": "ApiGatewayAdminOneDeployment90f9e9bb3f"
         },
         "MethodSettings": [
           {
@@ -113,9 +113,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeployment169349c1e9": {
+    "ApiGatewayAdminThreeDeployment127733f946": {
       "Properties": {
-        "Description": "RestApi deployment id: 169349c1e96a0f130ee35f7bb9d83b042c386d6f",
+        "Description": "RestApi deployment id: 127733f94631341b13b3d91531d39f307d0b4700",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -126,7 +126,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeployment169349c1e9"
+          "Ref": "ApiGatewayAdminThreeDeployment127733f946"
         },
         "MethodSettings": [
           {
@@ -181,9 +181,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeploymentca2a75b5dd": {
+    "ApiGatewayAdminTwoDeployment19f5544fe4": {
       "Properties": {
-        "Description": "RestApi deployment id: ca2a75b5dd3713c71543e80f2b6f5aac9538ea9c",
+        "Description": "RestApi deployment id: 19f5544fe49037ecad607e6d0a584c3a252b6367",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -194,7 +194,7 @@
     "ApiGatewayAdminTwoProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeploymentca2a75b5dd"
+          "Ref": "ApiGatewayAdminTwoDeployment19f5544fe4"
         },
         "MethodSettings": [
           {
@@ -219,7 +219,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -231,7 +231,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -243,7 +243,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/aws-cn/api_with_custom_domains_private.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domains_private.json
@@ -15,7 +15,7 @@
   },
   "Parameters": {
     "CertificateArn": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Description": "ARN of the ACM certificate for the domain",
       "Type": "String"
     },
@@ -33,7 +33,7 @@
   "Resources": {
     "ApiGatewayDomainNameV27c603ed871": {
       "Properties": {
-        "CertificateArn": "another-api-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "DomainName": "private.example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -124,9 +124,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMappingV2"
     },
-    "MyApiDeployment7c3b13a843": {
+    "MyApiDeployment3c30770aa3": {
       "Properties": {
-        "Description": "RestApi deployment id: 7c3b13a843cdd653d1310c6fd7881e8fe8e49da8",
+        "Description": "RestApi deployment id: 3c30770aa391b69cb92f7b4a5d5969d6f92ee5b4",
         "RestApiId": {
           "Ref": "MyApi"
         },
@@ -137,7 +137,7 @@
     "MyApiprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment7c3b13a843"
+          "Ref": "MyApiDeployment3c30770aa3"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-cn/api_with_custom_domains_private_basePath.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domains_private_basePath.json
@@ -15,7 +15,7 @@
   },
   "Parameters": {
     "CertificateArn": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Description": "ARN of the ACM certificate for the domain",
       "Type": "String"
     },
@@ -33,7 +33,7 @@
   "Resources": {
     "ApiGatewayDomainNameV27c603ed871": {
       "Properties": {
-        "CertificateArn": "another-api-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "DomainName": "private.example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -125,9 +125,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMappingV2"
     },
-    "MyApiDeploymente37f6c9943": {
+    "MyApiDeployment09c01d5525": {
       "Properties": {
-        "Description": "RestApi deployment id: e37f6c9943b5e1213efecf302864c9e775fcf695",
+        "Description": "RestApi deployment id: 09c01d5525be5534dba547e7bc84bad514d39efa",
         "RestApiId": {
           "Ref": "MyApi"
         },
@@ -153,7 +153,7 @@
     "MyApiprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymente37f6c9943"
+          "Ref": "MyApiDeployment09c01d5525"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-cn/capacity_provider_global_with_functions.json
+++ b/tests/translator/output/aws-cn/capacity_provider_global_with_functions.json
@@ -224,7 +224,7 @@
             "t2.small"
           ]
         },
-        "KmsKeyArn": "some-kms-arn",
+        "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/some-kms-key",
         "PermissionsConfig": {
           "CapacityProviderOperatorRoleArn": {
             "Fn::GetAtt": [

--- a/tests/translator/output/aws-cn/function_with_alias_and_all_properties_property.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_all_properties_property.json
@@ -36,7 +36,7 @@
         ],
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Fn::Sub": "arn:${AWS::Partition}:key:key"
+          "Fn::Sub": "arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key"
         },
         "Layers": [
           {
@@ -74,7 +74,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "HashChangeFunctionVersiona1a9d4d1e4",
+            "HashChangeFunctionVersioncfc41a568e",
             "Version"
           ]
         },
@@ -82,7 +82,7 @@
       },
       "Type": "AWS::Lambda::Alias"
     },
-    "HashChangeFunctionVersiona1a9d4d1e4": {
+    "HashChangeFunctionVersioncfc41a568e": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "Description": "sam-testing",
@@ -117,7 +117,7 @@
         ],
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Fn::Sub": "arn:${AWS::Partition}:key:key"
+          "Fn::Sub": "arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key"
         },
         "Layers": [
           {

--- a/tests/translator/output/aws-cn/function_with_kmskeyarn.json
+++ b/tests/translator/output/aws-cn/function_with_kmskeyarn.json
@@ -7,7 +7,7 @@
           "S3Key": "hello.zip"
         },
         "Handler": "hello.handler",
-        "KmsKeyArn": "thisIsaKey",
+        "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/this-is-a-key",
         "Role": {
           "Fn::GetAtt": [
             "FunctionWithKeyArnRole",
@@ -62,7 +62,10 @@
         },
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Ref": "myKey"
+          "Fn::GetAtt": [
+            "myKey",
+            "Arn"
+          ]
         },
         "Role": {
           "Fn::GetAtt": [

--- a/tests/translator/output/aws-cn/graphqlapi_ddb_datasource_all_properties.json
+++ b/tests/translator/output/aws-cn/graphqlapi_ddb_datasource_all_properties.json
@@ -78,7 +78,7 @@
           "Versioned": true
         },
         "Name": "AwesomeDataSourceName",
-        "ServiceRoleArn": "some-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-cn/graphqlapi_function_datasource_property.json
+++ b/tests/translator/output/aws-cn/graphqlapi_function_datasource_property.json
@@ -85,7 +85,7 @@
           "TableName": "SomeTable"
         },
         "Name": "InternalDataSource",
-        "ServiceRoleArn": "SomeRoleArn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/SomeRole",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-cn/graphqlapi_intrinsical_names.json
+++ b/tests/translator/output/aws-cn/graphqlapi_intrinsical_names.json
@@ -259,7 +259,7 @@
         "Name": {
           "Ref": "LambdaDSName"
         },
-        "ServiceRoleArn": "some-role-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-cn/graphqlapi_lambda_and_ddb_datasource.json
+++ b/tests/translator/output/aws-cn/graphqlapi_lambda_and_ddb_datasource.json
@@ -72,7 +72,7 @@
           "TableName": "some-table"
         },
         "Name": "MyDataSource",
-        "ServiceRoleArn": "my-ddb-role",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/my-ddb-role",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"
@@ -89,7 +89,7 @@
           "LambdaFunctionArn": "blah"
         },
         "Name": "MyDataSource",
-        "ServiceRoleArn": "my-lambda-role",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/my-lambda-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-cn/graphqlapi_logging_defined.json
+++ b/tests/translator/output/aws-cn/graphqlapi_logging_defined.json
@@ -4,7 +4,7 @@
       "Properties": {
         "AuthenticationType": "AWS_IAM",
         "LogConfig": {
-          "CloudWatchLogsRoleArn": "some-arn",
+          "CloudWatchLogsRoleArn": "arn:aws:iam::123456789012:role/some-role",
           "ExcludeVerboseContent": true,
           "FieldLogLevel": "ERROR"
         },

--- a/tests/translator/output/aws-cn/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/aws-cn/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -150,7 +150,7 @@
           "LambdaFunctionArn": "my-lambda-arn"
         },
         "Name": "PradsLambdaDataSource",
-        "ServiceRoleArn": "some-role-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-cn/http_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-cn/http_api_with_custom_domain_route53_multiple.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -20,7 +20,7 @@
         "DomainName": "admin.three.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -35,7 +35,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-cn/httpapi_with_propagate_tags.json
+++ b/tests/translator/output/aws-cn/httpapi_with_propagate_tags.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-cn/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-cn/mixed_api_with_custom_domain_route53_multiple.json
@@ -10,7 +10,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -19,7 +19,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -115,9 +115,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "MyRestApiDeployment61887a4eed": {
+    "MyRestApiDeployment43c6a2ef1d": {
       "Properties": {
-        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "Description": "RestApi deployment id: 43c6a2ef1d8b1c11ef2beb3f5a006b57a33d8b05",
         "RestApiId": {
           "Ref": "MyRestApi"
         },
@@ -128,7 +128,7 @@
     "MyRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyRestApiDeployment61887a4eed"
+          "Ref": "MyRestApiDeployment43c6a2ef1d"
         },
         "MethodSettings": [
           {

--- a/tests/translator/output/aws-cn/separate_route53_recordset_group.json
+++ b/tests/translator/output/aws-cn/separate_route53_recordset_group.json
@@ -62,9 +62,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeploymentdd3f545183": {
+    "ApiGatewayAdminOneDeployment5f4fcb9347": {
       "Properties": {
-        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "Description": "RestApi deployment id: 5f4fcb9347315a0decaa8f0140aae89cde47f8d1",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -75,7 +75,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+          "Ref": "ApiGatewayAdminOneDeployment5f4fcb9347"
         },
         "MethodSettings": [
           {
@@ -130,9 +130,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeploymentc2e9ae5463": {
+    "ApiGatewayAdminThreeDeployment6688e0289c": {
       "Properties": {
-        "Description": "RestApi deployment id: c2e9ae5463d31ad96611e5aab9b4ddd4fd7bde73",
+        "Description": "RestApi deployment id: 6688e0289c1446101169a6ba165a416cecf813b6",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -143,7 +143,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeploymentc2e9ae5463"
+          "Ref": "ApiGatewayAdminThreeDeployment6688e0289c"
         },
         "MethodSettings": [
           {
@@ -200,10 +200,10 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeployment2a68098964": {
+    "ApiGatewayAdminTwoDeploymente4496c9f53": {
       "Condition": "CreateProdResources",
       "Properties": {
-        "Description": "RestApi deployment id: 2a6809896451eb172efffcdcd18396e1a83df12a",
+        "Description": "RestApi deployment id: e4496c9f5342d32f9172f98949d461d993b1c008",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -215,7 +215,7 @@
       "Condition": "CreateProdResources",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeployment2a68098964"
+          "Ref": "ApiGatewayAdminTwoDeploymente4496c9f53"
         },
         "MethodSettings": [
           {
@@ -241,7 +241,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -253,7 +253,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -265,7 +265,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/aws-cn/websocket_api_domain_globals.json
+++ b/tests/translator/output/aws-cn/websocket_api_domain_globals.json
@@ -197,7 +197,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -212,7 +212,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-cn/websocket_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-cn/websocket_api_with_custom_domain_route53_multiple.json
@@ -293,7 +293,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -308,7 +308,7 @@
         "DomainName": "admin.three.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -323,7 +323,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-cn/websocket_api_with_propagate_tags.json
+++ b/tests/translator/output/aws-cn/websocket_api_with_propagate_tags.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-us-gov/api_with_basic_custom_domain.json
+++ b/tests/translator/output/aws-us-gov/api_with_basic_custom_domain.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyDomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName23cdccdf9c": {
       "Properties": {
-        "CertificateArn": "my-api-cert-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert",
         "DomainName": "api-example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -35,7 +35,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "another-api-arn"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -89,9 +89,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "MyAnotherApiDeploymenteb8302ec1b": {
+    "MyAnotherApiDeployment970c3666dd": {
       "Properties": {
-        "Description": "RestApi deployment id: eb8302ec1bd45ce6bb547e74633c4bbb3e503d4a",
+        "Description": "RestApi deployment id: 970c3666dd0c6659658c1a24ba7796c88da827eb",
         "RestApiId": {
           "Ref": "MyAnotherApi"
         }
@@ -101,7 +101,7 @@
     "MyAnotherApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeploymenteb8302ec1b"
+          "Ref": "MyAnotherApiDeployment970c3666dd"
         },
         "RestApiId": {
           "Ref": "MyAnotherApi"
@@ -158,9 +158,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeploymentb34773e43a": {
+    "MyApiDeploymenta319612f7c": {
       "Properties": {
-        "Description": "RestApi deployment id: b34773e43ad9a98f27deed4374d3a49449abd947",
+        "Description": "RestApi deployment id: a319612f7c30132f2bafe1cb54e3c0c8c68f7357",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -170,7 +170,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentb34773e43a"
+          "Ref": "MyApiDeploymenta319612f7c"
         },
         "RestApiId": {
           "Ref": "MyApi"
@@ -395,9 +395,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ServerlessRestApiDeployment790a4e6aa6": {
+    "ServerlessRestApiDeploymentb01e805e49": {
       "Properties": {
-        "Description": "RestApi deployment id: 790a4e6aa6ad06f44702e52a66e5fec0cd96be99",
+        "Description": "RestApi deployment id: b01e805e4969455e2881aeaa374fedc9032b1c9a",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -408,7 +408,7 @@
     "ServerlessRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment790a4e6aa6"
+          "Ref": "ServerlessRestApiDeploymentb01e805e49"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics.json
@@ -13,7 +13,7 @@
       "Type": "String"
     },
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyMTLSUri": {
@@ -41,7 +41,7 @@
           "TruststoreUri": "another-api-truststore-uri",
           "TruststoreVersion": "another-api-truststore-version"
         },
-        "RegionalCertificateArn": "another-api-arn",
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "SecurityPolicy": "TLS_1_2"
       },
       "Type": "AWS::ApiGateway::DomainName"
@@ -107,10 +107,10 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment32e59613e2": {
+    "MyApiDeployment188c4b85ac": {
       "Condition": "C1",
       "Properties": {
-        "Description": "RestApi deployment id: 32e59613e2e02a1f1d264849167ea359f10342f0",
+        "Description": "RestApi deployment id: 188c4b85ac2dfb05b384d72c2a08e7c367fee50a",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -121,7 +121,7 @@
       "Condition": "C1",
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment32e59613e2"
+          "Ref": "MyApiDeployment188c4b85ac"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics_http.json
+++ b/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics_http.json
@@ -13,7 +13,7 @@
       "Type": "String"
     },
     "MyDomainCert": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Type": "String"
     },
     "MyMTLSUriHTTP": {
@@ -34,7 +34,7 @@
         },
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "another-api-arn",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
             "EndpointType": "REGIONAL",
             "SecurityPolicy": "TLS_1_2"
           }

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName0caaf24ab1": {
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
         "DomainName": "example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -58,9 +58,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment1deeaff693": {
+    "MyApiDeployment1e82db2ccf": {
       "Properties": {
-        "Description": "RestApi deployment id: 1deeaff6933b892391de7a35e4cf92e79a47aea9",
+        "Description": "RestApi deployment id: 1e82db2ccf426c056a3e51fbe83470a63946f7df",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -70,7 +70,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment1deeaff693"
+          "Ref": "MyApiDeployment1e82db2ccf"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_hosted_zone_name.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_hosted_zone_name.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -12,7 +12,7 @@
   "Resources": {
     "ApiGatewayDomainName0caaf24ab1": {
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
         "DomainName": "example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -58,9 +58,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyApiDeployment501f2306c4": {
+    "MyApiDeployment2f3d4ee739": {
       "Properties": {
-        "Description": "RestApi deployment id: 501f2306c4860ed198c3020aa43d453cdbdd6b7a",
+        "Description": "RestApi deployment id: 2f3d4ee7390466aa17a88f05c9e6ab1fa6caae06",
         "RestApiId": {
           "Ref": "MyApi"
         }
@@ -70,7 +70,7 @@
     "MyApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment501f2306c4"
+          "Ref": "MyApiDeployment2f3d4ee739"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_hosted_zone_name_http.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_hosted_zone_name_http.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -15,7 +15,7 @@
         "DomainName": "example.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "cert-arn-in-us-east-1",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_http.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_http.json
@@ -1,7 +1,7 @@
 {
   "Parameters": {
     "ACMCertificateArn": {
-      "Default": "cert-arn-in-us-east-1",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
       "Type": "String"
     },
     "DomainName": {
@@ -15,7 +15,7 @@
         "DomainName": "example.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "cert-arn-in-us-east-1",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc123",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_multiple.json
@@ -40,9 +40,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeploymentdd3f545183": {
+    "ApiGatewayAdminOneDeployment5f4fcb9347": {
       "Properties": {
-        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "Description": "RestApi deployment id: 5f4fcb9347315a0decaa8f0140aae89cde47f8d1",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -53,7 +53,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+          "Ref": "ApiGatewayAdminOneDeployment5f4fcb9347"
         },
         "MethodSettings": [
           {
@@ -108,9 +108,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeployment7541e97159": {
+    "ApiGatewayAdminThreeDeployment30e2eaa7d5": {
       "Properties": {
-        "Description": "RestApi deployment id: 7541e971598cffe7cafab030d3fccc687d508f59",
+        "Description": "RestApi deployment id: 30e2eaa7d590e7a85c5ce8b5eb5926ffa28afc90",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -121,7 +121,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeployment7541e97159"
+          "Ref": "ApiGatewayAdminThreeDeployment30e2eaa7d5"
         },
         "MethodSettings": [
           {
@@ -176,9 +176,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeployment61887a4eed": {
+    "ApiGatewayAdminTwoDeployment43c6a2ef1d": {
       "Properties": {
-        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "Description": "RestApi deployment id: 43c6a2ef1d8b1c11ef2beb3f5a006b57a33d8b05",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -189,7 +189,7 @@
     "ApiGatewayAdminTwoProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeployment61887a4eed"
+          "Ref": "ApiGatewayAdminTwoDeployment43c6a2ef1d"
         },
         "MethodSettings": [
           {
@@ -214,7 +214,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -226,7 +226,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -238,7 +238,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53_multiple_intrinsic_hostedzoneid.json
@@ -45,9 +45,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeployment066bb1ceae": {
+    "ApiGatewayAdminOneDeployment90f9e9bb3f": {
       "Properties": {
-        "Description": "RestApi deployment id: 066bb1ceaebd0cafae99258bbe7130af8b676372",
+        "Description": "RestApi deployment id: 90f9e9bb3ff69b4b71008da58841c770681ed84c",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -58,7 +58,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeployment066bb1ceae"
+          "Ref": "ApiGatewayAdminOneDeployment90f9e9bb3f"
         },
         "MethodSettings": [
           {
@@ -113,9 +113,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeployment169349c1e9": {
+    "ApiGatewayAdminThreeDeployment127733f946": {
       "Properties": {
-        "Description": "RestApi deployment id: 169349c1e96a0f130ee35f7bb9d83b042c386d6f",
+        "Description": "RestApi deployment id: 127733f94631341b13b3d91531d39f307d0b4700",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -126,7 +126,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeployment169349c1e9"
+          "Ref": "ApiGatewayAdminThreeDeployment127733f946"
         },
         "MethodSettings": [
           {
@@ -181,9 +181,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeploymentca2a75b5dd": {
+    "ApiGatewayAdminTwoDeployment19f5544fe4": {
       "Properties": {
-        "Description": "RestApi deployment id: ca2a75b5dd3713c71543e80f2b6f5aac9538ea9c",
+        "Description": "RestApi deployment id: 19f5544fe49037ecad607e6d0a584c3a252b6367",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -194,7 +194,7 @@
     "ApiGatewayAdminTwoProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeploymentca2a75b5dd"
+          "Ref": "ApiGatewayAdminTwoDeployment19f5544fe4"
         },
         "MethodSettings": [
           {
@@ -219,7 +219,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -231,7 +231,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -243,7 +243,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/aws-us-gov/api_with_custom_domains_private.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domains_private.json
@@ -15,7 +15,7 @@
   },
   "Parameters": {
     "CertificateArn": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Description": "ARN of the ACM certificate for the domain",
       "Type": "String"
     },
@@ -33,7 +33,7 @@
   "Resources": {
     "ApiGatewayDomainNameV27c603ed871": {
       "Properties": {
-        "CertificateArn": "another-api-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "DomainName": "private.example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -124,9 +124,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMappingV2"
     },
-    "MyApiDeployment7c3b13a843": {
+    "MyApiDeployment3c30770aa3": {
       "Properties": {
-        "Description": "RestApi deployment id: 7c3b13a843cdd653d1310c6fd7881e8fe8e49da8",
+        "Description": "RestApi deployment id: 3c30770aa391b69cb92f7b4a5d5969d6f92ee5b4",
         "RestApiId": {
           "Ref": "MyApi"
         },
@@ -137,7 +137,7 @@
     "MyApiprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment7c3b13a843"
+          "Ref": "MyApiDeployment3c30770aa3"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-us-gov/api_with_custom_domains_private_basePath.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domains_private_basePath.json
@@ -15,7 +15,7 @@
   },
   "Parameters": {
     "CertificateArn": {
-      "Default": "another-api-arn",
+      "Default": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
       "Description": "ARN of the ACM certificate for the domain",
       "Type": "String"
     },
@@ -33,7 +33,7 @@
   "Resources": {
     "ApiGatewayDomainNameV27c603ed871": {
       "Properties": {
-        "CertificateArn": "another-api-arn",
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert",
         "DomainName": "private.example.com",
         "EndpointConfiguration": {
           "Types": [
@@ -125,9 +125,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMappingV2"
     },
-    "MyApiDeploymente37f6c9943": {
+    "MyApiDeployment09c01d5525": {
       "Properties": {
-        "Description": "RestApi deployment id: e37f6c9943b5e1213efecf302864c9e775fcf695",
+        "Description": "RestApi deployment id: 09c01d5525be5534dba547e7bc84bad514d39efa",
         "RestApiId": {
           "Ref": "MyApi"
         },
@@ -153,7 +153,7 @@
     "MyApiprodStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymente37f6c9943"
+          "Ref": "MyApiDeployment09c01d5525"
         },
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-us-gov/capacity_provider_global_with_functions.json
+++ b/tests/translator/output/aws-us-gov/capacity_provider_global_with_functions.json
@@ -224,7 +224,7 @@
             "t2.small"
           ]
         },
-        "KmsKeyArn": "some-kms-arn",
+        "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/some-kms-key",
         "PermissionsConfig": {
           "CapacityProviderOperatorRoleArn": {
             "Fn::GetAtt": [

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_all_properties_property.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_all_properties_property.json
@@ -36,7 +36,7 @@
         ],
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Fn::Sub": "arn:${AWS::Partition}:key:key"
+          "Fn::Sub": "arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key"
         },
         "Layers": [
           {
@@ -74,7 +74,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "HashChangeFunctionVersiona1a9d4d1e4",
+            "HashChangeFunctionVersioncfc41a568e",
             "Version"
           ]
         },
@@ -82,7 +82,7 @@
       },
       "Type": "AWS::Lambda::Alias"
     },
-    "HashChangeFunctionVersiona1a9d4d1e4": {
+    "HashChangeFunctionVersioncfc41a568e": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "Description": "sam-testing",
@@ -117,7 +117,7 @@
         ],
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Fn::Sub": "arn:${AWS::Partition}:key:key"
+          "Fn::Sub": "arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key"
         },
         "Layers": [
           {

--- a/tests/translator/output/aws-us-gov/function_with_kmskeyarn.json
+++ b/tests/translator/output/aws-us-gov/function_with_kmskeyarn.json
@@ -7,7 +7,7 @@
           "S3Key": "hello.zip"
         },
         "Handler": "hello.handler",
-        "KmsKeyArn": "thisIsaKey",
+        "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/this-is-a-key",
         "Role": {
           "Fn::GetAtt": [
             "FunctionWithKeyArnRole",
@@ -62,7 +62,10 @@
         },
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Ref": "myKey"
+          "Fn::GetAtt": [
+            "myKey",
+            "Arn"
+          ]
         },
         "Role": {
           "Fn::GetAtt": [

--- a/tests/translator/output/aws-us-gov/graphqlapi_ddb_datasource_all_properties.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_ddb_datasource_all_properties.json
@@ -78,7 +78,7 @@
           "Versioned": true
         },
         "Name": "AwesomeDataSourceName",
-        "ServiceRoleArn": "some-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-us-gov/graphqlapi_function_datasource_property.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_function_datasource_property.json
@@ -85,7 +85,7 @@
           "TableName": "SomeTable"
         },
         "Name": "InternalDataSource",
-        "ServiceRoleArn": "SomeRoleArn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/SomeRole",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-us-gov/graphqlapi_intrinsical_names.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_intrinsical_names.json
@@ -259,7 +259,7 @@
         "Name": {
           "Ref": "LambdaDSName"
         },
-        "ServiceRoleArn": "some-role-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-us-gov/graphqlapi_lambda_and_ddb_datasource.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_lambda_and_ddb_datasource.json
@@ -72,7 +72,7 @@
           "TableName": "some-table"
         },
         "Name": "MyDataSource",
-        "ServiceRoleArn": "my-ddb-role",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/my-ddb-role",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"
@@ -89,7 +89,7 @@
           "LambdaFunctionArn": "blah"
         },
         "Name": "MyDataSource",
-        "ServiceRoleArn": "my-lambda-role",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/my-lambda-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-us-gov/graphqlapi_logging_defined.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_logging_defined.json
@@ -4,7 +4,7 @@
       "Properties": {
         "AuthenticationType": "AWS_IAM",
         "LogConfig": {
-          "CloudWatchLogsRoleArn": "some-arn",
+          "CloudWatchLogsRoleArn": "arn:aws:iam::123456789012:role/some-role",
           "ExcludeVerboseContent": true,
           "FieldLogLevel": "ERROR"
         },

--- a/tests/translator/output/aws-us-gov/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -150,7 +150,7 @@
           "LambdaFunctionArn": "my-lambda-arn"
         },
         "Name": "PradsLambdaDataSource",
-        "ServiceRoleArn": "some-role-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/aws-us-gov/http_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-us-gov/http_api_with_custom_domain_route53_multiple.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -20,7 +20,7 @@
         "DomainName": "admin.three.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -35,7 +35,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-us-gov/httpapi_with_propagate_tags.json
+++ b/tests/translator/output/aws-us-gov/httpapi_with_propagate_tags.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-us-gov/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-us-gov/mixed_api_with_custom_domain_route53_multiple.json
@@ -10,7 +10,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -19,7 +19,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -115,9 +115,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "MyRestApiDeployment61887a4eed": {
+    "MyRestApiDeployment43c6a2ef1d": {
       "Properties": {
-        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "Description": "RestApi deployment id: 43c6a2ef1d8b1c11ef2beb3f5a006b57a33d8b05",
         "RestApiId": {
           "Ref": "MyRestApi"
         },
@@ -128,7 +128,7 @@
     "MyRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyRestApiDeployment61887a4eed"
+          "Ref": "MyRestApiDeployment43c6a2ef1d"
         },
         "MethodSettings": [
           {

--- a/tests/translator/output/aws-us-gov/separate_route53_recordset_group.json
+++ b/tests/translator/output/aws-us-gov/separate_route53_recordset_group.json
@@ -62,9 +62,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeploymentdd3f545183": {
+    "ApiGatewayAdminOneDeployment5f4fcb9347": {
       "Properties": {
-        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "Description": "RestApi deployment id: 5f4fcb9347315a0decaa8f0140aae89cde47f8d1",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -75,7 +75,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+          "Ref": "ApiGatewayAdminOneDeployment5f4fcb9347"
         },
         "MethodSettings": [
           {
@@ -130,9 +130,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeploymentc2e9ae5463": {
+    "ApiGatewayAdminThreeDeployment6688e0289c": {
       "Properties": {
-        "Description": "RestApi deployment id: c2e9ae5463d31ad96611e5aab9b4ddd4fd7bde73",
+        "Description": "RestApi deployment id: 6688e0289c1446101169a6ba165a416cecf813b6",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -143,7 +143,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeploymentc2e9ae5463"
+          "Ref": "ApiGatewayAdminThreeDeployment6688e0289c"
         },
         "MethodSettings": [
           {
@@ -200,10 +200,10 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeployment2a68098964": {
+    "ApiGatewayAdminTwoDeploymente4496c9f53": {
       "Condition": "CreateProdResources",
       "Properties": {
-        "Description": "RestApi deployment id: 2a6809896451eb172efffcdcd18396e1a83df12a",
+        "Description": "RestApi deployment id: e4496c9f5342d32f9172f98949d461d993b1c008",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -215,7 +215,7 @@
       "Condition": "CreateProdResources",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeployment2a68098964"
+          "Ref": "ApiGatewayAdminTwoDeploymente4496c9f53"
         },
         "MethodSettings": [
           {
@@ -241,7 +241,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -253,7 +253,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -265,7 +265,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/aws-us-gov/websocket_api_domain_globals.json
+++ b/tests/translator/output/aws-us-gov/websocket_api_domain_globals.json
@@ -197,7 +197,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -212,7 +212,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-us-gov/websocket_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/aws-us-gov/websocket_api_with_custom_domain_route53_multiple.json
@@ -293,7 +293,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -308,7 +308,7 @@
         "DomainName": "admin.three.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -323,7 +323,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/aws-us-gov/websocket_api_with_propagate_tags.json
+++ b/tests/translator/output/aws-us-gov/websocket_api_with_propagate_tags.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/capacity_provider_global_with_functions.json
+++ b/tests/translator/output/capacity_provider_global_with_functions.json
@@ -224,7 +224,7 @@
             "t2.small"
           ]
         },
-        "KmsKeyArn": "some-kms-arn",
+        "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/some-kms-key",
         "PermissionsConfig": {
           "CapacityProviderOperatorRoleArn": {
             "Fn::GetAtt": [

--- a/tests/translator/output/function_with_alias_and_all_properties_property.json
+++ b/tests/translator/output/function_with_alias_and_all_properties_property.json
@@ -36,7 +36,7 @@
         ],
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Fn::Sub": "arn:${AWS::Partition}:key:key"
+          "Fn::Sub": "arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key"
         },
         "Layers": [
           {
@@ -74,7 +74,7 @@
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "HashChangeFunctionVersiona1a9d4d1e4",
+            "HashChangeFunctionVersioncfc41a568e",
             "Version"
           ]
         },
@@ -82,7 +82,7 @@
       },
       "Type": "AWS::Lambda::Alias"
     },
-    "HashChangeFunctionVersiona1a9d4d1e4": {
+    "HashChangeFunctionVersioncfc41a568e": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "Description": "sam-testing",
@@ -117,7 +117,7 @@
         ],
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Fn::Sub": "arn:${AWS::Partition}:key:key"
+          "Fn::Sub": "arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key"
         },
         "Layers": [
           {

--- a/tests/translator/output/function_with_kmskeyarn.json
+++ b/tests/translator/output/function_with_kmskeyarn.json
@@ -7,7 +7,7 @@
           "S3Key": "hello.zip"
         },
         "Handler": "hello.handler",
-        "KmsKeyArn": "thisIsaKey",
+        "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/this-is-a-key",
         "Role": {
           "Fn::GetAtt": [
             "FunctionWithKeyArnRole",
@@ -62,7 +62,10 @@
         },
         "Handler": "hello.handler",
         "KmsKeyArn": {
-          "Ref": "myKey"
+          "Fn::GetAtt": [
+            "myKey",
+            "Arn"
+          ]
         },
         "Role": {
           "Fn::GetAtt": [

--- a/tests/translator/output/graphqlapi_ddb_datasource_all_properties.json
+++ b/tests/translator/output/graphqlapi_ddb_datasource_all_properties.json
@@ -78,7 +78,7 @@
           "Versioned": true
         },
         "Name": "AwesomeDataSourceName",
-        "ServiceRoleArn": "some-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/graphqlapi_function_datasource_property.json
+++ b/tests/translator/output/graphqlapi_function_datasource_property.json
@@ -85,7 +85,7 @@
           "TableName": "SomeTable"
         },
         "Name": "InternalDataSource",
-        "ServiceRoleArn": "SomeRoleArn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/SomeRole",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/graphqlapi_intrinsical_names.json
+++ b/tests/translator/output/graphqlapi_intrinsical_names.json
@@ -259,7 +259,7 @@
         "Name": {
           "Ref": "LambdaDSName"
         },
-        "ServiceRoleArn": "some-role-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/graphqlapi_lambda_and_ddb_datasource.json
+++ b/tests/translator/output/graphqlapi_lambda_and_ddb_datasource.json
@@ -72,7 +72,7 @@
           "TableName": "some-table"
         },
         "Name": "MyDataSource",
-        "ServiceRoleArn": "my-ddb-role",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/my-ddb-role",
         "Type": "AMAZON_DYNAMODB"
       },
       "Type": "AWS::AppSync::DataSource"
@@ -89,7 +89,7 @@
           "LambdaFunctionArn": "blah"
         },
         "Name": "MyDataSource",
-        "ServiceRoleArn": "my-lambda-role",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/my-lambda-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/graphqlapi_logging_defined.json
+++ b/tests/translator/output/graphqlapi_logging_defined.json
@@ -4,7 +4,7 @@
       "Properties": {
         "AuthenticationType": "AWS_IAM",
         "LogConfig": {
-          "CloudWatchLogsRoleArn": "some-arn",
+          "CloudWatchLogsRoleArn": "arn:aws:iam::123456789012:role/some-role",
           "ExcludeVerboseContent": true,
           "FieldLogLevel": "ERROR"
         },

--- a/tests/translator/output/graphqlapi_resolver_function_with_lambda_datasource.json
+++ b/tests/translator/output/graphqlapi_resolver_function_with_lambda_datasource.json
@@ -150,7 +150,7 @@
           "LambdaFunctionArn": "my-lambda-arn"
         },
         "Name": "PradsLambdaDataSource",
-        "ServiceRoleArn": "some-role-arn",
+        "ServiceRoleArn": "arn:aws:iam::123456789012:role/some-role",
         "Type": "AWS_LAMBDA"
       },
       "Type": "AWS::AppSync::DataSource"

--- a/tests/translator/output/http_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/http_api_with_custom_domain_route53_multiple.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -20,7 +20,7 @@
         "DomainName": "admin.three.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -35,7 +35,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/httpapi_with_propagate_tags.json
+++ b/tests/translator/output/httpapi_with_propagate_tags.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/mixed_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/mixed_api_with_custom_domain_route53_multiple.json
@@ -10,7 +10,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -19,7 +19,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -115,9 +115,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "MyRestApiDeployment61887a4eed": {
+    "MyRestApiDeployment43c6a2ef1d": {
       "Properties": {
-        "Description": "RestApi deployment id: 61887a4eed03102402cbaa575b5b1e398b0dc647",
+        "Description": "RestApi deployment id: 43c6a2ef1d8b1c11ef2beb3f5a006b57a33d8b05",
         "RestApiId": {
           "Ref": "MyRestApi"
         },
@@ -128,7 +128,7 @@
     "MyRestApiProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyRestApiDeployment61887a4eed"
+          "Ref": "MyRestApiDeployment43c6a2ef1d"
         },
         "MethodSettings": [
           {

--- a/tests/translator/output/separate_route53_recordset_group.json
+++ b/tests/translator/output/separate_route53_recordset_group.json
@@ -62,9 +62,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminOneDeploymentdd3f545183": {
+    "ApiGatewayAdminOneDeployment5f4fcb9347": {
       "Properties": {
-        "Description": "RestApi deployment id: dd3f545183668c401e771fd9a377cfeadcf88a35",
+        "Description": "RestApi deployment id: 5f4fcb9347315a0decaa8f0140aae89cde47f8d1",
         "RestApiId": {
           "Ref": "ApiGatewayAdminOne"
         },
@@ -75,7 +75,7 @@
     "ApiGatewayAdminOneProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminOneDeploymentdd3f545183"
+          "Ref": "ApiGatewayAdminOneDeployment5f4fcb9347"
         },
         "MethodSettings": [
           {
@@ -130,9 +130,9 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminThreeDeploymentc2e9ae5463": {
+    "ApiGatewayAdminThreeDeployment6688e0289c": {
       "Properties": {
-        "Description": "RestApi deployment id: c2e9ae5463d31ad96611e5aab9b4ddd4fd7bde73",
+        "Description": "RestApi deployment id: 6688e0289c1446101169a6ba165a416cecf813b6",
         "RestApiId": {
           "Ref": "ApiGatewayAdminThree"
         },
@@ -143,7 +143,7 @@
     "ApiGatewayAdminThreeProdStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminThreeDeploymentc2e9ae5463"
+          "Ref": "ApiGatewayAdminThreeDeployment6688e0289c"
         },
         "MethodSettings": [
           {
@@ -200,10 +200,10 @@
       },
       "Type": "AWS::ApiGateway::BasePathMapping"
     },
-    "ApiGatewayAdminTwoDeployment2a68098964": {
+    "ApiGatewayAdminTwoDeploymente4496c9f53": {
       "Condition": "CreateProdResources",
       "Properties": {
-        "Description": "RestApi deployment id: 2a6809896451eb172efffcdcd18396e1a83df12a",
+        "Description": "RestApi deployment id: e4496c9f5342d32f9172f98949d461d993b1c008",
         "RestApiId": {
           "Ref": "ApiGatewayAdminTwo"
         },
@@ -215,7 +215,7 @@
       "Condition": "CreateProdResources",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiGatewayAdminTwoDeployment2a68098964"
+          "Ref": "ApiGatewayAdminTwoDeploymente4496c9f53"
         },
         "MethodSettings": [
           {
@@ -241,7 +241,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -253,7 +253,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },
@@ -265,7 +265,7 @@
             "REGIONAL"
           ]
         },
-        "RegionalCertificateArn": "arn::cert::abc"
+        "RegionalCertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
       },
       "Type": "AWS::ApiGateway::DomainName"
     },

--- a/tests/translator/output/websocket_api_domain_globals.json
+++ b/tests/translator/output/websocket_api_domain_globals.json
@@ -197,7 +197,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -212,7 +212,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/websocket_api_with_custom_domain_route53_multiple.json
+++ b/tests/translator/output/websocket_api_with_custom_domain_route53_multiple.json
@@ -293,7 +293,7 @@
         "DomainName": "admin.two.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -308,7 +308,7 @@
         "DomainName": "admin.three.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],
@@ -323,7 +323,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],

--- a/tests/translator/output/websocket_api_with_propagate_tags.json
+++ b/tests/translator/output/websocket_api_with_propagate_tags.json
@@ -5,7 +5,7 @@
         "DomainName": "admin.one.amazon.com",
         "DomainNameConfigurations": [
           {
-            "CertificateArn": "arn::cert::abc",
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc",
             "EndpointType": "REGIONAL"
           }
         ],


### PR DESCRIPTION
## Summary

Follow-up to #3915. Fix the underlying cause instead of suppressing the checks: update test fixture inputs to use valid AWS ARN formats, regenerate outputs, then remove the temporary ignore rules from `.cfnlintrc.yaml`.

## Background

cfn-lint 1.49.0 ([aws-cloudformation/cfn-lint#4442](https://github.com/aws-cloudformation/cfn-lint/pull/4442)) expanded format coverage, adding ARN pattern validation for ACM certificates, IAM roles, KMS keys, and cross-resource Ref/GetAtt checking. The fix rules originally added in #3915 blanket-ignored these checks across all test fixtures, which also hides any future real issues. This PR fixes the fixtures properly.

## Changes

**Input YAML updates** — replace placeholder values with valid-format ARNs:

| Resource type | Old value | New value |
|---|---|---|
| ACM Certificate | `my-api-cert-arn` | `arn:aws:acm:us-east-1:123456789012:certificate/my-api-cert` |
| ACM Certificate | `cert-arn-in-us-east-1` | `arn:aws:acm:us-east-1:123456789012:certificate/abc123` |
| ACM Certificate | `another-api-arn` | `arn:aws:acm:us-east-1:123456789012:certificate/another-api-cert` |
| ACM Certificate | `arn::cert::abc` | `arn:aws:acm:us-east-1:123456789012:certificate/abc` |
| IAM Role | `some-arn`, `some-role-arn`, `SomeRoleArn` | `arn:aws:iam::123456789012:role/...` |
| IAM Role | `my-ddb-role`, `my-lambda-role` | `arn:aws:iam::123456789012:role/my-ddb-role`, `.../my-lambda-role` |
| KMS Key | `thisIsaKey`, `some-kms-arn` | `arn:aws:kms:us-east-1:123456789012:key/...` |
| KMS (Fn::Sub) | `arn:${AWS::Partition}:key:key` | `arn:${AWS::Partition}:kms:us-east-1:123456789012:key/my-key` |

**E1041 fix in `function_with_kmskeyarn.yaml`**: changed `KmsKeyArn: !Ref myKey` to `KmsKeyArn: !GetAtt myKey.Arn`. `Ref` on an `AWS::KMS::Key` returns a Key ID (UUID), not an ARN — per the [Lambda CreateFunction API](https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html), `KMSKeyArn` requires an ARN. This change makes the template actually correct.

**Output JSON regeneration**: 12 testcases with content-hashed logical IDs (API Gateway deployments, KMS ARN-dependent outputs) were regenerated by replaying the transformer. All 2117 transform tests pass.

**`.cfnlintrc.yaml`**: removed E1041, E1156, E1157, E1159, W1031 from `ignore_checks` (added in #3915).

## Testing

- All 2117 transform tests pass locally
- `cfn-lint 1.49.3 --format parseable` produces 0 errors against the generated templates