### PR TITLE
fix(integ-tests): Add IAM auth to API Gateway resources in integration tests

### DIFF
--- a/integration/combination/test_function_with_http_api.py
+++ b/integration/combination/test_function_with_http_api.py
@@ -18,9 +18,9 @@ class TestFunctionWithHttpApi(BaseTest):
 
         stack_outputs = self.get_stack_outputs()
         base_url = stack_outputs["ApiUrl"]
-        self.verify_get_request_response(base_url + "some/path", 200)
-        self.verify_get_request_response(base_url + "something", 404)
-        self.verify_get_request_response(base_url + "another/endpoint", 404)
+        self.verify_get_request_response_sigv4(base_url + "some/path", 200)
+        self.verify_get_request_response_sigv4(base_url + "something", 404)
+        self.verify_get_request_response_sigv4(base_url + "another/endpoint", 404)
 
     def test_function_with_http_api_default_path(self):
         self.create_and_verify_stack("combination/function_with_http_api_default_path")
@@ -28,5 +28,5 @@ class TestFunctionWithHttpApi(BaseTest):
         stack_outputs = self.get_stack_outputs()
         base_url = stack_outputs["ApiUrl"]
         # The $default route catches requests that don't explicitly match other routes
-        self.verify_get_request_response(base_url, 200)
-        self.verify_get_request_response(base_url + "something", 200)
+        self.verify_get_request_response_sigv4(base_url, 200)
+        self.verify_get_request_response_sigv4(base_url + "something", 200)

--- a/integration/combination/test_function_with_implicit_http_api.py
+++ b/integration/combination/test_function_with_implicit_http_api.py
@@ -12,6 +12,6 @@ class TestFunctionWithImplicitHttpApi(BaseTest):
 
         stack_outputs = self.get_stack_outputs()
         base_url = stack_outputs["ApiUrl"]
-        self.verify_get_request_response(base_url, 200)
-        self.verify_get_request_response(base_url + "something", 200)
-        self.verify_get_request_response(base_url + "another/endpoint", 200)
+        self.verify_get_request_response_sigv4(base_url, 200)
+        self.verify_get_request_response_sigv4(base_url + "something", 200)
+        self.verify_get_request_response_sigv4(base_url + "another/endpoint", 200)

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -4,11 +4,14 @@ import os
 import shutil
 from pathlib import Path
 from unittest.case import TestCase
+from urllib.parse import urlparse
 
 import boto3
 import botocore
 import pytest
 import requests
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.yaml_helper import yaml_parse
 from tenacity import (
@@ -545,6 +548,25 @@ class BaseTest(TestCase):
         after=after_log(LOG, logging.WARNING),
         reraise=True,
     )
