### PR TITLE
fix: use REGIONAL endpoint for integration test REST APIs

### DIFF
--- a/integration/resources/templates/combination/api_with_authorizer_apikey.yaml
+++ b/integration/resources/templates/combination/api_with_authorizer_apikey.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_authorizer_override_api_auth.yaml
+++ b/integration/resources/templates/combination/api_with_authorizer_override_api_auth.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_invokefunction_set_none.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApiWithAwsIamAuthNoCallerCredentials:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_authorizers_max.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_max.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_authorizers_max_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_max_openapi.yaml
@@ -1,5 +1,6 @@
 Globals:
   Api:
+    EndpointConfiguration: REGIONAL
     OpenApiVersion: 3.0.0
 Resources:
   MyApi:

--- a/integration/resources/templates/combination/api_with_authorizers_min.yaml
+++ b/integration/resources/templates/combination/api_with_authorizers_min.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_binary_media_types.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Parameters:
   Bucket:
     Type: String

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body.yaml
@@ -10,6 +10,7 @@ Parameters:
     Default: image~1gif
 Globals:
   Api:
+    EndpointConfiguration: REGIONAL
     # Send/receive binary data through the APIs
     BinaryMediaTypes:
       # These are equivalent to image/gif and image/png when deployed

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
@@ -12,6 +12,7 @@ Parameters:
     Default: image~1gif
 Globals:
   Api:
+    EndpointConfiguration: REGIONAL
     # Send/receive binary data through the APIs
     BinaryMediaTypes:
       # These are equivalent to image/gif and image/png when deployed

--- a/integration/resources/templates/combination/api_with_cors_and_apikey.yaml
+++ b/integration/resources/templates/combination/api_with_cors_and_apikey.yaml
@@ -5,6 +5,7 @@ Transform:
 
 Globals:
   Api:
+    EndpointConfiguration: REGIONAL
     Auth:
       ApiKeyRequired: true
       AddApiKeyRequiredToCorsPreflight: false

--- a/integration/resources/templates/combination/api_with_disable_execute_api_endpoint.yaml
+++ b/integration/resources/templates/combination/api_with_disable_execute_api_endpoint.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Parameters:
   DisableExecuteApiEndpointValue:
     Description: Variable to define if client can access default API endpoint.

--- a/integration/resources/templates/combination/api_with_disable_execute_api_endpoint_openapi_3.yaml
+++ b/integration/resources/templates/combination/api_with_disable_execute_api_endpoint_openapi_3.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Parameters:
   DisableExecuteApiEndpointValue:
     Description: Variable to define if client can access default API endpoint.

--- a/integration/resources/templates/combination/api_with_fail_on_warnings.yaml
+++ b/integration/resources/templates/combination/api_with_fail_on_warnings.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Parameters:
   FailOnWarningsValue:
     Type: String

--- a/integration/resources/templates/combination/api_with_gateway_responses.yaml
+++ b/integration/resources/templates/combination/api_with_gateway_responses.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_method_settings.yaml
+++ b/integration/resources/templates/combination/api_with_method_settings.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_propagate_tags.yaml
+++ b/integration/resources/templates/combination/api_with_propagate_tags.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_request_models.yaml
+++ b/integration/resources/templates/combination/api_with_request_models.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_request_models_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_request_models_openapi.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/combination/api_with_request_parameters_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_request_parameters_openapi.yaml
@@ -1,5 +1,6 @@
 Globals:
   Api:
+    EndpointConfiguration: REGIONAL
     OpenApiVersion: 3.0.1
     CacheClusterEnabled: true
     CacheClusterSize: '0.5'

--- a/integration/resources/templates/combination/api_with_resource_policies.yaml
+++ b/integration/resources/templates/combination/api_with_resource_policies.yaml
@@ -6,6 +6,7 @@ Conditions:
 
 Globals:
   Api:
