### PR TITLE
Improve companion stack sweeper function

### DIFF
--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -364,8 +364,8 @@ Resources:
                 try:
                   print(f"Deleting API: {api['name']}")
                   apig.delete_rest_api(restApiId=api['id'])
-                  time.sleep(35)
                 except Exception: pass
+                time.sleep(35)
 
           def _sweep_stacks(cfn, iam, cutoff, ctx):
             for page in cfn.get_paginator('list_stacks').paginate(StackStatusFilter=ELIGIBLE_STATUSES):

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -301,6 +301,10 @@ Resources:
             - !Sub "arn:${AWS::Partition}:s3:::*sam-integ-stack-*/*"
           - Effect: Allow
             Action:
+            - apigateway:DELETE
+            Resource: !Sub "arn:${AWS::Partition}:apigateway:${AWS::Region}::/restapis/*"
+          - Effect: Allow
+            Action:
             - logs:DeleteLogGroup
             Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*sam-integ-*"
           - Effect: Allow
@@ -324,8 +328,7 @@ Resources:
           import boto3, time
           from datetime import datetime, timezone, timedelta
 
-          STACK_PATTERN = 'sam-integ-stack-'
-          IAM_PATTERN = 'sam-integ-'
+          TEST_PATTERN = 'sam-integ-'
           ELIGIBLE_STATUSES = [
             'CREATE_COMPLETE', 'ROLLBACK_COMPLETE', 'ROLLBACK_FAILED',
             'REVIEW_IN_PROGRESS', 'DELETE_FAILED', 'UPDATE_FAILED',
@@ -335,76 +338,88 @@ Resources:
           def _has_time(ctx):
             return ctx.get_remaining_time_in_millis() > 30000
 
-          def _is_test(name, strict=False):
-            pattern = STACK_PATTERN if strict else IAM_PATTERN
-            return pattern in name and 'companion' not in name
+          def _is_test(name):
+            return TEST_PATTERN in name and 'companion' not in name
 
           def handler(event, ctx):
             cfn = boto3.client('cloudformation')
             iam = boto3.client('iam')
             logs = boto3.client('logs')
-            cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
-
+            apig = boto3.client('apigateway')
+            cutoff = datetime.now(timezone.utc) - timedelta(hours=6)
+            _sweep_apis(apig, cutoff, ctx)
             _sweep_stacks(cfn, iam, cutoff, ctx)
-            _sweep_log_groups(logs, cutoff, ctx)
+            _sweep_logs(logs, cutoff, ctx)
+
+          def _sweep_apis(apig, cutoff, ctx):
+            for page in apig.get_paginator('get_rest_apis').paginate():
+              for api in page['items']:
+                if not _has_time(ctx):
+                  return
+                if not _is_test(api.get('name', '')):
+                  continue
+                c = api.get('createdDate')
+                if c and c.replace(tzinfo=timezone.utc) >= cutoff:
+                  continue
+                try:
+                  print(f"Deleting API: {api['name']}")
+                  apig.delete_rest_api(restApiId=api['id'])
+                  time.sleep(35)
+                except Exception: pass
 
           def _sweep_stacks(cfn, iam, cutoff, ctx):
-            deleted = []
             for page in cfn.get_paginator('list_stacks').paginate(StackStatusFilter=ELIGIBLE_STATUSES):
-              for stack in page['StackSummaries']:
+              for s in page['StackSummaries']:
                 if not _has_time(ctx):
-                  print(f"Attempt to delete ({len(deleted)}) stacks: {deleted}")
                   return
-                name = stack['StackName']
-                if not _is_test(name, strict=True):
+                name = s['StackName']
+                if not _is_test(name):
                   continue
-                if stack['CreationTime'].replace(tzinfo=timezone.utc) >= cutoff:
+                if s['CreationTime'].replace(tzinfo=timezone.utc) >= cutoff:
                   continue
-                if stack['StackStatus'] == 'DELETE_FAILED':
+                if s['StackStatus'] == 'DELETE_FAILED':
                   _fix_and_retry(cfn, iam, name)
                 try:
+                  print(f"Deleting: {name}")
                   cfn.delete_stack(StackName=name)
-                  deleted.append(name)
                   time.sleep(1)
-                except Exception as e:
-                  print(f"delete_stack {name}: {e}")
-            print(f"Attempt to delete ({len(deleted)}) stacks: {deleted}")
+                except Exception: pass
 
-          def _fix_and_retry(cfn, iam, stack_name):
+          def _fix_and_retry(cfn, iam, name):
             try:
-              for event in cfn.describe_stack_events(StackName=stack_name)['StackEvents']:
-                if event.get('ResourceStatus') != 'DELETE_FAILED':
+              for ev in cfn.describe_stack_events(StackName=name)['StackEvents']:
+                if ev.get('ResourceStatus') != 'DELETE_FAILED':
                   continue
-                resource_type = event.get('ResourceType', '')
-                resource_id = event.get('PhysicalResourceId', '')
-                if not resource_id or not _is_test(resource_id):
+                rt = ev.get('ResourceType', '')
+                rid = ev.get('PhysicalResourceId', '')
+                if not rid or not _is_test(rid):
                   continue
-                if resource_type == 'AWS::IAM::Role':
-                  _force_delete_role(iam, resource_id)
-                elif resource_type == 'AWS::IAM::Policy':
-                  _force_delete_policy(iam, resource_id)
-                elif resource_type == 'AWS::S3::Bucket':
+                if rt == 'AWS::IAM::Role':
+                  _force_delete_role(iam, rid)
+                elif rt == 'AWS::IAM::Policy':
+                  _force_delete_policy(iam, rid)
+                elif rt == 'AWS::S3::Bucket':
                   try:
-                    bucket = boto3.resource('s3').Bucket(resource_id)
-                    bucket.object_versions.delete()
-                    bucket.objects.delete()
+                    b = boto3.resource('s3').Bucket(rid)
+                    b.object_versions.delete()
+                    b.objects.delete()
                   except Exception: pass
             except Exception as e:
-              print(f"fix_and_retry {stack_name}: {e}")
+              print(f"fix {name}: {e}")
 
-          def _force_delete_role(iam, role_name):
+          def _force_delete_role(iam, role):
             try:
-              for p in iam.list_role_policies(RoleName=role_name)['PolicyNames']:
-                iam.delete_role_policy(RoleName=role_name, PolicyName=p)
-              for p in iam.list_attached_role_policies(RoleName=role_name)['AttachedPolicies']:
-                iam.detach_role_policy(RoleName=role_name, PolicyArn=p['PolicyArn'])
-              iam.delete_role(RoleName=role_name)
+              for p in iam.list_role_policies(RoleName=role)['PolicyNames']:
+                iam.delete_role_policy(RoleName=role, PolicyName=p)
+              for p in iam.list_attached_role_policies(RoleName=role)['AttachedPolicies']:
+                iam.detach_role_policy(RoleName=role, PolicyArn=p['PolicyArn'])
+              iam.delete_role(RoleName=role)
             except Exception: pass
 
           def _force_delete_policy(iam, arn):
             try:
-              for page in iam.get_paginator('list_entities_for_policy').paginate(PolicyArn=arn, EntityFilter='Role'):
-                for r in page['PolicyRoles']:
+              for pg in iam.get_paginator('list_entities_for_policy').paginate(PolicyArn=arn, EntityFilter='Role'):
+                for r in pg['PolicyRoles']:
                   iam.detach_role_policy(RoleName=r['RoleName'], PolicyArn=arn)
               for v in iam.list_policy_versions(PolicyArn=arn)['Versions']:
                 if not v['IsDefaultVersion']:
@@ -412,24 +427,22 @@ Resources:
               iam.delete_policy(PolicyArn=arn)
             except Exception: pass
 
-          def _sweep_log_groups(logs, cutoff, ctx):
+          def _sweep_logs(logs, cutoff, ctx):
             cutoff_ms = int(cutoff.timestamp() * 1000)
-            deleted = 0
             for page in logs.get_paginator('describe_log_groups').paginate():
-              for log_group in page['logGroups']:
+              for lg in page['logGroups']:
                 if not _has_time(ctx):
                   return
-                name = log_group['logGroupName']
-                if STACK_PATTERN not in name:
+                name = lg['logGroupName']
+                if not _is_test(name):
                   continue
-                if log_group.get('creationTime', 0) >= cutoff_ms:
+                if lg.get('creationTime', 0) >= cutoff_ms:
                   continue
                 try:
+                  print(f"Deleting: {name}")
                   logs.delete_log_group(logGroupName=name)
-                  deleted += 1
                   time.sleep(1)
                 except Exception: pass
-            print(f"Log groups: {deleted} deleted")
 
   TestStackSweeperSchedule:
     Type: AWS::Events::Rule

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -447,7 +447,7 @@ Resources:
   TestStackSweeperSchedule:
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: rate(6 hours)
+      ScheduleExpression: rate(30 minutes)
       State: ENABLED
       Targets:
       - Arn: !GetAtt TestStackSweeperFunction.Arn

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -352,20 +352,19 @@ Resources:
             _sweep_logs(logs, cutoff, ctx)
 
           def _sweep_apis(apig, cutoff, ctx):
-            for page in apig.get_paginator('get_rest_apis').paginate():
-              for api in page['items']:
-                if ctx.get_remaining_time_in_millis() < 420000:
-                  return
-                if not _is_test(api.get('name', '')):
-                  continue
-                c = api.get('createdDate')
-                if c and c.replace(tzinfo=timezone.utc) >= cutoff:
-                  continue
-                try:
-                  print(f"Deleting API: {api['name']}")
-                  apig.delete_rest_api(restApiId=api['id'])
-                except Exception: pass
-                time.sleep(35)
+            try:
+              for page in apig.get_paginator('get_rest_apis').paginate():
+                for api in page['items']:
+                  if ctx.get_remaining_time_in_millis() < 420000: return
+                  if not _is_test(api.get('name', '')): continue
+                  c = api.get('createdDate')
+                  if c and c.replace(tzinfo=timezone.utc) >= cutoff: continue
+                  try:
+                    print(f"Deleting API: {api['name']}")
+                    apig.delete_rest_api(restApiId=api['id'])
+                  except Exception: pass
+                  time.sleep(35)
+            except Exception as e: print(f"api err: {e}")
 
           def _sweep_stacks(cfn, iam, cutoff, ctx):
             for page in cfn.get_paginator('list_stacks').paginate(StackStatusFilter=ELIGIBLE_STATUSES):

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -354,7 +354,7 @@ Resources:
           def _sweep_apis(apig, cutoff, ctx):
             for page in apig.get_paginator('get_rest_apis').paginate():
               for api in page['items']:
-                if not _has_time(ctx):
+                if ctx.get_remaining_time_in_millis() < 420000:
                   return
                 if not _is_test(api.get('name', '')):
                   continue


### PR DESCRIPTION
### Issue #, if available
N/A

### Description of changes
- Add API Gateway REST API cleanup phase to the sweeper function — deletes orphaned REST APIs matching `sam-integ-` pattern before stack deletion to avoid rate limit issues on `DeleteRestApi` (1 per 30s control plane limit, using 35s sleep).
- Add 8-minute time cap for the API phase to ensure stacks and log groups still get cleaned up.
- Unify pattern matching to a single `TEST_PATTERN = 'sam-integ-'` (removes dual `STACK_PATTERN`/`IAM_PATTERN`).
- Reduce cutoff age from 24h to 6h (aligns with the 6h sweep schedule).
- Replace deletion counters with per-resource `print(f"Deleting: {name}")` logging.
- Add `apigateway:DELETE` IAM permission to the sweeper role.

### Description of how you validated changes
Deployed companion stack to personal account (us-west-2).

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.