### PR TITLE
fix Globals.Function Architectures override behavior

### DIFF
--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -306,8 +306,12 @@ class Globals:
                         f"Must be one of the following values - {supported_displayed}",
                     )
 
+            override_properties = []
+            if resource_type == SamResourceType.Function.value:
+                override_properties = ["Architectures"]
+
             # Store all Global properties in a map with key being the AWS::Serverless::* resource type
-            _globals[resource_type] = GlobalProperties(properties)
+            _globals[resource_type] = GlobalProperties(properties, override_properties)
 
         return _globals
 
@@ -433,10 +437,16 @@ class GlobalProperties:
       ```
     (in other words, Deployments will be turned off for the Function)
 
+    **Overridable Properties**
+    Some top-level resource properties must replace the global value instead of following the default merge behavior.
+    For example, Function Architectures is a list, but Lambda accepts only one architecture value. If both global and
+    local Architectures are set, the local value must override the global value instead of concatenating lists.
+
     """
 
-    def __init__(self, global_properties) -> None:  # type: ignore[no-untyped-def]
+    def __init__(self, global_properties, override_properties=None) -> None:  # type: ignore[no-untyped-def]
         self.global_properties = global_properties
+        self.override_properties = override_properties or []
 
     def merge(self, local_properties):  # type: ignore[no-untyped-def]
         """
@@ -444,7 +454,18 @@ class GlobalProperties:
 
         :return local_properties: Dictionary of local properties
         """
-        return self._do_merge(self.global_properties, local_properties)  # type: ignore[no-untyped-call]
+        global_properties = self._drop_overridden_globals(self.global_properties, local_properties)
+        return self._do_merge(global_properties, local_properties)  # type: ignore[no-untyped-call]
+
+    def _drop_overridden_globals(self, global_properties, local_properties):  # type: ignore[no-untyped-def]
+        if not self.override_properties or not isinstance(global_properties, dict) or not isinstance(local_properties, dict):
+            return global_properties
+
+        global_properties = global_properties.copy()
+        for key in self.override_properties:
+            if key in global_properties and key in local_properties:
+                del global_properties[key]
+        return global_properties
 
     def _do_merge(self, global_value, local_value):  # type: ignore[no-untyped-def]
         """

--- a/tests/plugins/globals/test_globals.py
+++ b/tests/plugins/globals/test_globals.py
@@ -171,6 +171,34 @@ class GlobalPropertiesTestCases:
 
     mixed_type_inputs_must_be_handled = {"global": {"a": "b"}, "local": [1, 2, 3], "expected_output": [1, 2, 3]}
 
+    architectures_in_local_must_override_global_instead_of_concatenating = {
+        "global": {"Architectures": ["x86_64"]},
+        "local": {"Architectures": ["arm64"]},
+        "override_properties": ["Architectures"],
+        "expected_output": {"Architectures": ["arm64"]},
+    }
+
+    architectures_in_global_must_be_used_when_local_does_not_set_it = {
+        "global": {"Architectures": ["arm64"], "Runtime": "python3.12"},
+        "local": {"Runtime": "nodejs20.x"},
+        "override_properties": ["Architectures"],
+        "expected_output": {"Architectures": ["arm64"], "Runtime": "nodejs20.x"},
+    }
+
+    override_property_in_local_only_must_not_error = {
+        "global": {"Runtime": "python3.12"},
+        "local": {"Architectures": ["arm64"]},
+        "override_properties": ["Architectures"],
+        "expected_output": {"Runtime": "python3.12", "Architectures": ["arm64"]},
+    }
+
+    override_properties_only_apply_at_root = {
+        "global": {"Nested": {"Architectures": ["x86_64"]}},
+        "local": {"Nested": {"Architectures": ["arm64"]}},
+        "override_properties": ["Architectures"],
+        "expected_output": {"Nested": {"Architectures": ["x86_64", "arm64"]}},
+    }
+
 
 class TestGlobalPropertiesMerge(TestCase):
     # Get all attributes of the test case object which is not a built-in method like __str__
@@ -180,7 +208,7 @@ class TestGlobalPropertiesMerge(TestCase):
         if not configuration:
             raise Exception("Invalid configuration for test case " + testcase)
 
-        global_properties = GlobalProperties(configuration["global"])
+        global_properties = GlobalProperties(configuration["global"], configuration.get("override_properties"))
         actual = global_properties.merge(configuration["local"])
 
         self.assertEqual(actual, configuration["expected_output"])

--- a/tests/translator/input/globals_for_function.yaml
+++ b/tests/translator/input/globals_for_function.yaml
@@ -65,6 +65,8 @@ Resources:
       PermissionsBoundary: arn:aws:1234:iam:boundary/OverridePermissionsBoundary
       Layers:
       - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:MyLayer2:2
+      Architectures:
+      - arm64
       SnapStart:
         ApplyOn: None
       ReservedConcurrentExecutions: 100

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -3,7 +3,7 @@
     "FunctionWithOverrides": {
       "Properties": {
         "Architectures": [
-          "x86_64"
+          "arm64"
         ],
         "Code": {
           "S3Bucket": "sam-demo-bucket",

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -3,7 +3,7 @@
     "FunctionWithOverrides": {
       "Properties": {
         "Architectures": [
-          "x86_64"
+          "arm64"
         ],
         "Code": {
           "S3Bucket": "sam-demo-bucket",

--- a/tests/translator/output/globals_for_function.json
+++ b/tests/translator/output/globals_for_function.json
@@ -3,7 +3,7 @@
     "FunctionWithOverrides": {
       "Properties": {
         "Architectures": [
-          "x86_64"
+          "arm64"
         ],
         "Code": {
           "S3Bucket": "sam-demo-bucket",


### PR DESCRIPTION
### Issue #, if available

Fixes #3939 

### Description of changes

Updates `Globals.Function` merge behavior so resource-level `Architectures` overrides global `Architectures` instead of concatenating both lists.

`Architectures` is list-shaped, but Lambda functions support a single architecture value. This keeps the existing default list merge behavior for other properties, such as `Layers`, while handling `Architectures` like other overridable function properties.

### Description of how you validated changes

Ran:

```bash
python -m pytest tests/plugins/globals/test_globals.py --no-cov
```
Result: 48 passed.

Also updated the globals_for_function translator fixture to cover resource-level Architectures overriding Globals.Function.Architectures across standard, aws-cn, and aws-us-gov outputs.

*Integration tests were not added because this change is limited to Globals merge behavior and is covered by unit tests plus translator output fixtures.*

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
