### PR TITLE
fix: prefix integration test API names with `sam-integ-` prefix for sweeper cleaner  function

### DIFF
--- a/integration/resources/code/swagger1.json
+++ b/integration/resources/code/swagger1.json
@@ -6,7 +6,7 @@
   },
   "info": {
     "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
-    "title": "PetStore"
+    "title": "sam-integ-PetStore"
   },
   "paths": {
     "/": {

--- a/integration/resources/code/swagger2.json
+++ b/integration/resources/code/swagger2.json
@@ -6,7 +6,7 @@
   },
   "info": {
     "description": "Your first API with Amazon API Gateway. This is a sample API that integrates via HTTP with our demo Pet Store endpoints",
-    "title": "PetStore"
+    "title": "sam-integ-PetStore"
   },
   "paths": {
     "/": {

--- a/integration/resources/templates/combination/api_with_authorizer_override_api_auth.yaml
+++ b/integration/resources/templates/combination/api_with_authorizer_override_api_auth.yaml
@@ -8,7 +8,7 @@ Resources:
         swagger: '2.0'
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api
+          title: sam-integ-Simple-Api
         schemes:
         - https
         paths:

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body.yaml
@@ -27,7 +27,7 @@ Resources:
         swagger: '2.0'
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api
+          title: sam-integ-Simple-Api
         basePath: /demo
         schemes:
         - https

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
@@ -31,7 +31,7 @@ Resources:
         openapi: 3.0.1
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api
+          title: sam-integ-Simple-Api
         basePath: /none
         schemes:
         - https

--- a/integration/resources/templates/combination/api_with_usage_plan.yaml
+++ b/integration/resources/templates/combination/api_with_usage_plan.yaml
@@ -28,7 +28,7 @@ Resources:
         swagger: '2.0'
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api 1
+          title: sam-integ-Simple-Api-1
         basePath: /demo
         schemes:
         - https
@@ -59,7 +59,7 @@ Resources:
         openapi: 3.0.1
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api 2
+          title: sam-integ-Simple-Api-2
         basePath: /demo
         schemes:
         - https
@@ -90,7 +90,7 @@ Resources:
         openapi: 3.0.1
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api 3
+          title: sam-integ-Simple-Api-3
         basePath: /demo
         schemes:
         - https
@@ -121,7 +121,7 @@ Resources:
         openapi: 3.0.1
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api 4
+          title: sam-integ-Simple-Api-4
         basePath: /demo
         schemes:
         - https

--- a/integration/resources/templates/single/basic_api_inline_openapi.yaml
+++ b/integration/resources/templates/single/basic_api_inline_openapi.yaml
@@ -8,7 +8,7 @@ Resources:
         openapi: '3.0'
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api
+          title: sam-integ-Simple-Api
         basePath: /demo
         schemes:
         - https

--- a/integration/resources/templates/single/basic_api_inline_swagger.yaml
+++ b/integration/resources/templates/single/basic_api_inline_swagger.yaml
@@ -8,7 +8,7 @@ Resources:
         swagger: '2.0'
         info:
           version: '2016-09-23T22:23:23Z'
-          title: Simple Api
+          title: sam-integ-Simple-Api
         basePath: /demo
         schemes:
         - https


### PR DESCRIPTION
### Issue #, if available
N/A
### Description of changes
Add `sam-integ-` prefix to REST API titles in OpenAPI/Swagger specs used by integration tests. This ensures orphaned APIs from failed stack deletions are discoverable by the sweeper function's name-based filter pattern.

No test logic depends on these API name values.

### Description of how you validated changes

### Checklist

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
