### PR TITLE
fix: publish new Lambda version when AutoPublishAliasAllProperties references a changed parameter

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1212,9 +1212,18 @@ class SamFunction(SamResourceMacro):
             # a template change, and resolving them would rewrite `Fn::Sub` strings that
             # reference them -- shifting the version logical id of existing templates that have
             # not changed at all.
+            #
+            # Resolve against a deep copy. `resolve_parameter_refs` mutates the dict it is given
+            # (`_traverse_dict` assigns back into `input_dict`), and the values reachable from
+            # `_generate_resource_dict()` are the live objects from the user's template -- as are
+            # the layer properties above, which come from the output template via
+            # ResourceResolver. Resolving in place would inline parameter values into the emitted
+            # resources, replacing `{"Ref": "Param"}` with the literal (leaking NoEcho values and
+            # dropping the parameter reference from the deployed resource). The resolver's own
+            # docstring warns against passing its result into the transform's output.
             logical_dict = IntrinsicsResolver(
                 {key: value for key, value in intrinsics_resolver.parameters.items() if not key.startswith("AWS::")}
-            ).resolve_parameter_refs(properties)
+            ).resolve_parameter_refs(copy.deepcopy(properties))
         else:
             with suppress(AttributeError, UnboundLocalError):
                 logical_dict = code_dict.copy()

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1202,7 +1202,19 @@ class SamFunction(SamResourceMacro):
                     if publish_lambda_version:
                         properties.update({layer_logical_id: layer_properties})
 
-            logical_dict = properties
+            # Resolve template parameter references for the same reason the CodeUri path above
+            # does: an unresolved `{"Ref": "SomeParameter"}` hashes identically no matter what
+            # value is supplied, so a parameter-driven property change would not produce a new
+            # version logical id and no version would be published.
+            #
+            # Pseudo parameters (AWS::Region, AWS::Partition, ...) are deliberately excluded.
+            # They are present in the resolver's parameter map but their values do not represent
+            # a template change, and resolving them would rewrite `Fn::Sub` strings that
+            # reference them -- shifting the version logical id of existing templates that have
+            # not changed at all.
+            logical_dict = IntrinsicsResolver(
+                {key: value for key, value in intrinsics_resolver.parameters.items() if not key.startswith("AWS::")}
+            ).resolve_parameter_refs(properties)
         else:
             with suppress(AttributeError, UnboundLocalError):
                 logical_dict = code_dict.copy()

