### PR TITLE
feat: add AthenaQueryPolicy_v2 with current Athena API actions

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -170,6 +170,62 @@
         }
       }
     },
+    "AthenaQueryPolicy_v2": {
+      "Definition": {
+        "Statement": [
+          {
+            "Action": [
+              "athena:ListWorkGroups",
+              "athena:ListDataCatalogs",
+              "athena:ListDatabases",
+              "athena:ListTableMetadata",
+              "glue:GetDatabase",
+              "glue:GetDatabases",
+              "glue:GetTable",
+              "glue:GetTables",
+              "athena:GetDatabase",
+              "athena:GetTableMetadata"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+          },
+          {
+            "Action": [
+              "athena:StartQueryExecution",
+              "athena:GetQueryResults",
+              "athena:DeleteNamedQuery",
+              "athena:GetNamedQuery",
+              "athena:ListQueryExecutions",
+              "athena:StopQueryExecution",
+              "athena:GetQueryResultsStream",
+              "athena:ListNamedQueries",
+              "athena:CreateNamedQuery",
+              "athena:GetQueryExecution",
+              "athena:BatchGetNamedQuery",
+              "athena:BatchGetQueryExecution",
+              "athena:GetWorkGroup"
+            ],
+            "Effect": "Allow",
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${workgroupName}",
+                {
+                  "workgroupName": {
+                    "Ref": "WorkGroupName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "Description": "Gives permissions to execute Athena queries using current (non-deprecated) API actions",
+      "Parameters": {
+        "WorkGroupName": {
+          "Description": "Name of the Athena Workgroup"
+        }
+      }
+    },
     "CloudFormationDescribeStacksPolicy": {
       "Definition": {
         "Statement": [
@@ -2514,62 +2570,6 @@
       },
       "Description": "Gives access to create, delete, describe and detach ENIs",
       "Parameters": {}
-    },
-    "AthenaQueryPolicy_v2": {
-      "Definition": {
-        "Statement": [
-          {
-            "Action": [
-              "athena:ListWorkGroups",
-              "athena:ListDataCatalogs",
-              "athena:ListDatabases",
-              "athena:ListTableMetadata",
-              "glue:GetDatabase",
-              "glue:GetDatabases",
-              "glue:GetTable",
-              "glue:GetTables",
-              "athena:GetDatabase",
-              "athena:GetTableMetadata"
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-          },
-          {
-            "Action": [
-              "athena:StartQueryExecution",
-              "athena:GetQueryResults",
-              "athena:DeleteNamedQuery",
-              "athena:GetNamedQuery",
-              "athena:ListQueryExecutions",
-              "athena:StopQueryExecution",
-              "athena:GetQueryResultsStream",
-              "athena:ListNamedQueries",
-              "athena:CreateNamedQuery",
-              "athena:GetQueryExecution",
-              "athena:BatchGetNamedQuery",
-              "athena:BatchGetQueryExecution",
-              "athena:GetWorkGroup"
-            ],
-            "Effect": "Allow",
-            "Resource": {
-              "Fn::Sub": [
-                "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${workgroupName}",
-                {
-                  "workgroupName": {
-                    "Ref": "WorkGroupName"
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      },
-      "Description": "Gives permissions to execute Athena queries using current (non-deprecated) API actions",
-      "Parameters": {
-        "WorkGroupName": {
-          "Description": "Name of the Athena Workgroup"
-        }
-      }
     }
   },
   "Version": "0.0.1"

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -2514,6 +2514,63 @@
       },
       "Description": "Gives access to create, delete, describe and detach ENIs",
       "Parameters": {}
+    },
+    "AthenaQueryPolicy_v2": {
+      "Definition": {
+        "Statement": [
+          {
+            "Action": [
+              "athena:ListWorkGroups",
+              "athena:GetWorkGroup",
+              "athena:GetDatabase",
+              "athena:ListDataCatalogs",
+              "athena:ListDatabases",
+              "athena:ListTableMetadata",
+              "athena:GetTableMetadata",
+              "glue:GetDatabase",
+              "glue:GetDatabases",
+              "glue:GetTable",
+              "glue:GetTables"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+          },
+          {
+            "Action": [
+              "athena:StartQueryExecution",
+              "athena:GetQueryResults",
+              "athena:DeleteNamedQuery",
+              "athena:GetNamedQuery",
+              "athena:ListQueryExecutions",
+              "athena:StopQueryExecution",
+              "athena:GetQueryResultsStream",
+              "athena:ListNamedQueries",
+              "athena:CreateNamedQuery",
+              "athena:GetQueryExecution",
+              "athena:BatchGetNamedQuery",
+              "athena:BatchGetQueryExecution",
+              "athena:GetWorkGroup"
+            ],
+            "Effect": "Allow",
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${workgroupName}",
+                {
+                  "workgroupName": {
+                    "Ref": "WorkGroupName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "Description": "Gives permissions to execute Athena queries using current (non-deprecated) API actions",
+      "Parameters": {
+        "WorkGroupName": {
+          "Description": "Name of the Athena Workgroup"
+        }
+      }
     }
   },
   "Version": "0.0.1"

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -2521,12 +2521,9 @@
           {
             "Action": [
               "athena:ListWorkGroups",
-              "athena:GetWorkGroup",
-              "athena:GetDatabase",
               "athena:ListDataCatalogs",
               "athena:ListDatabases",
               "athena:ListTableMetadata",
-              "athena:GetTableMetadata",
               "glue:GetDatabase",
               "glue:GetDatabases",
               "glue:GetTable",
@@ -2549,7 +2546,9 @@
               "athena:GetQueryExecution",
               "athena:BatchGetNamedQuery",
               "athena:BatchGetQueryExecution",
-              "athena:GetWorkGroup"
+              "athena:GetWorkGroup",
+              "athena:GetDatabase",
+              "athena:GetTableMetadata"
             ],
             "Effect": "Allow",
             "Resource": {

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -2527,7 +2527,9 @@
               "glue:GetDatabase",
               "glue:GetDatabases",
               "glue:GetTable",
-              "glue:GetTables"
+              "glue:GetTables",
+              "athena:GetDatabase",
+              "athena:GetTableMetadata"
             ],
             "Effect": "Allow",
             "Resource": "*"
@@ -2546,9 +2548,7 @@
               "athena:GetQueryExecution",
               "athena:BatchGetNamedQuery",
               "athena:BatchGetQueryExecution",
-              "athena:GetWorkGroup",
-              "athena:GetDatabase",
-              "athena:GetTableMetadata"
+              "athena:GetWorkGroup"
             ],
             "Effect": "Allow",
             "Resource": {

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -190,3 +190,6 @@ Resources:
 
       - KMSEncryptPolicy_v2:
           KeyId: keyId
+
+      - AthenaQueryPolicy_v2:
+          WorkGroupName: name

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1,6 +1,7 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
@@ -20,12 +21,13 @@
             "Value": "SAM"
           }
         ]
-      },
-      "Type": "AWS::Lambda::Function"
+      }
     },
     "KitchenSinkFunctionRole": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
@@ -38,14 +40,14 @@
                 ]
               }
             }
-          ],
-          "Version": "2012-10-17"
+          ]
         },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -68,10 +70,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy0"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -89,10 +91,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy1"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -103,10 +105,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy2"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -117,10 +119,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy3"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -132,10 +134,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy4"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -172,10 +174,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy5"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -207,10 +209,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy6"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -228,10 +230,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy7"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -250,10 +252,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy8"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -285,10 +287,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy9"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -324,10 +326,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy10"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -338,10 +340,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy11"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -354,10 +356,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy12"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -378,10 +380,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy13"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -402,10 +404,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy14"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -424,10 +426,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy15"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -445,10 +447,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy16"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -466,10 +468,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy17"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -483,10 +485,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy18"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -521,10 +523,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy19"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -555,10 +557,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy20"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -579,10 +581,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy21"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -604,10 +606,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy22"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -638,10 +640,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy23"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -657,10 +659,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy24"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -695,10 +697,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy25"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -748,10 +750,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy26"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -763,10 +765,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy27"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -787,10 +789,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy28"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -808,10 +810,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy29"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -829,10 +831,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy30"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -846,10 +848,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy31"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -861,10 +863,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy32"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -876,10 +878,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy33"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -914,10 +916,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy34"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -955,10 +957,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy35"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -976,10 +978,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy36"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1014,10 +1016,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy37"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1028,10 +1030,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy38"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1051,10 +1053,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy39"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1068,10 +1070,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy40"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1093,10 +1095,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy41"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1108,10 +1110,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy42"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1127,10 +1129,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy43"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1141,10 +1143,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy44"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1162,10 +1164,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy45"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1188,10 +1190,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy46"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1207,10 +1209,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy47"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1228,10 +1230,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy48"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1258,10 +1260,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy49"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1279,10 +1281,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy50"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1361,10 +1363,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy51"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1414,10 +1416,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy52"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy53",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1433,10 +1435,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy53"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy54",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1480,10 +1482,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy54"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy55",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1513,10 +1515,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy55"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy56",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1546,10 +1548,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy56"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy57",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1565,10 +1567,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy57"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy58",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1586,10 +1588,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy58"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy59",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1607,10 +1609,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy59"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1637,10 +1639,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy60"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy61",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1659,10 +1661,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy61"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy62",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1701,10 +1703,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy62"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy63",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1724,10 +1726,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy63"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy64",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1749,21 +1751,18 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy64"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy65",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "athena:ListWorkGroups",
-                    "athena:GetWorkGroup",
-                    "athena:GetDatabase",
                     "athena:ListDataCatalogs",
                     "athena:ListDatabases",
                     "athena:ListTableMetadata",
-                    "athena:GetTableMetadata",
                     "glue:GetDatabase",
                     "glue:GetDatabases",
                     "glue:GetTable",
@@ -1786,7 +1785,9 @@
                     "athena:GetQueryExecution",
                     "athena:BatchGetNamedQuery",
                     "athena:BatchGetQueryExecution",
-                    "athena:GetWorkGroup"
+                    "athena:GetWorkGroup",
+                    "athena:GetDatabase",
+                    "athena:GetTableMetadata"
                   ],
                   "Effect": "Allow",
                   "Resource": {
@@ -1799,8 +1800,7 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy65"
+            }
           }
         ],
         "Tags": [
@@ -1809,8 +1809,7 @@
             "Value": "SAM"
           }
         ]
-      },
-      "Type": "AWS::IAM::Role"
+      }
     }
   }
 }

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1751,6 +1751,56 @@
               ]
             },
             "PolicyName": "KitchenSinkFunctionRolePolicy64"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "athena:ListWorkGroups",
