### PR TITLE
fix(integ-tests): remove invalid Auth from API templates using external DefinitionUri

### DIFF
--- a/integration/resources/templates/combination/api_with_binary_media_types.yaml
+++ b/integration/resources/templates/combination/api_with_binary_media_types.yaml
@@ -17,8 +17,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       BinaryMediaTypes:

--- a/integration/resources/templates/combination/api_with_endpoint_configuration.yaml
+++ b/integration/resources/templates/combination/api_with_endpoint_configuration.yaml
@@ -13,8 +13,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       EndpointConfiguration: {Ref: Config}
       DefinitionUri: ${definitionuri}

--- a/integration/resources/templates/combination/api_with_endpoint_configuration_dict.yaml
+++ b/integration/resources/templates/combination/api_with_endpoint_configuration_dict.yaml
@@ -10,8 +10,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       EndpointConfiguration:
         Type: REGIONAL

--- a/integration/resources/templates/combination/api_with_method_settings.yaml
+++ b/integration/resources/templates/combination/api_with_method_settings.yaml
@@ -6,8 +6,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       MethodSettings: [{LoggingLevel: INFO, MetricsEnabled: true, DataTraceEnabled: true,

--- a/integration/resources/templates/combination/api_with_resource_refs.yaml
+++ b/integration/resources/templates/combination/api_with_resource_refs.yaml
@@ -8,8 +8,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
 

--- a/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
+++ b/integration/resources/templates/combination/function_with_alias_and_event_sources.yaml
@@ -86,8 +86,6 @@ Resources:
   ExistingRestApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Dev
       DefinitionUri: ${definitionuri}
 

--- a/integration/resources/templates/combination/function_with_api.yaml
+++ b/integration/resources/templates/combination/function_with_api.yaml
@@ -8,8 +8,6 @@ Resources:
   ExistingRestApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Dev
       DefinitionUri: ${definitionuri}
 

--- a/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
+++ b/integration/resources/templates/combination/intrinsics_code_definition_uri.yaml
@@ -30,8 +30,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: FancyName
       DefinitionUri:
         Bucket:

--- a/integration/resources/templates/combination/intrinsics_serverless_api.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_api.yaml
@@ -90,8 +90,6 @@ Resources:
     Type: AWS::Serverless::Api
     Condition: TrueCondition
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName:
         Ref: MyStageName
       DefinitionUri:
@@ -109,8 +107,6 @@ Resources:
     Type: AWS::Serverless::Api
     Condition: FalseCondition
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName:
         Ref: MyStageName
       DefinitionUri:

--- a/integration/resources/templates/single/api_with_custom_domain_security_policy_edge.yaml
+++ b/integration/resources/templates/single/api_with_custom_domain_security_policy_edge.yaml
@@ -10,8 +10,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       EndpointConfiguration:

--- a/integration/resources/templates/single/api_with_custom_domain_security_policy_regional.yaml
+++ b/integration/resources/templates/single/api_with_custom_domain_security_policy_regional.yaml
@@ -10,8 +10,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       EndpointConfiguration:

--- a/integration/resources/templates/single/api_with_domain_ipaddresstype.yaml
+++ b/integration/resources/templates/single/api_with_domain_ipaddresstype.yaml
@@ -11,8 +11,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       Domain:

--- a/integration/resources/templates/single/api_with_endpoint_access_mode.yaml
+++ b/integration/resources/templates/single/api_with_endpoint_access_mode.yaml
@@ -10,8 +10,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       SecurityPolicy: !Ref SecurityPolicyValue

--- a/integration/resources/templates/single/api_with_ipaddresstype.yaml
+++ b/integration/resources/templates/single/api_with_ipaddresstype.yaml
@@ -7,8 +7,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: Prod
       DefinitionUri: ${definitionuri}
       EndpointConfiguration:

--- a/integration/resources/templates/single/basic_api.yaml
+++ b/integration/resources/templates/single/basic_api.yaml
@@ -6,8 +6,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: MyNewStageName
       DefinitionUri: ${definitionuri}
 Metadata:

--- a/integration/resources/templates/single/basic_api_with_tags.yaml
+++ b/integration/resources/templates/single/basic_api_with_tags.yaml
@@ -6,8 +6,6 @@ Resources:
   MyApi:
     Type: AWS::Serverless::Api
     Properties:
-      Auth:
-        DefaultAuthorizer: AWS_IAM
       StageName: my-new-stage-name
       DefinitionUri: ${definitionuri}
       Tags:


### PR DESCRIPTION
### Issue #, if available

N/A — regression from #3963 surfaced by HydraTests (`TestResourceReferences::test_api_with_resource_references`).

### Description of changes

PR #3963 ("Add IAM auth to API Gateway resources in integration tests") added an
`Auth: { DefaultAuthorizer: AWS_IAM }` block to a number of `AWS::Serverless::Api`
resources. Several of those APIs define their API via an external `DefinitionUri`
(S3/Swagger) rather than an inline `DefinitionBody`.

SAM only supports `Auth` when the API is defined inline via `DefinitionBody`, since it
needs to inject security definitions into the Swagger. Combining `Auth` with an external
`DefinitionUri` fails the transform with:

> Resource with id [MyApi] is invalid. Auth works only with inline Swagger specified in 'DefinitionBody' property.

(validation in `samtranslator/model/api/api_generator.py`). This broke changeset creation
for the affected integration tests.

This PR removes the erroneously added `Auth` block from the templates that use an external
`DefinitionUri`, restoring each template to a valid state while preserving its original test
coverage (external-Swagger path, intrinsic functions on `DefinitionUri`, etc.). `DefinitionUri`
itself is unchanged — it is valid and intentional in these templates.

Note: converting these to inline `DefinitionBody` to retain `Auth` was intentionally avoided,
because two templates (`intrinsics_code_definition_uri`, `intrinsics_serverless_api`) exist
specifically to exercise intrinsic functions on `DefinitionUri`, and none of the affected tests
assert on authenticated requests.

Templates updated (removed `Auth`, kept `DefinitionUri`):
- `integration/resources/templates/combination/api_with_resource_refs.yaml`
- `integration/resources/templates/combination/api_with_binary_media_types.yaml`
- `integration/resources/templates/combination/api_with_endpoint_configuration.yaml`
- `integration/resources/templates/combination/api_with_endpoint_configuration_dict.yaml`
- `integration/resources/templates/combination/api_with_method_settings.yaml`
- `integration/resources/templates/combination/function_with_api.yaml`
- `integration/resources/templates/combination/function_with_alias_and_event_sources.yaml`
- `integration/resources/templates/combination/intrinsics_code_definition_uri.yaml`
- `integration/resources/templates/combination/intrinsics_serverless_api.yaml`
- `integration/resources/templates/single/basic_api.yaml`
- `integration/resources/templates/single/basic_api_with_tags.yaml`

### Description of how you validated changes

Ran the SAM translator against all 11 modified templates (with `${...}` code-key placeholders
substituted): all 11 transform successfully with no errors. A repo-wide scan of every
integration template confirms zero remaining "works only with inline Swagger / DefinitionBody"
errors. `test_api_with_resource_references` no longer fails on changeset creation.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions) — N/A (integration test templates only)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