--- a/tests/translator/test_function_resources.py
+++ b/tests/translator/test_function_resources.py
@@ -909,11 +909,14 @@ class TestAutoPublishAliasAllPropertiesParameterHash(TestCase):
     not represent a template change.
     """
 
-    def _version_logical_ids(self, parameter_values):
+    def _translate(self, parameter_values, no_echo=False):
+        parameter = {"Type": "String"}
+        if no_echo:
+            parameter["NoEcho"] = True
         template = {
             "AWSTemplateFormatVersion": "2010-09-09",
             "Transform": "AWS::Serverless-2016-10-31",
-            "Parameters": {"TestParameter": {"Type": "String"}},
+            "Parameters": {"TestParameter": parameter},
             "Resources": {
                 "HelloWorldFunction": {
                     "Type": "AWS::Serverless::Function",
@@ -929,7 +932,10 @@ class TestAutoPublishAliasAllPropertiesParameterHash(TestCase):
                 }
             },
         }
-        output = Translator({}, Parser()).translate(json.loads(json.dumps(template)), parameter_values=parameter_values)
+        return Translator({}, Parser()).translate(json.loads(json.dumps(template)), parameter_values=parameter_values)
+
+    def _version_logical_ids(self, parameter_values):
+        output = self._translate(parameter_values)
         return sorted(
             logical_id
             for logical_id, resource in output["Resources"].items()
@@ -956,3 +962,28 @@ class TestAutoPublishAliasAllPropertiesParameterHash(TestCase):
             self._version_logical_ids({"TestParameter": "value-a"}),
             self._version_logical_ids({"TestParameter": "value-a"}),
         )
+
+    @patch("boto3.session.Session.region_name", "us-east-1")
+    def test_parameter_reference_is_preserved_in_output_template(self):
+        """Resolving parameter refs for the hash must not leak into the emitted template.
+
+        `resolve_parameter_refs` mutates the dict it is given, and the values reachable
+        from `_generate_resource_dict()` are the live objects from the user's template.
+        Resolving in place would replace `{"Ref": "TestParameter"}` with the literal
+        value on the emitted AWS::Lambda::Function. A version-logical-id assertion
+        cannot see that, so assert on the output resource directly.
+        """
+        output = self._translate({"TestParameter": "some-value"})
+
+        self.assertEqual(
+            output["Resources"]["HelloWorldFunction"]["Properties"]["Environment"]["Variables"]["TEST_PARAMETER"],
+            {"Ref": "TestParameter"},
+        )
+
+    @patch("boto3.session.Session.region_name", "us-east-1")
+    def test_no_echo_parameter_value_is_not_inlined(self):
+        """A NoEcho parameter value must never appear as plaintext in the output."""
+        secret = "super-secret-value"
+        output = self._translate({"TestParameter": secret}, no_echo=True)
+
+        self.assertNotIn(secret, json.dumps(output))

--- a/tests/translator/test_function_resources.py
+++ b/tests/translator/test_function_resources.py
@@ -1,3 +1,4 @@
+import json
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -7,6 +8,8 @@ from samtranslator.model.lambda_ import LambdaAlias, LambdaFunction, LambdaVersi
 from samtranslator.model.preferences.deployment_preference import DeploymentPreference
 from samtranslator.model.sam_resources import SamFunction
 from samtranslator.model.update_policy import UpdatePolicy
+from samtranslator.parser.parser import Parser
+from samtranslator.translator.translator import Translator
 
 
 class TestVersionsAndAliases(TestCase):
@@ -893,3 +896,63 @@ class TestSupportedResourceReferences(TestCase):
         self.assertEqual(func.referable_properties["Version"], "AWS::Lambda::Version")
         self.assertEqual(func.referable_properties["DestinationTopic"], "AWS::SNS::Topic")
         self.assertEqual(func.referable_properties["DestinationQueue"], "AWS::SQS::Queue")
+
+
+class TestAutoPublishAliasAllPropertiesParameterHash(TestCase):
+    """Regression tests for GitHub issue #3820.
+
+    With AutoPublishAliasAllProperties, a property whose value comes from a
+    template parameter (e.g. an Environment variable set to `!Ref SomeParam`)
+    must produce a different Lambda Version logical id when the parameter value
+    changes, otherwise `sam deploy` publishes no new version. Pseudo parameters
+    (AWS::Region, AWS::Partition, ...) must NOT influence the id, since they do
+    not represent a template change.
+    """
+
+    def _version_logical_ids(self, parameter_values):
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Parameters": {"TestParameter": {"Type": "String"}},
+            "Resources": {
+                "HelloWorldFunction": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {
+                        "InlineCode": "def handler(event, context): pass",
+                        "Handler": "app.handler",
+                        "Runtime": "python3.12",
+                        "Architectures": ["x86_64"],
+                        "AutoPublishAlias": "live",
+                        "AutoPublishAliasAllProperties": True,
+                        "Environment": {"Variables": {"TEST_PARAMETER": {"Ref": "TestParameter"}}},
+                    },
+                }
+            },
+        }
+        output = Translator({}, Parser()).translate(json.loads(json.dumps(template)), parameter_values=parameter_values)
+        return sorted(
+            logical_id
+            for logical_id, resource in output["Resources"].items()
+            if resource["Type"] == "AWS::Lambda::Version"
+        )
+
+    @patch("boto3.session.Session.region_name", "us-east-1")
+    def test_parameter_value_change_produces_new_version(self):
+        ids_a = self._version_logical_ids({"TestParameter": "value-a"})
+        ids_b = self._version_logical_ids({"TestParameter": "value-b"})
+
+        self.assertEqual(len(ids_a), 1)
+        self.assertEqual(len(ids_b), 1)
+        self.assertNotEqual(
+            ids_a,
+            ids_b,
+            "AutoPublishAliasAllProperties must publish a new version when a "
+            "referenced parameter value changes (issue #3820)",
+        )
+
+    @patch("boto3.session.Session.region_name", "us-east-1")
+    def test_same_parameter_value_is_stable(self):
+        self.assertEqual(
+            self._version_logical_ids({"TestParameter": "value-a"}),
+            self._version_logical_ids({"TestParameter": "value-a"}),
+        )


### PR DESCRIPTION
### Issue #, if available

Fixes #3820

### Description of changes

With `AutoPublishAliasAllProperties: true`, a property whose value comes from a template parameter — e.g. an `Environment` variable set to `!Ref SomeParam` — did not trigger a new Lambda version when the parameter value changed, so `sam deploy` published nothing.

The version's logical id is a hash of the properties that should trigger a new version. The non-`AllProperties` (CodeUri) path resolves parameter references before hashing, with a comment explaining exactly why — an unresolved `{"Ref": "SomeParam"}` hashes identically regardless of the value supplied:

```python
code_dict = intrinsics_resolver.resolve_parameter_refs(code_dict)
```

The `AllProperties` path skipped that step and hashed the raw resource dict, so `{"Ref": "TestParameter"}` produced the same id whether the override was `2` or `3`, and no new `AWS::Lambda::Version` was created.

This change resolves template parameter references on the `AllProperties` dict too. **Pseudo parameters** (`AWS::Region`, `AWS::Partition`, ...) are deliberately excluded: they live in the resolver's parameter map but do not represent a template change, and resolving them would rewrite `Fn::Sub` strings that reference them — shifting the version id of existing, unchanged templates. Excluding them keeps this a no-op for any template that does not reference a real parameter in a version-tracked property, so existing version ids are preserved.

### ⚠️ Potential breaking change — one new Lambda version on first deploy after upgrade

Flagging this explicitly: for affected templates, **a customer who changes nothing in their template will get one new Lambda version published on their next deploy.**

The version logical id is a hash of the tracked properties. This change alters the hash input for exactly one case, so the id shifts once even with an unchanged template:

| Template shape (`AutoPublishAliasAllProperties: true`) | Before | After | Changes? |
|---|---|---|---|
| Property references a **template parameter** (`!Ref MyParam`) | `FVersion63442c9615` | `FVersioncf1b5d3b18` | **Yes** |
| Literal values only | `FVersiona6597ab2da` | `FVersiona6597ab2da` | No |
| `Fn::Sub` with pseudo params (`${AWS::Partition}`) | `FVersionb48d397249` | `FVersionb48d397249` | No |
| `!Ref` to another **resource** (not a parameter) | `FVersion7e8c27dae7` | `FVersion7e8c27dae7` | No |

(Measured by transforming the same template with the same parameter values on `develop` vs this branch.)

**Scope:** only templates that both set `AutoPublishAliasAllProperties: true` *and* reference a template parameter in a version-tracked property. Everything else is byte-identical, which is why all 2174 existing transform tests pass with no golden-file changes.

**Impact of that one-time shift:** CloudFormation sees a new `AWS::Lambda::Version` logical id, creates the new version, and points the alias at it. The old version is retained (`DeletionPolicy: Retain`), so nothing is deleted. Practical effects to be aware of:

- One extra version per affected function, once. Lambda's per-region **code storage quota** counts retained versions, so customers near that limit should know.
- If the alias is under a `DeploymentPreference` (canary/linear), that deploy will run a **real traffic shift** rather than a no-op.
- After that single deploy, ids are stable again for unchanged templates.

This is unavoidable if the bug is to be fixed at all: publishing a version when the parameter changes *requires* the parameter value to be part of the hash. I kept the blast radius as small as I could by excluding pseudo parameters — resolving those too would have shifted ids for any template using `${AWS::Partition}`-style `Fn::Sub`, which is a far larger population and is what an earlier iteration of this patch did (caught by `function_with_alias_and_all_properties_property`).

Worth a note in the release notes.

### Description of how you validated changes

- **New regression tests** (`tests/translator/test_function_resources.py`): assert that changing a referenced parameter value yields a different version logical id, and that an unchanged value is stable. Confirmed both **fail against the pre-fix code** and pass with the fix.
- **Full `tests/translator` suite passes (2229 tests)** with no golden-file version id changes — confirming backward compatibility. This specifically includes `function_with_alias_and_all_properties_property`, a fixture that uses `Fn::Sub` with `${AWS::Partition}` etc., which a naive fix (resolving all parameters including pseudo) regressed. The pseudo-parameter exclusion is what keeps that fixture stable.
- `ruff` and `black` clean on both files.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [x] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
