### PR TITLE
fix: include API stage variables in the deployment hash

### DIFF
--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -131,6 +131,14 @@ class ApiGatewayDeployment(Resource):
             hash_input.append(str(openapi_version))
         if domain:
             hash_input.append(json.dumps(domain))
+        # Stage variables are applied with an UpdateStage call, which points the stage back at the
+        # deployment it already references. If they are not part of this hash, a variables-only
+        # change reuses the existing deployment: the new variables are never deployed, and any
+        # deployment made outside SAM since the last SAM deployment is reverted.
+        # Only added when set, so templates without stage variables keep their existing hash.
+        stage_variables = getattr(stage, "Variables", None)
+        if stage_variables:
+            hash_input.append(json.dumps(stage_variables, sort_keys=True))
         function_names = redeploy_restapi_parameters.get("function_names") if redeploy_restapi_parameters else None
         # The deployment logical id is <api logicalId> + "Deployment"
         # The keyword "Deployment" is removed and all the function names associated with api is obtained

--- a/tests/translator/output/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/api_with_openapi_definition_body_no_flag.json
@@ -55,9 +55,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment9252467a1e": {
+    "ExplicitApiDeploymente24cb02185": {
       "Properties": {
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1",
+        "Description": "RestApi deployment id: e24cb0218583daf7c5e537a4e639dfb3a2971fdf",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -70,7 +70,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeploymente24cb02185"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -230,9 +230,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymentdb4b9da82a": {
+    "ServerlessRestApiDeployment62318f9715": {
       "Properties": {
-        "Description": "RestApi deployment id: db4b9da82adc6031fcd32bf3a4954485464fc009",
+        "Description": "RestApi deployment id: 62318f9715b2b5932b597575f6a4a0eafd0cf7e3",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -245,7 +245,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentdb4b9da82a"
+          "Ref": "ServerlessRestApiDeployment62318f9715"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/api_with_swagger_and_openapi_with_auth.json
+++ b/tests/translator/output/api_with_swagger_and_openapi_with_auth.json
@@ -54,9 +54,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment7c4f7dda23": {
+    "ExplicitApiDeployment8e20079165": {
       "Properties": {
-        "Description": "RestApi deployment id: 7c4f7dda23acd71e4a653861510d82ad7809e562",
+        "Description": "RestApi deployment id: 8e20079165a6421b14f28fc3f812a282e9ca3d90",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -69,7 +69,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment7c4f7dda23"
+          "Ref": "ExplicitApiDeployment8e20079165"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -267,9 +267,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymente091b9b9a0": {
+    "ServerlessRestApiDeployment26fa62bf10": {
       "Properties": {
-        "Description": "RestApi deployment id: e091b9b9a0d7b8b9db6fee8c4ad295eb98edde08",
+        "Description": "RestApi deployment id: 26fa62bf10190a228c478ca0189e786b42e35acd",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -282,7 +282,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente091b9b9a0"
+          "Ref": "ServerlessRestApiDeployment26fa62bf10"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-cn/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/aws-cn/api_with_openapi_definition_body_no_flag.json
@@ -63,9 +63,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment9252467a1e": {
+    "ExplicitApiDeploymente24cb02185": {
       "Properties": {
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1",
+        "Description": "RestApi deployment id: e24cb0218583daf7c5e537a4e639dfb3a2971fdf",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -78,7 +78,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeploymente24cb02185"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -246,9 +246,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymente1212668e0": {
+    "ServerlessRestApiDeployment409ed00828": {
       "Properties": {
-        "Description": "RestApi deployment id: e1212668e096994ab32167666f5a877bd6ac5fad",
+        "Description": "RestApi deployment id: 409ed008280bb6489cdd1707ff7f2b66d5ad40bb",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -261,7 +261,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente1212668e0"
+          "Ref": "ServerlessRestApiDeployment409ed00828"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-cn/api_with_swagger_and_openapi_with_auth.json
+++ b/tests/translator/output/aws-cn/api_with_swagger_and_openapi_with_auth.json
@@ -62,9 +62,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment7c4f7dda23": {
+    "ExplicitApiDeployment8e20079165": {
       "Properties": {
-        "Description": "RestApi deployment id: 7c4f7dda23acd71e4a653861510d82ad7809e562",
+        "Description": "RestApi deployment id: 8e20079165a6421b14f28fc3f812a282e9ca3d90",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -77,7 +77,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment7c4f7dda23"
+          "Ref": "ExplicitApiDeployment8e20079165"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -283,9 +283,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeployment614ec93e15": {
+    "ServerlessRestApiDeploymente8a33c953e": {
       "Properties": {
-        "Description": "RestApi deployment id: 614ec93e159f50797f73789c416660484070ee2e",
+        "Description": "RestApi deployment id: e8a33c953ef3abf412bc61a49eecc59a9eb71bc8",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -298,7 +298,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment614ec93e15"
+          "Ref": "ServerlessRestApiDeploymente8a33c953e"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-cn/explicit_api.json
+++ b/tests/translator/output/aws-cn/explicit_api.json
@@ -69,9 +69,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment03f2a64f84": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 03f2a64f84966e7db9bc90b90fda3247d9a394d2",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -82,7 +82,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment03f2a64f84"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/aws-cn/explicit_api_openapi_3.json
+++ b/tests/translator/output/aws-cn/explicit_api_openapi_3.json
@@ -68,9 +68,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment03f2a64f84": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 03f2a64f84966e7db9bc90b90fda3247d9a394d2",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -81,7 +81,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment03f2a64f84"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/aws-cn/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_event_sources.json
@@ -24,9 +24,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment2acb558823": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 2acb558823d4068b07590e8cd40633b8597a3157",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -37,7 +37,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment2acb558823"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/aws-cn/global_handle_path_level_parameter.json
+++ b/tests/translator/output/aws-cn/global_handle_path_level_parameter.json
@@ -70,9 +70,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment9a254aa466": {
+    "ExplicitApiDeployment31e389dd75": {
       "Properties": {
-        "Description": "RestApi deployment id: 9a254aa466c6f818951dfb6e45fde65489beb153",
+        "Description": "RestApi deployment id: 31e389dd75bba46beb7a57c4256c48c5a9b127f4",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -85,7 +85,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9a254aa466"
+          "Ref": "ExplicitApiDeployment31e389dd75"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -253,9 +253,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymente1212668e0": {
+    "ServerlessRestApiDeployment409ed00828": {
       "Properties": {
-        "Description": "RestApi deployment id: e1212668e096994ab32167666f5a877bd6ac5fad",
+        "Description": "RestApi deployment id: 409ed008280bb6489cdd1707ff7f2b66d5ad40bb",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -268,7 +268,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymente1212668e0"
+          "Ref": "ServerlessRestApiDeployment409ed00828"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-cn/globals_for_api.json
+++ b/tests/translator/output/aws-cn/globals_for_api.json
@@ -69,9 +69,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment43e01e673d": {
+    "ExplicitApiDeployment0b29d48047": {
       "Properties": {
-        "Description": "RestApi deployment id: 43e01e673d7acbd09e4c38ff78dd6ddaf2ed1d55",
+        "Description": "RestApi deployment id: 0b29d480473c478bb1a2337fdc7ff0b80bbe48cd",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -84,7 +84,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment43e01e673d"
+          "Ref": "ExplicitApiDeployment0b29d48047"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -260,9 +260,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymentf6c326a165": {
+    "ServerlessRestApiDeployment3556755163": {
       "Properties": {
-        "Description": "RestApi deployment id: f6c326a1656cc9fbb0106cc645598d88575554eb",
+        "Description": "RestApi deployment id: 3556755163aac22f1710a4c6babf8de8932e55b6",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -275,7 +275,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentf6c326a165"
+          "Ref": "ServerlessRestApiDeployment3556755163"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-cn/intrinsic_functions.json
+++ b/tests/translator/output/aws-cn/intrinsic_functions.json
@@ -259,9 +259,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyExplicitApiDeployment7145dd00ce": {
+    "MyExplicitApiDeployment011ab6fdbf": {
       "Properties": {
-        "Description": "RestApi deployment id: 7145dd00cea59b4a62b4d7855add490c587f3f62",
+        "Description": "RestApi deployment id: 011ab6fdbfec2a0b749690c4c389b4f44e51a053",
         "RestApiId": {
           "Ref": "MyExplicitApi"
         },
@@ -272,7 +272,7 @@
     "MyExplicitApidevStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment7145dd00ce"
+          "Ref": "MyExplicitApiDeployment011ab6fdbf"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"

--- a/tests/translator/output/aws-us-gov/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/aws-us-gov/api_with_openapi_definition_body_no_flag.json
@@ -63,9 +63,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment9252467a1e": {
+    "ExplicitApiDeploymente24cb02185": {
       "Properties": {
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1",
+        "Description": "RestApi deployment id: e24cb0218583daf7c5e537a4e639dfb3a2971fdf",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -78,7 +78,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeploymente24cb02185"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -246,9 +246,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymentc969c99f9d": {
+    "ServerlessRestApiDeployment6ba28851eb": {
       "Properties": {
-        "Description": "RestApi deployment id: c969c99f9d6b6921dff605a206e8989bdb7d1bc7",
+        "Description": "RestApi deployment id: 6ba28851eb50150f1e4349e33bc5185400c063d9",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -261,7 +261,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc969c99f9d"
+          "Ref": "ServerlessRestApiDeployment6ba28851eb"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-us-gov/api_with_swagger_and_openapi_with_auth.json
+++ b/tests/translator/output/aws-us-gov/api_with_swagger_and_openapi_with_auth.json
@@ -62,9 +62,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment7c4f7dda23": {
+    "ExplicitApiDeployment8e20079165": {
       "Properties": {
-        "Description": "RestApi deployment id: 7c4f7dda23acd71e4a653861510d82ad7809e562",
+        "Description": "RestApi deployment id: 8e20079165a6421b14f28fc3f812a282e9ca3d90",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -77,7 +77,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment7c4f7dda23"
+          "Ref": "ExplicitApiDeployment8e20079165"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -283,9 +283,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeployment05a3d3687d": {
+    "ServerlessRestApiDeployment9d5c248b84": {
       "Properties": {
-        "Description": "RestApi deployment id: 05a3d3687d4bfb804b237d40817879c6559ac61c",
+        "Description": "RestApi deployment id: 9d5c248b84fd7e0c6d26463880550ef124b0e145",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -298,7 +298,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment05a3d3687d"
+          "Ref": "ServerlessRestApiDeployment9d5c248b84"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-us-gov/explicit_api.json
+++ b/tests/translator/output/aws-us-gov/explicit_api.json
@@ -69,9 +69,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment03f2a64f84": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 03f2a64f84966e7db9bc90b90fda3247d9a394d2",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -82,7 +82,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment03f2a64f84"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/aws-us-gov/explicit_api_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/explicit_api_openapi_3.json
@@ -68,9 +68,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment03f2a64f84": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 03f2a64f84966e7db9bc90b90fda3247d9a394d2",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -81,7 +81,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment03f2a64f84"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_event_sources.json
@@ -24,9 +24,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment2acb558823": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 2acb558823d4068b07590e8cd40633b8597a3157",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -37,7 +37,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment2acb558823"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/aws-us-gov/global_handle_path_level_parameter.json
+++ b/tests/translator/output/aws-us-gov/global_handle_path_level_parameter.json
@@ -70,9 +70,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment9a254aa466": {
+    "ExplicitApiDeployment31e389dd75": {
       "Properties": {
-        "Description": "RestApi deployment id: 9a254aa466c6f818951dfb6e45fde65489beb153",
+        "Description": "RestApi deployment id: 31e389dd75bba46beb7a57c4256c48c5a9b127f4",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -85,7 +85,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9a254aa466"
+          "Ref": "ExplicitApiDeployment31e389dd75"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -253,9 +253,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymentc969c99f9d": {
+    "ServerlessRestApiDeployment6ba28851eb": {
       "Properties": {
-        "Description": "RestApi deployment id: c969c99f9d6b6921dff605a206e8989bdb7d1bc7",
+        "Description": "RestApi deployment id: 6ba28851eb50150f1e4349e33bc5185400c063d9",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -268,7 +268,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc969c99f9d"
+          "Ref": "ServerlessRestApiDeployment6ba28851eb"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-us-gov/globals_for_api.json
+++ b/tests/translator/output/aws-us-gov/globals_for_api.json
@@ -69,9 +69,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment43e01e673d": {
+    "ExplicitApiDeployment0b29d48047": {
       "Properties": {
-        "Description": "RestApi deployment id: 43e01e673d7acbd09e4c38ff78dd6ddaf2ed1d55",
+        "Description": "RestApi deployment id: 0b29d480473c478bb1a2337fdc7ff0b80bbe48cd",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -84,7 +84,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment43e01e673d"
+          "Ref": "ExplicitApiDeployment0b29d48047"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -260,9 +260,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeployment6fd1928d9b": {
+    "ServerlessRestApiDeployment0a9707dedb": {
       "Properties": {
-        "Description": "RestApi deployment id: 6fd1928d9b9ad3c711a371e1337306458029f8bd",
+        "Description": "RestApi deployment id: 0a9707dedb5b0b282252fb37d74c2803a4ea3d1e",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -275,7 +275,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment6fd1928d9b"
+          "Ref": "ServerlessRestApiDeployment0a9707dedb"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/aws-us-gov/intrinsic_functions.json
+++ b/tests/translator/output/aws-us-gov/intrinsic_functions.json
@@ -259,9 +259,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyExplicitApiDeployment7145dd00ce": {
+    "MyExplicitApiDeployment011ab6fdbf": {
       "Properties": {
-        "Description": "RestApi deployment id: 7145dd00cea59b4a62b4d7855add490c587f3f62",
+        "Description": "RestApi deployment id: 011ab6fdbfec2a0b749690c4c389b4f44e51a053",
         "RestApiId": {
           "Ref": "MyExplicitApi"
         },
@@ -272,7 +272,7 @@
     "MyExplicitApidevStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment7145dd00ce"
+          "Ref": "MyExplicitApiDeployment011ab6fdbf"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"

--- a/tests/translator/output/explicit_api.json
+++ b/tests/translator/output/explicit_api.json
@@ -53,9 +53,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment03f2a64f84": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 03f2a64f84966e7db9bc90b90fda3247d9a394d2",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -66,7 +66,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment03f2a64f84"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/explicit_api_openapi_3.json
+++ b/tests/translator/output/explicit_api_openapi_3.json
@@ -52,9 +52,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment03f2a64f84": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 03f2a64f84966e7db9bc90b90fda3247d9a394d2",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -65,7 +65,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment03f2a64f84"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/function_with_alias_and_event_sources.json
@@ -16,9 +16,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "GetHtmlApiDeploymentf117c932f7": {
+    "GetHtmlApiDeployment2acb558823": {
       "Properties": {
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "Description": "RestApi deployment id: 2acb558823d4068b07590e8cd40633b8597a3157",
         "RestApiId": {
           "Ref": "GetHtmlApi"
         },
@@ -29,7 +29,7 @@
     "GetHtmlApiStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "GetHtmlApiDeploymentf117c932f7"
+          "Ref": "GetHtmlApiDeployment2acb558823"
         },
         "RestApiId": {
           "Ref": "GetHtmlApi"

--- a/tests/translator/output/global_handle_path_level_parameter.json
+++ b/tests/translator/output/global_handle_path_level_parameter.json
@@ -62,9 +62,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment9a254aa466": {
+    "ExplicitApiDeployment31e389dd75": {
       "Properties": {
-        "Description": "RestApi deployment id: 9a254aa466c6f818951dfb6e45fde65489beb153",
+        "Description": "RestApi deployment id: 31e389dd75bba46beb7a57c4256c48c5a9b127f4",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -77,7 +77,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9a254aa466"
+          "Ref": "ExplicitApiDeployment31e389dd75"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -237,9 +237,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymentdb4b9da82a": {
+    "ServerlessRestApiDeployment62318f9715": {
       "Properties": {
-        "Description": "RestApi deployment id: db4b9da82adc6031fcd32bf3a4954485464fc009",
+        "Description": "RestApi deployment id: 62318f9715b2b5932b597575f6a4a0eafd0cf7e3",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -252,7 +252,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentdb4b9da82a"
+          "Ref": "ServerlessRestApiDeployment62318f9715"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/globals_for_api.json
+++ b/tests/translator/output/globals_for_api.json
@@ -61,9 +61,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ExplicitApiDeployment43e01e673d": {
+    "ExplicitApiDeployment0b29d48047": {
       "Properties": {
-        "Description": "RestApi deployment id: 43e01e673d7acbd09e4c38ff78dd6ddaf2ed1d55",
+        "Description": "RestApi deployment id: 0b29d480473c478bb1a2337fdc7ff0b80bbe48cd",
         "RestApiId": {
           "Ref": "ExplicitApi"
         },
@@ -76,7 +76,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment43e01e673d"
+          "Ref": "ExplicitApiDeployment0b29d48047"
         },
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -244,9 +244,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "ServerlessRestApiDeploymentaa32438b68": {
+    "ServerlessRestApiDeployment56105d1476": {
       "Properties": {
-        "Description": "RestApi deployment id: aa32438b68e05d3771a975585dfbc7b012672b55",
+        "Description": "RestApi deployment id: 56105d1476c2b2ba36a1c595f0c9f323feb5efd9",
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         },
@@ -259,7 +259,7 @@
         "CacheClusterEnabled": true,
         "CacheClusterSize": "1.6",
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentaa32438b68"
+          "Ref": "ServerlessRestApiDeployment56105d1476"
         },
         "RestApiId": {
           "Ref": "ServerlessRestApi"

--- a/tests/translator/output/intrinsic_functions.json
+++ b/tests/translator/output/intrinsic_functions.json
@@ -243,9 +243,9 @@
       },
       "Type": "AWS::ApiGateway::RestApi"
     },
-    "MyExplicitApiDeployment7145dd00ce": {
+    "MyExplicitApiDeployment011ab6fdbf": {
       "Properties": {
-        "Description": "RestApi deployment id: 7145dd00cea59b4a62b4d7855add490c587f3f62",
+        "Description": "RestApi deployment id: 011ab6fdbfec2a0b749690c4c389b4f44e51a053",
         "RestApiId": {
           "Ref": "MyExplicitApi"
         },
@@ -256,7 +256,7 @@
     "MyExplicitApidevStage": {
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyExplicitApiDeployment7145dd00ce"
+          "Ref": "MyExplicitApiDeployment011ab6fdbf"
         },
         "RestApiId": {
           "Ref": "MyExplicitApi"

--- a/tests/translator/test_api_resource.py
+++ b/tests/translator/test_api_resource.py
@@ -112,6 +112,7 @@ class TestApiGatewayDeploymentResource(TestCase):
         prefix = "prefix"
         generator_mock = LogicalIdGeneratorMock.return_value
         stage = MagicMock()
+        stage.Variables = None
         id_val = "SomeLogicalId"
         full_hash = "127e3fb91142ab1ddc5f5446adb094442581a90d"
         generator_mock.gen.return_value = id_val
@@ -128,6 +129,52 @@ class TestApiGatewayDeploymentResource(TestCase):
         generator_mock.gen.assert_called_once_with()
         generator_mock.get_hash.assert_called_once_with(length=40)  # getting full SHA
         stage.update_deployment_ref.assert_called_once_with(id_val)
+
+    @patch("samtranslator.translator.logical_id_generator.LogicalIdGenerator")
+    def test_make_auto_deployable_with_stage_variables(self, LogicalIdGeneratorMock):
+        prefix = "prefix"
+        generator_mock = LogicalIdGeneratorMock.return_value
+        stage = MagicMock()
+        stage.Variables = {"stageVar": "value"}
+        id_val = "SomeLogicalId"
+        full_hash = "127e3fb91142ab1ddc5f5446adb094442581a90d"
+        generator_mock.gen.return_value = id_val
+        generator_mock.get_hash.return_value = full_hash
+
+        swagger = {"a": "b"}
+        deployment = ApiGatewayDeployment(logical_id=prefix)
+        deployment.make_auto_deployable(stage, swagger=swagger)
+
+        LogicalIdGeneratorMock.assert_called_once_with(
+            prefix, str(swagger) + ApiGatewayDeployment._X_HASH_DELIMITER + json.dumps(stage.Variables, sort_keys=True)
+        )
+
+    def test_make_auto_deployable_stage_variables_change_deployment_id(self):
+        swagger = {"a": "b"}
+
+        def deployment_id_for(variables):
+            stage = MagicMock()
+            stage.Variables = variables
+            deployment = ApiGatewayDeployment(logical_id="prefix")
+            deployment.make_auto_deployable(stage, swagger=swagger)
+            return deployment.logical_id
+
+        # Only the stage variables differ, so the deployment must not be reused: reusing it means
+        # the variable change is never deployed, and UpdateStage resets the active deployment.
+        self.assertNotEqual(deployment_id_for({"stageVar": "one"}), deployment_id_for({"stageVar": "two"}))
+
+    def test_make_auto_deployable_without_stage_variables_is_unchanged(self):
+        swagger = {"a": "b"}
+
+        def deployment_id_for(variables):
+            stage = MagicMock()
+            stage.Variables = variables
+            deployment = ApiGatewayDeployment(logical_id="prefix")
+            deployment.make_auto_deployable(stage, swagger=swagger)
+            return deployment.logical_id
+
+        # Templates that set no stage variables must keep their existing deployment logical id.
+        self.assertEqual(deployment_id_for(None), deployment_id_for({}))
 
     @patch("samtranslator.translator.logical_id_generator.LogicalIdGenerator")
     def test_make_auto_deployable_no_swagger(self, LogicalIdGeneratorMock):


### PR DESCRIPTION
## Which issue(s) does this change fix?

Fixes #3703

## Why is this change necessary?

`ApiGatewayDeployment.make_auto_deployable` builds its hash from the swagger body, the OpenAPI version, the custom domain and the associated function names — but not from the stage's `Variables`. Since `AWS::ApiGateway::Stage` does carry `Variables`, a template change that only touches stage variables produces the **same** deployment logical id, so CloudFormation creates no new `AWS::ApiGateway::Deployment`.

That has two effects, both described in the issue:

1. The stage-variable change is never actually deployed.
2. The `UpdateStage` call points the stage back at the deployment it already references. If any deployment was made outside SAM since the last SAM deployment, the stage silently reverts to the SAM-known deployment id — losing the out-of-band changes.

## How does it address the issue?

Stage variables are appended to `hash_input`, following the existing `if openapi_version:` / `if domain:` pattern.

They are appended **only when set**, which is the important part for backwards compatibility: templates that define no stage variables keep their current deployment logical id and see no churn. `sort_keys=True` keeps the hash stable regardless of key order in the template.

## What side effects does this change have?

Templates that **do** set stage variables get a new deployment logical id once, so the next deploy creates a new deployment. That is the intended behaviour — it is exactly the deployment that was previously being skipped — but it is a one-time redeploy for those stacks, so calling it out explicitly.

The 24 updated files under `tests/translator/output/` are that same effect in the checked-in expected outputs: only the deployment logical id and its `RestApi deployment id: <sha>` description changed. Eight testcases are affected (`explicit_api`, `explicit_api_openapi_3`, `api_with_openapi_definition_body_no_flag`, `api_with_swagger_and_openapi_with_auth`, `function_with_alias_and_event_sources`, `global_handle_path_level_parameter`, `globals_for_api`, `intrinsic_functions`) across the three partition folders. I rewrote just those identifiers rather than regenerating the files, so the diff stays reviewable.

## Testing

Verified on `develop` at `d24401d`, Python 3.12:

- Added three tests to `tests/translator/test_api_resource.py`:
  - stage variables are part of the hash input;
  - two stages differing **only** in variables produce different deployment logical ids (this is the regression test — it fails before the change);
  - a stage with no variables produces the same logical id as one with `{}`, which is the no-churn guard.
- Before the change: the first two fail. After: all pass.
- `tests/translator/` — 2423 passed, 0 failed (42 failed before the fixtures were refreshed).
- Whole suite: 268 failed / 4397 passed **with** the change versus 268 failed / 4394 passed on an otherwise clean tree — same failures either way (they are pre-existing environment failures in this sandbox, e.g. `test_region_configuration`, and need network/endpoint data), plus the 3 new passing tests. No regressions.
- `ruff check` (pinned `ruff~=0.15.6`) and `black --check` clean on both changed Python files; `git diff --check` clean.

One existing test needed a one-line change: `test_make_auto_deployable_with_swagger_dict` uses `stage = MagicMock()`, whose `.Variables` is a truthy `MagicMock` rather than the unset value a real `ApiGatewayStage` has, so it now sets `stage.Variables = None` to express "no stage variables".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
