### PR TITLE
fix(integ): replace AllowedTypes m5.* with ExcludedTypes for region compatibility

### DIFF
--- a/integration/combination/test_function_with_capacity_provider.py
+++ b/integration/combination/test_function_with_capacity_provider.py
@@ -150,10 +150,9 @@ class TestFunctionWithCapacityProvider(BaseTest):
             instance_requirements.get("Architectures", []),
             "AdvancedCapacityProvider should have x86_64 architecture",
         )
-        allowed_types = instance_requirements.get("AllowedInstanceTypes", [])
-        self.assertIn("m5.large", allowed_types, "AdvancedCapacityProvider should allow m5.large")
-        self.assertIn("m5.xlarge", allowed_types, "AdvancedCapacityProvider should allow m5.xlarge")
-        self.assertIn("m5.2xlarge", allowed_types, "AdvancedCapacityProvider should allow m5.2xlarge")
+        excluded_types = instance_requirements.get("ExcludedInstanceTypes", [])
+        self.assertIn("m6g.xlarge", excluded_types, "AdvancedCapacityProvider should exclude m6g.xlarge")
+        self.assertIn("m7a.2xlarge", excluded_types, "AdvancedCapacityProvider should exclude m7a.2xlarge")
 
         scaling_config = advanced_cp_config.get("CapacityProviderScalingConfig")
         self.assertIsNotNone(scaling_config, "AdvancedCapacityProvider should have scaling configuration")

--- a/integration/resources/templates/combination/function_lmi_default.yaml
+++ b/integration/resources/templates/combination/function_lmi_default.yaml
@@ -36,10 +36,9 @@ Resources:
       InstanceRequirements:
         Architectures:
         - x86_64
-        AllowedTypes:
-        - m5.large
-        - m5.xlarge
-        - m5.2xlarge
+        ExcludedTypes:
+        - m6g.xlarge
+        - m7a.2xlarge
       ScalingConfig:
         MaxVCpuCount: 64
         AverageCPUUtilization: 70


### PR DESCRIPTION
### Issue #, if available
N/A . 
### Description of changes

The `m5` EC2 instances are not available in newer regions. See the list here: https://docs.aws.amazon.com/ec2/latest/instancetypes/ec2-instance-regions.html 

This change is to makes the integration test region-agnostic while still exercising the InstanceRequirements configuration path.

### Description of how you validated changes
Instead of specifying allowed types (which limits to specific families), use `ExcludedTypes` with a deny list so Lambda can select from any available instance type in the region.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