+    EndpointConfiguration: REGIONAL
     OpenApiVersion: 3.0.1
     Auth:
       ResourcePolicy:

--- a/integration/resources/templates/combination/api_with_resource_policies_aws_account.yaml
+++ b/integration/resources/templates/combination/api_with_resource_policies_aws_account.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyLambdaFunction:
     Type: AWS::Serverless::Function

--- a/integration/resources/templates/combination/api_with_resource_refs.yaml
+++ b/integration/resources/templates/combination/api_with_resource_refs.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 # Test to verify that resource references available on the Api resource are properly resolved
 
 Resources:

--- a/integration/resources/templates/combination/api_with_usage_plan.yaml
+++ b/integration/resources/templates/combination/api_with_usage_plan.yaml
@@ -4,6 +4,7 @@ Parameters:
     Default: PER_API
 Globals:
   Api:
+    EndpointConfiguration: REGIONAL
     OpenApiVersion: '2.0'
     Auth:
       ApiKeyRequired: true

--- a/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
+++ b/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 # Testing Alias Invoke with ALL event sources supported by Lambda
 # We are looking to check if the event sources and their associated Lambda::Permission resources are
 # connect to the Alias and *not* the function

--- a/integration/resources/templates/combination/function_with_all_event_types.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types.yaml
@@ -1,4 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
 
 Parameters:
   ScheduleName:

--- a/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
+++ b/integration/resources/templates/combination/function_with_all_event_types_condition_false.yaml
@@ -1,4 +1,8 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Conditions:
   MyCondition:
     Fn::Equals:

--- a/integration/resources/templates/combination/function_with_api.yaml
+++ b/integration/resources/templates/combination/function_with_api.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
 
   # Create one API resource. This will be referred to by the Lambda function

--- a/integration/resources/templates/combination/function_with_implicit_api_and_conditions.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_api_and_conditions.yaml
@@ -1,4 +1,8 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Description: A template to test for implicit API condition handling.
 Conditions:
   MyCondition:

--- a/integration/resources/templates/combination/function_with_implicit_api_with_timeout.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_api_with_timeout.yaml
@@ -1,4 +1,8 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Description: A template to test timeout support for implicit APIs.
 
 Resources:

--- a/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
+++ b/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 # Must support explicit bucket, key and version in CodeUri and DefinitionUri parameters
 
 Parameters:

--- a/integration/resources/templates/combination/intrinsics_serverless_api.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_api.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Parameters:
   Bucket:
     Type: String

--- a/integration/resources/templates/combination/state_machine_with_api.yaml
+++ b/integration/resources/templates/combination/state_machine_with_api.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
 
   # Create one API resource. This will be referred to by the State machine

--- a/integration/resources/templates/single/basic_api.yaml
+++ b/integration/resources/templates/single/basic_api.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/single/basic_api_inline_openapi.yaml
+++ b/integration/resources/templates/single/basic_api_inline_openapi.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/single/basic_api_inline_swagger.yaml
+++ b/integration/resources/templates/single/basic_api_inline_swagger.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/single/basic_api_with_mode.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/single/basic_api_with_mode_update.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode_update.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api

--- a/integration/resources/templates/single/basic_api_with_tags.yaml
+++ b/integration/resources/templates/single/basic_api_with_tags.yaml
@@ -1,3 +1,7 @@
+Globals:
+  Api:
+    EndpointConfiguration: REGIONAL
+
 Resources:
   MyApi:
     Type: AWS::Serverless::Api


### PR DESCRIPTION

### Issue #, if available
N/A
### Description of changes

Switch all integration test templates that create REST APIs from the default EDGE to REGIONAL via `Globals.Api.EndpointConfiguration.`

This avoids hitting the stricter quota limit of edge-optimized APIs. Templates that explicitly test EDGE behavior (custom domain edge tests, security policy edge tests) are left unchanged.

### Description of how you validated changes
Deployed and run test in my personal  AWS Account, 

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