+                    "athena:GetWorkGroup",
+                    "athena:GetDatabase",
+                    "athena:ListDataCatalogs",
+                    "athena:ListDatabases",
+                    "athena:ListTableMetadata",
+                    "athena:GetTableMetadata",
+                    "glue:GetDatabase",
+                    "glue:GetDatabases",
+                    "glue:GetTable",
+                    "glue:GetTables"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": [
+                    "athena:StartQueryExecution",
+                    "athena:GetQueryResults",
+                    "athena:DeleteNamedQuery",
+                    "athena:GetNamedQuery",
+                    "athena:ListQueryExecutions",
+                    "athena:StopQueryExecution",
+                    "athena:GetQueryResultsStream",
+                    "athena:ListNamedQueries",
+                    "athena:CreateNamedQuery",
+                    "athena:GetQueryExecution",
+                    "athena:BatchGetNamedQuery",
+                    "athena:BatchGetQueryExecution",
+                    "athena:GetWorkGroup"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${workgroupName}",
+                      {
+                        "workgroupName": "name"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy65"
           }
         ],
         "Tags": [

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1766,7 +1766,9 @@
                     "glue:GetDatabase",
                     "glue:GetDatabases",
                     "glue:GetTable",
-                    "glue:GetTables"
+                    "glue:GetTables",
+                    "athena:GetDatabase",
+                    "athena:GetTableMetadata"
                   ],
                   "Effect": "Allow",
                   "Resource": "*"