+    def verify_get_request_response_sigv4(self, url, expected_status_code, headers=None):
+        """
+        Verify if a SigV4-signed get request to a certain url returns the expected status code.
+        Use this for APIs with IAM authorization.
+        """
+        response = self.do_get_request_with_sigv4(url, headers)
+        if response.status_code != expected_status_code:
+            raise StatusCodeError(
+                f"SigV4 request to {url} failed with status: {response.status_code}, expected status: {expected_status_code}"
+            )
+        return response
+
+    @retry(
+        stop=stop_after_attempt(6),
+        wait=wait_exponential(multiplier=1, min=16, max=64) + wait_random(0, 1),
+        retry=retry_if_exception_type(StatusCodeError),
+        after=after_log(LOG, logging.WARNING),
+        reraise=True,
+    )
     def verify_options_request(self, url, expected_status_code, headers=None):
         """
         Verify if the option request to a certain url return the expected status code
@@ -578,6 +600,22 @@ class BaseTest(TestCase):
         if response.status_code != expected_status_code:
             raise StatusCodeError(
                 f"Request to {url} failed with status: {response.status_code}, expected status: {expected_status_code}"
+            )
+        return response
+
+    @retry(
+        stop=stop_after_attempt(6),
+        wait=wait_exponential(multiplier=1, min=16, max=64) + wait_random(0, 1),
+        retry=retry_if_exception_type(StatusCodeError),
+        after=after_log(LOG, logging.WARNING),
+        reraise=True,
+    )
+    def verify_post_request_sigv4(self, url: str, body_obj, expected_status_code: int, headers=None):
+        """Return response to SigV4-signed POST request and verify matches expected status code."""
+        response = self.do_post_request_with_sigv4(url, body_obj, headers)
+        if response.status_code != expected_status_code:
+            raise StatusCodeError(
+                f"SigV4 POST request to {url} failed with status: {response.status_code}, expected status: {expected_status_code}"
             )
         return response
 
@@ -636,6 +674,29 @@ class BaseTest(TestCase):
             )
         return response
 
+    def do_get_request_with_sigv4(self, url, headers=None):
+        """
+        Perform a SigV4-signed GET request to an APIGW endpoint with IAM auth.
+        """
+        parsed = urlparse(url)
+        request_headers = {"host": parsed.hostname}
+        if headers:
+            request_headers.update(headers)
+
+        aws_request = AWSRequest(method="GET", url=url, headers=request_headers)
+        session = botocore.session.Session()
+        credentials = session.get_credentials().get_frozen_credentials()
+        SigV4Auth(credentials, "execute-api", self.my_region).add_auth(aws_request)
+
+        response = requests.get(url, headers=dict(aws_request.headers))
+        amazon_headers = RequestUtils(response).get_amazon_headers()
+        if self.internal:
+            REQUEST_LOGGER.info(
+                "SigV4 request made to " + url,
+                extra={"test": self.testcase, "status": response.status_code, "headers": amazon_headers},
+            )
+        return response
+
     def do_options_request_with_logging(self, url, headers=None):
         """
         Perform a options request to an APIGW endpoint and log relevant info
@@ -666,6 +727,28 @@ class BaseTest(TestCase):
         if self.internal:
             REQUEST_LOGGER.info(
                 "POST request made to " + url,
+                extra={"test": self.testcase, "status": response.status_code, "headers": amazon_headers},
+            )
+        return response
+
+    def do_post_request_with_sigv4(self, url: str, body_obj, headers=None):
+        """Perform a SigV4-signed POST request to an APIGW endpoint with IAM auth."""
+        parsed = urlparse(url)
+        body = json.dumps(body_obj)
+        request_headers = {"host": parsed.hostname, "content-type": "application/json"}
+        if headers:
+            request_headers.update(headers)
+
+        aws_request = AWSRequest(method="POST", url=url, headers=request_headers, data=body)
+        session = botocore.session.Session()
+        credentials = session.get_credentials().get_frozen_credentials()
+        SigV4Auth(credentials, "execute-api", self.my_region).add_auth(aws_request)
+
+        response = requests.post(url, data=body, headers=dict(aws_request.headers))
+        amazon_headers = RequestUtils(response).get_amazon_headers()
+        if self.internal:
+            REQUEST_LOGGER.info(
+                "SigV4 POST request made to " + url,
                 extra={"test": self.testcase, "status": response.status_code, "headers": amazon_headers},
             )
         return response

--- a/integration/resources/templates/combination/api_with_binary_media_types.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types.yaml
@@ -17,6 +17,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       BinaryMediaTypes:

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body.yaml
@@ -22,6 +22,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionBody:
         # Simple HTTP Proxy API

--- a/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types_with_definition_body_openapi.yaml
@@ -26,6 +26,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionBody:
         # Simple HTTP Proxy API

--- a/integration/resources/templates/combination/api_with_custom_domains_edge.yaml
+++ b/integration/resources/templates/combination/api_with_custom_domains_edge.yaml
@@ -32,6 +32,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       OpenApiVersion: 3.0.1
       StageName: Prod
       Domain:

--- a/integration/resources/templates/combination/api_with_disable_execute_api_endpoint.yaml
+++ b/integration/resources/templates/combination/api_with_disable_execute_api_endpoint.yaml
@@ -12,6 +12,8 @@ Resources:
   RestApiGateway:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DisableExecuteApiEndpoint:
         Ref: DisableExecuteApiEndpointValue

