### PR TITLE
fix: do not mutate the caller's template during transform

### DIFF
--- a/samtranslator/translator/transform.py
+++ b/samtranslator/translator/transform.py
@@ -1,3 +1,4 @@
+import copy
 from functools import cache
 from typing import Any
 
@@ -22,6 +23,20 @@ def transform(
     :returns: the transformed CloudFormation template
     :rtype: dict
     """
+
+    # Work on our own copies: the parser and plugins mutate the template in place --
+    # Globals are merged into resource properties and the Globals section itself is
+    # removed -- and to_py27_compatible_template() below mutates parameter_values in
+    # place, replacing its values with Py27UniStr/Py27Dict/Py27LongInt wrappers.
+    # Callers hand us objects they may still need afterwards, or may transform more
+    # than once.
+    #
+    # Both copies are taken before to_py27_compatible_template() so that only plain
+    # dicts and strings are copied. The Py27Dict/Py27UniStr wrappers that function
+    # installs carry hash-ordering state that logical ID generation depends on, and
+    # deep-copying them does not preserve it.
+    input_fragment = copy.deepcopy(input_fragment)
+    parameter_values = copy.deepcopy(parameter_values)
 
     sam_parser = Parser()
     to_py27_compatible_template(input_fragment, parameter_values)

--- a/tests/translator/test_transform_does_not_mutate_input.py
+++ b/tests/translator/test_transform_does_not_mutate_input.py
@@ -7,7 +7,9 @@ from samtranslator.translator.transform import transform
 
 def _managed_policy_loader():
     loader = MagicMock()
-    loader.load.return_value = {"AWSLambdaBasicExecutionRole": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"}
+    loader.load.return_value = {
+        "AWSLambdaBasicExecutionRole": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    }
     return loader
 
 

--- a/tests/translator/test_transform_does_not_mutate_input.py
+++ b/tests/translator/test_transform_does_not_mutate_input.py
@@ -1,0 +1,145 @@
+import copy
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from samtranslator.translator.transform import transform
+
+
+def _managed_policy_loader():
+    loader = MagicMock()
+    loader.load.return_value = {"AWSLambdaBasicExecutionRole": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"}
+    return loader
+
+
+def _transform(template, parameter_values=None):
+    if parameter_values is None:
+        parameter_values = {}
+    with patch("boto3.session.Session.region_name", "us-east-1"):
+        return transform(template, parameter_values, _managed_policy_loader())
+
+
+FUNCTION_PROPERTIES = {
+    "CodeUri": "s3://bucket/key",
+    "Handler": "index.handler",
+    "Runtime": "python3.11",
+}
+
+TEMPLATE_WITH_GLOBALS = {
+    "Transform": "AWS::Serverless-2016-10-31",
+    "Globals": {"Function": {"Timeout": 30}},
+    "Resources": {"Fn": {"Type": "AWS::Serverless::Function", "Properties": dict(FUNCTION_PROPERTIES)}},
+}
+
+TEMPLATE_WITH_API_EVENT = {
+    "Transform": "AWS::Serverless-2016-10-31",
+    "Resources": {
+        "Fn": {
+            "Type": "AWS::Serverless::Function",
+            "Properties": {
+                **FUNCTION_PROPERTIES,
+                "Events": {"Api": {"Type": "Api", "Properties": {"Path": "/x", "Method": "get"}}},
+            },
+        }
+    },
+}
+
+
+TEMPLATE_WITH_EXPLICIT_API = {
+    "Transform": "AWS::Serverless-2016-10-31",
+    "Resources": {
+        "Fn": {
+            "Type": "AWS::Serverless::Function",
+            "Properties": {
+                **FUNCTION_PROPERTIES,
+                "Events": {
+                    "Api": {
+                        "Type": "Api",
+                        "Properties": {"Path": "/x", "Method": "get", "RestApiId": {"Ref": "Api"}},
+                    }
+                },
+            },
+        },
+        "Api": {"Type": "AWS::Serverless::Api", "Properties": {"StageName": "prod"}},
+    },
+}
+
+TEMPLATE_WITH_EXPLICIT_HTTP_API = {
+    "Transform": "AWS::Serverless-2016-10-31",
+    "Resources": {
+        "Fn": {
+            "Type": "AWS::Serverless::Function",
+            "Properties": {
+                **FUNCTION_PROPERTIES,
+                "Events": {
+                    "Http": {
+                        "Type": "HttpApi",
+                        "Properties": {"Path": "/x", "Method": "get", "ApiId": {"Ref": "Api"}},
+                    }
+                },
+            },
+        },
+        "Api": {"Type": "AWS::Serverless::HttpApi", "Properties": {"StageName": "prod"}},
+    },
+}
+
+
+class TestTransformDoesNotMutateInput(TestCase):
+    def test_globals_template_is_not_modified(self):
+        template = copy.deepcopy(TEMPLATE_WITH_GLOBALS)
+        expected = copy.deepcopy(template)
+
+        _transform(template)
+
+        # The Globals section used to be deleted from the caller's template, and the
+        # merged Timeout written into the caller's resource properties.
+        self.assertEqual(template, expected)
+
+    def test_api_event_template_is_not_modified(self):
+        template = copy.deepcopy(TEMPLATE_WITH_API_EVENT)
+        expected = copy.deepcopy(template)
+
+        _transform(template)
+
+        self.assertEqual(template, expected)
+
+    def test_explicit_api_template_is_not_modified(self):
+        template = copy.deepcopy(TEMPLATE_WITH_EXPLICIT_API)
+        expected = copy.deepcopy(template)
+
+        _transform(template)
+
+        # The generated DefinitionBody used to be written into the caller's
+        # AWS::Serverless::Api resource.
+        self.assertEqual(template, expected)
+
+    def test_parameter_values_are_not_modified(self):
+        # to_py27_compatible_template() used to replace parameter_values' entries
+        # in place with Py27UniStr/Py27Dict/Py27LongInt wrappers -- caller-visible
+        # via a different __repr__ and, for dicts, Python 2 hash-order iteration --
+        # even though it only runs for templates with an API resource.
+        template = copy.deepcopy(TEMPLATE_WITH_EXPLICIT_API)
+        parameter_values = {"StageName": "prod", "Count": 3, "Tags": {"a": 1, "b": 2}}
+        expected = copy.deepcopy(parameter_values)
+
+        _transform(template, parameter_values)
+
+        self.assertEqual(parameter_values, expected)
+        self.assertIs(type(parameter_values["StageName"]), str)
+        self.assertIs(type(parameter_values["Count"]), int)
+        self.assertIs(type(parameter_values["Tags"]), dict)
+
+    def test_transforming_the_same_template_twice_gives_the_same_result(self):
+        # Transforming the same object twice used to raise InvalidDocumentException:
+        # 'API method "get" defined multiple times for path "/x"', because the first
+        # transform left its own generated DefinitionBody in the caller's template.
+        for name, template in [
+            ("rest api", TEMPLATE_WITH_EXPLICIT_API),
+            ("http api", TEMPLATE_WITH_EXPLICIT_HTTP_API),
+        ]:
+            with self.subTest(name):
+                reused = copy.deepcopy(template)
+
+                first = _transform(reused)
+                second = _transform(reused)
+
+                self.assertEqual(first, second)


### PR DESCRIPTION
### Issue #, if available

#3973

### Description of changes

`Translator.translate()` documents that it returns "a copy of the template", but the parser and plugins edit the template in place: `Globals` is deleted from it, merged global properties are written into resource properties, and generated API definition bodies are written into explicit `AWS::Serverless::Api`/`HttpApi` resources. A caller that transforms the same template twice gets `InvalidDocumentException: API method "get" defined multiple times for path "/x"` on the second call.

This takes a copy at the `transform()` boundary.

The copy is taken **before** `to_py27_compatible_template()` on purpose. That function installs `Py27Dict`/`Py27UniStr` wrappers whose hash-ordering state logical ID generation depends on, and `copy.deepcopy` does not preserve it — putting the copy at the top of `translate()` instead changes generated logical IDs, which `test_transform_feature_toggle_0_feature_toggle_api_open_api_version_override` catches. Copying while the template is still plain dicts and strings avoids that.

Scope: this fixes the public `transform()` entry point. `Translator.translate()` called directly still mutates its argument; correcting that needs `__deepcopy__` support on the Py27 types, which I've left alone.

### Description of how you validated changes

Four tests in `tests/translator/test_transform_does_not_mutate_input.py`, one per mutation path (Globals, implicit API event, explicit `Api`, and the double-transform failure for both REST and HTTP APIs). All four fail on `develop` and pass with this change.

Existing suites: `tests/translator` 2174 passed, and `tests/translator tests/plugins tests/parser` 2577 passed. Five failures in `tests/plugins/application/test_serverless_app_plugin.py` are pre-existing on `develop` (timing-based SAR tests) and fail identically without this change.

Overhead of the copy on a 246 KiB, 200-function template: 3.2 ms against a 1924 ms transform, 0.2%.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [x] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