@@ -1785,9 +1787,7 @@
                     "athena:GetQueryExecution",
                     "athena:BatchGetNamedQuery",
                     "athena:BatchGetQueryExecution",
-                    "athena:GetWorkGroup",
-                    "athena:GetDatabase",
-                    "athena:GetTableMetadata"
+                    "athena:GetWorkGroup"
                   ],
                   "Effect": "Allow",
                   "Resource": {

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1,7 +1,6 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
-      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
@@ -21,13 +20,12 @@
             "Value": "SAM"
           }
         ]
-      }
+      },
+      "Type": "AWS::Lambda::Function"
     },
     "KitchenSinkFunctionRole": {
-      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
@@ -40,14 +38,14 @@
                 ]
               }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -70,10 +68,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy0"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -91,10 +89,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy1"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -105,10 +103,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy2"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -119,10 +117,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy3"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -134,10 +132,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy4"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -174,10 +172,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy5"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -209,10 +207,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy6"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -230,10 +228,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy7"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -252,10 +250,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy8"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -287,10 +285,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy9"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -326,10 +324,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy10"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -340,10 +338,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy11"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -356,10 +354,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy12"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -380,10 +378,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy13"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -404,10 +402,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy14"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -426,10 +424,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy15"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -447,10 +445,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy16"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -468,10 +466,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy17"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -485,10 +483,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy18"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -523,10 +521,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy19"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -557,10 +555,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy20"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -581,10 +579,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy21"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -606,10 +604,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy22"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -640,10 +638,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy23"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -659,10 +657,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy24"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -697,10 +695,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy25"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -750,10 +748,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy26"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -765,10 +763,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy27"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -789,10 +787,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy28"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -810,10 +808,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy29"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -831,10 +829,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy30"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -848,10 +846,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy31"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -863,10 +861,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy32"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -878,10 +876,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy33"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -916,10 +914,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy34"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -957,10 +955,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy35"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -978,10 +976,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy36"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1016,10 +1014,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy37"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1030,10 +1028,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy38"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1053,10 +1051,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy39"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1070,10 +1068,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy40"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1095,10 +1093,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy41"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1110,10 +1108,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy42"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1129,10 +1127,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy43"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1143,10 +1141,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy44"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1164,10 +1162,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy45"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1190,10 +1188,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy46"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1209,10 +1207,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy47"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1230,10 +1228,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy48"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1260,10 +1258,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy49"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1281,10 +1279,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy50"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1363,10 +1361,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy51"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1416,10 +1414,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy52"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy53",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1435,10 +1433,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy53"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy54",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1482,10 +1480,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy54"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy55",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1515,10 +1513,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy55"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy56",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1548,10 +1546,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy56"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy57",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1567,10 +1565,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy57"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy58",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1588,10 +1586,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy58"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy59",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1609,10 +1607,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy59"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy60",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1639,10 +1637,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy60"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy61",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1661,10 +1659,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy61"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy62",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1703,10 +1701,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy62"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy63",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1726,10 +1724,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy63"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy64",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1751,10 +1749,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy64"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy65",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1800,7 +1798,8 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy65"
           }
         ],
         "Tags": [
@@ -1809,7 +1808,8 @@
             "Value": "SAM"
           }
         ]
