### PR TITLE
test: pin cfn-lint to 1.55 to prevent random failures

### DIFF
--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -9,7 +9,8 @@ if [ ! -d "${VENV}" ]; then
     python3 -m venv "${VENV}"
 fi
 
-"${VENV}/bin/python" -m pip install cfn-lint --upgrade --quiet
+# pinning 1.55.0 for now because there are some issues with 1.56.0
+"${VENV}/bin/python" -m pip install cfn-lint==1.55.0 --upgrade --quiet
 # update cfn schema with retry logic (can fail due to network issues)
 # --regions us-east-1 avoids a cfn-lint bug where updating all regions causes a
 # multiprocessing pickle error. See https://github.com/aws-cloudformation/cfn-lint/issues/4379


### PR DESCRIPTION
### Issue #, if available

Issues in the tests when running `make pr`

```
...
tests/translator/output/function_with_deployment_preference_multiple_combinations.json:284:13:284:18:E1020:'MinimalFunctionWithMinimalDeploymentPreferenceDeploymentGroup' is not one of ['AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']
tests/translator/output/function_with_disabled_traffic_hook.json:42:13:42:18:E1020:'ServerlessDeploymentApplication' is not one of ['AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']
tests/translator/output/function_with_disabled_traffic_hook.json:45:13:45:18:E1020:'preTrafficHook' is not one of ['AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']
tests/translator/output/function_with_disabled_traffic_hook.json:48:13:48:18:E1020:'FunctionDeploymentGroup' is not one of ['AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']
tests/translator/output/function_with_events_and_propagate_tags.json:132:13:132:18:E1020:'ServerlessDeploymentApplication' is not one of ['ScheduleName', 'AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']
tests/translator/output/function_with_events_and_propagate_tags.json:135:13:135:18:E1020:'MyAwesomeFunctionDeploymentGroup' is not one of ['ScheduleName', 'AWS::AccountId', 'AWS::NoValue', 'AWS::NotificationARNs', 'AWS::Partition', 'AWS::Region', 'AWS::StackId', 'AWS::StackName', 'AWS::URLSuffix']
make: *** [lint] Error 2
```

It looks like it's checking for references, but it's not allowing the custom values existing in the template, and only global variables.


### Description of changes
pin `cfn-lint` version to 1.55.0

### Description of how you validated changes
`make pr`

### Checklist

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
