### PR TITLE
test: fix subnets ref parameters in tests

### DIFF
--- a/tests/translator/input/basic_function.yaml
+++ b/tests/translator/input/basic_function.yaml
@@ -1,10 +1,10 @@
 Parameters:
   SomeParameter:
     Type: String
-    Default: param
+    Default: subnet-987654
   SomeOtherParameter:
     Type: String
-    Default: otherparam
+    Default: subnet-123456
 Resources:
   MinimalFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/output/aws-cn/basic_function.json
+++ b/tests/translator/output/aws-cn/basic_function.json
@@ -1,11 +1,11 @@
 {
   "Parameters": {
     "SomeOtherParameter": {
-      "Default": "otherparam",
+      "Default": "subnet-123456",
       "Type": "String"
     },
     "SomeParameter": {
-      "Default": "param",
+      "Default": "subnet-987654",
       "Type": "String"
     }
   },

--- a/tests/translator/output/aws-us-gov/basic_function.json
+++ b/tests/translator/output/aws-us-gov/basic_function.json
@@ -1,11 +1,11 @@
 {
   "Parameters": {
     "SomeOtherParameter": {
-      "Default": "otherparam",
+      "Default": "subnet-123456",
       "Type": "String"
     },
     "SomeParameter": {
-      "Default": "param",
+      "Default": "subnet-987654",
       "Type": "String"
     }
   },

--- a/tests/translator/output/basic_function.json
+++ b/tests/translator/output/basic_function.json
@@ -1,11 +1,11 @@
 {
   "Parameters": {
     "SomeOtherParameter": {
-      "Default": "otherparam",
+      "Default": "subnet-123456",
       "Type": "String"
     },
     "SomeParameter": {
-      "Default": "param",
+      "Default": "subnet-987654",
       "Type": "String"
     }
   },


### PR DESCRIPTION
cfn-lint complains that the parameters that are passed to a subnet property don't look like subnets

### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