-      }
+      },
+      "Type": "AWS::IAM::Role"
     }
   }
 }

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1,6 +1,7 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
@@ -20,12 +21,13 @@
             "Value": "SAM"
           }
         ]
-      },
-      "Type": "AWS::Lambda::Function"
+      }
     },
     "KitchenSinkFunctionRole": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
@@ -38,14 +40,14 @@
                 ]
               }
             }
-          ],
-          "Version": "2012-10-17"
+          ]
         },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -68,10 +70,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy0"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -89,10 +91,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy1"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -103,10 +105,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy2"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -117,10 +119,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy3"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -132,10 +134,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy4"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -172,10 +174,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy5"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -207,10 +209,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy6"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -228,10 +230,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy7"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -250,10 +252,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy8"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -285,10 +287,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy9"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -324,10 +326,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy10"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -338,10 +340,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy11"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -354,10 +356,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy12"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -378,10 +380,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy13"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -402,10 +404,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy14"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -424,10 +426,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy15"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -445,10 +447,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy16"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -466,10 +468,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy17"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -483,10 +485,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy18"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -521,10 +523,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy19"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -555,10 +557,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy20"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -579,10 +581,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy21"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -604,10 +606,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy22"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -638,10 +640,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy23"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -657,10 +659,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy24"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -695,10 +697,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy25"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -748,10 +750,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy26"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -763,10 +765,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy27"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -787,10 +789,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy28"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -808,10 +810,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy29"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -829,10 +831,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy30"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -846,10 +848,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy31"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -861,10 +863,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy32"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -876,10 +878,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy33"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -914,10 +916,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy34"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -955,10 +957,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy35"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -976,10 +978,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy36"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1014,10 +1016,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy37"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1028,10 +1030,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy38"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1051,10 +1053,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy39"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1068,10 +1070,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy40"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1093,10 +1095,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy41"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1108,10 +1110,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy42"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1127,10 +1129,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy43"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1141,10 +1143,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy44"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1162,10 +1164,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy45"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1188,10 +1190,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy46"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1207,10 +1209,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy47"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1228,10 +1230,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy48"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1258,10 +1260,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy49"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1279,10 +1281,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy50"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1361,10 +1363,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy51"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1414,10 +1416,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy52"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy53",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1433,10 +1435,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy53"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy54",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1480,10 +1482,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy54"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy55",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1513,10 +1515,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy55"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy56",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1546,10 +1548,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy56"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy57",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1565,10 +1567,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy57"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy58",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1586,10 +1588,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy58"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy59",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1607,10 +1609,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy59"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1637,10 +1639,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy60"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy61",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1659,10 +1661,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy61"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy62",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1701,10 +1703,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy62"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy63",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1724,10 +1726,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy63"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy64",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1749,21 +1751,18 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy64"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy65",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "athena:ListWorkGroups",