--- a/integration/resources/templates/combination/api_with_disable_execute_api_endpoint_openapi_3.yaml
+++ b/integration/resources/templates/combination/api_with_disable_execute_api_endpoint_openapi_3.yaml
@@ -12,6 +12,8 @@ Resources:
   RestApiGateway:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       OpenApiVersion: 3.0
       DisableExecuteApiEndpoint:

--- a/integration/resources/templates/combination/api_with_endpoint_configuration.yaml
+++ b/integration/resources/templates/combination/api_with_endpoint_configuration.yaml
@@ -13,6 +13,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       EndpointConfiguration: {Ref: Config}
       DefinitionUri: ${definitionuri}

--- a/integration/resources/templates/combination/api_with_endpoint_configuration_dict.yaml
+++ b/integration/resources/templates/combination/api_with_endpoint_configuration_dict.yaml
@@ -10,6 +10,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       EndpointConfiguration:
         Type: REGIONAL

--- a/integration/resources/templates/combination/api_with_fail_on_warnings.yaml
+++ b/integration/resources/templates/combination/api_with_fail_on_warnings.yaml
@@ -11,6 +11,8 @@ Resources:
   RestApiGateway:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       FailOnWarnings:
         Ref: FailOnWarningsValue

--- a/integration/resources/templates/combination/api_with_method_settings.yaml
+++ b/integration/resources/templates/combination/api_with_method_settings.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       MethodSettings: [{LoggingLevel: INFO, MetricsEnabled: true, DataTraceEnabled: true,

--- a/integration/resources/templates/combination/api_with_request_models.yaml
+++ b/integration/resources/templates/combination/api_with_request_models.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       Models:
         User:

--- a/integration/resources/templates/combination/api_with_request_models_openapi.yaml
+++ b/integration/resources/templates/combination/api_with_request_models_openapi.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       OpenApiVersion: 3.0.1
       StageName: Prod
       Models:

--- a/integration/resources/templates/combination/api_with_resource_refs.yaml
+++ b/integration/resources/templates/combination/api_with_resource_refs.yaml
@@ -8,6 +8,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
 

--- a/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
+++ b/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
@@ -86,6 +86,8 @@ Resources:
   ExistingRestApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Dev
       DefinitionUri: ${definitionuri}
 

--- a/integration/resources/templates/combination/function_with_api.yaml
+++ b/integration/resources/templates/combination/function_with_api.yaml
@@ -8,6 +8,8 @@ Resources:
   ExistingRestApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Dev
       DefinitionUri: ${definitionuri}
 

--- a/integration/resources/templates/combination/function_with_http_api.yaml
+++ b/integration/resources/templates/combination/function_with_http_api.yaml
@@ -20,6 +20,9 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
       DefinitionBody:
         info:
           version: '1.0'

--- a/integration/resources/templates/combination/function_with_http_api_default_path.yaml
+++ b/integration/resources/templates/combination/function_with_http_api_default_path.yaml
@@ -20,6 +20,9 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
       DefinitionBody:
         info:
           version: '1.0'

--- a/integration/resources/templates/combination/function_with_implicit_http_api.yaml
+++ b/integration/resources/templates/combination/function_with_implicit_http_api.yaml
@@ -1,3 +1,9 @@
+Globals:
+  HttpApi:
+    Auth:
+      EnableIamAuthorizer: true
+      DefaultAuthorizer: AWS_IAM
+
 Resources:
 
   MyLambdaFunction:

--- a/integration/resources/templates/combination/http_api_with_custom_domains_regional.yaml
+++ b/integration/resources/templates/combination/http_api_with_custom_domains_regional.yaml
@@ -57,6 +57,9 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/combination/http_api_with_custom_domains_regional_ownership_verification.yaml
+++ b/integration/resources/templates/combination/http_api_with_custom_domains_regional_ownership_verification.yaml
@@ -61,6 +61,9 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_false.yaml
+++ b/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_false.yaml
@@ -30,6 +30,9 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
       DisableExecuteApiEndpoint: false
       StageName: Prod
 Outputs:

--- a/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_true.yaml
+++ b/integration/resources/templates/combination/http_api_with_disable_execute_api_endpoint_true.yaml
@@ -30,6 +30,9 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
       DisableExecuteApiEndpoint: true
       StageName: Prod
 

--- a/integration/resources/templates/combination/http_api_with_fail_on_warnings_and_default_stage_name.yaml
+++ b/integration/resources/templates/combination/http_api_with_fail_on_warnings_and_default_stage_name.yaml
@@ -7,6 +7,9 @@ Resources:
   AppApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
       FailOnWarnings: !Ref FailOnWarningsValue
       StageName: $default
   AppFunction:

--- a/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
+++ b/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
@@ -30,6 +30,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: FancyName
       DefinitionUri:
         Bucket:

--- a/integration/resources/templates/combination/intrinsics_serverless_api.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_api.yaml
@@ -90,6 +90,8 @@ Resources:
     Type: AWS::Serverless::Api
     Condition: TrueCondition
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName:
         Ref: MyStageName
       DefinitionUri:
@@ -107,6 +109,8 @@ Resources:
     Type: AWS::Serverless::Api
     Condition: FalseCondition
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName:
         Ref: MyStageName
       DefinitionUri:

--- a/integration/resources/templates/combination/state_machine_with_api.yaml
+++ b/integration/resources/templates/combination/state_machine_with_api.yaml
@@ -8,6 +8,8 @@ Resources:
   ExistingRestApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Dev
 
   MyStateMachine:

--- a/integration/resources/templates/combination/websocket_api_basic.yaml
+++ b/integration/resources/templates/combination/websocket_api_basic.yaml
@@ -8,6 +8,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       Name: MyApi
       RouteSelectionExpression: $request.body.action
       Routes:

--- a/integration/resources/templates/combination/websocket_api_basic_config.yaml
+++ b/integration/resources/templates/combination/websocket_api_basic_config.yaml
@@ -8,6 +8,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       ApiKeySelectionExpression: $request.header.x-api-key
       Description: Toy API
       DisableExecuteApiEndpoint: false

--- a/integration/resources/templates/combination/websocket_api_custom_domains_regional.yaml
+++ b/integration/resources/templates/combination/websocket_api_custom_domains_regional.yaml
@@ -39,6 +39,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       Name: MyApi
       RouteSelectionExpression: $request.body.action
       Routes:

--- a/integration/resources/templates/combination/websocket_api_multiple_api.yaml
+++ b/integration/resources/templates/combination/websocket_api_multiple_api.yaml
@@ -8,6 +8,8 @@ Resources:
   Api1:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       RouteSelectionExpression: $request.body.action
       Routes:
         $default:
@@ -15,6 +17,8 @@ Resources:
   Api2:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       Name: Api2
       RouteSelectionExpression: $request.body.action
       Routes:

--- a/integration/resources/templates/combination/websocket_api_multiple_routes.yaml
+++ b/integration/resources/templates/combination/websocket_api_multiple_routes.yaml
@@ -26,6 +26,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       RouteSelectionExpression: $request.body.action
       Routes:
         $connect:

--- a/integration/resources/templates/combination/websocket_api_route_config.yaml
+++ b/integration/resources/templates/combination/websocket_api_route_config.yaml
@@ -8,6 +8,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       Routes:
         $connect:
           ApiKeyRequired: false

--- a/integration/resources/templates/combination/websocket_api_route_settings.yaml
+++ b/integration/resources/templates/combination/websocket_api_route_settings.yaml
@@ -12,6 +12,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       RouteSelectionExpression: $request.body.action
       RouteSettings:
         sendMessage:

--- a/integration/resources/templates/combination/websocket_api_stage_config.yaml
+++ b/integration/resources/templates/combination/websocket_api_stage_config.yaml
@@ -8,6 +8,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       Name: MyApi
       PropagateTags: true
       Routes:

--- a/integration/resources/templates/combination/websocket_api_with_disable_execute_api_endpoint.yaml
+++ b/integration/resources/templates/combination/websocket_api_with_disable_execute_api_endpoint.yaml
@@ -13,6 +13,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       DisableExecuteApiEndpoint: !Ref DisableExecuteApiEndpointValue
       Name: MyApi
       RouteSelectionExpression: $request.body.action

--- a/integration/resources/templates/combination/websocket_api_with_disable_schema_validation.yaml
+++ b/integration/resources/templates/combination/websocket_api_with_disable_schema_validation.yaml
@@ -14,6 +14,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       DisableSchemaValidation: true
       Name: MyApi
       RouteSelectionExpression: $request.body.action

--- a/integration/resources/templates/combination/websocket_api_with_ip_address_type.yaml
+++ b/integration/resources/templates/combination/websocket_api_with_ip_address_type.yaml
@@ -13,6 +13,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::WebSocketApi
     Properties:
+      Auth:
+        AuthType: AWS_IAM
       IpAddressType: !Ref IpAddressType
       Name: MyApi
       RouteSelectionExpression: $request.body.action

--- a/integration/resources/templates/single/api_with_custom_domain_security_policy_edge.yaml
+++ b/integration/resources/templates/single/api_with_custom_domain_security_policy_edge.yaml
@@ -10,6 +10,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       EndpointConfiguration:

--- a/integration/resources/templates/single/api_with_custom_domain_security_policy_regional.yaml
+++ b/integration/resources/templates/single/api_with_custom_domain_security_policy_regional.yaml
@@ -10,6 +10,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       EndpointConfiguration:

--- a/integration/resources/templates/single/api_with_domain_ipaddresstype.yaml
+++ b/integration/resources/templates/single/api_with_domain_ipaddresstype.yaml
@@ -11,6 +11,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       Domain:

--- a/integration/resources/templates/single/api_with_endpoint_access_mode.yaml
+++ b/integration/resources/templates/single/api_with_endpoint_access_mode.yaml
@@ -10,6 +10,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       SecurityPolicy: !Ref SecurityPolicyValue

--- a/integration/resources/templates/single/api_with_ipaddresstype.yaml
+++ b/integration/resources/templates/single/api_with_ipaddresstype.yaml
@@ -7,6 +7,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       EndpointConfiguration:

--- a/integration/resources/templates/single/basic_api.yaml
+++ b/integration/resources/templates/single/basic_api.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: MyNewStageName
       DefinitionUri: ${definitionuri}
 Metadata:

--- a/integration/resources/templates/single/basic_api_inline_openapi.yaml
+++ b/integration/resources/templates/single/basic_api_inline_openapi.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: MyNewStageName
       DefinitionBody:
         # Simple HTTP Proxy API

--- a/integration/resources/templates/single/basic_api_inline_swagger.yaml
+++ b/integration/resources/templates/single/basic_api_inline_swagger.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: MyNewStageName
       DefinitionBody:
         # Simple HTTP Proxy API

--- a/integration/resources/templates/single/basic_api_with_mode.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: MyNewStageName
       Mode: overwrite
 

--- a/integration/resources/templates/single/basic_api_with_mode_update.yaml
+++ b/integration/resources/templates/single/basic_api_with_mode_update.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: MyNewStageName
       Mode: overwrite
 

--- a/integration/resources/templates/single/basic_api_with_tags.yaml
+++ b/integration/resources/templates/single/basic_api_with_tags.yaml
@@ -6,6 +6,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: my-new-stage-name
       DefinitionUri: ${definitionuri}
       Tags:

--- a/integration/resources/templates/single/basic_http_api.yaml
+++ b/integration/resources/templates/single/basic_http_api.yaml
@@ -2,6 +2,9 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
       DefinitionBody:
         info:
           version: '1.0'

--- a/integration/resources/templates/single/function_alias_with_http_api_events.yaml
+++ b/integration/resources/templates/single/function_alias_with_http_api_events.yaml
@@ -1,6 +1,10 @@
 Resources:
   MyHttpApi:
     Type: AWS::Serverless::HttpApi
+    Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/integration/resources/templates/single/function_with_http_api_events.yaml
+++ b/integration/resources/templates/single/function_with_http_api_events.yaml
@@ -1,6 +1,10 @@
 Resources:
   MyHttpApi:
     Type: AWS::Serverless::HttpApi
+    Properties:
+      Auth:
+        EnableIamAuthorizer: true
+        DefaultAuthorizer: AWS_IAM
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/integration/resources/templates/single/state_machine_with_api.yaml
+++ b/integration/resources/templates/single/state_machine_with_api.yaml
@@ -3,6 +3,8 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
+      Auth:
+        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       EndpointConfiguration:
         Type: REGIONAL

--- a/integration/single/test_basic_api.py
+++ b/integration/single/test_basic_api.py
@@ -47,21 +47,21 @@ class TestBasicApi(BaseTest):
         stack_output = self.get_stack_outputs()
         api_endpoint = stack_output.get("ApiEndpoint")
 
-        self.verify_get_request_response(f"{api_endpoint}/get", 200)
+        self.verify_get_request_response_sigv4(f"{api_endpoint}/get", 200)
 
         # Removes get from the API
         self.update_and_verify_stack(file_path="single/basic_api_with_mode_update")
 
-        # API Gateway by default returns 403 if a path do not exist
-        self.verify_get_request_response.retry_with(
+        # With IAM auth, API Gateway returns 404 for non-existent routes (instead of 403 without auth)
+        self.verify_get_request_response_sigv4.retry_with(
             stop=stop_after_attempt(20),
             wait=wait_exponential(multiplier=1, min=4, max=10) + wait_random(0, 1),
             retry=retry_if_exception_type(StatusCodeError),
             after=after_log(LOG, logging.WARNING),
             reraise=True,
-        )(self, f"{api_endpoint}/get", 403)
+        )(self, f"{api_endpoint}/get", 404)
 
-        LOG.log(msg=f"retry times {self.verify_get_request_response.retry.statistics}", level=logging.WARNING)
+        LOG.log(msg=f"retry times {self.verify_get_request_response_sigv4.retry.statistics}", level=logging.WARNING)
 
     def test_basic_api_inline_openapi(self):
         """
@@ -134,7 +134,7 @@ class TestBasicApi(BaseTest):
         # This will be the wait time before triggering the APIGW request
         time.sleep(10)
 
-        response = self.verify_post_request(api_endpoint, input_json, 200)
+        response = self.verify_post_request_sigv4(api_endpoint, input_json, 200)
 
         LOG.log(msg=f"retry times {self.verify_get_request_response.retry.statistics}", level=logging.WARNING)
 


### PR DESCRIPTION
## Summary

Add IAM authorization to all API Gateway resources created by integration tests.

## Changes

- **WebSocket APIs**: Added `Auth.AuthType: AWS_IAM` (11 templates)
- **HTTP APIs**: Added `Auth.EnableIamAuthorizer: true` + `DefaultAuthorizer: AWS_IAM` (10 templates)
- **REST APIs**: Added `Auth.DefaultAuthorizer: AWS_IAM` (27 templates)
- Added SigV4 request signing helpers to `base_test.py`
- Updated tests that verify HTTP responses to use SigV4 signed requests
- Updated expected status code from 403 to 404 for deleted routes with IAM auth

## Testing

Verified locally against account 830899278857 (us-west-2):
- `test_basic_http_api` ✅
- `test_websocket_api_with_disable_execute_api_endpoint` ✅
- `test_function_with_http_api` ✅
- `test_function_with_http_api_default_path` ✅
- `test_function_with_implicit_http_api` ✅
- `test_state_machine_with_api_single_quotes_input` ✅
- `test_basic_api_inline_openapi` ✅
- `test_basic_api_with_mode` ✅