### PR TITLE
fix: update companion stack to use `mq.m7i.large` for regions that do not support `mq.t3.micro`

### DIFF
--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -13,6 +13,8 @@ Conditions:
     Fn::Equals: [!Ref CreateMskCluster, 'true']
   ShouldCreateMq:
     Fn::Equals: [!Ref CreateMqBroker, 'true']
+  IsAkl:
+    Fn::Equals: [!Ref "AWS::Region", "ap-southeast-6"]
 
 Resources:
   PreCreatedVpc:
@@ -216,7 +218,7 @@ Resources:
       DeploymentMode: SINGLE_INSTANCE
       EngineType: ACTIVEMQ
       EngineVersion: '5.18'
-      HostInstanceType: mq.t3.micro
+      HostInstanceType: !If [IsAkl, "mq.m7i.large", "mq.t3.micro"]
       Logs: {Audit: true, General: true}
       PubliclyAccessible: true
       AutoMinorVersionUpgrade: true

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -13,7 +13,7 @@ Conditions:
     Fn::Equals: [!Ref CreateMskCluster, 'true']
   ShouldCreateMq:
     Fn::Equals: [!Ref CreateMqBroker, 'true']
-  IsAkl:
+  HasNewMqInstanceTypes:
     Fn::Equals: [!Ref "AWS::Region", ap-southeast-6]
 
 Resources:
@@ -218,7 +218,7 @@ Resources:
       DeploymentMode: SINGLE_INSTANCE
       EngineType: ACTIVEMQ
       EngineVersion: '5.18'
-      HostInstanceType: !If [IsAkl, mq.m7i.large, mq.t3.micro]
+      HostInstanceType: !If [HasNewMqInstanceTypes, mq.m7i.large, mq.t3.micro]
       Logs: {Audit: true, General: true}
       PubliclyAccessible: true
       AutoMinorVersionUpgrade: true

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -14,7 +14,7 @@ Conditions:
   ShouldCreateMq:
     Fn::Equals: [!Ref CreateMqBroker, 'true']
   IsAkl:
-    Fn::Equals: [!Ref "AWS::Region", "ap-southeast-6"]
+    Fn::Equals: [!Ref "AWS::Region", ap-southeast-6]
 
 Resources:
   PreCreatedVpc:
@@ -218,7 +218,7 @@ Resources:
       DeploymentMode: SINGLE_INSTANCE
       EngineType: ACTIVEMQ
       EngineVersion: '5.18'
-      HostInstanceType: !If [IsAkl, "mq.m7i.large", "mq.t3.micro"]
+      HostInstanceType: !If [IsAkl, mq.m7i.large, mq.t3.micro]
       Logs: {Audit: true, General: true}
       PubliclyAccessible: true
       AutoMinorVersionUpgrade: true


### PR DESCRIPTION
### Issue #, if available

Currently (ap-southeast-6) does not support `mq.t3.micro` for ActiveMQ. Use `mq.m7i.large` (smallest available) the region, `mq.t3.micro` everywhere else.

### Description of changes
Add conditional check for HostInstantType. 

### Description of how you validated changes

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