-                    "athena:GetWorkGroup",
-                    "athena:GetDatabase",
                     "athena:ListDataCatalogs",
                     "athena:ListDatabases",
                     "athena:ListTableMetadata",
-                    "athena:GetTableMetadata",
                     "glue:GetDatabase",
                     "glue:GetDatabases",
                     "glue:GetTable",
@@ -1786,7 +1785,9 @@
                     "athena:GetQueryExecution",
                     "athena:BatchGetNamedQuery",
                     "athena:BatchGetQueryExecution",
-                    "athena:GetWorkGroup"
+                    "athena:GetWorkGroup",
+                    "athena:GetDatabase",
+                    "athena:GetTableMetadata"
                   ],
                   "Effect": "Allow",
                   "Resource": {
@@ -1799,8 +1800,7 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy65"
+            }
           }
         ],
         "Tags": [
@@ -1809,8 +1809,7 @@
             "Value": "SAM"
           }
         ]
-      },
-      "Type": "AWS::IAM::Role"
+      }
     }
   }
 }

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1,7 +1,6 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
-      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
@@ -21,13 +20,12 @@
             "Value": "SAM"
           }
         ]
-      }
+      },
+      "Type": "AWS::Lambda::Function"
     },
     "KitchenSinkFunctionRole": {
-      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
@@ -40,14 +38,14 @@
                 ]
               }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -70,10 +68,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy0"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -91,10 +89,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy1"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -105,10 +103,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy2"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -119,10 +117,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy3"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -134,10 +132,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy4"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -174,10 +172,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy5"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -209,10 +207,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy6"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -230,10 +228,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy7"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -252,10 +250,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy8"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -287,10 +285,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy9"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -326,10 +324,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy10"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -340,10 +338,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy11"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -356,10 +354,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy12"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -380,10 +378,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy13"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -404,10 +402,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy14"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -426,10 +424,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy15"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -447,10 +445,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy16"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -468,10 +466,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy17"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -485,10 +483,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy18"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -523,10 +521,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy19"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -557,10 +555,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy20"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -581,10 +579,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy21"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -606,10 +604,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy22"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -640,10 +638,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy23"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -659,10 +657,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy24"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -697,10 +695,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy25"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -750,10 +748,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy26"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -765,10 +763,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy27"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -789,10 +787,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy28"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -810,10 +808,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy29"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -831,10 +829,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy30"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -848,10 +846,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy31"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -863,10 +861,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy32"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -878,10 +876,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy33"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -916,10 +914,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy34"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -957,10 +955,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy35"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -978,10 +976,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy36"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1016,10 +1014,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy37"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1030,10 +1028,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy38"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1053,10 +1051,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy39"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1070,10 +1068,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy40"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1095,10 +1093,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy41"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1110,10 +1108,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy42"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1129,10 +1127,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy43"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1143,10 +1141,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy44"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1164,10 +1162,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy45"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1190,10 +1188,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy46"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1209,10 +1207,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy47"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1230,10 +1228,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy48"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1260,10 +1258,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy49"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1281,10 +1279,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy50"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1363,10 +1361,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy51"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1416,10 +1414,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy52"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy53",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1435,10 +1433,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy53"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy54",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1482,10 +1480,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy54"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy55",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1515,10 +1513,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy55"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy56",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1548,10 +1546,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy56"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy57",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1567,10 +1565,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy57"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy58",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1588,10 +1586,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy58"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy59",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1609,10 +1607,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy59"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy60",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1639,10 +1637,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy60"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy61",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1661,10 +1659,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy61"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy62",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1703,10 +1701,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy62"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy63",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1726,10 +1724,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy63"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy64",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1751,10 +1749,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy64"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy65",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1800,7 +1798,8 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy65"
           }
         ],
         "Tags": [
@@ -1809,7 +1808,8 @@
             "Value": "SAM"
           }
         ]
-      }
+      },
+      "Type": "AWS::IAM::Role"
     }
   }
 }

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1751,6 +1751,56 @@
               ]
             },
             "PolicyName": "KitchenSinkFunctionRolePolicy64"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "athena:ListWorkGroups",
+                    "athena:GetWorkGroup",
+                    "athena:GetDatabase",
+                    "athena:ListDataCatalogs",
+                    "athena:ListDatabases",
+                    "athena:ListTableMetadata",
+                    "athena:GetTableMetadata",
+                    "glue:GetDatabase",
+                    "glue:GetDatabases",
+                    "glue:GetTable",
+                    "glue:GetTables"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": [
+                    "athena:StartQueryExecution",
+                    "athena:GetQueryResults",
+                    "athena:DeleteNamedQuery",
+                    "athena:GetNamedQuery",
+                    "athena:ListQueryExecutions",
+                    "athena:StopQueryExecution",
+                    "athena:GetQueryResultsStream",
+                    "athena:ListNamedQueries",
+                    "athena:CreateNamedQuery",
+                    "athena:GetQueryExecution",
+                    "athena:BatchGetNamedQuery",
+                    "athena:BatchGetQueryExecution",
+                    "athena:GetWorkGroup"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${workgroupName}",
+                      {
+                        "workgroupName": "name"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy65"
           }
         ],
         "Tags": [

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1766,7 +1766,9 @@
                     "glue:GetDatabase",
                     "glue:GetDatabases",
                     "glue:GetTable",
-                    "glue:GetTables"
+                    "glue:GetTables",
+                    "athena:GetDatabase",
+                    "athena:GetTableMetadata"
                   ],
                   "Effect": "Allow",
                   "Resource": "*"
@@ -1785,9 +1787,7 @@
                     "athena:GetQueryExecution",
                     "athena:BatchGetNamedQuery",
                     "athena:BatchGetQueryExecution",
-                    "athena:GetWorkGroup",
-                    "athena:GetDatabase",
-                    "athena:GetTableMetadata"
+                    "athena:GetWorkGroup"
                   ],
                   "Effect": "Allow",
                   "Resource": {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1,6 +1,7 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
@@ -20,12 +21,13 @@
             "Value": "SAM"
           }
         ]
-      },
-      "Type": "AWS::Lambda::Function"
+      }
     },
     "KitchenSinkFunctionRole": {
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
@@ -38,14 +40,14 @@
                 ]
               }
             }
-          ],
-          "Version": "2012-10-17"
+          ]
         },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -68,10 +70,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy0"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -89,10 +91,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy1"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -103,10 +105,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy2"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -117,10 +119,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy3"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -132,10 +134,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy4"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -172,10 +174,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy5"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -207,10 +209,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy6"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -228,10 +230,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy7"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -250,10 +252,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy8"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -285,10 +287,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy9"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -324,10 +326,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy10"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -338,10 +340,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy11"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -354,10 +356,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy12"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -378,10 +380,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy13"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -402,10 +404,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy14"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -424,10 +426,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy15"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -445,10 +447,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy16"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -466,10 +468,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy17"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -483,10 +485,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy18"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -521,10 +523,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy19"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -555,10 +557,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy20"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -579,10 +581,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy21"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -604,10 +606,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy22"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -638,10 +640,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy23"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -657,10 +659,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy24"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -695,10 +697,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy25"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -748,10 +750,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy26"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -763,10 +765,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy27"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -787,10 +789,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy28"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -808,10 +810,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy29"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -829,10 +831,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy30"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -846,10 +848,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy31"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -861,10 +863,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy32"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -876,10 +878,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy33"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -914,10 +916,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy34"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -955,10 +957,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy35"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -976,10 +978,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy36"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1014,10 +1016,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy37"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1028,10 +1030,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy38"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1051,10 +1053,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy39"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1068,10 +1070,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy40"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1093,10 +1095,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy41"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1108,10 +1110,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy42"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1127,10 +1129,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy43"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1141,10 +1143,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy44"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1162,10 +1164,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy45"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1188,10 +1190,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy46"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1207,10 +1209,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy47"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1228,10 +1230,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy48"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1258,10 +1260,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy49"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1279,10 +1281,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy50"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1361,10 +1363,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy51"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1414,10 +1416,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy52"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy53",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1433,10 +1435,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy53"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy54",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1480,10 +1482,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy54"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy55",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1513,10 +1515,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy55"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy56",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1546,10 +1548,10 @@
                   ]
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy56"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy57",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1565,10 +1567,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy57"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy58",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1586,10 +1588,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy58"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy59",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1607,10 +1609,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy59"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy60",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1637,10 +1639,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy60"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy61",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1659,10 +1661,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy61"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy62",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1701,10 +1703,10 @@
                   "Resource": "*"
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy62"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy63",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1724,10 +1726,10 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy63"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy64",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1749,21 +1751,18 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy64"
+            }
           },
           {
+            "PolicyName": "KitchenSinkFunctionRolePolicy65",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "athena:ListWorkGroups",
-                    "athena:GetWorkGroup",
-                    "athena:GetDatabase",
                     "athena:ListDataCatalogs",
                     "athena:ListDatabases",
                     "athena:ListTableMetadata",
-                    "athena:GetTableMetadata",
                     "glue:GetDatabase",
                     "glue:GetDatabases",
                     "glue:GetTable",
@@ -1786,7 +1785,9 @@
                     "athena:GetQueryExecution",
                     "athena:BatchGetNamedQuery",
                     "athena:BatchGetQueryExecution",
-                    "athena:GetWorkGroup"
+                    "athena:GetWorkGroup",
+                    "athena:GetDatabase",
+                    "athena:GetTableMetadata"
                   ],
                   "Effect": "Allow",
                   "Resource": {
@@ -1799,8 +1800,7 @@
                   }
                 }
               ]
-            },
-            "PolicyName": "KitchenSinkFunctionRolePolicy65"
+            }
           }
         ],
         "Tags": [
@@ -1809,8 +1809,7 @@
             "Value": "SAM"
           }
         ]
-      },
-      "Type": "AWS::IAM::Role"
+      }
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1751,6 +1751,56 @@
               ]
             },
             "PolicyName": "KitchenSinkFunctionRolePolicy64"
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "athena:ListWorkGroups",
+                    "athena:GetWorkGroup",
+                    "athena:GetDatabase",
+                    "athena:ListDataCatalogs",
+                    "athena:ListDatabases",
+                    "athena:ListTableMetadata",
+                    "athena:GetTableMetadata",
+                    "glue:GetDatabase",
+                    "glue:GetDatabases",
+                    "glue:GetTable",
+                    "glue:GetTables"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": [
+                    "athena:StartQueryExecution",
+                    "athena:GetQueryResults",
+                    "athena:DeleteNamedQuery",
+                    "athena:GetNamedQuery",
+                    "athena:ListQueryExecutions",
+                    "athena:StopQueryExecution",
+                    "athena:GetQueryResultsStream",
+                    "athena:ListNamedQueries",
+                    "athena:CreateNamedQuery",
+                    "athena:GetQueryExecution",
+                    "athena:BatchGetNamedQuery",
+                    "athena:BatchGetQueryExecution",
+                    "athena:GetWorkGroup"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${workgroupName}",
+                      {
+                        "workgroupName": "name"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy65"
           }
         ],
         "Tags": [

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1,7 +1,6 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
-      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
@@ -21,13 +20,12 @@
             "Value": "SAM"
           }
         ]
-      }
+      },
+      "Type": "AWS::Lambda::Function"
     },
     "KitchenSinkFunctionRole": {
-      "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
@@ -40,14 +38,14 @@
                 ]
               }
             }
-          ]
+          ],
+          "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         ],
         "Policies": [
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -70,10 +68,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy0"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -91,10 +89,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy1"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -105,10 +103,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy2"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -119,10 +117,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy3"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -134,10 +132,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy4"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -174,10 +172,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy5"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -209,10 +207,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy6"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -230,10 +228,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy7"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -252,10 +250,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy8"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -287,10 +285,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy9"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -326,10 +324,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy10"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -340,10 +338,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy11"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -356,10 +354,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy12"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -380,10 +378,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy13"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -404,10 +402,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy14"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -426,10 +424,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy15"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -447,10 +445,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy16"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -468,10 +466,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy17"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -485,10 +483,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy18"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -523,10 +521,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy19"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -557,10 +555,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy20"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -581,10 +579,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy21"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -606,10 +604,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy22"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -640,10 +638,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy23"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -659,10 +657,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy24"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -697,10 +695,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy25"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -750,10 +748,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy26"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -765,10 +763,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy27"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -789,10 +787,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy28"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -810,10 +808,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy29"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -831,10 +829,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy30"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -848,10 +846,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy31"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -863,10 +861,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy32"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -878,10 +876,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy33"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -916,10 +914,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy34"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -957,10 +955,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy35"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -978,10 +976,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy36"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1016,10 +1014,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy37"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1030,10 +1028,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy38"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1053,10 +1051,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy39"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1070,10 +1068,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy40"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1095,10 +1093,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy41"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1110,10 +1108,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy42"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1129,10 +1127,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy43"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1143,10 +1141,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy44"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1164,10 +1162,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy45"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1190,10 +1188,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy46"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1209,10 +1207,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy47"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1230,10 +1228,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy48"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1260,10 +1258,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy49"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1281,10 +1279,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy50"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1363,10 +1361,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy51"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1416,10 +1414,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy52"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy53",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1435,10 +1433,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy53"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy54",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1482,10 +1480,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy54"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy55",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1515,10 +1513,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy55"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy56",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1548,10 +1546,10 @@
                   ]
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy56"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy57",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1567,10 +1565,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy57"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy58",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1588,10 +1586,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy58"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy59",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1609,10 +1607,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy59"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy60",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1639,10 +1637,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy60"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy61",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1661,10 +1659,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy61"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy62",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1703,10 +1701,10 @@
                   "Resource": "*"
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy62"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy63",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1726,10 +1724,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy63"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy64",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1751,10 +1749,10 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy64"
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy65",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1800,7 +1798,8 @@
                   }
                 }
               ]
-            }
+            },
+            "PolicyName": "KitchenSinkFunctionRolePolicy65"
           }
         ],
         "Tags": [
@@ -1809,7 +1808,8 @@
             "Value": "SAM"
           }
         ]
-      }
+      },
+      "Type": "AWS::IAM::Role"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1766,7 +1766,9 @@
                     "glue:GetDatabase",
                     "glue:GetDatabases",
                     "glue:GetTable",
-                    "glue:GetTables"
+                    "glue:GetTables",
+                    "athena:GetDatabase",
+                    "athena:GetTableMetadata"
                   ],
                   "Effect": "Allow",
                   "Resource": "*"
@@ -1785,9 +1787,7 @@
                     "athena:GetQueryExecution",
                     "athena:BatchGetNamedQuery",
                     "athena:BatchGetQueryExecution",
-                    "athena:GetWorkGroup",
-                    "athena:GetDatabase",
-                    "athena:GetTableMetadata"
+                    "athena:GetWorkGroup"
                   ],
                   "Effect": "Allow",
                   "Resource": {


### PR DESCRIPTION
## Summary

Adds `AthenaQueryPolicy_v2` with current (non-deprecated) Athena API actions, following the established `_v2` pattern.

The original `AthenaQueryPolicy` is preserved unchanged for backward compatibility (per DEVELOPMENT_GUIDE.md: "A specific SAM template should always transform into the same CloudFormation template").

### Changes
- **New**: `AthenaQueryPolicy_v2` with updated actions (`athena:GetWorkGroup`, `athena:ListDataCatalogs`, `athena:GetDatabase`, `athena:ListDatabases`, `athena:ListTableMetadata`, `athena:GetTableMetadata`) + required Glue Data Catalog permissions (`glue:GetDatabase`, `glue:GetDatabases`, `glue:GetTable`, `glue:GetTables`)
- **Unchanged**: Original `AthenaQueryPolicy` (deprecated APIs still work, users won't see silent IAM changes on stack update)

### Migration
Users should update their SAM templates from `AthenaQueryPolicy` to `AthenaQueryPolicy_v2` at their convenience.

Fixes #3785